### PR TITLE
Downcase Cache-Control key in asset pipeline guide example

### DIFF
--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -754,7 +754,7 @@ setting
 
 ```ruby
 config.public_file_server.headers = {
-  "Cache-Control" => "public, max-age=31536000"
+  "cache-control" => "public, max-age=31536000"
 }
 ```
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because #52653 downcased the
`cache-control` header key in the generated `development.rb.tt` and
`test.rb.tt` environment templates so that newly generated
applications follow the Rack 3 SPEC, which requires response headers
to be lowercase. However, the Asset Pipeline guide's "CDNs and the
Cache-Control Header" section still shows the
`config.public_file_server.headers` example with the old
`"Cache-Control"` casing, which no longer matches what is generated
for new apps.

### Detail

This Pull Request changes the guide's code example to use
`"cache-control"`, matching the generator templates. The prose
mentions of `Cache-Control` (referring to the HTTP header name itself)
are left as-is since header names are conventionally capitalized in
text and are case-insensitive on the wire.

### Additional information

N/A

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.