### PR TITLE
Fix `disable_joins` on `has_many :through` with polymorphic join tables

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Fix `disable_joins` on `has_many :through` associations
+    with polymorphic join tables missing the type filter.
+
+    When using `disable_joins: true` on a `has_many :through` association
+    that goes through a polymorphic join table, the scope only filtered by
+    the foreign key id but not by the polymorphic type column. This caused
+    the association to return records belonging to a different parent type.
+
+    *Fabian Mersch*
+
 *   Honor foreign key names on SQLite3.
 
     SQLite3 did not read foreign key names, so `remove_foreign_key(name:)`

--- a/activerecord/lib/active_record/associations/disable_joins_association_scope.rb
+++ b/activerecord/lib/active_record/associations/disable_joins_association_scope.rb
@@ -33,6 +33,11 @@ module ActiveRecord
         def add_constraints(reflection, key, join_ids, owner, ordered)
           scope = reflection.build_scope(reflection.aliased_table).where(key => join_ids)
 
+          if reflection.type
+            polymorphic_type = transform_value(owner.class.polymorphic_name)
+            scope = apply_scope(scope, reflection.aliased_table, reflection.type, polymorphic_type)
+          end
+
           relation = reflection.klass.scope_for_association
           scope.merge!(
             relation.except(:select, :create_with, :includes, :preload, :eager_load, :joins, :left_outer_joins)

--- a/activerecord/test/cases/associations/has_many_through_disable_joins_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_disable_joins_associations_test.rb
@@ -21,7 +21,7 @@ require "models/cpk/book"
 require "models/cpk/order"
 
 class HasManyThroughDisableJoinsAssociationsTest < ActiveRecord::TestCase
-  fixtures :posts, :authors, :comments, :pirates, :author_addresses
+  fixtures :posts, :authors, :comments, :pirates, :author_addresses, :tags
 
   def setup
     @author = authors(:mary)
@@ -208,5 +208,16 @@ class HasManyThroughDisableJoinsAssociationsTest < ActiveRecord::TestCase
 
     assert_equal author.orders.to_a, author.no_joins_orders.to_a
     assert_equal [order2, order1], author.no_joins_orders.to_a
+  end
+
+  def test_disable_joins_through_polymorphic_association
+    tag = tags(:misc)
+    post = posts(:welcome)
+    comment = comments(:greetings)
+    comment.tags << tag
+
+    # Both records must have the same id for the error to occur.
+    assert_equal post.id, comment.id
+    assert_not_includes post.no_join_tags, tag
   end
 end

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -20,6 +20,9 @@ class Comment < ActiveRecord::Base
 
   has_many :ratings
 
+  has_many :taggings, as: :taggable
+  has_many :tags, through: :taggings
+
   belongs_to :first_post, foreign_key: :post_id
   belongs_to :special_post_with_default_scope, foreign_key: :post_id
 

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -145,6 +145,7 @@ class Post < ActiveRecord::Base
         .to_a
     end
   end
+  has_many :no_join_tags, through: :taggings, source: :tag, disable_joins: true
 
   has_many :indestructible_taggings, as: :taggable, counter_cache: :indestructible_tags_count
   has_many :indestructible_tags, through: :indestructible_taggings, source: :tag


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

When using `disable_joins: true` on a `has_many :through` association that goes through a polymorphic join table, the scope only filters by the foreign key id but does **not** filter by the polymorphic type column. This can cause the association to return records belonging to a different parent type.

For example, given:

```ruby
class Post < ActiveRecord::Base
  has_many :taggings, as: :taggable
  has_many :tags, through: :taggings
  has_many :no_join_tags, through: :taggings, source: :tag, disable_joins: true
end

class Comment < ActiveRecord::Base
  has_many :taggings, as: :taggable
  has_many :tags, through: :taggings
end
```

Calling `post.no_join_tags` would generate:

```sql
SELECT * FROM taggings WHERE taggable_id = 1
```

...instead of the correct:

```sql
SELECT * FROM taggings WHERE taggable_id = 1 AND taggable_type = 'Post'
```

This means a tag added to a `Comment` with the same id would be incorrectly returned as a tag of the `Post`.

### Detail

This Pull Request adds a polymorphic type condition in `DisableJoinsAssociationScope#add_constraints`, mirroring the same pattern already used in the regular (join-based) association scope in `AssociationScope#last_chain_scope`. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
