### PR TITLE
Read composite foreign key names from the schema on SQLite3

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Honor composite foreign key names and deferrable modes on SQLite3.
+
+    `remove_foreign_key(name:)` could not find a composite foreign key by
+    name, and custom names and `deferrable:` modes of composite foreign keys
+    were lost on table rebuilds and missing from the schema dump.
+
+    *Kenta Ishizaki*
+
 *   `connected_to_all_shards` now raises `ArgumentError` when called on a model
     that is not connected to any shards, rather than silently doing nothing.
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -466,7 +466,8 @@ module ActiveRecord
       alias :add_belongs_to :add_reference
 
       FK_NAME_REGEX = /\ACONSTRAINT\s+"([^"]+)"/
-      FK_REGEX = /.*FOREIGN KEY\s+\("([^"]+)"\)\s+REFERENCES\s+"(\w+)"\s+\("(\w+)"\)/
+      FK_REGEX = /.*FOREIGN KEY\s+\(("[^"]+"(?:\s*,\s*"[^"]+")*)\)\s+REFERENCES\s+"(\w+)"\s+\(("[^"]+"(?:\s*,\s*"[^"]+")*)\)/
+      QUOTED_COLUMN_REGEX = /"([^"]+)"/
       DEFERRABLE_REGEX = /DEFERRABLE INITIALLY (\w+)/
       def foreign_keys(table_name)
         # SQLite returns 1 row for each column of composite foreign keys.
@@ -483,13 +484,17 @@ module ActiveRecord
                       _, mode = fk_string.match(DEFERRABLE_REGEX).to_a
                       _, name = fk_string.match(FK_NAME_REGEX).to_a
                       deferred = mode&.downcase&.to_sym || false
-                      [[table, from, to], { deferrable: deferred, name: name }]
+                      from_columns = from&.scan(QUOTED_COLUMN_REGEX)&.flatten
+                      to_columns = to&.scan(QUOTED_COLUMN_REGEX)&.flatten
+                      [[table, from_columns, to_columns], { deferrable: deferred, name: name }]
                     end
 
         grouped_fk = fk_info.group_by { |row| row["id"] }.values.each { |group| group.sort_by! { |row| row["seq"] } }
         grouped_fk.map do |group|
           row = group.first
-          fk_def = fk_defs[[row["table"], row["from"], row["to"]]]
+          columns = group.map { |row| row["from"] }
+          primary_keys = group.map { |row| row["to"] }
+          fk_def = fk_defs[[row["table"], columns, primary_keys]]
           options = {
             on_delete: extract_foreign_key_action(row["on_delete"]),
             on_update: extract_foreign_key_action(row["on_update"]),
@@ -501,8 +506,8 @@ module ActiveRecord
             options[:column] = row["from"]
             options[:primary_key] = row["to"]
           else
-            options[:column] = group.map { |row| row["from"] }
-            options[:primary_key] = group.map { |row| row["to"] }
+            options[:column] = columns
+            options[:primary_key] = primary_keys
           end
           ForeignKeyDefinition.new(table_name, row["table"], options)
         end
@@ -854,7 +859,22 @@ module ActiveRecord
                 # column definitions can have a comma in them, so split on commas followed
                 # by a space and a column name in quotes or followed by the keyword CONSTRAINT
                 .split(/,(?=\s(?:CONSTRAINT|"(?:#{Regexp.union(column_names).source})"))/i)
+                # quoted column names can also appear inside the parenthesized column
+                # lists of a composite FOREIGN KEY constraint, so rejoin the parts of
+                # any definition that was split in the middle of one
+                .each_with_object([]) do |part, definitions|
+                  if definitions.last && unbalanced_parentheses?(definitions.last)
+                    definitions.last << "," << part
+                  else
+                    definitions << part
+                  end
+                end
                 .map(&:strip)
+        end
+
+        def unbalanced_parentheses?(definition)
+          definition = definition.gsub(/"[^"]*"|'[^']*'/, "")
+          definition.count("(") != definition.count(")")
         end
 
         def table_info(table_name)

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -1223,12 +1223,77 @@ if ActiveRecord::Base.lease_connection.supports_foreign_keys?
           assert_empty @connection.foreign_keys(:astronauts)
         end
 
+        def test_add_composite_foreign_key_with_name
+          @connection.add_foreign_key :astronauts, :rockets, primary_key: [:tenant_id, :id], name: "custom_composite_fk"
+
+          foreign_keys = @connection.foreign_keys(:astronauts)
+          assert_equal 1, foreign_keys.size
+
+          fk = foreign_keys.first
+          assert_equal "custom_composite_fk", fk.name
+          assert_equal ["rocket_tenant_id", "rocket_id"], fk.column
+        end
+
+        def test_remove_composite_foreign_key_by_name
+          @connection.add_foreign_key :astronauts, :rockets, primary_key: [:tenant_id, :id], name: "custom_composite_fk"
+          assert_equal 1, @connection.foreign_keys(:astronauts).size
+
+          @connection.remove_foreign_key :astronauts, name: "custom_composite_fk"
+          assert_empty @connection.foreign_keys(:astronauts)
+        end
+
+        def test_composite_foreign_key_name_persists_when_table_is_altered
+          @connection.add_foreign_key :astronauts, :rockets, primary_key: [:tenant_id, :id], name: "custom_composite_fk"
+
+          @connection.add_column :astronauts, :nickname, :string
+          @connection.remove_column :astronauts, :nickname
+
+          fk = @connection.foreign_keys(:astronauts).first
+          assert_equal "custom_composite_fk", fk.name
+          assert_equal ["rocket_tenant_id", "rocket_id"], fk.column
+        end
+
+        if ActiveRecord::Base.lease_connection.supports_deferrable_constraints?
+          def test_composite_deferrable_foreign_key
+            @connection.add_foreign_key :astronauts, :rockets, primary_key: [:tenant_id, :id], deferrable: :deferred
+
+            fk = @connection.foreign_keys(:astronauts).first
+            assert_equal :deferred, fk.deferrable
+          end
+
+          def test_composite_deferrable_foreign_key_persists_when_table_is_altered
+            @connection.add_foreign_key :astronauts, :rockets, primary_key: [:tenant_id, :id], deferrable: :deferred
+
+            @connection.add_column :astronauts, :nickname, :string
+            @connection.remove_column :astronauts, :nickname
+
+            fk = @connection.foreign_keys(:astronauts).first
+            assert_equal :deferred, fk.deferrable
+          end
+
+          def test_schema_dumping_with_deferrable
+            @connection.add_foreign_key :astronauts, :rockets, primary_key: [:tenant_id, :id], deferrable: :deferred
+
+            output = dump_table_schema "astronauts"
+
+            assert_match %r{\s+add_foreign_key "astronauts", "rockets", column: \["rocket_tenant_id", "rocket_id"\], primary_key: \["tenant_id", "id"\], deferrable: :deferred$}, output
+          end
+        end
+
         def test_schema_dumping
           @connection.add_foreign_key :astronauts, :rockets, primary_key: [:tenant_id, :id]
 
           output = dump_table_schema "astronauts"
 
           assert_match %r{\s+add_foreign_key "astronauts", "rockets", column: \["rocket_tenant_id", "rocket_id"\], primary_key: \["tenant_id", "id"\]$}, output
+        end
+
+        def test_schema_dumping_with_name
+          @connection.add_foreign_key :astronauts, :rockets, primary_key: [:tenant_id, :id], name: "custom_composite_fk"
+
+          output = dump_table_schema "astronauts"
+
+          assert_match %r{\s+add_foreign_key "astronauts", "rockets", column: \["rocket_tenant_id", "rocket_id"\], primary_key: \["tenant_id", "id"\], name: "custom_composite_fk"$}, output
         end
       end
     end


### PR DESCRIPTION
### Behavior

On SQLite3, `foreign_keys(table)` returned `name: nil` and `deferrable: nil` for composite foreign keys, while single-column foreign keys (since #58096) report both. Given:

```ruby
create_table :rockets, primary_key: [:tenant_id, :id] do |t|
  t.integer :tenant_id
  t.integer :id
end
create_table :astronauts do |t|
  t.integer :rocket_id
  t.integer :rocket_tenant_id
end
add_foreign_key :astronauts, :rockets, primary_key: [:tenant_id, :id],
  name: "custom_composite_fk", deferrable: :deferred
```

| | before | after |
| --- | --- | --- |
| `foreign_keys(:astronauts).first.name` | `nil` | `"custom_composite_fk"` |
| `foreign_keys(:astronauts).first.deferrable` | `nil` | `:deferred` |
| `remove_foreign_key :astronauts, name: "custom_composite_fk"` | raises `ArgumentError: Table 'astronauts' has no foreign key for {name: ...}` | removes the key |
| custom name after a later `remove_column` / `change_column_null` (table rebuild) | recreated as `CONSTRAINT ""` | preserved |
| `DEFERRABLE INITIALLY DEFERRED` after a table rebuild | dropped | preserved |
| `name:` / `deferrable:` in the schema dump | dropped | emitted |

Since every `alter_table` rebuild recreates the foreign keys from `foreign_keys`, any unrelated schema change on the table silently stripped a composite foreign key's custom name and its deferrable mode from the database, and neither survived a `schema.rb` round-trip.

### Why this is correct

Composite foreign keys are now introspected through the same path as single-column ones, so `foreign_keys` reports the same `name:` and `deferrable:` that MySQL and PostgreSQL already report for composite keys. With the definition complete, name-based `remove_foreign_key`, preservation across table rebuilds, and the schema dump all follow from the existing shared machinery — no behavior changes for single-column foreign keys.

Tested with new regression tests in `activerecord/test/cases/migration/foreign_key_test.rb` (`CompositeForeignKeyTest`), all red before the fix on SQLite3 and green after; the tests are cross-adapter and also pass on PostgreSQL. Follow-up to #58096.