### PR TITLE
Read back SQLite3 defaults containing "|" or in exponent notation

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Read back SQLite3 column defaults containing `|` or written in exponent notation.
+
+    Previously, `column.default` was `nil` for string defaults containing `|`
+    (e.g. `default: "a|b"`) and for float defaults quoted in exponent notation
+    (e.g. `default: 1.0e-08`). Such defaults were omitted from the schema dump
+    and lost on any schema change that rebuilds the table.
+
+    *Kenta Ishizaki*
+
 *   `connected_to_all_shards` now raises `ArgumentError` when called on a model
     that is not connected to any shards, rather than silently doing nothing.
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -582,13 +582,13 @@ module ActiveRecord
           when /^null$/i
             nil
           # Quoted types
-          when /^'([^|]*)'$/m
+          when /\A'((?:[^']|'')*)'\z/m
             $1.gsub("''", "'")
           # Quoted types
-          when /^"([^|]*)"$/m
+          when /\A"((?:[^"]|"")*)"\z/m
             $1.gsub('""', '"')
           # Numeric types
-          when /\A-?\d+(\.\d*)?\z/
+          when /\A-?\d+(\.\d*)?([eE][-+]?\d+)?\z/
             $&
           # Binary columns
           when /x'(.*)'/

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -656,6 +656,48 @@ module ActiveRecord
         end
       end
 
+      def test_columns_with_string_default_containing_pipe
+        with_example_table "id integer PRIMARY KEY AUTOINCREMENT, name varchar DEFAULT 'a|b'" do
+          column = @conn.columns("ex").find { |x| x.name == "name" }
+          assert_equal "a|b", column.default
+          assert_nil column.default_function
+        end
+      end
+
+      def test_columns_with_string_default_containing_escaped_quote
+        with_example_table "id integer PRIMARY KEY AUTOINCREMENT, name varchar DEFAULT 'it''s'" do
+          column = @conn.columns("ex").find { |x| x.name == "name" }
+          assert_equal "it's", column.default
+          assert_nil column.default_function
+        end
+      end
+
+      def test_columns_with_float_default_in_exponent_notation
+        with_example_table "id integer PRIMARY KEY AUTOINCREMENT, small float DEFAULT 1.0e-08, big float DEFAULT 1.0e+20" do
+          columns = @conn.columns("ex")
+          assert_equal 1.0e-08, columns.find { |x| x.name == "small" }.default
+          assert_equal 1.0e+20, columns.find { |x| x.name == "big" }.default
+        end
+      end
+
+      def test_columns_with_concatenation_default_is_extracted_as_default_function
+        with_example_table "id integer PRIMARY KEY AUTOINCREMENT, name varchar DEFAULT ('foo'||'bar')" do
+          column = @conn.columns("ex").find { |x| x.name == "name" }
+          assert_nil column.default
+          assert_equal "'foo'||'bar'", column.default_function
+        end
+      end
+
+      def test_alter_table_preserves_string_default_containing_pipe
+        with_example_table "id integer PRIMARY KEY AUTOINCREMENT, name varchar DEFAULT 'a|b', number integer" do
+          @conn.remove_column :ex, :number
+
+          assert_includes @conn.query_value("SELECT sql FROM sqlite_master WHERE name = 'ex'"), "'a|b'"
+          column = @conn.columns("ex").find { |x| x.name == "name" }
+          assert_equal "a|b", column.default
+        end
+      end
+
       def test_columns_with_not_null
         with_example_table "id integer PRIMARY KEY AUTOINCREMENT, number integer not null" do
           column = @conn.columns("ex").find { |x| x.name == "number" }


### PR DESCRIPTION
### Behavior

On SQLite3, two classes of column defaults that Active Record itself writes (or that plain SQL can write) could not be read back from the table definition:

- string defaults containing a `|` character, and
- float defaults whose quoted form uses exponent notation — which is how Ruby serializes floats below `1e-4` or at `1e16` and above, so `t.float :x, default: 1.0e-08` stores exactly this shape.

Both hit the same three symptoms: the default reads back as `nil`, it is omitted from the schema dump, and it is **silently deleted from the database** by any schema change that rebuilds the table (`remove_column`, `change_column_null`, adding/removing a foreign key, ...), because the rebuild recreates the column from the `nil` read-back.

```ruby
create_table :items do |t|
  t.string :sep,  default: "a|b"
  t.float  :tiny, default: 1.0e-08
  t.float  :huge, default: 1.0e+20
end
```

| | Before | After |
|---|---|---|
| `columns(:items)` — `sep.default` | `nil` | `"a\|b"` |
| `columns(:items)` — `tiny.default` / `huge.default` | `nil` / `nil` | `1.0e-08` / `1.0e+20` |
| `sep.default_function` / `tiny.default_function` | `nil` (not treated as a function either) | `nil` (unchanged — these are literals) |
| `schema.rb` | `t.string "sep"` / `t.float "tiny"` — `default:` dropped | `default: "a\|b"` / `default: 1.0e-08` round-trip |
| DDL after `remove_column :items, :junk` (table rebuild) | `"sep" varchar, "tiny" float` — DEFAULT clauses **deleted from the live database** | `"sep" varchar DEFAULT 'a\|b', "tiny" float DEFAULT 1.0e-08` preserved |

Unchanged behavior, covered by tests:

- Expression defaults such as `DEFAULT ('foo'||'bar')` still come back as `default_function` (existing coverage in `test_change_column_default_supports_default_function_with_concatenation_operator` plus a new adapter-level test).
- Escaped quotes inside string defaults (`DEFAULT 'it''s'`) still read back unescaped as `"it's"`.

### Why this is correct

Both shapes are valid SQLite literals that the adapter itself emits: `quote("a|b")` produces `'a|b'`, and `quote(1.0e-08)` produces `1.0e-08` verbatim (`Float#to_s`). A value the adapter writes as a plain literal must read back as a plain literal — reading it back as `nil` makes the schema dump lossy and turns unrelated migrations into silent data-definition loss on an adapter where nearly every ALTER goes through a table rebuild.

The `|` exclusion existed only to keep concatenation expressions like `'foo'||'bar'` out of the literal branch. Matching the default as one complete quoted SQLite literal achieves the same thing — after the first complete quoted literal, a concat expression still has trailing `||'bar'`, so it fails the literal match and continues to be classified as a `default_function` (which matches on `||`). A single `|` inside the quotes is just part of the literal. Similarly, exponent notation is ordinary numeric literal syntax in SQLite; the extracted string is cast by the column type, so `1.0e-08` becomes the correct `Float` exactly as `10.5` already did.