### PR TITLE
Keep the primary key when renaming its column on SQLite3

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Keep the primary key when renaming its column on SQLite3.
+
+    `rename_column` on a primary key column rebuilt the table without any
+    primary key, so the renamed column silently lost its `PRIMARY KEY`
+    constraint (including on the default `id`). Renaming a column that is
+    part of a composite primary key raised `SQLite3::SQLException`. The
+    primary key now follows the rename in both cases.
+
+    *Kenta Ishizaki*
+
 *   `connected_to_all_shards` now raises `ArgumentError` when called on a model
     that is not connected to any shards, rather than silently doing nothing.
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -657,26 +657,29 @@ module ActiveRecord
         end
 
         def copy_table(from, to, options = {})
+          rename = options[:rename] || {}
           from_primary_key = primary_key(from)
+          to_primary_key = if from_primary_key.is_a?(Array)
+            from_primary_key.map { |name| rename[name] || rename[name.to_sym] || name }
+          elsif from_primary_key
+            rename[from_primary_key] || rename[from_primary_key.to_sym] || from_primary_key
+          end
           options[:id] = false
           create_table(to, **options) do |definition|
             @definition = definition
-            if from_primary_key.is_a?(Array)
-              @definition.primary_keys from_primary_key
+            if to_primary_key.is_a?(Array)
+              @definition.primary_keys to_primary_key
             end
 
             columns(from).each do |column|
-              column_name = options[:rename] ?
-                (options[:rename][column.name] ||
-                 options[:rename][column.name.to_sym] ||
-                 column.name) : column.name
+              column_name = rename[column.name] || rename[column.name.to_sym] || column.name
 
               column_options = {
                 limit: column.limit,
                 precision: column.precision,
                 scale: column.scale,
                 collation: column.collation,
-                primary_key: column_name == from_primary_key
+                primary_key: column_name == to_primary_key
               }
 
               # column.null is true unless there is an explicit NOT NULL
@@ -687,7 +690,7 @@ module ActiveRecord
               #
               # We always add a NOT NULL constraint for PKs, and `null: true` is
               # invalid for them. That is why we skip in that case.
-              column_options[:null] = column.null unless column_name == from_primary_key
+              column_options[:null] = column.null unless column_name == to_primary_key
 
               if column.virtual?
                 column_options[:as] = column.default_function

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -836,6 +836,56 @@ module ActiveRecord
         BarcodeCpk.reset_column_information
       end
 
+      def test_rename_column_preserves_custom_primary_key
+        @conn.create_table(:things, primary_key: :code, id: :string) do |t|
+          t.string :name
+        end
+
+        @conn.rename_column(:things, :code, :ref)
+
+        assert_equal "ref", @conn.primary_key(:things)
+
+        @conn.execute("INSERT INTO things (ref, name) VALUES ('abc', 'first')")
+        assert_raises(ActiveRecord::RecordNotUnique) do
+          @conn.execute("INSERT INTO things (ref, name) VALUES ('abc', 'second')")
+        end
+      end
+
+      def test_rename_column_preserves_default_primary_key
+        @conn.create_table(:things) do |t|
+          t.string :name
+        end
+
+        @conn.rename_column(:things, :id, :ident)
+
+        assert_equal "ident", @conn.primary_key(:things)
+
+        pk_column = @conn.columns(:things).find { |col| col.name == "ident" }
+        assert_predicate pk_column, :auto_increment?
+      end
+
+      def test_rename_column_preserves_composite_primary_key
+        @conn.create_table(:things, primary_key: [:region, :code]) do |t|
+          t.string :region
+          t.string :code
+          t.string :name
+        end
+
+        @conn.rename_column(:things, :code, :sku)
+
+        assert_equal ["region", "sku"], @conn.primary_keys(:things)
+      end
+
+      def test_rename_column_keeps_primary_key_when_another_column_is_renamed
+        @conn.create_table(:things, primary_key: :code, id: :string) do |t|
+          t.string :name
+        end
+
+        @conn.rename_column(:things, :name, :title)
+
+        assert_equal "code", @conn.primary_key(:things)
+      end
+
       def test_custom_primary_key_in_create_table
         connection = Barcode.lease_connection
         connection.create_table :barcodes, id: false, force: true do |t|


### PR DESCRIPTION
### Behavior

SQLite3 emulates `ALTER TABLE` by rebuilding the table, but the rebuild did not carry the primary key over when the renamed column was the primary key itself:

```ruby
create_table :things, primary_key: :code, id: :string
rename_column :things, :code, :ref
```

| | before | after |
| --- | --- | --- |
| `primary_key(:things)` after renaming the PK column | `nil` (rebuilt table has no `PRIMARY KEY` at all) | `"ref"` |
| inserting two rows with the same `ref` | succeeds (constraint silently gone) | raises `ActiveRecord::RecordNotUnique` |
| `rename_column :things, :id, :ident` on the default `id` | primary key (and `AUTOINCREMENT`) silently dropped | `primary_key(:things)` is `"ident"`, still auto-increment |
| `rename_column` on one column of a composite primary key | raises `SQLite3::SQLException: expressions prohibited in PRIMARY KEY and UNIQUE constraints` | succeeds; `primary_keys` reports both columns, one under its new name |
| `rename_column` on a non-PK column | primary key intact | unchanged |

### Why this is correct

The table rebuild already translates every column name through the rename mapping, but it declared the primary key under the old column names — so a renamed single-column primary key never matched (leaving the rebuilt table with no primary key), and a renamed composite primary key referenced columns that no longer existed (which SQLite rejects). Declaring the primary key under the renamed column names makes the constraint follow the rename, matching how `rename_column` behaves on the other adapters, which rename in place and never touch constraints.

When nothing is renamed, or the renamed column is not part of the primary key, the translation is an identity mapping and the rebuild is byte-for-byte identical to before.