### PR TITLE
Parse exclusion constraint WHERE predicates without corrupting them

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Fix PostgreSQL exclusion constraint `where:` predicates being corrupted on read.
+
+    Introspecting an exclusion constraint whose `WHERE` predicate is a bare
+    boolean column or a function call returned a mangled predicate (e.g.
+    `where: "active"` came back as `"ctiv"`), so `schema.rb` was dumped with
+    an invalid predicate and `db:schema:load` failed. Predicates containing
+    the string `" WHERE "` were truncated. Both now round-trip intact.
+
+    *Kenta Ishizaki*
+
 *   `connected_to_all_shards` now raises `ArgumentError` when called on a model
     that is not connected to any shards, rather than silently doing nothing.
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -858,10 +858,14 @@ module ActiveRecord
           SQL
 
           exclusion_info.map do |row|
-            method_and_elements, predicate = row["constraintdef"].split(" WHERE ")
+            method_and_elements, predicate = row["constraintdef"].split(" WHERE ", 2)
             method_and_elements_parts = method_and_elements.match(/EXCLUDE(?: USING (?<using>\S+))? \((?<expression>.+)\)/)
-            predicate.remove!(/ DEFERRABLE(?: INITIALLY (?:IMMEDIATE|DEFERRED))?/) if predicate
-            predicate = predicate.from(2).to(-3) if predicate # strip 2 opening and closing parentheses
+            if predicate
+              predicate.remove!(/ DEFERRABLE(?: INITIALLY (?:IMMEDIATE|DEFERRED))?/)
+              # The `WHERE` clause is wrapped in parentheses, and the predicate
+              # itself may be wrapped in another pair.
+              predicate = strip_wrapping_parentheses(strip_wrapping_parentheses(predicate))
+            end
 
             deferrable = extract_constraint_deferrable(row["condeferrable"], row["condeferred"])
 
@@ -1292,6 +1296,31 @@ module ActiveRecord
 
           def extract_constraint_deferrable(deferrable, deferred)
             deferrable && (deferred ? :deferred : :immediate)
+          end
+
+          # Removes a pair of parentheses if and only if it wraps the whole
+          # expression, so that "(a)" becomes "a" but "(a) OR (b)" is unchanged.
+          def strip_wrapping_parentheses(expression)
+            return expression unless expression.start_with?("(") && expression.end_with?(")")
+
+            depth = 0
+            quote = nil
+            last_index = expression.length - 1
+
+            expression.each_char.with_index do |char, index|
+              if quote
+                quote = nil if char == quote
+              elsif char == "'" || char == '"'
+                quote = char
+              elsif char == "("
+                depth += 1
+              elsif char == ")"
+                depth -= 1
+                return expression if depth == 0 && index < last_index
+              end
+            end
+
+            depth == 0 ? expression[1..-2] : expression
           end
 
           def reference_name_for_table(table_name)

--- a/activerecord/test/cases/migration/exclusion_constraint_test.rb
+++ b/activerecord/test/cases/migration/exclusion_constraint_test.rb
@@ -17,6 +17,8 @@ if ActiveRecord::Base.lease_connection.supports_exclusion_constraints?
           @connection.create_table "invoices", force: true do |t|
             t.date :start_date
             t.date :end_date
+            t.boolean :active
+            t.string :name
           end
         end
 
@@ -90,6 +92,41 @@ if ActiveRecord::Base.lease_connection.supports_exclusion_constraints?
           assert_equal "excl_rails_74c9160f55", constraint.name
           assert_equal false, constraint.deferrable
           assert_equal "daterange(start_date, end_date) WITH &&", constraint.expression
+        end
+
+        def test_add_exclusion_constraint_with_boolean_column_where_predicate
+          @connection.add_exclusion_constraint :invoices, "daterange(start_date, end_date) WITH &&", using: :gist, where: "active"
+
+          constraint = @connection.exclusion_constraints("invoices").first
+          assert_equal "active", constraint.where
+        end
+
+        def test_add_exclusion_constraint_with_function_call_where_predicate
+          @connection.add_exclusion_constraint :invoices, "daterange(start_date, end_date) WITH &&", using: :gist, where: "starts_with(name, 'a')"
+
+          constraint = @connection.exclusion_constraints("invoices").first
+          assert_equal "starts_with((name)::text, 'a'::text)", constraint.where
+        end
+
+        def test_add_exclusion_constraint_with_where_predicate_containing_where_string
+          @connection.add_exclusion_constraint :invoices, "daterange(start_date, end_date) WITH &&", using: :gist, where: "name = ' WHERE '"
+
+          constraint = @connection.exclusion_constraints("invoices").first
+          assert_equal "(name)::text = ' WHERE '::text", constraint.where
+        end
+
+        def test_add_exclusion_constraint_with_top_level_boolean_where_predicate
+          @connection.add_exclusion_constraint :invoices, "daterange(start_date, end_date) WITH &&", using: :gist, where: "(start_date IS NOT NULL) OR (end_date IS NOT NULL)"
+
+          constraint = @connection.exclusion_constraints("invoices").first
+          assert_equal "(start_date IS NOT NULL) OR (end_date IS NOT NULL)", constraint.where
+        end
+
+        def test_schema_dumping_with_where_predicate
+          @connection.add_exclusion_constraint :invoices, "daterange(start_date, end_date) WITH &&", using: :gist, where: "active", name: "invoices_date_overlap_when_active"
+
+          output = dump_table_schema "invoices"
+          assert_match %r{t\.exclusion_constraint "daterange\(start_date, end_date\) WITH &&", where: "active", using: :gist, name: "invoices_date_overlap_when_active"}, output
         end
 
         def test_add_exclusion_constraint_deferrable_false


### PR DESCRIPTION
### Behavior

Reading back a PostgreSQL exclusion constraint corrupts its `where:` predicate for some expression shapes, and the corrupted value flows straight into `schema.rb`:

```ruby
add_exclusion_constraint :invoices, "daterange(start_date, end_date) WITH &&",
  using: :gist, where: "active"
```

| `where:` given | read back (before) | read back (after) |
| --- | --- | --- |
| `"active"` | `"ctiv"` | `"active"` |
| `"starts_with(name, 'a')"` | `"tarts_with((name)::text, 'a'::text"` | `"starts_with((name)::text, 'a'::text)"` |
| `"name = ' WHERE '"` | `"(name)::text ="` | `"(name)::text = ' WHERE '::text"` |
| `"price > 100"` | `"price > 100"` (already correct) | `"price > 100"` (unchanged) |
| `"(a IS NOT NULL) AND (b IS NOT NULL)"` | correct (unchanged) | correct (unchanged) |

Before, dumping the first schema produced

```ruby
t.exclusion_constraint "daterange(start_date, end_date) WITH &&", where: "ctiv", using: :gist, ...
```

and `db:schema:load` on that dump failed with `PG::UndefinedColumn: column "ctiv" does not exist`. After, every predicate round-trips intact and re-dumping a loaded schema is stable.

### Why this is correct

`pg_get_constraintdef` always parenthesizes the `WHERE` clause, but wraps the predicate itself in a second pair of parentheses only for some expression shapes (e.g. comparisons and boolean combinations, but not a bare boolean column or a function call). Stripping a fixed number of characters is therefore wrong for exactly the shapes PostgreSQL emits with a single pair. The fix removes only parentheses that provably enclose the whole predicate — `(a)` unwraps, `(a) OR (b)` does not — so single- and double-parenthesized deparses both come back as the predicate PostgreSQL stores, and predicates whose top level is already a parenthesized `OR`/`AND` of subexpressions are left byte-for-byte as before. Quoted string literals are skipped when matching parentheses, so predicates containing `'('`, `')'`, or doubled quotes round-trip too (verified against live PostgreSQL 17 for all shapes above plus adversarial literals, each re-created from its read-back value and confirmed stable on a second introspection).

Splitting the constraint definition at the first `" WHERE "` only (instead of every occurrence) keeps predicates containing that literal string intact.

The existing introspection and schema-dump expectations (`(start_date IS NOT NULL) AND (end_date IS NOT NULL)`-style predicates) pass unmodified, so dumps of currently-working schemas do not change.

Introduced in cbc7b59749.