### PR TITLE
Allow to use thread module reader / writer in a ractor:

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/attribute_accessors_per_thread.rb
+++ b/activesupport/lib/active_support/core_ext/module/attribute_accessors_per_thread.rb
@@ -47,8 +47,8 @@ class Module
       if default.nil?
         class_eval(<<~RUBY, __FILE__, __LINE__ + 1)
           def self.#{sym}
-            @__thread_mattr_#{sym} ||= "attr_#{sym}_\#{object_id}"
-            ::ActiveSupport::IsolatedExecutionState[@__thread_mattr_#{sym}]
+            key = "attr_#{sym}_\#{object_id}"
+            ::ActiveSupport::IsolatedExecutionState[key]
           end
         RUBY
       else
@@ -57,11 +57,11 @@ class Module
 
         class_eval(<<~RUBY, __FILE__, __LINE__ + 1)
           def self.#{sym}
-            @__thread_mattr_#{sym} ||= "attr_#{sym}_\#{object_id}"
-            value = ::ActiveSupport::IsolatedExecutionState[@__thread_mattr_#{sym}]
+            key = "attr_#{sym}_\#{object_id}"
+            value = ::ActiveSupport::IsolatedExecutionState[key]
 
-            if value.nil? && !::ActiveSupport::IsolatedExecutionState.key?(@__thread_mattr_#{sym})
-              ::ActiveSupport::IsolatedExecutionState[@__thread_mattr_#{sym}] = #{sym}_default_value
+            if value.nil? && !::ActiveSupport::IsolatedExecutionState.key?(key)
+              ::ActiveSupport::IsolatedExecutionState[key] = #{sym}_default_value
             else
               value
             end
@@ -106,8 +106,8 @@ class Module
       # subclasses to maintain independent values.
       class_eval(<<~RUBY, __FILE__, __LINE__ + 1)
         def self.#{sym}=(obj)
-          @__thread_mattr_#{sym} ||= "attr_#{sym}_\#{object_id}"
-          ::ActiveSupport::IsolatedExecutionState[@__thread_mattr_#{sym}] = obj
+          key = "attr_#{sym}_\#{object_id}"
+          ::ActiveSupport::IsolatedExecutionState[key] = obj
         end
       RUBY
 

--- a/activesupport/test/core_ext/module/attribute_accessor_per_thread_test.rb
+++ b/activesupport/test/core_ext/module/attribute_accessor_per_thread_test.rb
@@ -207,4 +207,20 @@ class ModuleAttributeAccessorPerThreadTest < ActiveSupport::TestCase
     assert_equal "super", @class.baz
     assert_equal "sub", @subclass.baz
   end
+
+  if RUBY_VERSION >= "4.0"
+    class TestObj
+      thread_mattr_accessor :foo
+    end
+
+    def test_getter_and_setter_is_accessible_from_a_ractor
+      value = Ractor.new do
+        TestObj.foo = :test
+
+        TestObj.foo
+      end.value
+
+      assert_equal(:test, value)
+    end
+  end
 end


### PR DESCRIPTION
### Motivation / Background

It's currently not possible to call such code in a Ractor:

```ruby
class Request
  thread_mattr_reader :id
end

Request.id = 123

Ractor.new { Request.id } # Ractor Isolation Error
```

The isolation error comes from a memoized instance variable set on the class.

### Detail

Removing the memoization and computing the key is the simplest solution but it comes with a microbenchmark performance tradeoff. I figured this tradeoff was acceptable as each access is still in the ns range, and unless this is called in a loop, I think this overhead should be negligible.

### Additional information

```
ruby 4.0.1 (2026-01-13 revision e04267a14b) +PRISM [arm64-darwin25]
Warming up --------------------------------------
  set without memoization   554.489k i/100ms
Calculating -------------------------------------
  set without memoization      5.562M (± 3.0%) i/s  (179.78 ns/i) -     28.279M in   5.084031s

  Comparison:
     set with memoization:  8816371.9 i/s
  set without memoization:  5562306.6 i/s - 1.59x  slower

ruby 4.0.1 (2026-01-13 revision e04267a14b) +PRISM [arm64-darwin25]
Warming up --------------------------------------
  get without memoization   692.209k i/100ms
Calculating -------------------------------------
  get without memoization      6.866M (± 4.7%) i/s  (145.65 ns/i) -     34.610M in   5.040870s

  Comparison:
     get with memoization: 13532915.9 i/s
  get without memoization:  6865967.6 i/s - 1.97x  slower
```

<details>
<summary> ➡️  Benchmark script </summary>

```ruby
require "benchmark/ips"
require "active_support"
require "active_support/core_ext/module/attribute_accessors_per_thread"

class Request
  thread_mattr_accessor :id
end

Benchmark.ips do |x|
  x.report("set with memoization") do
    Request.id = "12345"
  end

  x.hold!("temp_set_result")

  x.report("set without memoization") do
    Request.id = "12345"
  end

  x.compare!
end

Benchmark.ips do |x|
  x.report("get with memoization") do
    Request.id
  end

  x.hold!("temp_get_result")

  x.report("get without memoization") do
    Request.id
  end

  x.compare!
end
```
</details>

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
