### PR TITLE
Re-document application template advanced usage [ci skip]

### DIFF
--- a/guides/source/generators.md
+++ b/guides/source/generators.md
@@ -650,9 +650,30 @@ upload your private files to a server).
 
 The above `template.rb` file uses helper methods such as `after_bundle` and
 `rails_command` and also adds user interactivity with methods like `yes?`. All
-of these methods are part of the [Rails Template
-API][`Rails::Generators::Actions`]. The following sections shows how to use
-more of these methods with examples.
+of these methods are part of the [Rails Generators API](#rails-generators-api).
+
+### Customizing the Generator Instance
+
+The application template is evaluated in the context of a
+`Rails::Generators::AppGenerator` instance. It uses the
+[`apply`](https://www.rubydoc.info/gems/thor/Thor/Actions#apply-instance_method)
+action provided by Thor.
+
+This means you can extend and change the instance to match your needs.
+
+For example by overwriting the `source_paths` method to contain the
+location of your template. Now methods like `copy_file` will accept
+relative paths to your template's location:
+
+```ruby
+# ~/my_template/template.rb
+def source_paths
+  [__dir__]
+end
+
+# copies ~/my_template/initializer.rb
+copy_file "initializer.rb", "config/initializers/my_initializer.rb"
+```
 
 Rails Generators API
 --------------------

--- a/guides/source/generators.md
+++ b/guides/source/generators.md
@@ -650,9 +650,26 @@ upload your private files to a server).
 
 The above `template.rb` file uses helper methods such as `after_bundle` and
 `rails_command` and also adds user interactivity with methods like `yes?`. All
-of these methods are part of the [Rails Template
-API][`Rails::Generators::Actions`]. The following sections shows how to use
-more of these methods with examples.
+of these methods are part of the [Rails Generators API](#rails-generators-api).
+
+### Customizing the Generator Instance
+
+The application template is evaluated in the context of a
+`Rails::Generators::AppGenerator` instance. It uses the
+[`apply`](https://www.rubydoc.info/gems/thor/Thor/Actions#apply-instance_method)
+action provided by Thor.
+
+This means you can extend and change the instance to match your needs.
+
+For example by overwriting the `source_paths` method to contain the
+location of your template. Now methods like `copy_file` will accept
+relative paths to your template's location:
+
+```ruby
+def source_paths
+  [__dir__]
+end
+```
 
 Rails Generators API
 --------------------


### PR DESCRIPTION
https://github.com/rails/rails/pull/55020 merged the Application Template and the Generators guides together, but the old Application Template [Advanced Usage](https://github.com/rails/rails/blob/04df9bc3d120b51447bde54caa56e9237cb8da0e/guides/source/rails_application_templates.md?plain=1#L278-L296) section was left out.

This section had useful information on tweaking `source_paths` so Thor methods like `copy_file` can reference files relative to the template's directory (`__dir__`). This is a common thing to do in advanced application templates, so I think it deserves to remain documented. Lack of such documentation may have contributed to [recent confusion](https://discuss.rubyonrails.org/t/add-template-source-dir-to-templating-support/91327) in the Rails discussion board.

This PR restores the Advanced Usage section.