### PR TITLE
Make AbstractController::Base#action_methods ractor safe

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -614,8 +614,11 @@ module ActionMailer
 
       def action_methods
         methods = super
-        methods.add("mail") if self == ActionMailer::Base
-        methods
+        if self == ActionMailer::Base
+          methods.dup.add("mail").freeze
+        else
+          methods
+        end
       end
 
     private

--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -97,7 +97,7 @@ module AbstractController
           # public instance methods of Base and its ancestors.
           methods = public_instance_methods(true) - internal_methods
           methods.map!(&:name)
-          methods.to_set
+          methods.to_set.freeze
         end
       end
 

--- a/actionpack/lib/abstract_controller/url_for.rb
+++ b/actionpack/lib/abstract_controller/url_for.rb
@@ -27,7 +27,7 @@ module AbstractController
 
       def action_methods
         @action_methods ||= if _routes
-          super - _routes.named_routes.helper_names
+          (super - _routes.named_routes.helper_names).freeze
         else
           super
         end

--- a/actionpack/test/controller/base_test.rb
+++ b/actionpack/test/controller/base_test.rb
@@ -142,6 +142,8 @@ class ControllerClassTests < ActiveSupport::TestCase
 end
 
 class ControllerInstanceTests < ActiveSupport::TestCase
+  include ActiveSupport::Testing::RactorsAssertions
+
   def setup
     @empty = EmptyController.new
     @empty.set_request!(ActionDispatch::Request.empty)
@@ -166,6 +168,16 @@ class ControllerInstanceTests < ActiveSupport::TestCase
     assert_includes ActionController::Base.instance_methods, :status
     assert_equal Set.new(["status", "hello"]), SimpleController.action_methods
     assert_equal Set.new(["status", "hello"]), ChildController.action_methods
+  end
+
+  def test_action_methods_is_ractor_safe_by_default
+    SimpleController.action_methods
+
+    value = on_ractor do
+      SimpleController.action_methods
+    end
+
+    assert_equal Set.new(["status", "hello"]), value
   end
 
   def test_temporary_anonymous_controllers


### PR DESCRIPTION
### Motivation / Background

`action_methods` returns a Set containing all methods that should be considered as action. This set isn't frozen, so any time it is referenced in a ractor, a Ractor Isolation error is raised.

### Detail

This patch simply freeze the Set. We discussed about the possibility that this change could break existing application that overrides `action_methods` (like Action Mailer do) but decided it's unlikely.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
