### PR TITLE
Guard tests for PostgreSQL 11, 12, and 15 changes

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/enum_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/enum_test.rb
@@ -132,6 +132,8 @@ class PostgresqlEnumTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_schema_dump_added_enum_value
+    skip "ALTER TYPE ... ADD VALUE in a transaction block requires PostgreSQL 12+" unless @connection.database_version >= 12_00_00
+
     @connection.add_enum_value :mood, :angry, before: :ok
     @connection.add_enum_value :mood, :nervous, after: :ok
     @connection.add_enum_value :mood, :glad

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -1261,7 +1261,7 @@ module ActiveRecord
         @connection.execute "DROP DOMAIN IF EXISTS postgresql_domain_nested"
         @connection.execute "DROP DOMAIN IF EXISTS postgresql_domain_base"
         reset_pool
-      end
+      end if ActiveRecord::Base.lease_connection.database_version >= 11_00_00
 
       def test_load_additional_types_cascades_dependency_lookups_after_initial_bulk_load
         reset_pool
@@ -1282,7 +1282,7 @@ module ActiveRecord
         connection&.execute "DROP DOMAIN IF EXISTS postgresql_domain_nested_after_bulk"
         connection&.execute "DROP DOMAIN IF EXISTS postgresql_domain_base_after_bulk"
         reset_pool
-      end
+      end if ActiveRecord::Base.lease_connection.database_version >= 11_00_00
 
       def test_only_warn_on_first_encounter_of_unrecognized_oid
         reset_pool

--- a/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
@@ -369,7 +369,7 @@ class PostgreSQLReferentialIntegrityTest < ActiveRecord::PostgreSQLTestCase
   ensure
     @connection.drop_table "partitioned_table_with_foreign_key", if_exists: true, force: true
     @connection.drop_table "table_referenced_by_partioned_table", if_exists: true
-  end
+  end if ActiveRecord::Base.lease_connection.database_version >= 11_00_00
 
   def test_check_all_foreign_keys_valid_detects_violation_in_validated_foreign_key
     skip unless @connection.supports_enforced_foreign_keys?

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -997,7 +997,7 @@ class DirtyTest < ActiveRecord::TestCase
     record_with_defaults.update!(random_number: 140)
 
     assert_equal [1050, 1400], record_with_defaults.previous_changes[:virtual_stored_number]
-  end if current_adapter?(:PostgreSQLAdapter)
+  end if current_adapter?(:PostgreSQLAdapter) && supports_virtual_columns?
 
   private
     def with_partial_writes(klass, on = true)

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -97,7 +97,7 @@ class PersistenceTest < ActiveRecord::TestCase
 
       record_with_defaults.update!(random_number: 105)
       assert_equal 1050,  record_with_defaults.virtual_stored_number
-    end
+    end if supports_virtual_columns?
 
     def test_returning_columns_on_update_does_not_include_id
       record_with_defaults = Default.create

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -257,7 +257,11 @@ class SchemaDumperTest < ActiveRecord::TestCase
       assert_match 't.unique_constraint ["position_1"], name: "test_unique_constraints_position_deferrable_false"', output
       assert_match 't.unique_constraint ["position_2"], deferrable: :immediate, name: "test_unique_constraints_position_deferrable_immediate"', output
       assert_match 't.unique_constraint ["position_3"], deferrable: :deferred, name: "test_unique_constraints_position_deferrable_deferred"', output
-      assert_match 't.unique_constraint ["position_4"], nulls_not_distinct: true, name: "test_unique_constraints_position_nulls_not_distinct"', output
+      if supports_nulls_not_distinct?
+        assert_match 't.unique_constraint ["position_4"], nulls_not_distinct: true, name: "test_unique_constraints_position_nulls_not_distinct"', output
+      else
+        assert_match 't.unique_constraint ["position_4"], name: "test_unique_constraints_position_nulls_not_distinct"', output
+      end
     end
 
     def test_schema_does_not_dump_unique_constraints_as_indexes

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -225,7 +225,7 @@ _SQL
       CREATE TRIGGER before_insert_trigger
       BEFORE INSERT ON pk_autopopulated_by_a_trigger_records
       FOR EACH ROW
-      EXECUTE FUNCTION populate_column();
+      EXECUTE PROCEDURE populate_column();
     SQL
   end
 end


### PR DESCRIPTION
### Motivation / Background

Active Record supports PostgreSQL 10 and newer, but CI only runs against `postgres:alpine`, currently PostgreSQL 18. Running the full suite (`rake test:postgresql`) against the Docker images `postgres:17` down to `postgres:10` shows that some tests exercise server features newer than the minimum supported version without a guard, and that on PostgreSQL 10 the test schema does not load at all.

This pull request only updates tests and the test schema; it does not change any library code.

### Detail

One commit per PostgreSQL version whose changes the tests rely on.

**Guard tests for PostgreSQL 15 changes**

On PostgreSQL 14.23:

```
Failure:
SchemaDumperTest#test_schema_dumps_unique_constraints [test/cases/schema_dumper_test.rb:260]:
Expected /t\.unique_constraint\ \["position_4"\],\ nulls_not_distinct:\ true,\ name:\ "test_unique_constraints_position_nulls_not_distinct"/ to match ...
```

`UNIQUE NULLS NOT DISTINCT` requires PostgreSQL 15. On older servers the adapter omits the clause, the constraint is created without it, and the schema dump omits the flag. The assertion now branches on `supports_nulls_not_distinct?`, following `test_schema_dumps_nulls_not_distinct` in the same file.

**Guard tests for PostgreSQL 12 changes**

On PostgreSQL 11.16:

```
Error:
PersistenceTest#test_fills_auto_populated_columns_on_update:
NoMethodError: undefined method 'virtual_stored_number' for an instance of Default

Failure:
DirtyTest#test_virtual_column_loaded_change_on_update [test/cases/dirty_test.rb:999]:
Expected: [1050, 1400]
  Actual: nil

Error:
PostgresqlEnumTest#test_schema_dump_added_enum_value:
ActiveRecord::StatementInvalid: PG::ActiveSqlTransaction: ERROR:  ALTER TYPE ... ADD cannot run inside a transaction block
```

Generated columns require PostgreSQL 12, and the test schema creates the `virtual_stored_number` column only when `supports_virtual_columns?` is true, so the two tests reading that column are now guarded with the same predicate. `ALTER TYPE ... ADD VALUE` inside a transaction block also requires PostgreSQL 12; no `supports_*?` predicate covers it, so the enum test skips below `database_version` 12_00_00.

**Guard tests for PostgreSQL 11 changes**

On PostgreSQL 10.21 the test schema fails to load, so no test can run:

```
PG::SyntaxError: ERROR:  syntax error at or near "FUNCTION" (ActiveRecord::StatementInvalid)
test/schema/postgresql_specific_schema.rb:213
```

`CREATE TRIGGER ... EXECUTE FUNCTION` requires PostgreSQL 11. The trigger now uses `EXECUTE PROCEDURE`, which works on every supported version and is already used by `partitioned_insert_trigger` in the same file.

With the schema loading, three tests error:

```
Error:
ActiveRecord::ConnectionAdapters::PostgreSQLAdapterTest#test_load_additional_types_cascades_dependency_lookups:
ActiveRecord::StatementInvalid: PG::UndefinedObject: ERROR:  type "postgresql_domain_base[]" does not exist

Error:
ActiveRecord::ConnectionAdapters::PostgreSQLAdapterTest#test_load_additional_types_cascades_dependency_lookups_after_initial_bulk_load:
ActiveRecord::StatementInvalid: PG::UndefinedObject: ERROR:  type "postgresql_domain_nested_after_bulk[]" does not exist

Error:
PostgreSQLReferentialIntegrityTest#test_all_foreign_keys_valid_having_foreign_keys_with_partitioned_table:
ActiveRecord::StatementInvalid: PG::InFailedSqlTransaction: ERROR:  current transaction is aborted, commands ignored until end of transaction block
```

Arrays of domain types require PostgreSQL 11. The partitioned table test fails on its `CREATE TABLE` with "primary key constraints are not supported on partitioned tables" (primary and foreign key constraints on partitioned tables require PostgreSQL 11); the reported error is the `ensure` block failing inside the aborted transaction. The foreign key in this test is declared on the partitioned table; foreign keys referencing a partitioned table arrived in PostgreSQL 12 and are not used by the suite.

These three tests clean up in `ensure` blocks, where `Minitest/SkipEnsure` disallows `skip`, so they are guarded at definition time (`end if ActiveRecord::Base.lease_connection.database_version >= 11_00_00`), following the existing style in `dirty_test.rb`.

### Additional information

PostgreSQL commits that introduced each behavior change:

- PostgreSQL 15
  - https://github.com/postgres/postgres/commit/94aa7cc5f707712f592885995a28e018c7c80488 — Add UNIQUE null treatment option
- PostgreSQL 12
  - https://github.com/postgres/postgres/commit/212fab9926b2f0f04b0187568e7124b70e8deee5 — Relax transactional restrictions on ALTER TYPE ... ADD VALUE (redux).
- PostgreSQL 11
  - https://github.com/postgres/postgres/commit/e0dc839e72d43e6c299deca892a8209e11dd88f6 — Change PROCEDURE to FUNCTION in CREATE TRIGGER syntax
  - https://github.com/postgres/postgres/commit/c12d570fa147d0ec273df53de3a2802925d551ba — Support arrays over domains.
  - https://github.com/postgres/postgres/commit/eb7ed3f3063401496e4aa4bd68fa33f0be31a72f — Allow UNIQUE indexes on partitioned tables
  - https://github.com/postgres/postgres/commit/3de241dba86f3dd000434f70aebba725fb928032 — Foreign keys on partitioned tables

The full suite passes against PostgreSQL 10 through 18 with this branch. On PostgreSQL 18.4 the changed test files report the same runs, assertions, and skips as main, so nothing is skipped on the version CI tests.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
