### PR TITLE
Raise for empty shards on `connected_to_all_shards`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   `connected_to_all_shards` now raises `ArgumentError` when called on a model
+    that is not connected to any shards, rather than silently doing nothing.
+
+    *Eileen M. Alayce*
+
 *   Honor foreign key names on SQLite3.
 
     SQLite3 did not read foreign key names, so `remove_foreign_key(name:)`

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -197,6 +197,10 @@ module ActiveRecord
     # will be forwarded to each +connected_to+ call. +prevent_writes+
     # defaults to +true+ when using the +reading+ role.
     def connected_to_all_shards(role: nil, prevent_writes: role == ActiveRecord.reading_role, &blk)
+      if shard_keys.empty?
+        raise ArgumentError, "`connected_to_all_shards` cannot be called on a model that is not connected to any shards."
+      end
+
       shard_keys.map do |shard|
         connected_to(shard: shard, role: role, prevent_writes: prevent_writes, &blk)
       end

--- a/activerecord/test/cases/shard_keys_test.rb
+++ b/activerecord/test/cases/shard_keys_test.rb
@@ -83,16 +83,19 @@ module ActiveRecord
     end
 
     def test_connected_to_all_shards
-      unsharded_results = UnshardedBase.connected_to_all_shards do
-        UnshardedBase.connection_pool.db_config.name
-      end
-
       sharded_results = ShardedBase.connected_to_all_shards do
         ShardedBase.connection_pool.db_config.name
       end
 
-      assert_empty unsharded_results
       assert_equal(["shard_one", "shard_two"], sharded_results)
+    end
+
+    def test_connected_to_all_shards_raises_when_not_sharded
+      error = assert_raises ArgumentError do
+        UnshardedBase.connected_to_all_shards { }
+      end
+
+      assert_equal "`connected_to_all_shards` cannot be called on a model that is not connected to any shards.", error.message
     end
 
     def test_connected_to_all_shards_can_switch_each_to_reading_role


### PR DESCRIPTION
If an app isn't sharded then `connected_to_all_shards` should raise an error because `shard_keys` will be empty. While the issue argued that it should work by using default, the app isn't actually sharded. For an app to be sharded there at minimum needs to be 2 connection configs with different schemas because 1 is the router and 1 is a shard which represents a 1x partition of a database.

Closes: https://github.com/rails/rails/issues/58114