### PR TITLE
Action Controller: Fix bug to support `render(renderable: …) { … }`

### DIFF
--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -24,8 +24,8 @@ module AbstractController
     #
     # Supported options depend on the underlying `render_to_body` implementation.
     def render(*args, &block)
-      options = _normalize_render(*args, &block)
-      rendered_body = render_to_body(options)
+      options = _normalize_render(*args)
+      rendered_body = render_to_body(options, &block)
       if options[:html]
         _set_html_content_type
       else
@@ -42,7 +42,7 @@ module AbstractController
     # extends it to be anything that responds to the method each), this method needs
     # to be overridden in order to still return a string.
     def render_to_string(*args, &block)
-      options = _normalize_render(*args, &block)
+      options = _normalize_render(*args)
       render_to_body(options, &block)
     end
 
@@ -111,8 +111,8 @@ module AbstractController
     end
 
     # Normalize args and options.
-    def _normalize_render(*args, &block) # :nodoc:
-      options = _normalize_args(*args, &block)
+    def _normalize_render(*args) # :nodoc:
+      options = _normalize_args(*args)
       _process_variant(options)
       _normalize_options(options)
       options

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -610,8 +610,8 @@ class TestController < ActionController::Base
     format = params[:format]
 
     renderable = Object.new
-    renderable.singleton_class.define_method :render_in do |view_context, **, &|
-      view_context.render inline: <<~ERB.strip, locals: locals
+    renderable.singleton_class.define_method :render_in do |view_context, **, &block|
+      view_context.render inline: block&.call || <<~ERB.strip, locals: locals
         Hello, <%= name %>
       ERB
     end
@@ -621,7 +621,23 @@ class TestController < ActionController::Base
       end
     end
 
-    render renderable: renderable
+    if block_given?
+      yield(renderable, locals, format)
+    else
+      render(renderable: renderable)
+    end
+  end
+
+  def render_renderable_with_option_and_block
+    render_renderable do |renderable, locals|
+      render(renderable: renderable) { locals[:name] }
+    end
+  end
+
+  def render_renderable_with_object_and_block
+    render_renderable do |renderable, locals|
+      render(renderable) { locals[:name] }
+    end
   end
 
   before_action only: :render_with_filters do
@@ -733,6 +749,8 @@ class RenderTest < ActionController::TestCase
     get :render_call_to_partial_with_layout, to: "test#render_call_to_partial_with_layout"
     get :render_call_to_partial_with_layout_in_main_layout_and_within_content_for_layout, to: "test#render_call_to_partial_with_layout_in_main_layout_and_within_content_for_layout"
     get :render_renderable, to: "test#render_renderable"
+    get :render_renderable_with_object_and_block, to: "test#render_renderable_with_object_and_block"
+    get :render_renderable_with_option_and_block, to: "test#render_renderable_with_option_and_block"
     get :render_custom_code, to: "test#render_custom_code"
     get :render_file_from_template, to: "test#render_file_from_template"
     get :render_file_not_using_full_path, to: "test#render_file_not_using_full_path"
@@ -1521,6 +1539,20 @@ class RenderTest < ActionController::TestCase
 
   def test_render_renderable
     get :render_renderable, params: { format: :html, locals: { name: "Local" } }
+
+    assert_equal "Hello, Local", @response.body
+    assert_equal "text/html", @response.media_type
+  end
+
+  def test_render_renderable_with_object_and_block
+    get :render_renderable_with_object_and_block, params: { format: :html, locals: { name: "Hello, Local" } }
+
+    assert_equal "Hello, Local", @response.body
+    assert_equal "text/html", @response.media_type
+  end
+
+  def test_render_renderable_with_option_and_block
+    get :render_renderable_with_option_and_block, params: { format: :html, locals: { name: "Hello, Local" } }
 
     assert_equal "Hello, Local", @response.body
     assert_equal "text/html", @response.media_type


### PR DESCRIPTION
https://github.com/rails/rails/issues/58026

### Motivation / Background

As outlined in the corresponding ticket, the following combination of template and controller code does not behave as expected:

```ruby
# app/model/greeting.rb
class Greeting
  def render_in(view_context, **)
    if block_given?
      view_context.render(html: yield)
    else
      view_context.render(inline: <<~ERB.strip, **)
        Hello, <%= local_assigns[:name] %>
      ERB
    end
  end
end

# app/controllers/demo_controller.rb
class DemoController < ApplicationController
  layout false

  def show
    render(Greeting.new) { "From a block" }
  end
end

# config/routes.rb
Rails.application.routes.draw do
  root "demo#show"
end
```

A request to the root endpoint renders output as:

```shell
$ curl localhost:3000
<!-- BEGIN inline template
-->Hello, <!-- END inline template -->%
```

### Detail

This behavior indicates a breakdown in argument passing throughout the Action Controller rendering method invocation chain.

### Additional information

This diff's changeset modifies the behavior of
`AbstractController::Rendering#render` to forward along the `&block` argument to the `#render_to_body` method delegation in support of invoking `render` within a controller action with both a `:renderable` option and a block.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
