### PR TITLE
Allow to access `Controller#controller_path` in a Ractor

### DIFF
--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -117,7 +117,7 @@ module AbstractController
       #     MyApp::MyPostsController.controller_path # => "my_app/my_posts"
       #
       def controller_path
-        @controller_path ||= name.delete_suffix("Controller").underscore unless anonymous?
+        @controller_path ||= name.delete_suffix("Controller").underscore.freeze unless anonymous?
       end
 
       def configure # :nodoc:

--- a/actionpack/test/controller/base_test.rb
+++ b/actionpack/test/controller/base_test.rb
@@ -2,6 +2,7 @@
 
 require "abstract_unit"
 require "active_support/logger"
+require "active_support/testing/ractors_assertions"
 require "controller/fake_models"
 
 # Provide some controller to run the tests on.
@@ -11,6 +12,9 @@ module Submodule
 end
 
 class EmptyController < ActionController::Base
+end
+
+class CatController < ActionController::Base
 end
 
 class SimpleController < ActionController::Base
@@ -96,11 +100,21 @@ class WithoutRouterTest < ActionController::TestCase
 end
 
 class ControllerClassTests < ActiveSupport::TestCase
+  include ActiveSupport::Testing::RactorsAssertions
+
   def test_controller_path
     assert_equal "empty", EmptyController.controller_path
     assert_equal EmptyController.controller_path, EmptyController.new.controller_path
     assert_equal "submodule/contained_empty", Submodule::ContainedEmptyController.controller_path
     assert_equal Submodule::ContainedEmptyController.controller_path, Submodule::ContainedEmptyController.new.controller_path
+  end
+
+  def test_controller_path_is_eagerly_set_and_accessible_from_a_ractor
+    value = on_ractor do
+      CatController.controller_path
+    end
+
+    assert_equal("cat", value)
   end
 
   def test_controller_name


### PR DESCRIPTION
### Motivation / Background

I'd like to be able to call `SomeController#controller_path` inside a Ractor. It currently is not possible because this method returns a unfrozen string.

### Detail

As simple as freezing the string.

Worth noting that the memoization doesn't trip Ractor safety because the writer is set thanks to an existing `inherited` hook.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
