### PR TITLE
Fix preloader reusing stale already-loaded associations in grouped queries

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Fix the preloader reusing stale already-loaded associations in grouped queries.
+
+    When two associations backed by the same table were preloaded in one call
+    and one owner's association was loaded but stale (its foreign key was
+    written after the association loaded), the preloader reused the stale
+    target under the owner's new key, suppressed the batched query for that
+    key, and marked sibling associations as loaded with a `nil` target. Stale
+    associations are now treated as not loaded, so the preload refreshes
+    them — matching the association reader, which already reloads stale
+    targets on access.
+
+    *Hans Go*
+
 *   `connected_to_all_shards` now raises `ArgumentError` when called on a model
     that is not connected to any shards, rather than silently doing nothing.
 

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -174,7 +174,8 @@ module ActiveRecord
         end
 
         def loaded?(owner)
-          owner.association(reflection.name).loaded?
+          association = owner.association(reflection.name)
+          association.loaded? && !association.stale_target?
         end
 
         def target_for(owner)

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -908,6 +908,18 @@ class PreloaderTest < ActiveRecord::TestCase
     end
   end
 
+  def test_preload_grouped_queries_does_not_reuse_stale_already_loaded_records
+    book = books(:awdr)
+    post = posts(:misc_by_bob)
+    book.author # load the association, then leave it stale with a raw foreign-key write
+    book.author_id = authors(:bob).id
+
+    ActiveRecord::Associations::Preloader.new(records: [book, post], associations: :author).call
+
+    assert_equal authors(:bob), post.author
+    assert_equal authors(:bob), book.author
+  end
+
   def test_preload_grouped_queries_of_middle_records
     comments = [
       comments(:eager_sti_on_associations_s_comment1),


### PR DESCRIPTION
### Summary

`ActiveRecord::Associations::Preloader` can silently mark an association as loaded with a `nil` target — issuing **zero queries** — when two associations backed by the same table are preloaded in one call and one owner's association is loaded but **stale** (its foreign key was written after the association loaded, e.g. by mass assignment of form params).

### Reproduction (stock fixtures)

```ruby
book = books(:awdr)               # author: david
post = posts(:misc_by_bob)        # author: bob
book.author                       # load the association (david)
book.author_id = authors(:bob).id # raw FK write → loaded association now stale

ActiveRecord::Associations::Preloader.new(records: [book, post], associations: :author).call

post.author # => nil  (association marked loaded, no query ever ran)
```

### Mechanism

`LoaderQuery::LoaderRecords#populate_keys_to_load_and_already_loaded_records` treats any owner whose association is `loaded?` as an already-loaded record source: it stores the loaded target under the owner's **current** key and subtracts that key from the batch query:

```ruby
if loaded_owner = owners.find { |owner| loader.loaded?(owner) }
  already_loaded_records_by_key[key] = loader.target_for(loaded_owner)
else
  keys_to_load << key
end
...
@keys_to_load.subtract(already_loaded_records_by_key.keys)
```

With a stale association, the stored record does not actually have that key: above, key `bob.id` maps to the loaded `david` record. The batched query for `bob.id` is suppressed, and every sibling loader resolving to `bob.id` finds no matching record among the raw records — so its association is marked loaded with a `nil` target. The only symptom is the *absence* of a query, which makes this very hard to diagnose in production (we traced it from a Sentry `DelegationError` through query-log forensics before it reduced to the three lines above).

The association *reader* already handles exactly this staleness — `Association#stale_target?` forces a reload on access — so a raw FK write is otherwise safe. The preloader is the one component that trusts `loaded?` without the staleness check.

### Fix

Treat stale associations as not loaded in `Preloader::Association#loaded?`:

```ruby
def loaded?(owner)
  association = owner.association(reflection.name)
  association.loaded? && !association.stale_target?
end
```

This makes the preload refresh stale associations (consistent with the reader) and restores the suppressed batch query for the affected keys. One deliberate behavior change: an association loaded with a `nil` target whose owner's FK is present is indistinguishable from the corrupted state, so it is re-queried rather than reused — a query that returns no rows in the legitimate dangling-FK case.

### Verification

- New regression test `test_preload_grouped_queries_does_not_reuse_stale_already_loaded_records` fails before the fix (`post.author => nil`) and passes after.
- `test/cases/associations_test.rb`, `associations/eager_test.rb`, `associations/belongs_to_associations_test.rb`, `associations/has_many_associations_test.rb`, `associations/has_many_through_associations_test.rb`, `associations/nested_through_associations_test.rb`, `associations/cascaded_eager_loading_test.rb` all green (sqlite3).

The affected code is identical on `main`, `8-0-stable`, and `7-2-stable`; we'd appreciate backports to both stable branches (we hit this in production on 7.2 and are mid-upgrade to 8.0). The commit cherry-picks cleanly onto both.
