### PR TITLE
Allow using custom Action Cable WebSocket server and executor implementations

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Make executor and WebSocket server configurable.
+
+    You can provide a custom implementation of an executor (timers and async callbacks) or a WebSocket server (low-level WebSocket connections handling):
+
+    ```ruby
+    config.action_cable.executor = -> (server) { MyCustomNonThreadedExecutor.new(server, foo: "bar") }
+    config.action_cable.websocket_server = -> (server) { MyCustomWebSocketHandler.new(server) }
+    ```
+
+    The `server` parameter provides a current `ActionCable::Server::Base` instance (which acts as an Action Cable application container).
+
+    *Vladimir Dementyev*
+
+*   Make heartbeat (ping) interval configurable via `config.action_cable.beat_interval`
+
+    *Vladimir Dementyev*
+
 *   Move `ActionCable::Server::Configuration` to `ActionCable::Configuration`.
 
     The old constant remains available as an alias.

--- a/actioncable/app/javascript/action_cable/connection_monitor.js
+++ b/actioncable/app/javascript/action_cable/connection_monitor.js
@@ -118,7 +118,7 @@ class ConnectionMonitor {
 
 }
 
-ConnectionMonitor.staleThreshold = 6 // Server::Connections::BEAT_INTERVAL * 2 (missed two pings)
+ConnectionMonitor.staleThreshold = 6 // config.action_cable.beat_interval * 2 (missed two pings)
 ConnectionMonitor.reconnectionBackoffRate = 0.15
 
 export default ConnectionMonitor

--- a/actioncable/lib/action_cable/configuration.rb
+++ b/actioncable/lib/action_cable/configuration.rb
@@ -14,10 +14,11 @@ module ActionCable
     attr_accessor :logger, :log_tags
     attr_accessor :connection_class, :worker_pool_size, :executor_pool_size
     attr_accessor :disable_request_forgery_protection, :allowed_request_origins, :allow_same_origin_as_host, :filter_parameters
-    attr_accessor :cable, :url, :mount_path
+    attr_accessor :cable, :url, :mount_path, :beat_interval
     attr_accessor :precompile_assets
     attr_accessor :health_check_path, :health_check_application
     attr_writer :pubsub_adapter
+    attr_accessor :executor, :websocket_server
 
     def initialize
       @log_tags = []
@@ -25,6 +26,11 @@ module ActionCable
       @connection_class = -> { ActionCable::Connection::Base }
       @worker_pool_size = 4
       @executor_pool_size = 10
+
+      @beat_interval = 3
+
+      @executor = ->(server) { ActionCable::Server::ThreadedExecutor.new(max_size: server.config.executor_pool_size, name: "streamer") }
+      @websocket_server = ->(server) { ActionCable::Server::WebSocketServer.new(server) }
 
       @disable_request_forgery_protection = false
       @allow_same_origin_as_host = true

--- a/actioncable/lib/action_cable/server/base.rb
+++ b/actioncable/lib/action_cable/server/base.rb
@@ -6,29 +6,6 @@ require "monitor"
 
 module ActionCable
   module Server
-    # A wrapper over ConcurrentRuby::ThreadPoolExecutor and Concurrent::TimerTask
-    class ThreadedExecutor # :nodoc:
-      def initialize(max_size: 10, name: "server")
-        @executor = Concurrent::ThreadPoolExecutor.new(
-          name: "ActionCable-#{name}",
-          min_threads: 1,
-          max_threads: max_size,
-          max_queue: 0,
-        )
-      end
-
-      def post(task = nil, &block)
-        task ||= block
-        @executor << task
-      end
-
-      def timer(interval, &block)
-        Concurrent::TimerTask.new(execution_interval: interval, &block).tap(&:execute)
-      end
-
-      def shutdown = @executor.shutdown
-    end
-
     # # Action Cable Server Base
     #
     # A singleton ActionCable::Server instance is available via ActionCable.server.
@@ -73,7 +50,7 @@ module ActionCable
           # worker pool, which we halt below, so the entries would otherwise leak.
           connections_map.clear
 
-          @websocket_server&.restart
+          @websocket_server&.try(:restart)
 
           # Shutdown the executor
           @executor.shutdown if @executor
@@ -92,12 +69,12 @@ module ActionCable
 
       # An actual implementation of a Rack-compatible WebSocket server
       def websocket_server
-        @websocket_server || @mutex.synchronize { @websocket_server ||= ActionCable::Server::WebSocketServer.new(self) }
+        @websocket_server || @mutex.synchronize { @websocket_server ||= config.websocket_server.call(self) }
       end
 
       # Executor is used by various actions within Action Cable (e.g., pub/sub operations) to run code asynchronously.
       def executor
-        @executor || @mutex.synchronize { @executor ||= ThreadedExecutor.new(max_size: config.executor_pool_size, name: "streamer") }
+        @executor || @mutex.synchronize { @executor ||= config.executor.call(self) }
       end
 
       # Adapter used for all streams/broadcasting.

--- a/actioncable/lib/action_cable/server/base.rb
+++ b/actioncable/lib/action_cable/server/base.rb
@@ -32,12 +32,10 @@ module ActionCable
     # # Action Cable Server Base
     #
     # A singleton ActionCable::Server instance is available via ActionCable.server.
-    # It's used by the Rack process that starts the Action Cable server, but is also
-    # used by the user to reach the RemoteConnections object, which is used for
-    # finding and disconnecting connections across all servers.
-    #
-    # Also, this is the server instance used for broadcasting. See Broadcasting for
-    # more information.
+    # It acts as an entry point to an Action Cable application providing access to the underlying
+    # WebSocket server implementation, the RemoteConnections object, which is used for
+    # finding and disconnecting connections across all servers, and the pubsub adapter
+    # used for broadcasting. See Broadcasting for more information.
     class Base
       include ActionCable::Server::Broadcasting
       include ActionCable::Server::Connections
@@ -49,19 +47,14 @@ module ActionCable
       def self.logger; config.logger; end
       delegate :logger, to: :config
 
+      delegate :call, to: :websocket_server
+
       attr_reader :mutex
 
       def initialize(config: self.class.config)
         @config = config
         @mutex = Monitor.new
-        @remote_connections = @event_loop = @worker_pool = @executor = @pubsub = @heartbeat_timer = nil
-      end
-
-      # Called by Rack to set up the server.
-      def call(env)
-        return config.health_check_application.call(env) if env["PATH_INFO"] == config.health_check_path
-        setup_heartbeat_timer
-        Socket.new(self, env).process
+        @remote_connections = @websocket_server = @executor = @pubsub = nil
       end
 
       # Disconnect all the connections identified by `identifiers` on this server or
@@ -80,13 +73,7 @@ module ActionCable
           # worker pool, which we halt below, so the entries would otherwise leak.
           connections_map.clear
 
-          # Shutdown the heartbeat timer
-          @heartbeat_timer.shutdown if @heartbeat_timer
-          @heartbeat_timer = nil
-
-          # Shutdown the worker pool
-          @worker_pool.halt if @worker_pool
-          @worker_pool = nil
+          @websocket_server&.restart
 
           # Shutdown the executor
           @executor.shutdown if @executor
@@ -103,28 +90,9 @@ module ActionCable
         @remote_connections || @mutex.synchronize { @remote_connections ||= RemoteConnections.new(self) }
       end
 
-      def event_loop
-        @event_loop || @mutex.synchronize { @event_loop ||= StreamEventLoop.new }
-      end
-
-      # The worker pool is where we run connection callbacks and channel actions. We
-      # do as little as possible on the server's main thread. The worker pool is an
-      # executor service that's backed by a pool of threads working from a task queue.
-      # The thread pool size maxes out at 4 worker threads by default. Tune the size
-      # yourself with `config.action_cable.worker_pool_size`.
-      #
-      # Using Active Record, Redis, etc within your channel actions means you'll get a
-      # separate connection from each thread in the worker pool. Plan your deployment
-      # accordingly: 5 servers each running 5 Puma workers each running an 8-thread
-      # worker pool means at least 200 database connections.
-      #
-      # Also, ensure that your database connection pool size is as least as large as
-      # your worker pool size. Otherwise, workers may oversubscribe the database
-      # connection pool and block while they wait for other workers to release their
-      # connections. Use a smaller worker pool or a larger database connection pool
-      # instead.
-      def worker_pool
-        @worker_pool || @mutex.synchronize { @worker_pool ||= ActionCable::Server::Worker.new(max_size: config.worker_pool_size) }
+      # An actual implementation of a Rack-compatible WebSocket server
+      def websocket_server
+        @websocket_server || @mutex.synchronize { @websocket_server ||= ActionCable::Server::WebSocketServer.new(self) }
       end
 
       # Executor is used by various actions within Action Cable (e.g., pub/sub operations) to run code asynchronously.

--- a/actioncable/lib/action_cable/server/connections.rb
+++ b/actioncable/lib/action_cable/server/connections.rb
@@ -11,8 +11,6 @@ module ActionCable
     # you can't use this collection as a full list of all of the connections
     # established against your application. Instead, use RemoteConnections for that.
     module Connections # :nodoc:
-      BEAT_INTERVAL = 3
-
       def connections = connections_map.values
 
       def each_connection(...)
@@ -28,17 +26,6 @@ module ActionCable
 
       def remove_connection(connection)
         connections_map.delete connection.object_id
-      end
-
-      # WebSocket connection implementations differ on when they'll mark a connection
-      # as stale. We basically never want a connection to go stale, as you then can't
-      # rely on being able to communicate with the connection. To solve this, a 3
-      # second heartbeat runs on all connections. If the beat fails, we automatically
-      # disconnect.
-      def setup_heartbeat_timer
-        @heartbeat_timer ||= executor.timer(BEAT_INTERVAL) do
-          executor.post { each_connection(&:beat) }
-        end
       end
 
       def open_connections_statistics

--- a/actioncable/lib/action_cable/server/socket.rb
+++ b/actioncable/lib/action_cable/server/socket.rb
@@ -10,15 +10,17 @@ module ActionCable
     # This connection object is also responsible for handling encoding and decoding of messages, so the user-level
     # connection object shouldn't know about such details.
     class Socket
-      attr_reader :server, :env, :protocol, :logger, :connection
+      attr_reader :server, :websocket_server, :env, :protocol, :logger, :connection
       private attr_reader :worker_pool
 
-      delegate :event_loop, :pubsub, :config, to: :server
+      delegate :config, :event_loop, to: :websocket_server
 
-      def initialize(server, env, coder: ActiveSupport::JSON)
-        @server, @env, @coder = server, env, coder
+      def initialize(websocket_server, env, coder: ActiveSupport::JSON)
+        @websocket_server, @env, @coder = websocket_server, env, coder
 
-        @worker_pool = server.worker_pool
+        @server = websocket_server.server
+        @worker_pool = websocket_server.worker_pool
+
         @logger = server.new_tagged_logger { request }
 
         @websocket      = WebSocket.new(env, self, event_loop)

--- a/actioncable/lib/action_cable/server/threaded_executor.rb
+++ b/actioncable/lib/action_cable/server/threaded_executor.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# :markup: markdown
+
+module ActionCable
+  module Server
+    # A wrapper over ConcurrentRuby::ThreadPoolExecutor and Concurrent::TimerTask
+    class ThreadedExecutor # :nodoc:
+      def initialize(max_size: 10, name: "server")
+        @executor = Concurrent::ThreadPoolExecutor.new(
+          name: "ActionCable-#{name}",
+          min_threads: 1,
+          max_threads: max_size,
+          max_queue: 0,
+        )
+      end
+
+      def post(task = nil, &block)
+        task ||= block
+        @executor << task
+      end
+
+      def timer(interval, &block)
+        Concurrent::TimerTask.new(execution_interval: interval, &block).tap(&:execute)
+      end
+
+      def shutdown = @executor.shutdown
+    end
+  end
+end

--- a/actioncable/lib/action_cable/server/web_socket_server.rb
+++ b/actioncable/lib/action_cable/server/web_socket_server.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "monitor"
+
+module ActionCable
+  module Server
+    # A default WebSocket server implementation with Rack interface and
+    # a thread-pool executor to process user commands and broadcasting callbacks
+    class WebSocketServer
+      BEAT_INTERVAL = 3
+
+      attr_reader :server
+      delegate :config, :executor, to: :server
+
+      def initialize(server)
+        @server = server
+        @mutex = Monitor.new
+        @event_loop = @worker_pool = @heartbeat_timer = nil
+      end
+
+      # Called by Rack to set up the server.
+      def call(env)
+        return config.health_check_application.call(env) if env["PATH_INFO"] == config.health_check_path
+        setup_heartbeat_timer
+        Socket.new(self, env).process
+      end
+
+      def restart
+        @mutex.synchronize do
+          # Shutdown the heartbeat timer
+          @heartbeat_timer.shutdown if @heartbeat_timer
+          @heartbeat_timer = nil
+
+          # Shutdown the worker pool
+          @worker_pool.halt if @worker_pool
+          @worker_pool = nil
+        end
+      end
+
+      # WebSocket connection implementations differ on when they'll mark a connection
+      # as stale. We basically never want a connection to go stale, as you then can't
+      # rely on being able to communicate with the connection. To solve this, a 3
+      # second heartbeat runs on all connections. If the beat fails, we automatically
+      # disconnect.
+      def setup_heartbeat_timer
+        @heartbeat_timer ||= executor.timer(BEAT_INTERVAL) do
+          executor.post { server.each_connection(&:beat) }
+        end
+      end
+
+      def event_loop
+        @event_loop || @mutex.synchronize { @event_loop ||= StreamEventLoop.new }
+      end
+
+      # The worker pool is where we run connection callbacks and channel actions. We
+      # do as little as possible on the server's main thread. The worker pool is an
+      # executor service that's backed by a pool of threads working from a task queue.
+      # The thread pool size maxes out at 4 worker threads by default. Tune the size
+      # yourself with `config.action_cable.worker_pool_size`.
+      #
+      # Using Active Record, Redis, etc within your channel actions means you'll get a
+      # separate connection from each thread in the worker pool. Plan your deployment
+      # accordingly: 5 servers each running 5 Puma workers each running an 8-thread
+      # worker pool means at least 200 database connections.
+      #
+      # Also, ensure that your database connection pool size is as least as large as
+      # your worker pool size. Otherwise, workers may oversubscribe the database
+      # connection pool and block while they wait for other workers to release their
+      # connections. Use a smaller worker pool or a larger database connection pool
+      # instead.
+      def worker_pool
+        @worker_pool || @mutex.synchronize { @worker_pool ||= ActionCable::Server::Worker.new(max_size: config.worker_pool_size) }
+      end
+    end
+  end
+end

--- a/actioncable/lib/action_cable/server/web_socket_server.rb
+++ b/actioncable/lib/action_cable/server/web_socket_server.rb
@@ -7,8 +7,6 @@ module ActionCable
     # A default WebSocket server implementation with Rack interface and
     # a thread-pool executor to process user commands and broadcasting callbacks
     class WebSocketServer
-      BEAT_INTERVAL = 3
-
       attr_reader :server
       delegate :config, :executor, to: :server
 
@@ -43,7 +41,7 @@ module ActionCable
       # second heartbeat runs on all connections. If the beat fails, we automatically
       # disconnect.
       def setup_heartbeat_timer
-        @heartbeat_timer ||= executor.timer(BEAT_INTERVAL) do
+        @heartbeat_timer ||= executor.timer(config.beat_interval) do
           executor.post { server.each_connection(&:beat) }
         end
       end

--- a/actioncable/test/connection/base_test.rb
+++ b/actioncable/test/connection/base_test.rb
@@ -83,7 +83,7 @@ class ActionCable::Connection::BaseTest < ActionCable::TestCase
   end
 
   test "#broadcast" do
-    connection = Connection.new(ActionCable.server, ActionCable::Server::Socket.new(ActionCable.server, {}))
+    connection = Connection.new(ActionCable.server, ActionCable::Server::Socket.new(ActionCable.server.websocket_server, {}))
 
     messages = capture_broadcasts("test") do
       connection.broadcast("test", { message: "hello" })

--- a/actioncable/test/server/base_test.rb
+++ b/actioncable/test/server/base_test.rb
@@ -77,4 +77,31 @@ class BaseTest < ActionCable::TestCase
     assert_same ActionCable::Configuration, ActionCable::Server::Configuration
     assert_instance_of ActionCable::Configuration, ActionCable::Server::Base.config
   end
+
+  test "uses configured executor" do
+    executor = []
+
+    config = ActionCable::Configuration.new
+    config.executor = -> (server) { executor.tap { _1 << server } }
+
+    @server = ActionCable::Server::Base.new(config:)
+
+    assert_same @server.executor, executor
+    assert_same @server.executor[0], @server
+  end
+
+  test "uses configured websocket server" do
+    ws_class = Data.define(:server) do
+      def call(env) = [418, {}, ["It's tea time!"]]
+    end
+
+    config = ActionCable::Configuration.new
+    config.websocket_server = -> (server) { ws_class.new(server) }
+
+    @server = ActionCable::Server::Base.new(config:)
+
+    assert_instance_of ws_class, @server.websocket_server
+    assert_same @server.websocket_server.server, @server
+    assert_equal 418, @server.call({})[0]
+  end
 end

--- a/actioncable/test/server/base_test.rb
+++ b/actioncable/test/server/base_test.rb
@@ -61,8 +61,8 @@ class BaseTest < ActionCable::TestCase
     end
   end
 
-  test "#restart shuts down worker pool" do
-    assert_called(@server.worker_pool, :halt) do
+  test "#restart restarts websocker_server" do
+    assert_called(@server.websocket_server, :restart) do
       @server.restart
     end
   end
@@ -71,17 +71,6 @@ class BaseTest < ActionCable::TestCase
     assert_called(@server.pubsub, :shutdown) do
       @server.restart
     end
-  end
-
-  test "#restart shuts down the heartbeat timer" do
-    @server.send(:setup_heartbeat_timer)
-    timer = @server.instance_variable_get(:@heartbeat_timer)
-    assert_predicate timer, :running?
-
-    @server.restart
-
-    assert_not timer.running?
-    assert_nil @server.instance_variable_get(:@heartbeat_timer)
   end
 
   test "server configuration is available from ActionCable" do

--- a/actioncable/test/server/socket_test.rb
+++ b/actioncable/test/server/socket_test.rb
@@ -34,7 +34,7 @@ class ActionCable::Server::SocketTest < ActionCable::TestCase
 
   test "making a connection with invalid headers" do
     run_in_eventmachine do
-      socket = ActionCable::Server::Socket.new(@server, Rack::MockRequest.env_for("/test"))
+      socket = ActionCable::Server::Socket.new(@server.websocket_server, Rack::MockRequest.env_for("/test"))
       response = socket.process
       assert_equal 404, response[0]
     end
@@ -137,7 +137,7 @@ class ActionCable::Server::SocketTest < ActionCable::TestCase
           "HTTP_HOST" => "localhost", "HTTP_ORIGIN" => "http://rubyonrails.org", "rack.hijack" => CallMeMaybe.new
       )
 
-      socket = ActionCable::Server::Socket.new(@server, env)
+      socket = ActionCable::Server::Socket.new(@server.websocket_server, env)
       response = socket.process
       assert_equal 404, response[0]
     end
@@ -148,6 +148,6 @@ class ActionCable::Server::SocketTest < ActionCable::TestCase
       env = Rack::MockRequest.env_for "/test", "HTTP_CONNECTION" => "upgrade", "HTTP_UPGRADE" => "websocket",
         "HTTP_HOST" => "localhost", "HTTP_ORIGIN" => "http://rubyonrails.com"
 
-      ActionCable::Server::Socket.new(@server, env)
+      ActionCable::Server::Socket.new(@server.websocket_server, env)
     end
 end

--- a/actioncable/test/server/web_socket_server_test.rb
+++ b/actioncable/test/server/web_socket_server_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "stubs/test_server"
+require "active_support/core_ext/hash/indifferent_access"
+
+class WebSocketServerTest < ActionCable::TestCase
+  def setup
+    @server = ActionCable::Server::Base.new
+    @ws_server = ActionCable::Server::WebSocketServer.new(@server)
+  end
+
+  class FakeConnection
+    def close
+    end
+  end
+
+  test "#restart shuts down worker pool" do
+    assert_called(@ws_server.worker_pool, :halt) do
+      @ws_server.restart
+    end
+  end
+
+  test "#restart shuts down the heartbeat timer" do
+    @ws_server.send(:setup_heartbeat_timer)
+    timer = @ws_server.instance_variable_get(:@heartbeat_timer)
+    assert_predicate timer, :running?
+
+    @ws_server.restart
+
+    assert_not timer.running?
+    assert_nil @ws_server.instance_variable_get(:@heartbeat_timer)
+  end
+end

--- a/actioncable/test/stubs/test_server.rb
+++ b/actioncable/test/stubs/test_server.rb
@@ -24,12 +24,12 @@ class TestServer < ActionCable::Server::Base
     @mutex = Monitor.new
   end
 
+  #=== Action Cable Server interface ===
+
+  def websocket_server = self
+
   def pubsub
     @pubsub ||= @config.subscription_adapter.new(self)
-  end
-
-  def event_loop
-    @event_loop ||= ActionCable::Server::StreamEventLoop.new
   end
 
   def executor
@@ -38,11 +38,19 @@ class TestServer < ActionCable::Server::Base
     end
   end
 
+  def new_tagged_logger = ActionCable::Server::TaggedLoggerProxy.new(logger, tags: [])
+
+  #=== WebSocket server interface ===
+
+  def event_loop
+    @event_loop ||= ActionCable::Server::StreamEventLoop.new
+  end
+
   def worker_pool
     @worker_pool ||= ActionCable::Server::Worker.new(max_size: 5).tap do |wp|
       wp.instance_variable_set(:@executor, Concurrent.global_io_executor)
     end
   end
 
-  def new_tagged_logger = ActionCable::Server::TaggedLoggerProxy.new(logger, tags: [])
+  def server = self
 end


### PR DESCRIPTION
### Motivation / Background

This is a follow-up to https://github.com/rails/rails/pull/50979 and an alternative to #57803 proposed [here](https://github.com/rails/rails/pull/57803#issuecomment-4842578205).

**tl;dr** Make using alternative WebSocket servers (primarily, Async) possible just by the means of updating the Action Cable configuration. For that, we introduce two new configuration parameters:

```
config.action_cable.websocket_server = -> (server) { MyCustomWebSocketHandler.new(server) }
config.action_cable.executor = -> (server) { MyCustomNonThreadedExecutor.new(server, foo: "bar") }
```

We also introduces the same configureability for the executor (a component responsible for timers and async callbacks).

### Detail

- Extract `ActionCable::Server::WebSocketServer` from `ActionCable::Server::Base`. Now the base class acts more like an Action Cable application container, an entry-point to all other components (pub/sub, WS server, executor).
- Refactored `ActionCable::Server::Socket` to use the new `WebSocketServer`
- Added `executor` and `websocket_server` accessors to `Configuration`
- Moved `ActionCable::Server::ThreadedExecutor` to a separate file
- Moved `#start_heartbeat_timer` from `Connections` to `WebSocketServer`. Now `Connections`'s sole responsibility is to manage the connections state.

Misc changes:

- Replaced the `BEAT_INTERVAL` constant with the configuration parameter (`config.beat_interval`)

### Additional information

The surface of the proposed refactoring is intentionally kept as small as possible: no new _namespaces_ / folder (like, `server/websocket_server`), no internal API changes, minimal test stubs updates.

The mounting part (`mount ActionCable.server => mount_path`) stays untouched (we delegate `#call` to `websocket_server`). I rejected the previous idea of adding a `mountable?` predicate—we already can use the `mount_path` parameter for that (just set it to `nil`).

I ended up with Procs based on the current default values: we provide a thread pool name for the default threaded executor; it carries no meaning outside of this object, so no need to extend configuration for that. The `websocket_server` uses Procs for consistency sake.

#### What a potential WebSocket server implementation must provide?

A custom WebSocket server implementation MUST:

- Provide a Rack-compatible interface (`#call`) (unless you want to mount/run it yourself; in this case, `ActionCable.server.websocket_server` won't be used at all).
- Implement the heartbeat logic (send pings to connected clients). 

Managing connections (`#add_connection`, `#remove_connection`) is recommended but not strictly necessary (it's not used by any internal feature). Same goes about the `#restart` callback (that's why we use `try(...)`).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
