### PR TITLE
Cooldown dependabot version updates (does not impact security updates)

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Cooldown dependabot version updates to 7 days. Does not impact security updates.
+
+    Reduces the likelihood of compromised dependencies being installed after successful supply chain attacks on
+    RubyGems or GitHub Actions.
+
+    Please note dependabot ignores this cooldown for security updates so known vulnerabilities are patched sooner.
+
+    *Eliot Sykes*
+
 *   Validate subcommand in `rails plugin` command.
 
     `rails plugin foo bar` silently ignored the invalid subcommand "foo"

--- a/railties/lib/rails/generators/rails/app/templates/github/dependabot.yml
+++ b/railties/lib/rails/generators/rails/app/templates/github/dependabot.yml
@@ -4,9 +4,13 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
+  cooldown:
+    default-days: 7
   open-pull-requests-limit: 10
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: weekly
+  cooldown:
+    default-days: 7
   open-pull-requests-limit: 10

--- a/railties/lib/rails/generators/rails/plugin/templates/github/dependabot.yml
+++ b/railties/lib/rails/generators/rails/plugin/templates/github/dependabot.yml
@@ -4,9 +4,13 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
+  cooldown:
+    default-days: 7
   open-pull-requests-limit: 10
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: weekly
+  cooldown:
+    default-days: 7
   open-pull-requests-limit: 10


### PR DESCRIPTION
### Motivation / Background

Reduces the likelihood of compromised dependencies being installed after successful supply chain attacks on RubyGems (or other gem sources) or GitHub Actions.

Please note dependabot ignores this cooldown for security updates so known vulnerabilities are patched sooner.

### Detail

Configures a 7-day `cooldown` in the `dependabot.yml` files used for new apps and plugins.

### Additional information

From the `cooldown` docs:
> Defines a cooldown period for dependency updates, allowing updates to be delayed for a configurable number of days. The cooldown option is only available for version updates, not security updates. [link](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-)

There are two recent PRs related to cooldowns:
* #57701
* #57779

I opted for a 7-day not 2-day cooldown as it seems prudent to allow more time for detecting any compromised gems that pass rubygem.org's automated security scans. Also [@p8's comment on the brakeman PR](https://github.com/rails/rails/pull/57779#issuecomment-4772192178) highlights a recommendation to use 7 days.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
