### PR TITLE
Fix `Relation#one?` doc example calling `any?`

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -396,8 +396,7 @@ module ActiveRecord
 
     # Returns true if there are any records.
     #
-    #
-    # When an argument is given, returns true if at least one records matches
+    # When an argument is given, returns true if at least one record matches
     # the argument via the case-equality operator (<tt>===</tt>).
     #
     #    posts.any?(Post)    # => true if at least one record
@@ -411,11 +410,11 @@ module ActiveRecord
 
     # Returns true if there is exactly one record.
     #
-    # When an argument is given, returns true if exactly one records matches the
+    # When an argument is given, returns true if exactly one record matches the
     # argument via the case-equality operator (<tt>===</tt>).
     #
-    #    posts.one?(Post) # => true if exactly one record
-    #    posts.any?(Comment) # => false
+    #    posts.one?(Post)    # => true if exactly one record
+    #    posts.one?(Comment) # => false
     def one?(*args)
       return false if @none
 


### PR DESCRIPTION
The second code example in the `ActiveRecord::Relation#one?` documentation calls `posts.any?(Comment)` instead of `posts.one?(Comment)`, so the example doesn't demonstrate the method being documented:

```ruby
# Returns true if there is exactly one record.
#
#    posts.one?(Post) # => true if exactly one record
#    posts.any?(Comment) # => false
```

>[!NOTE]
>
> Documentation-only:
> 
> * The `one?` example now calls `one?`, and its `# =>` result comments are aligned the same way as the `any?` examples above it.
> * "returns true if at least/exactly one record**s** matches" → "one record matches" in both `any?` and `one?`.
> * Removed a stray duplicated blank comment line in the `any?` doc.