### PR TITLE
Prevent truncation of migration and metadata tables when using schemas

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -284,7 +284,8 @@ module ActiveRecord
       end
 
       def truncate_tables(*table_names) # :nodoc:
-        table_names -= [pool.schema_migration.table_name, pool.internal_metadata.table_name]
+        excluded = [pool.schema_migration.table_name, pool.internal_metadata.table_name]
+        table_names.delete_if { |name| excluded.any? { |e| name == e || name.end_with?(".#{e}") } }
 
         return if table_names.empty?
 

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -500,6 +500,41 @@ module ActiveRecord
       reset_fixtures("posts", "authors", "author_addresses")
     end
 
+    def test_truncate_tables_ignores_schema_qualified_internal_tables
+      internal_metadata = @connection.pool.internal_metadata
+      internal_metadata[:foo] = "bar"
+
+      assert_operator Post.count, :>, 0
+      assert_operator internal_metadata.count, :>, 0
+
+      @connection.truncate_tables("posts", "myschema.#{internal_metadata.table_name}")
+
+      assert_equal 0, Post.count
+      assert_operator internal_metadata.count, :>, 0
+
+      original_prefix = ActiveRecord::Base.table_name_prefix
+      ActiveRecord::Base.table_name_prefix = "myschema."
+      begin
+        @connection.truncate_tables("myschema.#{internal_metadata.table_name}")
+
+        assert_operator internal_metadata.count, :>, 0
+
+        @connection.truncate_tables(internal_metadata.table_name)
+
+        assert_operator internal_metadata.count, :>, 0
+      ensure
+        ActiveRecord::Base.table_name_prefix = original_prefix
+      end
+
+      @connection.truncate_tables("public.#{internal_metadata.table_name}")
+
+      assert_operator internal_metadata.count, :>, 0
+    ensure
+      ActiveRecord::Base.table_name_prefix = original_prefix if defined?(original_prefix)
+      reset_fixtures("posts")
+      internal_metadata.delete_all_entries
+    end
+
     def test_truncate_tables_with_query_cache
       @connection.enable_query_cache!
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because `ActiveRecord::ConnectionAdapters::DatabaseStatements#truncate_tables` truncates the migrations and metadata tables when the table names are schema-qualified

### Detail

This Pull Request changes `ActiveRecord::ConnectionAdapters::DatabaseStatements#truncate_tables` so that the existing exclusion for the migrations and metadata tables takes account of:
- the internal table names being schema-qualified via `ActiveRecord::Base.table_name_prefix` (e.g. `my_schema.`)
- the table names to truncate being schema-qualified but not the internal table names (not currently used internally, but needed for future work to better handle tables with the same name in different schemas in the Postgres adapter)

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
