### PR TITLE
Fix `ActiveSupport::ProxyLogger` doc examples

### DIFF
--- a/activesupport/lib/active_support/proxy_logger.rb
+++ b/activesupport/lib/active_support/proxy_logger.rb
@@ -104,7 +104,7 @@ module ActiveSupport
     #
     # Output:
     #
-    #   E, [2022-05-12T16:25:55.349414 #36328] ERROR -- mung: No good
+    #   E, [2022-05-12T16:25:55.349414 #36328] ERROR -- : No good
     #   E, [2022-05-12T16:26:35.841134 #36328] ERROR -- gnum: No good
     #
     # These convenience methods have implicit severity:
@@ -126,12 +126,12 @@ module ActiveSupport
     end
     alias_method :log, :add
 
-    # Forward the given +msg+ to the underlying logger with no formatting
+    # Forwards the given +msg+ to the underlying logger with no formatting and
     # returns the number of characters written,
     # or +nil+ if the underlying logger is +nil+:
     #
     #   logger = ProxyLogger.new(Logger.new($stderr))
-    #   logger << 'My message.' # => 10
+    #   logger << 'My message.' # => 11
     #
     # Output:
     #


### PR DESCRIPTION
Two examples in the `ActiveSupport::ProxyLogger` docs show values that don't match what the code actually produces:

- The `#add` example calls `logger.add(Logger::ERROR, 'No good')` without a progname, but the documented output shows `ERROR -- mung: No good`. The docs were adapted from Ruby's stdlib `Logger` docs, where the example logger is created with `progname: 'mung'`; the example here never sets one.
- The `#<<` example documents `logger << 'My message.' # => 10`, but `'My message.'` is 11 characters, so the call returns `11`.

Running the examples as written:

```ruby
logger = ActiveSupport::ProxyLogger.new(Logger.new($stderr), :error)
logger.add(Logger::INFO, 'Will not show')
logger.add(Logger::ERROR, 'No good')
logger.add(Logger::ERROR, 'No good', 'gnum')
# E, [2026-07-15T22:10:30.326061 #7026] ERROR -- : No good
# E, [2026-07-15T22:10:30.326114 #7026] ERROR -- gnum: No good

logger = ActiveSupport::ProxyLogger.new(Logger.new($stderr))
logger << 'My message.' # => 11
```

> [!NOTE]
> 
> Documentation-only change:
> 
> - `#add`: change the first output line to `ERROR -- : No good` to match a call with no progname. (The second line, `ERROR -- gnum: No good`, is already correct since that call passes `'gnum'`.)
> - `#<<`: change the documented return value from `10` to `11`, and join the sentence fragments in the method description ("Forwards the given `msg` to the underlying logger with no formatting and returns the number of characters written, ...").