### PR TITLE
Don't leak orphaned raw_email blob on duplicate inbound email delivery

### DIFF
--- a/actionmailbox/CHANGELOG.md
+++ b/actionmailbox/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Don't leak an orphaned `raw_email` blob when a duplicate inbound email is delivered.
+
+    `InboundEmail.create_and_extract_message_id!` uploaded the raw email blob before
+    the `create!` that could raise `RecordNotUnique` for a re-delivered message, leaving
+    the blob orphaned in storage. Duplicate deliveries now short-circuit before uploading,
+    and the just-created blob is purged on the race-safe `RecordNotUnique` backstop.
+
+    *Ayush Billore*
+
 *   Return `422 Unprocessable Content` for malformed Mailgun, Postmark, and SendGrid raw email parameters.
 
     *Andrii Furmanets*

--- a/actionmailbox/app/models/action_mailbox/inbound_email/message_id.rb
+++ b/actionmailbox/app/models/action_mailbox/inbound_email/message_id.rb
@@ -17,9 +17,12 @@ module ActionMailbox::InboundEmail::MessageId
       message_checksum = OpenSSL::Digest::SHA1.hexdigest(source)
       message_id = extract_message_id(source) || generate_missing_message_id(message_checksum)
 
-      create! raw_email: create_and_upload_raw_email!(source),
-        message_id: message_id, message_checksum: message_checksum, **options
+      return if exists?(message_id: message_id, message_checksum: message_checksum)
+
+      raw_email = create_and_upload_raw_email!(source)
+      create! raw_email: raw_email, message_id: message_id, message_checksum: message_checksum, **options
     rescue ActiveRecord::RecordNotUnique
+      raw_email&.purge_later
       nil
     end
 

--- a/actionmailbox/test/unit/inbound_email/message_id_test.rb
+++ b/actionmailbox/test/unit/inbound_email/message_id_test.rb
@@ -12,4 +12,14 @@ class ActionMailbox::InboundEmail::MessageIdTest < ActiveSupport::TestCase
     inbound_email = create_inbound_email_from_source "Date: Fri, 28 Sep 2018 11:08:55 -0700\r\nTo: a@example.com\r\nMime-Version: 1.0\r\nContent-Type: text/plain\r\nContent-Transfer-Encoding: 7bit\r\n\r\nHello!"
     assert_not_nil inbound_email.message_id
   end
+
+  test "duplicate delivery is a no-op and does not leak an orphaned raw_email blob" do
+    source = "Message-ID: <dup@example.com>\r\nFrom: a@example.com\r\nTo: b@example.com\r\nSubject: hello\r\n\r\nbody"
+
+    ActionMailbox::InboundEmail.create_and_extract_message_id!(source)
+
+    assert_no_difference -> { ActiveStorage::Blob.count } do
+      assert_nil ActionMailbox::InboundEmail.create_and_extract_message_id!(source)
+    end
+  end
 end


### PR DESCRIPTION
### Summary

Fixes #57933.

`ActionMailbox::InboundEmail.create_and_extract_message_id!` uploads the raw
email blob as an argument to `create!`, which is evaluated *before* the
`create!` that raises `ActiveRecord::RecordNotUnique` for a re-delivered
message. The exception is rescued to `nil`, but the already-created-and-
uploaded blob is left orphaned in storage with no owning record.

Duplicate deliveries are common in practice (ingress providers such as
Postmark/Mailgun retry and redeliver), so these orphaned `message/rfc822`
blobs accumulate indefinitely — and invisibly, since the exception is
intentionally swallowed.

### Fix

- Short-circuit with an `exists?(message_id:, message_checksum:)` check before
  uploading, so a duplicate delivery creates no blob at all (the common case).
  The check mirrors the `[message_id, message_checksum]` unique index.
- Keep the `rescue ActiveRecord::RecordNotUnique` as a race-safe backstop for
  concurrent duplicate deliveries, and `purge_later` the just-created blob on
  that path so a lost race doesn't leak either.

### Testing

Added a regression test asserting that a duplicate delivery returns `nil` and
does not change `ActiveStorage::Blob.count`. Full Action Mailbox suite passes.

Two things to double check before submitting:
- Base repository = rails/rails, base branch = main.
- The CHANGELOG attribution reads Ayush Billore while the commit author is abime — GitHub will link the commit to your account fine, but if a reviewer prefers them to match, let me know and I can align them.
