### PR TITLE
Fix Rubocop violation in `config/puma.rb` - Approach 2

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
@@ -35,7 +35,7 @@ plugin :tmp_restart
 
 <% unless skip_solid? -%>
 # Run the Solid Queue supervisor inside of Puma for single-server deployments.
-plugin :solid_queue if !["", "false", "0"].include?(ENV["SOLID_QUEUE_IN_PUMA"].to_s.downcase)
+plugin :solid_queue if ActiveModel::Type::Boolean.new.cast(ENV["SOLID_QUEUE_IN_PUMA"])
 
 <% end -%>
 # Specify the PID file. Defaults to tmp/pids/server.pid in development.


### PR DESCRIPTION
Closes https://github.com/rails/rails/pull/58129 (alternative PR).
Follow-up to https://github.com/rails/rails/pull/57424.

This PR fixes a `Layout/SpaceInsideArrayLiteralBrackets` Rubocop violation introduced in https://github.com/rails/rails/pull/57424, which causes `bin/rubocop` and `bin/ci` to fail on apps created with `rails new myapp --main`.

I personally prefer this approach and find it easier to read, but your mileage may vary.