### PR TITLE
Fix `rubocop.yml` indentation

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/rubocop.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/rubocop.yml.tt
@@ -3,8 +3,8 @@ inherit_gem: { rubocop-rails-omakase: rubocop.yml }
 
 <% if depend_on_bootsnap? -%>
 AllCops:
-    # This configuration should be kept in sync with `config/bootsnap.rb`
-    StringLiteralsFrozenByDefault: true
+  # This configuration should be kept in sync with `config/bootsnap.rb`
+  StringLiteralsFrozenByDefault: true
 
 <% end -%>
 # Overwrite or add rules to create your own house style


### PR DESCRIPTION
Follow-up to https://github.com/rails/rails/pull/57252. Yaml files generated by Rails have 2-space indentation, not 4.