### PR TITLE
Don't force multi statement for MySQL tx isolation

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Only use multi statement for `SET TRANSACTION ISOLATION LEVEL; BEGIN` if
+    MySQL connection is configured to use multi statement.
+
+    *Eliseu Daroit*, *Hartley McGuire*, *Matthew Draper*
+
 *   `connected_to_all_shards` now raises `ArgumentError` when called on a model
     that is not connected to any shards, rather than silently doing nothing.
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -262,12 +262,24 @@ module ActiveRecord
       def begin_isolated_db_transaction(isolation) # :nodoc:
         # From MySQL manual: The [SET TRANSACTION] statement applies only to the next single transaction performed within the session.
         # So we don't need to implement #reset_isolation_level
-        execute_batch(
-          ["SET TRANSACTION ISOLATION LEVEL #{transaction_isolation_levels.fetch(isolation)}", "BEGIN"],
-          "TRANSACTION",
-          allow_retry: true,
-          materialize_transactions: false,
-        )
+        if multi_statements_enabled?
+          execute_batch(
+            ["SET TRANSACTION ISOLATION LEVEL #{transaction_isolation_levels.fetch(isolation)}", "BEGIN"],
+            "TRANSACTION",
+            allow_retry: true,
+            materialize_transactions: false,
+          )
+        else
+          with_raw_connection(allow_retry: true, materialize_transactions: false) do
+            query_command(
+              "SET TRANSACTION ISOLATION LEVEL #{transaction_isolation_levels.fetch(isolation)}",
+              "TRANSACTION",
+              allow_retry: false,
+              materialize_transactions: false,
+            )
+            query_command("BEGIN", "TRANSACTION", allow_retry: false, materialize_transactions: false)
+          end
+        end
       end
 
       def commit_db_transaction # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
@@ -34,6 +34,10 @@ module ActiveRecord
         end
 
         private
+          def multi_statements_enabled?
+            @config[:multi_statement]
+          end
+
           def perform_query(raw_connection, intent)
             reset_multi_statement = if intent.batch && !@config[:multi_statement]
               raw_connection.set_server_option(::Trilogy::SET_SERVER_MULTI_STATEMENTS_ON)

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/transaction_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/transaction_test.rb
@@ -7,6 +7,8 @@ module ActiveRecord
   class TransactionTest < ActiveRecord::AbstractMysqlTestCase
     self.use_transactional_tests = false
 
+    include ConnectionHelper
+
     class Sample < ActiveRecord::Base
       self.table_name = "samples"
     end
@@ -33,6 +35,51 @@ module ActiveRecord
 
       Thread.abort_on_exception = @abort
       Thread.report_on_exception = @original_report_on_exception
+    end
+
+    test "begins isolated transactions with separate queries if multi statement disabled" do
+      connection = Sample.lease_connection
+      connection.connect!
+
+      connection.instance_variable_get(:@raw_connection).stub(:set_server_option, -> (*) { flunk "Server option changed!" }) do
+        queries = capture_notifications("sql.active_record") do
+          connection.begin_isolated_db_transaction(:read_committed)
+        end.map { _1.payload[:sql] }
+
+        assert_equal ["SET TRANSACTION ISOLATION LEVEL READ COMMITTED", "BEGIN"], queries
+      ensure
+        connection&.rollback_db_transaction
+      end
+    end
+
+    test "begins isolated transactions with one query if multi statement enabled" do
+      adapter_name = ActiveRecord::Base.lease_connection.adapter_name
+
+      run_without_connection do |orig_connection|
+        case adapter_name
+        when "Trilogy"
+          ActiveRecord::Base.establish_connection(
+            orig_connection.merge(multi_statement: true)
+          )
+        else
+          ActiveRecord::Base.establish_connection(
+            orig_connection.merge(flags: %w[MULTI_STATEMENTS])
+          )
+        end
+
+        connection = Sample.lease_connection
+        connection.send(:max_allowed_packet) # eagerly compute so execute_batch doesn't do it lazily
+
+        connection.instance_variable_get(:@raw_connection).stub(:set_server_option, -> (*) { flunk "Server option changed!" }) do
+          queries = capture_notifications("sql.active_record") do
+            connection.begin_isolated_db_transaction(:read_committed)
+          end.map { _1.payload[:sql] }
+
+          assert_equal ["SET TRANSACTION ISOLATION LEVEL READ COMMITTED;\nBEGIN"], queries
+        ensure
+          connection&.rollback_db_transaction
+        end
+      end
     end
 
     test "raises Deadlocked when a deadlock is encountered" do


### PR DESCRIPTION
Previously, the abstract MySQL adapter's `begin_isolated_db_transaction` was [refactored][1] to use multi statements to ensure that `SET TRANSACTION ISOLATION LEVEL` and `BEGIN` would be retried as a unit. This prevented a potential bug where a `BEGIN` could be retried and lose a previously configured isolation level.

However, this approach has a few downsides. Firstly, enabling and disabling multi statement actually _increases_ the number of round trips to the database compared to using separate queries. Additionally, this doesn't work well for applications using ProxySQL because the combination of `SET TRANSACTION ISOLATION` and multi statement will disable connection multiplexing  ([sysown/proxysql#4896](https://github.com/sysown/proxysql/issues/4896))..

This commit refactors `begin_isolatd_db_transaction` to retain the "unit of retryability" fix, but in a way that doesn't increase database roundtrips or break ProxySQL multiplexing: it now uses `with_raw_connection`'s `allow_retry` when the connection is not configured to use multi statement, but continues to use `execute_batch` when multi statement enabled.

[1]: https://github.com/rails/rails/commit/4908dc305fa48142449224581377f8450313ef40
