### PR TITLE
Add query predicate hooks for Active Record types

### DIFF
--- a/activemodel/lib/active_model/type/value.rb
+++ b/activemodel/lib/active_model/type/value.rb
@@ -114,6 +114,18 @@ module ActiveModel
         false
       end
 
+      def transforms_query_predicates? # :nodoc:
+        false
+      end
+
+      def query_attribute(attribute) # :nodoc:
+        attribute
+      end
+
+      def query_value(attribute, value, predicate_builder:) # :nodoc:
+        predicate_builder.build_bind_attribute(attribute.name, value, self)
+      end
+
       def map(value, &) # :nodoc:
         value
       end

--- a/activemodel/lib/active_model/type/value.rb
+++ b/activemodel/lib/active_model/type/value.rb
@@ -114,15 +114,44 @@ module ActiveModel
         false
       end
 
-      def transforms_query_predicates? # :nodoc:
+      # Returns true if the type customizes how attributes and values are
+      # rendered in hash-based +where+ predicates. When this method returns
+      # true, equality, array (+IN+), and range (+BETWEEN+) predicates are
+      # built by passing the attribute through Value#query_attribute and each
+      # value through Value#query_value. Returns +false+ by default. Types
+      # whose read-side SQL differs from what +cast+ and +serialize+ produce
+      # (e.g. a UUID stored as binary comparing as
+      # <tt>id = UUID_TO_BIN(?)</tt>) should override this method to return
+      # +true+.
+      def transforms_query_predicates?
         false
       end
 
-      def query_attribute(attribute) # :nodoc:
+      # Returns the Arel node used for the attribute side of a +where+
+      # predicate. Only called when Value#transforms_query_predicates?
+      # returns +true+. The default implementation returns the attribute
+      # unchanged. Override this method to wrap the column reference, for
+      # example in a SQL function call.
+      #
+      # +attribute+ The Arel attribute for the column being compared.
+      def query_attribute(attribute)
         attribute
       end
 
-      def query_value(attribute, value, predicate_builder:) # :nodoc:
+      # Returns the Arel node used for the value side of a +where+
+      # predicate. Only called when Value#transforms_query_predicates?
+      # returns +true+. The default implementation returns a bind parameter
+      # for +value+. Override this method to wrap the bind parameter, for
+      # example in a SQL function call.
+      #
+      # +attribute+ The Arel attribute for the column being compared.
+      #
+      # +value+ The value being compared against, before type casting.
+      #
+      # +predicate_builder+ The ActiveRecord::PredicateBuilder building the
+      # predicate. Call +predicate_builder.build_bind_attribute+ to create a
+      # bind parameter for +value+.
+      def query_value(attribute, value, predicate_builder:)
         predicate_builder.build_bind_attribute(attribute.name, value, self)
       end
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,48 @@
+*   Add query predicate hooks for Active Model types.
+
+    Types can override `transforms_query_predicates?`, `query_attribute`, and
+    `query_value` to customize how hash `where` predicates are built while
+    preserving normal casting and serialization behavior.
+
+    For example, a UUID type stored in MySQL `binary(16)` can accept UUID
+    strings while rendering predicates as `id = UUID_TO_BIN(?)`:
+
+    ```ruby
+    def transforms_query_predicates?
+      true
+    end
+
+    def query_value(attribute, value, predicate_builder:)
+      Arel::Nodes::NamedFunction.new(
+        "UUID_TO_BIN",
+        [predicate_builder.build_bind_attribute(attribute.name, value, self)]
+      )
+    end
+    ```
+
+    `query_attribute` transforms the left-hand side of the predicate, so a text
+    type can compare through a normalized expression such as
+    `lower(name) = lower(?)`:
+
+    ```ruby
+    def transforms_query_predicates?
+      true
+    end
+
+    def query_attribute(attribute)
+      Arel::Nodes::NamedFunction.new("lower", [attribute])
+    end
+
+    def query_value(attribute, value, predicate_builder:)
+      Arel::Nodes::NamedFunction.new(
+        "lower",
+        [predicate_builder.build_bind_attribute(attribute.name, value, self)]
+      )
+    end
+    ```
+
+    *Kir Shatrov*, *Jean-Samuel Aubry-Guzzi*
+
 *   Fix `pluck` ignoring records assigned to a new record's association.
 
     ```ruby

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -107,7 +107,7 @@ module ActiveRecord
       end
 
       attr = table[name]
-      bind = predicate_builder.build_bind_attribute(attr.name, value)
+      bind = predicate_builder.build_bind_attribute(attr.name, value, model.type_for_attribute(attr.name))
       yield attr, bind
     end
 
@@ -1412,14 +1412,14 @@ module ActiveRecord
             end
           else
             type = model.type_for_attribute(attr.name)
-            value = predicate_builder.build_bind_attribute(attr.name, type.cast(value))
+            value = predicate_builder.build_bind_attribute(attr.name, type.cast(value), type)
           end
           [attr, value]
         end
       end
 
       def _increment_attribute(attribute, value = 1)
-        bind = predicate_builder.build_bind_attribute(attribute.name, value.abs)
+        bind = predicate_builder.build_bind_attribute(attribute.name, value.abs, model.type_for_attribute(attribute.name))
         expr = table.coalesce(attribute, 0)
         expr = value < 0 ? expr - bind : expr + bind
         expr.expr

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -56,16 +56,65 @@ module ActiveRecord
 
     def build(attribute, value, operator = nil)
       value = value.id if value.respond_to?(:id)
-      if operator ||= table.type(attribute.name).force_equality?(value) && :eq
-        bind = build_bind_attribute(attribute.name, value)
-        attribute.public_send(operator, bind)
+      type = table.type(attribute.name)
+
+      if operator ||= type.force_equality?(value) && :eq
+        if type.transforms_query_predicates?
+          build_predicate(attribute, value, operator, type, true)
+        else
+          bind = build_bind_attribute(attribute.name, value, type)
+          attribute.public_send(operator, bind)
+        end
       else
         handler_for(value).call(attribute, value)
       end
     end
 
-    def build_bind_attribute(column_name, value)
-      Relation::QueryAttribute.new(column_name, value, table.type(column_name))
+    def build_predicate(attribute, value, operator = :eq, type = table.type(attribute.name), transformable = type.transforms_query_predicates?)
+      if transformable
+        right = query_value(attribute, value, type)
+        left = right.nil? ? attribute : type.query_attribute(attribute)
+      else
+        right = build_bind_attribute(attribute.name, value, type)
+        left = attribute
+      end
+
+      left.public_send(operator, right)
+    end
+
+    def build_array_predicate(attribute, values)
+      type = table.type(attribute.name)
+
+      if type.transforms_query_predicates?
+        type.query_attribute(attribute).in(
+          values.map { |value| query_value(attribute, value, type) }
+        )
+      else
+        Arel::Nodes::HomogeneousIn.new(values, attribute, :in)
+      end
+    end
+
+    def build_range_predicate(attribute, range)
+      type = table.type(attribute.name)
+
+      type.query_attribute(attribute).between(
+        RangeHandler::RangeWithBinds.new(
+          query_value(attribute, range.begin, type),
+          query_value(attribute, range.end, type),
+          range.exclude_end?
+        )
+      )
+    end
+
+    def build_bind_attribute(column_name, value, type = table.type(column_name))
+      Relation::QueryAttribute.new(column_name, value, type)
+    end
+
+    def query_value(attribute, value, type = table.type(attribute.name))
+      bind = build_bind_attribute(attribute.name, value, type)
+      return bind if bind.nil? || bind.infinite? || bind.unboundable?
+
+      type.query_value(attribute, value, predicate_builder: self)
     end
 
     def resolve_arel_attribute(table_name, column_name, &block)

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -40,7 +40,7 @@ module ActiveRecord
     # for any value that <tt>===</tt> the class given. For example:
     #
     #     MyCustomDateRange = Struct.new(:start, :end)
-    #     handler = proc do |column, range|
+    #     handler = proc do |column, range, type|
     #       Arel::Nodes::Between.new(column,
     #         Arel::Nodes::And.new([range.start, range.end])
     #       )
@@ -55,37 +55,31 @@ module ActiveRecord
     end
 
     def build(attribute, value, operator = nil)
-      value = value.id if value.respond_to?(:id)
       type = table.type(attribute.name)
+
+      predicate_for(attribute, value, operator, type)
+    end
+
+    def predicate_for(attribute, value, operator, type)
+      value = value.id if value.respond_to?(:id)
 
       if operator ||= type.force_equality?(value) && :eq
         if type.transforms_query_predicates?
-          build_predicate(attribute, value, operator, type, true)
+          right = query_value(attribute, value, type)
+          left = right.nil? ? attribute : type.query_attribute(attribute)
         else
-          bind = build_bind_attribute(attribute.name, value, type)
-          attribute.public_send(operator, bind)
+          right = build_bind_attribute(attribute.name, value, type)
+          left = attribute
         end
+
+        left.public_send(operator, right)
       else
-        handler_for(value).call(attribute, value)
+        handler_for(value).call(attribute, value, type)
       end
     end
 
-    def build_predicate(attribute, value, operator = :eq, type = table.type(attribute.name), transformable = type.transforms_query_predicates?)
+    def array_predicate_for(attribute, values, type, transformable)
       if transformable
-        right = query_value(attribute, value, type)
-        left = right.nil? ? attribute : type.query_attribute(attribute)
-      else
-        right = build_bind_attribute(attribute.name, value, type)
-        left = attribute
-      end
-
-      left.public_send(operator, right)
-    end
-
-    def build_array_predicate(attribute, values)
-      type = table.type(attribute.name)
-
-      if type.transforms_query_predicates?
         type.query_attribute(attribute).in(
           values.map { |value| query_value(attribute, value, type) }
         )
@@ -94,9 +88,7 @@ module ActiveRecord
       end
     end
 
-    def build_range_predicate(attribute, range)
-      type = table.type(attribute.name)
-
+    def range_predicate_for(attribute, range, type)
       type.query_attribute(attribute).between(
         RangeHandler::RangeWithBinds.new(
           query_value(attribute, range.begin, type),
@@ -106,15 +98,8 @@ module ActiveRecord
       )
     end
 
-    def build_bind_attribute(column_name, value, type = table.type(column_name))
+    def build_bind_attribute(column_name, value, type)
       Relation::QueryAttribute.new(column_name, value, type)
-    end
-
-    def query_value(attribute, value, type = table.type(attribute.name))
-      bind = build_bind_attribute(attribute.name, value, type)
-      return bind if bind.nil? || bind.infinite? || bind.unboundable?
-
-      type.query_value(attribute, value, predicate_builder: self)
     end
 
     def resolve_arel_attribute(table_name, column_name, &block)
@@ -235,6 +220,13 @@ module ActiveRecord
 
       def handler_for(object)
         @handlers.detect { |klass, _| klass === object }.last
+      end
+
+      def query_value(attribute, value, type)
+        bind = build_bind_attribute(attribute.name, value, type)
+        return bind if bind.nil? || bind.infinite? || bind.unboundable?
+
+        type.query_value(attribute, value, predicate_builder: self)
       end
   end
 end

--- a/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
@@ -9,9 +9,10 @@ module ActiveRecord
         @predicate_builder = predicate_builder
       end
 
-      def call(attribute, value)
+      def call(attribute, value, type)
         return attribute.in([]) if value.empty?
 
+        transformable = type.transforms_query_predicates?
         values = value.map { |x| x.is_a?(Base) ? x.id : x }
         nils = values.compact!
         ranges = values.extract! { |v| v.is_a?(Range) }
@@ -19,8 +20,8 @@ module ActiveRecord
         values_predicate =
           case values.length
           when 0 then NullPredicate
-          when 1 then predicate_builder.build(attribute, values.first)
-          else predicate_builder.build_array_predicate(attribute, values)
+          when 1 then predicate_builder.predicate_for(attribute, values.first, nil, type)
+          else predicate_builder.array_predicate_for(attribute, values, type, transformable)
           end
 
         if nils
@@ -30,7 +31,7 @@ module ActiveRecord
         if ranges.empty?
           values_predicate
         else
-          array_predicates = ranges.map! { |range| predicate_builder.build(attribute, range) }
+          array_predicates = ranges.map! { |range| predicate_builder.predicate_for(attribute, range, nil, type) }
           values_predicate.or(
             Arel::Nodes::Grouping.new Arel::Nodes::Or.new(array_predicates)
           )

--- a/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
@@ -20,7 +20,7 @@ module ActiveRecord
           case values.length
           when 0 then NullPredicate
           when 1 then predicate_builder.build(attribute, values.first)
-          else Arel::Nodes::HomogeneousIn.new(values, attribute, :in)
+          else predicate_builder.build_array_predicate(attribute, values)
           end
 
         if nils

--- a/activerecord/lib/active_record/relation/predicate_builder/basic_object_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/basic_object_handler.rb
@@ -8,8 +8,7 @@ module ActiveRecord
       end
 
       def call(attribute, value)
-        bind = predicate_builder.build_bind_attribute(attribute.name, value)
-        attribute.eq(bind)
+        predicate_builder.build_predicate(attribute, value)
       end
 
       private

--- a/activerecord/lib/active_record/relation/predicate_builder/basic_object_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/basic_object_handler.rb
@@ -7,8 +7,8 @@ module ActiveRecord
         @predicate_builder = predicate_builder
       end
 
-      def call(attribute, value)
-        predicate_builder.build_predicate(attribute, value)
+      def call(attribute, value, type)
+        predicate_builder.predicate_for(attribute, value, :eq, type)
       end
 
       private

--- a/activerecord/lib/active_record/relation/predicate_builder/range_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/range_handler.rb
@@ -9,8 +9,8 @@ module ActiveRecord
         @predicate_builder = predicate_builder
       end
 
-      def call(attribute, value)
-        predicate_builder.build_range_predicate(attribute, value)
+      def call(attribute, value, type)
+        predicate_builder.range_predicate_for(attribute, value, type)
       end
 
       private

--- a/activerecord/lib/active_record/relation/predicate_builder/range_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/range_handler.rb
@@ -10,9 +10,7 @@ module ActiveRecord
       end
 
       def call(attribute, value)
-        begin_bind = predicate_builder.build_bind_attribute(attribute.name, value.begin)
-        end_bind = predicate_builder.build_bind_attribute(attribute.name, value.end)
-        attribute.between(RangeWithBinds.new(begin_bind, end_bind, value.exclude_end?))
+        predicate_builder.build_range_predicate(attribute, value)
       end
 
       private

--- a/activerecord/lib/active_record/relation/predicate_builder/relation_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/relation_handler.rb
@@ -3,7 +3,7 @@
 module ActiveRecord
   class PredicateBuilder
     class RelationHandler # :nodoc:
-      def call(attribute, value)
+      def call(attribute, value, _type)
         if value.eager_loading?
           value = value.send(:apply_join_dependency)
         end

--- a/activerecord/test/cases/relation/predicate_builder_test.rb
+++ b/activerecord/test/cases/relation/predicate_builder_test.rb
@@ -5,6 +5,41 @@ require "models/reply"
 
 module ActiveRecord
   class PredicateBuilderTest < ActiveRecord::TestCase
+    class UnaccentedString < ActiveRecord::Type::String
+      def transforms_query_predicates?
+        true
+      end
+
+      def query_attribute(attribute)
+        normalize(attribute)
+      end
+
+      def query_value(attribute, value, predicate_builder:)
+        normalize(predicate_builder.build_bind_attribute(attribute.name, value))
+      end
+
+      private
+        def normalize(node)
+          Arel::Nodes::NamedFunction.new(
+            "lower",
+            [Arel::Nodes::NamedFunction.new("custom_immutable_unaccent", [node])]
+          )
+        end
+    end
+
+    class UuidToBinString < ActiveRecord::Type::String
+      UUID_STRING = ActiveRecord::Type::String.new
+
+      def transforms_query_predicates?
+        true
+      end
+
+      def query_value(attribute, value, predicate_builder:)
+        bind = Relation::QueryAttribute.new(attribute.name, value, UUID_STRING)
+        Arel::Nodes::NamedFunction.new("UUID_TO_BIN", [bind])
+      end
+    end
+
     def setup
       Topic.predicate_builder.register_handler(Regexp, proc do |column, value|
         Arel::Nodes::InfixOperation.new("~", column, Arel::Nodes.build_quoted(value.source))
@@ -42,5 +77,71 @@ module ActiveRecord
       Topic.where(defaults).to_sql
       assert_equal({ topics: { title: "rails" }, "topics.approved" => true }, defaults)
     end
+
+    def test_attribute_type_can_transform_query_attribute_and_value
+      topic = topic_model_with_title_type(UnaccentedString.new)
+      sql = topic.where(title: "CAFE").to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "WHERE #{normalized_title} = #{normalized_value("CAFE")}"
+
+      assert_equal expected_sql, sql
+    end
+
+    def test_attribute_type_can_transform_array_query_values
+      topic = topic_model_with_title_type(UnaccentedString.new)
+      sql = topic.where(title: ["CAFE", "BAR"]).to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "WHERE #{normalized_title} IN (#{normalized_value("CAFE")}, #{normalized_value("BAR")})"
+
+      assert_equal expected_sql, sql
+    end
+
+    def test_attribute_type_can_transform_range_query_values
+      topic = topic_model_with_title_type(UnaccentedString.new)
+      sql = topic.where(title: "A".."Z").to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "WHERE #{normalized_title} BETWEEN #{normalized_value("A")} AND #{normalized_value("Z")}"
+
+      assert_equal expected_sql, sql
+    end
+
+    def test_attribute_type_can_transform_only_query_value
+      topic = topic_model_with_title_type(UuidToBinString.new)
+      uuid = "6ccd780c-baba-1026-9564-5b8c656024db"
+      sql = topic.where(title: uuid).to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "WHERE #{quote_table_name("topics.title")} = UUID_TO_BIN('#{uuid}')"
+
+      assert_equal expected_sql, sql
+    end
+
+    def test_attribute_type_query_transform_keeps_nil_predicates_unwrapped
+      topic = topic_model_with_title_type(UnaccentedString.new)
+      sql = topic.where(title: nil).to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "WHERE #{quote_table_name("topics.title")} IS NULL"
+
+      assert_equal expected_sql, sql
+    end
+
+    private
+      def quoted_topics
+        quote_table_name("topics")
+      end
+
+      def normalized_title
+        "lower(custom_immutable_unaccent(#{quote_table_name("topics.title")}))"
+      end
+
+      def normalized_value(value)
+        "lower(custom_immutable_unaccent(#{ActiveRecord::Base.lease_connection.quote(value)}))"
+      end
+
+      def topic_model_with_title_type(type)
+        Class.new(Topic) do
+          self.table_name = "topics"
+          attribute :title, type
+        end
+      end
   end
 end

--- a/activerecord/test/cases/relation/predicate_builder_test.rb
+++ b/activerecord/test/cases/relation/predicate_builder_test.rb
@@ -15,7 +15,7 @@ module ActiveRecord
       end
 
       def query_value(attribute, value, predicate_builder:)
-        normalize(predicate_builder.build_bind_attribute(attribute.name, value))
+        normalize(predicate_builder.build_bind_attribute(attribute.name, value, self))
       end
 
       private
@@ -41,7 +41,7 @@ module ActiveRecord
     end
 
     def setup
-      Topic.predicate_builder.register_handler(Regexp, proc do |column, value|
+      Topic.predicate_builder.register_handler(Regexp, proc do |column, value, _type|
         Arel::Nodes::InfixOperation.new("~", column, Arel::Nodes.build_quoted(value.source))
       end)
     end
@@ -138,7 +138,7 @@ module ActiveRecord
       end
 
       def topic_model_with_title_type(type)
-        Class.new(Topic) do
+        Class.new(ActiveRecord::Base) do
           self.table_name = "topics"
           attribute :title, type
         end


### PR DESCRIPTION
### Motivation / Background

I'm taking over the work started in https://github.com/rails/rails/pull/57395 by @kirs.

This PR contains the original code with changes to address @rafaelfranca comments.

### Detail

This adds internal predicate-builder hooks that let Active Record attribute types customize how attributes and query values are represented in hash `where` predicates.

Types can define:

- `query_attribute(attribute)` to transform the left-hand side of predicates
- `query_value(attribute, value, predicate_builder:)` to transform bound values while preserving prepared binds

The predicate builder uses these hooks for equality predicates, array predicates, and ranges.

#### Why this is needed

Some database-backed types need a different SQL representation for reads than for writes.

For example, a MySQL UUID type stored in `binary(16)` should let callers pass readable UUID strings while rendering predicates as:

```sql
id = UUID_TO_BIN(?)
```

Another case is a text column that stores the original user-provided value, but should compare using a normalized expression:

```sql
lower(custom_immutable_unaccent(name)) = lower(custom_immutable_unaccent(?))
```

These transformations cannot live in `cast` or `serialize`, because they are only needed when building predicates.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
