### PR TITLE
Fix SQLite schema dump for multiline virtual tables, generated columns, and collations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix SQLite3 schema dump for multiline virtual table, generated column, and
+    collation definitions.
+
+    SQLite stores multiline DDL with newlines, which the single-line schema
+    regexes failed to match. Dumping a virtual table raised `NoMethodError`, and
+    multiline generated columns and collations were silently dropped.
+
+    *Tim Burgan*
+
 *   Only use multi statement for `SET TRANSACTION ISOLATION LEVEL; BEGIN` if
     MySQL connection is configured to use multi statement.
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -354,8 +354,8 @@ module ActiveRecord
         SQL
 
         query_rows(query).each_with_object({}) do |(table_name, sql), memo|
-          _, module_name, arguments = sql.match(VIRTUAL_TABLE_REGEX).to_a
-          memo[table_name] = [module_name, arguments]
+          _, module_name, arguments = sql.squish.match(VIRTUAL_TABLE_REGEX).to_a
+          memo[table_name] = [module_name, arguments&.strip]
         end.to_a
       end
 
@@ -792,11 +792,12 @@ module ActiveRecord
 
           if column_strings.any?
             column_strings.each do |column_string|
+              column_string = column_string.squish
               # This regex will match the column name and collation type and will save
               # the value in $1 and $2 respectively.
               collation_hash[$1] = $2 if COLLATE_REGEX =~ column_string
               auto_increments[$1] = true if PRIMARY_KEY_AUTOINCREMENT_REGEX =~ column_string
-              generated_columns[$1] = $2 if GENERATED_ALWAYS_AS_REGEX =~ column_string
+              generated_columns[$1] = $2.strip if GENERATED_ALWAYS_AS_REGEX =~ column_string
             end
 
             basic_structure.map do |column|
@@ -853,7 +854,7 @@ module ActiveRecord
                 .sub(FINAL_CLOSE_PARENS_REGEX, "")
                 # column definitions can have a comma in them, so split on commas followed
                 # by a space and a column name in quotes or followed by the keyword CONSTRAINT
-                .split(/,(?=\s(?:CONSTRAINT|"(?:#{Regexp.union(column_names).source})"))/i)
+                .split(/,(?=\s+(?:CONSTRAINT|"(?:#{Regexp.union(column_names).source})"))/i)
                 .map(&:strip)
         end
 

--- a/activerecord/test/cases/adapters/sqlite3/collation_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/collation_test.rb
@@ -61,4 +61,21 @@ class SQLite3CollationTest < ActiveRecord::SQLite3TestCase
     assert_match %r{t\.string\s+"string_nocase",\s+collation: "NOCASE"$}, output
     assert_match %r{t\.text\s+"text_rtrim",\s+collation: "RTRIM"$}, output
   end
+
+  test "collation survives multiline DDL" do
+    @connection.execute(<<~SQL)
+      CREATE TABLE multiline_collation (
+        "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+        "a" varchar COLLATE "NOCASE",
+        "b" varchar COLLATE "RTRIM"
+      )
+    SQL
+
+    columns = @connection.columns(:multiline_collation).index_by(&:name)
+
+    assert_equal "NOCASE", columns["a"].collation
+    assert_equal "RTRIM",  columns["b"].collation
+  ensure
+    @connection.drop_table :multiline_collation, if_exists: true
+  end
 end

--- a/activerecord/test/cases/adapters/sqlite3/virtual_column_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/virtual_column_test.rb
@@ -134,5 +134,45 @@ if ActiveRecord::Base.lease_connection.supports_virtual_columns?
     ensure
       @connection.drop_table :regular_columns, if_exists: true
     end
+
+    def test_generated_column_expression_survives_multiline_ddl
+      @connection.execute(<<~SQL)
+        CREATE TABLE multiline_generated (
+          "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+          "price" integer,
+          "qty" integer,
+          "total" integer GENERATED ALWAYS AS (
+            "price" * "qty"
+          ) STORED
+        )
+      SQL
+
+      column = @connection.columns("multiline_generated").find { |c| c.name == "total" }
+
+      assert_predicate column, :virtual?
+      assert_equal %{"price" * "qty"}, column.default_function
+    ensure
+      @connection.drop_table :multiline_generated, if_exists: true
+    end
+
+    def test_schema_dump_with_multiline_generated_column
+      @connection.execute(<<~SQL)
+        CREATE TABLE multiline_gadgets (
+          "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+          "price" integer,
+          "qty" integer,
+          "total" integer GENERATED ALWAYS AS (
+            "price" * "qty"
+          ) STORED
+        )
+      SQL
+
+      output = dump_table_schema("multiline_gadgets")
+
+      assert_no_match(/as: nil/, output)
+      assert_match(/as: ".*price.*qty.*"/, output)
+    ensure
+      @connection.drop_table :multiline_gadgets, if_exists: true
+    end
   end
 end

--- a/activerecord/test/cases/adapters/sqlite3/virtual_table_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/virtual_table_test.rb
@@ -48,4 +48,31 @@ class SQLite3VirtualTableTest < ActiveRecord::SQLite3TestCase
     assert_equal "bar", match[1]
     assert_equal "", match[2]
   end
+
+  def test_schema_dump_with_multiline_virtual_table_definition
+    @connection.drop_table :multiline_search, if_exists: true
+    @connection.execute(<<~SQL)
+      CREATE VIRTUAL TABLE multiline_search USING fts5(
+        title,
+        body,
+        tokenize='porter unicode61'
+      )
+    SQL
+
+    output = dump_all_table_schema
+
+    assert_includes output, 'create_virtual_table "multiline_search", "fts5", ["title", "body", "tokenize=\'porter unicode61\'"]'
+  ensure
+    @connection.drop_table :multiline_search, if_exists: true
+  end
+
+  def test_virtual_table_regex_matches_squished_multiline_definitions
+    regex = ActiveRecord::ConnectionAdapters::SQLite3Adapter::VIRTUAL_TABLE_REGEX
+
+    sql = "CREATE VIRTUAL TABLE foo USING fts5(\n  title,\n  body,\n  tokenize='porter unicode61'\n)"
+    match = sql.squish.match(regex)
+    assert_not_nil match
+    assert_equal "fts5", match[1]
+    assert_equal "title, body, tokenize='porter unicode61'", match[2].strip
+  end
 end


### PR DESCRIPTION
### Motivation / Background

Fixes #58123. Fixes #58131.

SQLite's schema regexes assume single-line DDL, but SQLite stores the `CREATE` statement in `sqlite_master` verbatim, newlines and all. Write the DDL multiline (the natural way with a heredoc in a migration) and the introspection break in two ways that've been reported:

- #58123: `bin/rails db:schema:dump` crashes with `NoMethodError: undefined   method 'split' for nil` on a multiline `CREATE VIRTUAL TABLE` (like an FTS5   table). `VIRTUAL_TABLE_REGEX` doesn't match, so the capture comes back `nil`. 
- #58131: multiline `GENERATED ALWAYS AS (...)` columns and `COLLATE` clauses are  *silently* dropped. `db/schema.rb` reloads with `as: nil` (a permanently-NULL column) and missing collations. No crash, just quiet corruption.

#56969 did fix the empty-parens case on this same regex. This PR fixes the multiline issue.

### Detail

Normalise the stored SQL with `squish` before matching, rather than only adding the `m` flag.

Adding `m` _does_ stop the crash, but the captured args keep their newlines, so the dumper's `arguments.split(", ")` never splits and you get a mess:

```ruby
create_virtual_table "search", "fts5", ["\n  title,\n  body,\n  tokenize='...'\n"]
```

`squish` collapses the whitespace first, so the dump comes out identical to the single-line form:

```ruby
create_virtual_table "search", "fts5", ["title", "body", "tokenize='porter unicode61'"]
```

For generated columns and collations there's a second bug behind #58131: the column split in `table_structure_sql` only allowed a single whitespace char after the comma, so indented DDL never split and the whole table body came back as one chunk. Only the first column's collation/expression could be captured, which is why a second collated column silently lost its `COLLATE`. Changing `\s` to `\s+` fixes the split, and `squish` on each column string then lets the existing regexes match.

### Additional information

One trade-off: `squish` collapses whitespace inside string literals too. In practice that only matters for a literal with repeated spaces inside a generated expression or FTS5 option, which I've not hit in real schemas. Happy to switch to the narrower `m`-flag plus arg-normalisation if you'd rather keep literals byte-for-byte.

I did add a CHANGELOG entry since this changes what actually gets dumped, not just the crash. Happy to drop if the doesn't meet the guidelines but I was a bit unclear.

Tests cover all cases from both issues: multiline virtual table, multiline
generated column, and multiple collated columns. `rubocop` is clean.

### Checklist

- [x] This Pull Request is related to one change (one root cause: single-line regex vs multiline DDL)
- [x] Commit message has a detailed description of what changed and why
- [x] Tests are added
- [x] CHANGELOG updated (behavior change: previously-dropped columns and collations now dump)
