### PR TITLE
Better `rails routes`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add composable metadata selectors and structured output formatters to the route inspector.
+
+    Route metadata can now be selected independently from request-path recognition. JSON and TSV formatters expose separate route fields, including controller, action, endpoint, constraints, source location, and engine provenance.
+
+    *Ben Moskovitz*
+
 *   Fix `ActionController::Live` streams hanging on client disconnect.
 
     `ActionController::Live::Buffer#abort` cleared the streaming queue but never

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,6 +1,6 @@
 *   Add composable metadata selectors and structured output formatters to the route inspector.
 
-    Route metadata can now be selected independently from request-path recognition. JSON and TSV formatters expose separate route fields, including controller, action, endpoint, constraints, source location, and engine provenance.
+    Route metadata can now be selected independently from request-path recognition. JSON and TSV formatters expose separate route fields, including controller, action, endpoint, constraints, source location, and engine provenance. Filtered output omits application and engine sections without matching routes, and Rack application endpoints with default inspection use their class name instead of runtime state.
 
     *Ben Moskovitz*
 

--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -19,6 +19,8 @@ module ActionDispatch
           "#{controller}##{action}"
         when rack_app.is_a?(Proc)
           "Inline handler (Proc/Lambda)"
+        when rack_app.method(:inspect).owner == Kernel
+          rack_app.class.name || "Anonymous Rack application"
         else
           rack_app.inspect
         end
@@ -122,18 +124,25 @@ module ActionDispatch
       def format(formatter, filter = {})
         selectors = normalize_filter(filter)
         all_routes = { nil => @routes }.merge(@engines)
+        sections = all_routes.map do |engine_name, routes|
+          routes = filter_routes(routes, selectors).map { |route| route.to_h.merge(engine: engine_name) }
+          [engine_name, routes]
+        end
 
-        all_routes.each do |engine_name, routes|
-          format_routes(formatter, selectors, filter, engine_name, routes)
+        if selectors.any?
+          sections.select! { |_, routes| routes.any? }
+          sections = [[nil, []]] if sections.empty?
+        end
+
+        sections.each do |engine_name, routes|
+          format_routes(formatter, filter, engine_name, routes)
         end
 
         formatter.result
       end
 
       private
-        def format_routes(formatter, selectors, filter, engine_name, routes)
-          routes = filter_routes(routes, selectors).map { |route| route.to_h.merge(engine: engine_name) }
-
+        def format_routes(formatter, filter, engine_name, routes)
           formatter.section_title "Routes for #{engine_name || "application"}" if @engines.any?
           if routes.any?
             formatter.header routes

--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -4,6 +4,7 @@
 
 require "delegate"
 require "io/console/size"
+require "json"
 
 module ActionDispatch
   module Routing
@@ -92,6 +93,10 @@ module ActionDispatch
         { name: name,
           verb: verb,
           path: path,
+          controller: controller,
+          action: action,
+          endpoint: endpoint,
+          constraints: constraints,
           reqs: reqs,
           source_location: source_location,
           action_source_location: action_source_location,
@@ -127,7 +132,7 @@ module ActionDispatch
 
       private
         def format_routes(formatter, selectors, filter, engine_name, routes)
-          routes = filter_routes(routes, selectors).map(&:to_h)
+          routes = filter_routes(routes, selectors).map { |route| route.to_h.merge(engine: engine_name) }
 
           formatter.section_title "Routes for #{engine_name || "application"}" if @engines.any?
           if routes.any?
@@ -365,6 +370,97 @@ module ActionDispatch
 
           def route_header(index:)
             "--[ Route #{index} ]".ljust(@width, "-")
+          end
+      end
+
+      class Structured < Base # :nodoc:
+        FIELDS = %i(name verb path controller action endpoint constraints source_location engine).freeze
+
+        def initialize
+          super
+          @routes = []
+        end
+
+        def section(routes)
+          @routes.concat(routes.map { |route| structured_route(route) })
+        end
+
+        def no_routes(*)
+        end
+
+        private
+          def structured_route(route)
+            FIELDS.to_h do |field|
+              value = route[field]
+              value = normalize_constraints(value) if field == :constraints
+              value = normalize_source_location(value) if field == :source_location
+              [field, value]
+            end
+          end
+
+          def normalize_constraints(value)
+            case value
+            when Hash
+              value.to_h { |key, constraint| [key.to_s, normalize_constraints(constraint)] }
+            when Array
+              value.map { |constraint| normalize_constraints(constraint) }
+            when Symbol
+              value.to_s
+            when Regexp
+              value.inspect
+            when NilClass, String, Numeric, TrueClass, FalseClass
+              value
+            else
+              stable_constraint_name(value)
+            end
+          end
+
+          def stable_constraint_name(value)
+            inspected = value.inspect
+            return inspected unless inspected.match?(/#<.+:0x[0-9a-f]+/i)
+
+            value.class.name || value.class.superclass&.name || "anonymous"
+          end
+
+          def normalize_source_location(value)
+            return unless value
+
+            file, separator, line = value.rpartition(":")
+            return { file: value, line: nil } if separator.empty? || !/\A\d+\z/.match?(line)
+
+            { file: file, line: line.to_i }
+          end
+      end
+
+      class JSON < Structured
+        def result
+          ::JSON.generate(@routes)
+        end
+      end
+
+      class TSV < Structured
+        def result
+          rows = [FIELDS]
+          rows.concat(@routes.map { |route| FIELDS.map { |field| tsv_value(field, route[field]) } })
+          rows.map { |row| row.map { |value| escape_tsv(value) }.join("\t") }.join("\n") << "\n"
+        end
+
+        private
+          def tsv_value(field, value)
+            if field == :constraints
+              ::JSON.generate(value)
+            elsif field == :source_location
+              [value&.dig(:file), value&.dig(:line)].compact.join(":")
+            else
+              value
+            end
+          end
+
+          def escape_tsv(value)
+            value = value.to_s
+            return value unless /["\t\r\n]/.match?(value)
+
+            "\"#{value.gsub('"', '""')}\""
           end
       end
 

--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -8,10 +8,8 @@ require "io/console/size"
 module ActionDispatch
   module Routing
     class RouteWrapper < SimpleDelegator # :nodoc:
-      def matches_filter?(filter, value)
-        return __getobj__.path.match(value) if filter == :exact_path_match
-
-        value.match?(public_send(filter))
+      def matches_path?(path)
+        __getobj__.path.match(path)
       end
 
       def endpoint
@@ -107,24 +105,29 @@ module ActionDispatch
     # executes `bin/rails routes` or looks at the RoutingError page. People should
     # not use this class.
     class RoutesInspector # :nodoc:
+      FIELD_FILTERS = %i(name path controller action verb).freeze
+      LEGACY_SEARCH_FIELDS = %i(controller action verb name path).freeze
+      SEARCH_FIELDS = %i(name verb path controller action constraints source_location).freeze
+
       def initialize(routes)
         @routes = wrap_routes(routes)
         @engines = load_engines_routes
       end
 
       def format(formatter, filter = {})
+        selectors = normalize_filter(filter)
         all_routes = { nil => @routes }.merge(@engines)
 
         all_routes.each do |engine_name, routes|
-          format_routes(formatter, filter, engine_name, routes)
+          format_routes(formatter, selectors, filter, engine_name, routes)
         end
 
         formatter.result
       end
 
       private
-        def format_routes(formatter, filter, engine_name, routes)
-          routes = filter_routes(routes, normalize_filter(filter)).map(&:to_h)
+        def format_routes(formatter, selectors, filter, engine_name, routes)
+          routes = filter_routes(routes, selectors).map(&:to_h)
 
           formatter.section_title "Routes for #{engine_name || "application"}" if @engines.any?
           if routes.any?
@@ -154,31 +157,86 @@ module ActionDispatch
         end
 
         def normalize_filter(filter)
-          if filter[:controller]
-            { controller: /#{filter[:controller].underscore.sub(/_?controller\z/, "")}/ }
-          elsif filter[:grep]
-            grep_pattern = Regexp.new(filter[:grep])
-            path = URI::RFC2396_PARSER.escape(filter[:grep])
-            normalized_path = ("/" + path).squeeze("/")
+          selectors = []
+          regex = filter[:regex]
+          exact = filter[:exact]
 
-            {
-              controller: grep_pattern,
-              action: grep_pattern,
-              verb: grep_pattern,
-              name: grep_pattern,
-              path: grep_pattern,
-              exact_path_match: normalized_path,
-            }
+          if filter[:search]
+            selectors << search_selector(filter[:search], regex: regex)
+          end
+
+          FIELD_FILTERS.each do |field|
+            next unless filter[field]
+
+            value = if field == :controller && !regex
+              normalize_controller(filter[field])
+            else
+              filter[field]
+            end
+
+            selectors << field_selector(field, value, regex: regex, exact: exact)
+          end
+
+          if filter[:recognize]
+            selectors << recognition_selector(filter[:recognize])
+          end
+
+          if filter[:grep]
+            selectors << legacy_grep_selector(filter[:grep])
+          end
+
+          selectors
+        end
+
+        def search_selector(value, regex: false)
+          matcher = field_matcher(value, regex: regex)
+          -> route { SEARCH_FIELDS.any? { |field| matcher.call(route.public_send(field)) } }
+        end
+
+        def field_selector(field, value, regex: false, exact: false)
+          matcher = field_matcher(value, regex: regex, exact: exact)
+          -> route { matcher.call(route.public_send(field)) }
+        end
+
+        def recognition_selector(value)
+          path = normalize_path(value)
+          -> route { route.matches_path?(path) }
+        end
+
+        def legacy_grep_selector(value)
+          pattern = Regexp.new(value)
+          path = normalize_path(value)
+
+          lambda do |route|
+            LEGACY_SEARCH_FIELDS.any? { |field| pattern.match?(route.public_send(field)) } || route.matches_path?(path)
           end
         end
 
-        def filter_routes(routes, filter)
-          if filter
-            routes.select do |route|
-              filter.any? { |filter_type, value| route.matches_filter?(filter_type, value) }
-            end
+        def field_matcher(value, regex: false, exact: false)
+          if regex
+            pattern = Regexp.new(value)
+            -> field_value { pattern.match?(field_value.to_s) }
+          elsif exact
+            -> field_value { field_value.to_s == value }
           else
-            routes
+            -> field_value { field_value.to_s.include?(value) }
+          end
+        end
+
+        def normalize_controller(controller)
+          controller.underscore.sub(/_?controller\z/, "")
+        end
+
+        def normalize_path(path)
+          path = URI::RFC2396_PARSER.escape(path)
+          ("/" + path).squeeze("/")
+        end
+
+        def filter_routes(routes, selectors)
+          return routes if selectors.empty?
+
+          routes.select do |route|
+            selectors.all? { |selector| selector.call(route) }
           end
         end
     end
@@ -211,6 +269,8 @@ module ActionDispatch
               "No routes were found for this controller."
             elsif filter.key?(:grep)
               "No routes were found for this grep pattern."
+            elsif filter.any?
+              "No routes matched the supplied selectors."
             elsif routes.none?
               if engine
                 "No routes defined."

--- a/actionpack/test/dispatch/routing/inspector_test.rb
+++ b/actionpack/test/dispatch/routing/inspector_test.rb
@@ -33,6 +33,21 @@ end
 module ActionDispatch
   module Routing
     class RoutesInspectorTest < ActiveSupport::TestCase
+      class RouteCollector < ConsoleFormatter::Base
+        def initialize
+          super
+          @routes = []
+        end
+
+        def section(routes)
+          @routes.concat(routes)
+        end
+
+        def result
+          @routes
+        end
+      end
+
       setup do
         @set = ActionDispatch::Routing::RouteSet.new
       end
@@ -335,6 +350,140 @@ module ActionDispatch
                       "          PATCH  /posts/:id(.:format)      posts#update",
                       "          PUT    /posts/:id(.:format)      posts#update",
                       "          DELETE /posts/:id(.:format)      posts#destroy"], output
+      end
+
+      def test_search_matches_literal_route_metadata_without_recognising_paths
+        routes = collect(search: "/photos/:id(.:format)") do
+          resources :photos
+        end
+
+        assert_equal %w[show update update destroy], routes.map { |route| route[:reqs].split("#").last }
+
+        routes = collect(search: "/photos/7") do
+          resources :photos
+        end
+
+        assert_empty routes
+      end
+
+      def test_search_treats_regular_expression_metacharacters_literally
+        routes = collect(search: "[") do
+          get "/photos", to: "photos#index"
+        end
+
+        assert_empty routes
+      end
+
+      def test_search_matches_constraints_and_source_locations
+        ActionDispatch::Routing::Mapper.route_source_locations = true
+
+        routes = collect(search: "A-Z") do
+          get "/photos/:id", to: "photos#show", id: /[A-Z]\d{5}/
+        end
+        assert_equal [{ id: /[A-Z]\d{5}/ }], routes.map { |route| route[:constraints] }
+
+        routes = collect(search: "inspector_test.rb") do
+          get "/photos/:id", to: "photos#show"
+        end
+        assert_equal ["photos#show"], routes.map { |route| route[:reqs] }
+      ensure
+        ActionDispatch::Routing::Mapper.route_source_locations = false
+      end
+
+      def test_field_selectors_are_anded
+        routes = collect(controller: "Admin::AuditsController", verb: "POST", action: "create") do
+          get "/admin/audits", to: "admin/audits#index"
+          post "/admin/audits", to: "admin/audits#create"
+          post "/admin/events", to: "admin/events#create"
+        end
+
+        assert_equal ["admin/audits#create"], routes.map { |route| route[:reqs] }
+      end
+
+      def test_field_selectors_support_regular_expression_and_exact_matching
+        routes = collect(name: "audit_export", exact: true) do
+          get "/audit_exports", to: "audit_exports#index", as: :audit_export
+          get "/audit_exports/preview", to: "audit_exports#preview", as: :audit_export_preview
+        end
+        assert_equal ["audit_export"], routes.map { |route| route[:name] }
+
+        routes = collect(action: "^creat", regex: true) do
+          get "/audits", to: "audits#index"
+          post "/audits", to: "audits#create"
+        end
+        assert_equal ["audits#create"], routes.map { |route| route[:reqs] }
+      end
+
+      def test_controller_selector_canonicalises_literals_and_preserves_raw_regular_expressions
+        routes = collect(controller: "Admin::AuditsController") do
+          get "/admin/audits", to: "admin/audits#index"
+        end
+        assert_equal ["admin/audits#index"], routes.map { |route| route[:reqs] }
+
+        routes = collect(controller: "admin/.*") do
+          get "/admin/audits", to: "admin/audits#index"
+        end
+        assert_empty routes
+
+        routes = collect(controller: "^admin/.*$", regex: true) do
+          get "/admin/audits", to: "admin/audits#index"
+        end
+        assert_equal ["admin/audits#index"], routes.map { |route| route[:reqs] }
+      end
+
+      def test_exact_verb_matches_the_complete_verb_field
+        routes = collect(verb: "PUT", exact: true) do
+          match "/articles/:id", to: "articles#update", via: [:put, :patch]
+        end
+        assert_empty routes
+
+        routes = collect(verb: "PUT|PATCH", exact: true) do
+          match "/articles/:id", to: "articles#update", via: [:put, :patch]
+        end
+        assert_equal ["PUT|PATCH"], routes.map { |route| route[:verb] }
+      end
+
+      def test_recognition_is_independent_and_combines_with_field_selectors
+        routes = collect(recognize: "/photos/7", verb: "GET") do
+          resources :photos
+          get "*path", to: "fallback#show"
+        end
+
+        assert_equal ["photos#show", "fallback#show"], routes.map { |route| route[:reqs] }
+
+        routes = collect(recognize: "/photos/7", verb: "POST") do
+          resources :photos
+          get "*path", to: "fallback#show"
+        end
+
+        assert_empty routes
+      end
+
+      def test_legacy_grep_unions_metadata_search_and_path_recognition
+        routes = collect(grep: "posts") do
+          get "/posts", to: "posts#index"
+          get "/articles/:id", to: "articles#show"
+          get "/events", to: "events#index"
+        end
+        assert_equal ["posts#index"], routes.map { |route| route[:reqs] }
+
+        routes = collect(grep: "/articles/7") do
+          get "/posts", to: "posts#index"
+          get "/articles/:id", to: "articles#show"
+          get "/events", to: "events#index"
+        end
+        assert_equal ["articles#show"], routes.map { |route| route[:reqs] }
+      end
+
+      def test_new_selectors_have_a_generic_no_routes_message
+        output = draw(name: "missing") do
+          get "/photos", to: "photos#index"
+        end
+
+        assert_equal [
+          "No routes matched the supplied selectors.",
+          "For more information about routes, see the Rails guide: https://guides.rubyonrails.org/routing.html."
+        ], output
       end
 
       def test_routes_when_expanded
@@ -686,6 +835,12 @@ module ActionDispatch
       end
 
       private
+        def collect(**options, &block)
+          @set.draw(&block)
+          inspector = ActionDispatch::Routing::RoutesInspector.new(@set.routes)
+          inspector.format(RouteCollector.new, options)
+        end
+
         def draw(formatter: ActionDispatch::Routing::ConsoleFormatter::Sheet.new, **options, &block)
           @set.draw(&block)
           inspector = ActionDispatch::Routing::RoutesInspector.new(@set.routes)

--- a/actionpack/test/dispatch/routing/inspector_test.rb
+++ b/actionpack/test/dispatch/routing/inspector_test.rb
@@ -486,6 +486,97 @@ module ActionDispatch
         ], output
       end
 
+      def test_json_formatter_outputs_structured_route_data
+        ActionDispatch::Routing::Mapper.route_source_locations = true
+
+        output = render(ConsoleFormatter::JSON.new) do
+          get "/photos/:id", to: "photos#show", as: :photo, id: /[A-Z]\d{5}/
+          get "/health", to: proc { [200, {}, ["OK"]] }
+          get "/old", to: redirect("/new")
+        end
+        routes = ::JSON.parse(output)
+
+        assert_equal %w[name verb path controller action endpoint constraints source_location engine], routes.first.keys
+
+        photo = routes.find { |route| route["name"] == "photo" }
+        assert_equal "GET", photo["verb"]
+        assert_equal "/photos/:id(.:format)", photo["path"]
+        assert_equal "photos", photo["controller"]
+        assert_equal "show", photo["action"]
+        assert_equal "photos#show", photo["endpoint"]
+        assert_equal({ "id" => "/[A-Z]\\d{5}/" }, photo["constraints"])
+        assert_match(/inspector_test\.rb/, photo.dig("source_location", "file"))
+        assert_kind_of Integer, photo.dig("source_location", "line")
+        assert_nil photo["engine"]
+
+        health = routes.find { |route| route["name"] == "health" }
+        assert_nil health["controller"]
+        assert_nil health["action"]
+        assert_equal "Inline handler (Proc/Lambda)", health["endpoint"]
+
+        old = routes.find { |route| route["name"] == "old" }
+        assert_equal "redirect(301, /new)", old["endpoint"]
+      ensure
+        ActionDispatch::Routing::Mapper.route_source_locations = false
+      end
+
+      def test_json_formatter_flattens_engine_routes_with_engine_provenance
+        engine = Class.new(Rails::Engine) do
+          def self.inspect
+            "Blog::Engine"
+          end
+        end
+        engine.routes.draw do
+          get "/cart", to: "cart#show"
+        end
+
+        output = render(ConsoleFormatter::JSON.new) do
+          mount engine => "/blog", as: :blog
+        end
+        routes = ::JSON.parse(output)
+
+        mount = routes.find { |route| route["name"] == "blog" }
+        assert_equal "Blog::Engine", mount["endpoint"]
+        assert_nil mount["engine"]
+
+        cart = routes.find { |route| route["name"] == "cart" }
+        assert_equal "cart#show", cart["endpoint"]
+        assert_equal "Blog::Engine", cart["engine"]
+      end
+
+      def test_json_formatter_outputs_an_empty_array_without_human_messages
+        assert_equal "[]", render(ConsoleFormatter::JSON.new) { }
+        output = render(ConsoleFormatter::JSON.new, name: "missing") do
+          get "/photos", to: "photos#index"
+        end
+        assert_equal "[]", output
+      end
+
+      def test_tsv_formatter_uses_the_json_schema_and_encodes_structured_fields
+        ActionDispatch::Routing::Mapper.route_source_locations = true
+
+        output = render(ConsoleFormatter::TSV.new) do
+          get "/photos/:id", to: "photos#show", as: :photo, id: /[A-Z]\d{5}/
+        end
+        rows = output.lines.map { |line| line.chomp.split("\t", -1) }
+        headers = rows.first
+        route = headers.zip(rows.second.map { |value| unescape_tsv(value) }).to_h
+
+        assert_equal ConsoleFormatter::Structured::FIELDS.map(&:to_s), headers
+        assert_equal "photo", route["name"]
+        assert_equal "photos#show", route["endpoint"]
+        assert_equal({ "id" => "/[A-Z]\\d{5}/" }, ::JSON.parse(route["constraints"]))
+        assert_match %r{\A.+inspector_test\.rb:\d+\z}, route["source_location"]
+      ensure
+        ActionDispatch::Routing::Mapper.route_source_locations = false
+      end
+
+      def test_tsv_formatter_outputs_only_the_header_without_routes
+        output = render(ConsoleFormatter::TSV.new) { }
+
+        assert_equal "name\tverb\tpath\tcontroller\taction\tendpoint\tconstraints\tsource_location\tengine\n", output
+      end
+
       def test_routes_when_expanded
         ActionDispatch::Routing::Mapper.route_source_locations = true
         engine = Class.new(Rails::Engine) do
@@ -797,6 +888,11 @@ module ActionDispatch
 
         assert hash.key?(:action_source_line)
         assert_kind_of Integer, hash[:action_source_line]
+
+        assert_equal "inspector_test_app/posts", hash[:controller]
+        assert_equal "index", hash[:action]
+        assert_equal "inspector_test_app/posts#index", hash[:endpoint]
+        assert_equal({}, hash[:constraints])
       end
 
       def test_action_source_file_and_line_returns_tuple
@@ -835,6 +931,20 @@ module ActionDispatch
       end
 
       private
+        def unescape_tsv(value)
+          if value.start_with?('"') && value.end_with?('"')
+            value[1...-1].gsub('""', '"')
+          else
+            value
+          end
+        end
+
+        def render(formatter, **options, &block)
+          @set.draw(&block)
+          inspector = ActionDispatch::Routing::RoutesInspector.new(@set.routes)
+          inspector.format(formatter, options)
+        end
+
         def collect(**options, &block)
           @set.draw(&block)
           inspector = ActionDispatch::Routing::RoutesInspector.new(@set.routes)

--- a/actionpack/test/dispatch/routing/inspector_test.rb
+++ b/actionpack/test/dispatch/routing/inspector_test.rb
@@ -10,6 +10,11 @@ class MountedRackApp
   end
 end
 
+class StatefulRackApp
+  def call(env)
+  end
+end
+
 class Rails::DummyController
 end
 
@@ -267,6 +272,17 @@ module ActionDispatch
         assert_equal [
           "          Prefix Verb URI Pattern Controller#Action",
           "mounted_rack_app      /foo        MountedRackApp"
+        ], output
+      end
+
+      def test_rails_routes_shows_class_name_for_rack_app_with_default_inspect
+        output = draw do
+          mount StatefulRackApp.new => "/cable", as: :cable
+        end
+
+        assert_equal [
+          "Prefix Verb URI Pattern Controller#Action",
+          " cable      /cable      StatefulRackApp"
         ], output
       end
 
@@ -765,10 +781,6 @@ module ActionDispatch
         end
 
         assert_equal [
-          "Routes for application:",
-          "No routes were found for this grep pattern.",
-          "For more information about routes, see the Rails guide: https://guides.rubyonrails.org/routing.html.",
-          "",
           "Routes for Blog::Engine:",
           "Prefix Verb URI Pattern     Controller#Action",
           "  cart GET  /cart(.:format) cart#show"
@@ -794,9 +806,31 @@ module ActionDispatch
           "Routes for application:",
           "No routes were found for this grep pattern.",
           "For more information about routes, see the Rails guide: https://guides.rubyonrails.org/routing.html.",
-          "",
-          "Routes for Blog::Engine:",
-          "No routes were found for this grep pattern.",
+        ], output
+      end
+
+      def test_expanded_routes_omit_engine_sections_without_matches
+        engine = Class.new(Rails::Engine) do
+          def self.inspect
+            "Blog::Engine"
+          end
+        end
+        engine.routes.draw do
+          get "/cart", to: "cart#show"
+        end
+
+        output = draw(name: "custom_assets", formatter: ConsoleFormatter::Expanded.new(width: 23)) do
+          get "/custom/assets", to: "custom_assets#show"
+          mount engine => "/blog", as: :blog
+        end
+
+        assert_equal [
+          "[ Routes for application ]",
+          "--[ Route 1 ]----------",
+          "Prefix            | custom_assets",
+          "Verb              | GET",
+          "URI               | /custom/assets(.:format)",
+          "Controller#Action | custom_assets#show"
         ], output
       end
 

--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -864,9 +864,7 @@ Inspecting an Application
 
 ### `bin/rails routes`
 
-The `bin/rails routes` command lists all defined routes in your application,
-including the URI Pattern and HTTP verb, as well as the Controller Action it
-maps to.
+The `bin/rails routes` command lists all defined routes in your application, including the URI Pattern and HTTP verb, as well as the Controller Action it maps to.
 
 ```bash
 $ bin/rails routes
@@ -877,25 +875,42 @@ $ bin/rails routes
   ...
 ```
 
-This can be useful for tracking down a routing issue, or simply getting an
-overview of the resources and routes that are part of a Rails application. You
-can also narrow down the output of the `routes` command with options like
-`--controller(-c)` or `--grep(-g)`:
+This can be useful for tracking down a routing issue, or simply getting an overview of the resources and routes that are part of a Rails application. Use `--search` (`-s`) to find literal text across the route's name, verb, path, controller, action, constraints, or source location, or use `--name`, `--verb`, `--path`, `--controller`, and `--action` to select a particular field:
 
 ```bash
-# Only show routes where the controller name contains "users"
-$ bin/rails routes --controller users
+# Search names, verbs, paths, controllers, actions, constraints, and source locations
+$ bin/rails routes --search users
 
-# Show routes handled by namespace Admin::UsersController
-$ bin/rails routes -c admin/users
+# Select POST routes handled by Admin::UsersController
+$ bin/rails routes --controller Admin::UsersController --verb POST
 
-# Search by name, path, or controller/action with -g (or --grep)
-$ bin/rails routes -g users
+# Select one complete route name
+$ bin/rails routes --exact --name admin_users
 ```
 
-There is also an option, `bin/rails routes --expanded`, that displays even more
-information about each route, including the line number in your
-`config/routes.rb` where that route is defined:
+Within `--search`, the metadata fields are combined with OR semantics. Different selectors are combined with AND semantics, so each additional selector narrows the result.
+
+Search and field-selector values are literal, case-sensitive substrings by default. `--regex` interprets them as regular expressions. `--exact` instead compares the complete value of each field selector; it doesn't change `--search` or `--recognize`. `--regex` and `--exact` can't be combined.
+
+In literal and exact modes, controller class names are converted to the form stored by the router. For example, `Admin::PostsController` becomes `admin/posts`. In regular-expression mode, the expression is applied directly to that stored form, such as `--regex --controller '^admin/(posts|users)$'`.
+
+Request-path recognition is explicit and can be combined with metadata selectors:
+
+```bash
+$ bin/rails routes --recognize /photos/7
+$ bin/rails routes --recognize /photos/7 --verb GET
+```
+
+The default table can also be rendered as expanded blocks, JSON, or TSV:
+
+```bash
+$ bin/rails routes --format table
+$ bin/rails routes --format expanded
+$ bin/rails routes --format json
+$ bin/rails routes --format tsv
+```
+
+The existing `--expanded` (`-E`) option is an alias for `--format expanded`. Expanded output displays more information about each route, including the line number in your `config/routes.rb` where that route is defined:
 
 ```bash
 $ bin/rails routes --expanded
@@ -919,8 +934,16 @@ Controller#Action | posts#index
 Source Location   | /Users/bhumi/Code/try_markdown/config/routes.rb:4
 ```
 
-TIP: In development mode, you can also access the same routes info by going to
-`http://localhost:3000/rails/info/routes`
+JSON and TSV use separate `name`, `verb`, `path`, `controller`, `action`, `endpoint`, `constraints`, `source_location`, and `engine` fields. This makes their output suitable for tools such as `jq` without parsing the human-readable table.
+
+```bash
+$ bin/rails routes --format json | jq '.[] | select(.controller == "admin/posts")'
+$ bin/rails routes --format tsv --verb POST
+```
+
+The existing `--grep` (`-g`) option remains available with its existing behaviour: it treats its value as a regular expression across its legacy metadata fields and also attempts to recognize it as a request path.
+
+TIP: In development mode, you can also access the same routes info by going to `http://localhost:3000/rails/info/routes`
 
 ### `bin/rails about`
 

--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -901,7 +901,7 @@ $ bin/rails routes --recognize /photos/7
 $ bin/rails routes --recognize /photos/7 --verb GET
 ```
 
-The default table can also be rendered as expanded blocks, JSON, or TSV:
+The default table can also be rendered as expanded blocks, JSON, or TSV with `--format` (`-f`):
 
 ```bash
 $ bin/rails routes --format table

--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -1446,6 +1446,8 @@ Different selectors are combined with AND semantics, while `--search` uses OR se
 $ bin/rails routes --controller Admin::UsersController --verb POST
 ```
 
+When selectors are supplied, table and expanded output omit application and engine sections without matching routes.
+
 Search and field-selector values are literal substrings by default, so characters such as `.`, `*`, and `[` have no special meaning. `--regex` enables regular-expression matching for `--search` and the field selectors:
 
 ```bash
@@ -1473,7 +1475,7 @@ The existing `--grep` (`-g`) option remains available with its existing behaviou
 
 ### Formatting Routes
 
-The default output format is `table`. You can also render routes as expanded blocks, JSON, or TSV:
+The default output format is `table`. You can also render routes as expanded blocks, JSON, or TSV with `--format` (`-f`):
 
 ```bash
 $ bin/rails routes --format table
@@ -1500,7 +1502,7 @@ Each machine-readable route has these fields:
 | `source_location` | object or null | Route declaration file and line |
 | `engine` | string or null | Containing engine name, or null for application routes |
 
-For a controller route, `endpoint` is the familiar `photos#show` destination. It also preserves the destination of routes without a controller, such as `Blog::Engine` for a mounted engine, `Inline handler (Proc/Lambda)` for an inline handler, or `redirect(301, /articles)` for a redirect.
+For a controller route, `endpoint` is the familiar `photos#show` destination. It also preserves the destination of routes without a controller, such as `Blog::Engine` for a mounted engine, `Inline handler (Proc/Lambda)` for an inline handler, or `redirect(301, /articles)` for a redirect. Rack application instances with default inspection use their class name, such as `ActionCable::Server::Base`, rather than including runtime state.
 
 A source location is represented as an object:
 

--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -1424,21 +1424,99 @@ Controller#Action | users#edit
 
 ### Searching Routes
 
-You can search through your routes with the grep option: `-g`. This outputs any routes that partially match the URL helper method name, the HTTP verb, or the URL path.
+Use `--search` (`-s`) to search route metadata. It performs a literal, case-sensitive substring search across the name, verb, declared path, controller, action, constraints, and route source location:
 
 ```bash
-$ bin/rails routes -g new_comment
-$ bin/rails routes -g POST
-$ bin/rails routes -g admin
+$ bin/rails routes --search users
 ```
 
-If you only want to see the routes that map to a specific controller, there's the controller option: `-c`.
+Use a field selector when you know which part of the route you want to match:
 
 ```bash
-$ bin/rails routes -c users
-$ bin/rails routes -c admin/users
-$ bin/rails routes -c Comments
-$ bin/rails routes -c Articles::CommentsController
+$ bin/rails routes --name admin_users
+$ bin/rails routes --verb POST
+$ bin/rails routes --path /admin/users
+$ bin/rails routes --controller Admin::UsersController
+$ bin/rails routes --action create
+```
+
+Different selectors are combined with AND semantics, while `--search` uses OR semantics across its metadata fields. For example, this finds only POST routes handled by `Admin::UsersController`:
+
+```bash
+$ bin/rails routes --controller Admin::UsersController --verb POST
+```
+
+Search and field-selector values are literal substrings by default, so characters such as `.`, `*`, and `[` have no special meaning. `--regex` enables regular-expression matching for `--search` and the field selectors:
+
+```bash
+$ bin/rails routes --regex --controller '^admin/(users|accounts)$'
+```
+
+`--exact` makes field selectors compare the complete stored value. It doesn't affect `--search` or `--recognize`:
+
+```bash
+$ bin/rails routes --exact --name admin_users
+```
+
+`--regex` and `--exact` can't be combined.
+
+In literal and exact modes, controller class names are canonicalised before matching. For example, `CartController` becomes `cart`, and `Admin::PostsController` becomes `admin/posts`. Regular-expression controller values aren't canonicalised; they match the routing-form controller directly.
+
+Use `--recognize` (`-r`) to test which declared routes recognize a request path. Unlike `--search`, recognition matches dynamic segments:
+
+```bash
+$ bin/rails routes --recognize /photos/7
+$ bin/rails routes --recognize /photos/7 --verb GET
+```
+
+The existing `--grep` (`-g`) option remains available with its existing behaviour. It treats its value as a regular expression across the route's controller, action, verb, name, and path, and also attempts to recognize the value as a request path.
+
+### Formatting Routes
+
+The default output format is `table`. You can also render routes as expanded blocks, JSON, or TSV:
+
+```bash
+$ bin/rails routes --format table
+$ bin/rails routes --format expanded
+$ bin/rails routes --format json
+$ bin/rails routes --format tsv
+```
+
+`--expanded` and `-E` are aliases for `--format expanded`.
+
+JSON and TSV contain the same selected application and engine routes in inspector order, without section headings or a human-readable no-match message. JSON produces a compact array, or `[]` when there are no matches. TSV produces a header followed by one route per row, or only the header when there are no matches.
+
+Each machine-readable route has these fields:
+
+| Field | JSON type | Meaning |
+| --- | --- | --- |
+| `name` | string | Route name, or an empty string for an unnamed route |
+| `verb` | string | Complete displayed verb field, or an empty string for all verbs |
+| `path` | string | Declared URI pattern |
+| `controller` | string or null | Routing-form controller for controller routes |
+| `action` | string or null | Action for controller routes |
+| `endpoint` | string | Destination handler shown by the inspector |
+| `constraints` | object | JSON-safe route constraints |
+| `source_location` | object or null | Route declaration file and line |
+| `engine` | string or null | Containing engine name, or null for application routes |
+
+For a controller route, `endpoint` is the familiar `photos#show` destination. It also preserves the destination of routes without a controller, such as `Blog::Engine` for a mounted engine, `Inline handler (Proc/Lambda)` for an inline handler, or `redirect(301, /articles)` for a redirect.
+
+A source location is represented as an object:
+
+```json
+{
+  "file": "/app/config/routes.rb",
+  "line": 42
+}
+```
+
+Constraints are converted recursively to deterministic JSON values. Symbols become strings, regular expressions use their inspected form, hash keys become strings, and custom constraint objects use a stable class or type name. In TSV, the `constraints` cell contains compact JSON, while `source_location` uses `path/to/file.rb:line` format. Tabs, quotes, and newlines in cells are quoted.
+
+For example, JSON output can be passed directly to `jq`:
+
+```bash
+$ bin/rails routes --format json | jq '.[] | select(.controller == "admin/users")'
 ```
 
 TIP: The output from `bin/rails routes` is easier to read if you widen your terminal window until the output lines don't wrap or use the `--expanded` option.
@@ -1461,6 +1539,8 @@ edit_person GET    /people/:id/edit(.:format) people#edit
             PUT    /people/:id(.:format)      people#update
             DELETE /people/:id(.:format)      people#destroy
 ```
+
+Unused-route reporting continues to support `--controller` and `--grep`. It can't be combined with the other selectors or with `--format` and `--expanded`.
 
 ### Routes in Rails Console
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,6 +1,6 @@
 *   Add composable selectors and output formats to `bin/rails routes`.
 
-    Use `--search` for literal metadata search, `--recognize` for request-path recognition, or `--name`, `--path`, `--controller`, `--action`, and `--verb` to select individual fields. Selectors compose with AND semantics and support explicit `--regex` and `--exact` matching. `--format` now supports table, expanded, JSON, and TSV output.
+    Use `--search` for literal metadata search, `--recognize` for request-path recognition, or `--name`, `--path`, `--controller`, `--action`, and `--verb` to select individual fields. Selectors compose with AND semantics and support explicit `--regex` and `--exact` matching. `--format` (`-f`) now supports table, expanded, JSON, and TSV output.
 
     Existing `--grep`, `--controller`, and `--expanded` commands remain supported.
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add composable selectors and output formats to `bin/rails routes`.
+
+    Use `--search` for literal metadata search, `--recognize` for request-path recognition, or `--name`, `--path`, `--controller`, `--action`, and `--verb` to select individual fields. Selectors compose with AND semantics and support explicit `--regex` and `--exact` matching. `--format` now supports table, expanded, JSON, and TSV output.
+
+    Existing `--grep`, `--controller`, and `--expanded` commands remain supported.
+
+    *Ben Moskovitz*
+
 *   Validate subcommand in `rails plugin` command.
 
     `rails plugin foo bar` silently ignored the invalid subcommand "foo"

--- a/railties/lib/rails/commands/routes/routes_command.rb
+++ b/railties/lib/rails/commands/routes/routes_command.rb
@@ -15,7 +15,7 @@ module Rails
       class_option :verb, desc: "Filter routes by HTTP verb."
       class_option :regex, type: :boolean, desc: "Interpret search and filter values as regular expressions."
       class_option :exact, type: :boolean, desc: "Match complete field values."
-      class_option :format, enum: %w(table expanded json tsv), desc: "Choose the output format."
+      class_option :format, aliases: "-f", enum: %w(table expanded json tsv), desc: "Choose the output format."
       class_option :expanded, type: :boolean, aliases: "-E", desc: "Print routes expanded vertically with parts explained."
       class_option :unused, type: :boolean, aliases: "-u", desc: "Print unused routes."
 

--- a/railties/lib/rails/commands/routes/routes_command.rb
+++ b/railties/lib/rails/commands/routes/routes_command.rb
@@ -7,12 +7,30 @@ module Rails
     class RoutesCommand < Base # :nodoc:
       class_option :controller, aliases: "-c", desc: "Filter by a specific controller, e.g. PostsController or Admin::PostsController."
       class_option :grep, aliases: "-g", desc: "Grep routes by a specific pattern."
+      class_option :search, aliases: "-s", desc: "Search route metadata for literal text."
+      class_option :recognize, aliases: "-r", desc: "Find routes that recognize a request path."
+      class_option :name, desc: "Filter routes by name."
+      class_option :path, desc: "Filter routes by path."
+      class_option :action, desc: "Filter routes by action."
+      class_option :verb, desc: "Filter routes by HTTP verb."
+      class_option :regex, type: :boolean, desc: "Interpret search and filter values as regular expressions."
+      class_option :exact, type: :boolean, desc: "Match complete field values."
+      class_option :format, enum: %w(table expanded json tsv), desc: "Choose the output format."
       class_option :expanded, type: :boolean, aliases: "-E", desc: "Print routes expanded vertically with parts explained."
       class_option :unused, type: :boolean, aliases: "-u", desc: "Print unused routes."
+
+      class_exclusive :regex, :exact
+      class_exclusive :format, :expanded
 
       no_commands do
         def invoke_command(*)
           if options.key?("unused")
+            incompatible_options = options.keys & %w(search recognize name path action verb regex exact format expanded)
+            if incompatible_options.any?
+              switches = incompatible_options.map { |option| "--#{option.dasherize}" }.join(", ")
+              raise Error, "The --unused option cannot be combined with #{switches}."
+            end
+
             Rails::Command.invoke "unused_routes", ARGV
           else
             super
@@ -26,6 +44,8 @@ module Rails
         require "action_dispatch/routing/inspector"
 
         say inspector.format(formatter, routes_filter)
+      rescue RegexpError => error
+        raise Error, error.message
       end
 
       private
@@ -34,15 +54,25 @@ module Rails
         end
 
         def formatter
-          if options.key?("expanded")
+          format = options[:format]
+          format = "expanded" if options.key?("expanded")
+
+          case format
+          when "expanded"
             ActionDispatch::Routing::ConsoleFormatter::Expanded.new
-          else
+          when "json"
+            ActionDispatch::Routing::ConsoleFormatter::JSON.new
+          when "tsv"
+            ActionDispatch::Routing::ConsoleFormatter::TSV.new
+          when "table", nil
             ActionDispatch::Routing::ConsoleFormatter::Sheet.new
           end
         end
 
         def routes_filter
-          options.symbolize_keys.slice(:controller, :grep)
+          filter = options.symbolize_keys.slice(:controller, :grep, :search, :recognize, :name, :path, :action, :verb, :regex, :exact)
+          filter.delete(:grep) if filter.key?(:controller)
+          filter
         end
     end
   end

--- a/railties/lib/rails/commands/unused_routes/unused_routes_command.rb
+++ b/railties/lib/rails/commands/unused_routes/unused_routes_command.rb
@@ -68,7 +68,9 @@ module Rails
         end
 
         def routes_filter
-          options.symbolize_keys.slice(:controller, :grep)
+          filter = options.symbolize_keys.slice(:controller, :grep)
+          filter.delete(:grep) if filter.key?(:controller)
+          filter
         end
     end
   end

--- a/railties/test/commands/routes_test.rb
+++ b/railties/test/commands/routes_test.rb
@@ -492,7 +492,7 @@ rails_conductor_inbound_email_incinerate POST /rails/conductor/action_mailbox/:i
       end
     RUBY
 
-    routes = JSON.parse(run_routes_command([ "--format", "json", "--exact", "--name", "photo" ]))
+    routes = JSON.parse(run_routes_command([ "-f", "json", "--exact", "--name", "photo" ]))
     assert_equal 1, routes.size
     assert_equal "photos#show", routes.first["endpoint"]
     assert_equal({ "id" => "/[A-Z]\\d{5}/" }, routes.first["constraints"])

--- a/railties/test/commands/routes_test.rb
+++ b/railties/test/commands/routes_test.rb
@@ -3,6 +3,7 @@
 require "isolation/abstract_unit"
 require "rails/command"
 require "io/console/size"
+require "json"
 
 class Rails::Command::RoutesTest < ActiveSupport::TestCase
   setup :build_app
@@ -419,6 +420,132 @@ rails_conductor_inbound_email_incinerate POST /rails/conductor/action_mailbox/:i
     MESSAGE
   end
 
+  test "rails routes separates metadata search from request recognition" do
+    app_file "config/routes.rb", <<-RUBY
+      Rails.application.routes.draw do
+        resources :photos
+        get "*path", to: "fallback#show"
+      end
+    RUBY
+
+    output = run_routes_command([ "-s", "/photos/7" ])
+    assert_includes output, "No routes matched the supplied selectors."
+    assert_not_includes output, "photos#show"
+    assert_not_includes output, "fallback#show"
+
+    output = run_routes_command([ "--recognize", "/photos/7" ])
+    assert_includes output, "photos#show"
+    assert_includes output, "fallback#show"
+  end
+
+  test "rails routes combines field selectors" do
+    app_file "config/routes.rb", <<-RUBY
+      Rails.application.routes.draw do
+        get "/admin/audits", to: "admin/audits#index"
+        post "/admin/audits", to: "admin/audits#create"
+        post "/admin/events", to: "admin/events#create"
+      end
+    RUBY
+
+    output = run_routes_command([ "--controller", "Admin::AuditsController", "--verb", "POST" ])
+    assert_includes output, "admin/audits#create"
+    assert_not_includes output, "admin/audits#index"
+    assert_not_includes output, "admin/events#create"
+
+    output = run_routes_command([ "--exact", "--name", "admin_audits" ])
+    assert_includes output, "admin/audits#index"
+    assert_not_includes output, "admin/audits#create"
+  end
+
+  test "rails routes makes controller regular expressions explicit" do
+    app_file "config/routes.rb", <<-RUBY
+      Rails.application.routes.draw do
+        get "/admin/audits", to: "admin/audits#index"
+      end
+    RUBY
+
+    output = run_routes_command([ "--controller", "admin/.*" ])
+    assert_includes output, "No routes were found for this controller."
+    assert_not_includes output, "admin/audits#index"
+
+    output = run_routes_command([ "--regex", "--controller", "^admin/.*$" ])
+    assert_includes output, "admin/audits#index"
+  end
+
+  test "rails routes preserves controller precedence over grep" do
+    app_file "config/routes.rb", <<-RUBY
+      Rails.application.routes.draw do
+        get "/cart", to: "cart#show"
+        get "/users", to: "users#index"
+      end
+    RUBY
+
+    output = run_routes_command([ "--controller", "cart", "--grep", "users" ])
+    assert_includes output, "cart#show"
+    assert_not_includes output, "users#index"
+  end
+
+  test "rails routes supports structured output formats" do
+    app_file "config/routes.rb", <<-RUBY
+      Rails.application.routes.draw do
+        get "/photos/:id", to: "photos#show", as: :photo, id: /[A-Z]\\d{5}/
+      end
+    RUBY
+
+    routes = JSON.parse(run_routes_command([ "--format", "json", "--exact", "--name", "photo" ]))
+    assert_equal 1, routes.size
+    assert_equal "photos#show", routes.first["endpoint"]
+    assert_equal({ "id" => "/[A-Z]\\d{5}/" }, routes.first["constraints"])
+    assert_match(/config\/routes\.rb/, routes.first.dig("source_location", "file"))
+
+    output = run_routes_command([ "--format", "tsv", "--exact", "--name", "photo" ])
+    assert_equal "name\tverb\tpath\tcontroller\taction\tendpoint\tconstraints\tsource_location\tengine", output.lines.first.chomp
+    assert_includes output, "photos#show"
+    assert_match(/config\/routes\.rb:\d+\z/, output.lines.second.chomp.split("\t", -1)[7])
+
+    assert_equal [], JSON.parse(run_routes_command([ "--format", "json", "--exact", "--name", "missing" ]))
+  end
+
+  test "rails routes supports the expanded format name" do
+    app_file "config/routes.rb", <<-RUBY
+      Rails.application.routes.draw do
+        get "/cart", to: "cart#show"
+      end
+    RUBY
+
+    output = IO.stub(:console_size, [0, 27]) do
+      run_routes_command([ "--format", "expanded", "--exact", "--name", "cart" ])
+    end
+
+    assert_includes output, "--[ Route 1 ]"
+    assert_includes output, "Controller#Action | cart#show"
+  end
+
+  test "rails routes rejects invalid selector and formatter options" do
+    output = run_routes_command([ "--regex", "--exact", "--search", "posts" ], allow_failure: true)
+    assert_equal 1, $?.exitstatus
+    assert_includes output, "exclusive options"
+
+    output = run_routes_command([ "--format", "json", "--expanded" ], allow_failure: true)
+    assert_equal 1, $?.exitstatus
+    assert_includes output, "exclusive options"
+
+    output = run_routes_command([ "--format", "invalid" ], allow_failure: true)
+    assert_equal 1, $?.exitstatus
+    assert_includes output, "to be one of table, expanded, json, tsv"
+
+    output = run_routes_command([ "--regex", "--search", "[" ], allow_failure: true)
+    assert_equal 1, $?.exitstatus
+    assert_includes output, "premature end of char-class"
+  end
+
+  test "rails routes rejects new selectors and formatters with unused routes" do
+    output = run_routes_command([ "--unused", "--recognize", "/posts" ], allow_failure: true)
+
+    assert_equal 1, $?.exitstatus
+    assert_includes output, "The --unused option cannot be combined with --recognize."
+  end
+
   test "rails routes with unused option" do
     app_file "config/routes.rb", <<-RUBY
       Rails.application.routes.draw do
@@ -431,7 +558,7 @@ rails_conductor_inbound_email_incinerate POST /rails/conductor/action_mailbox/:i
   end
 
   private
-    def run_routes_command(args = [])
-      rails "routes", args
+    def run_routes_command(args = [], allow_failure: false)
+      rails "routes", args, allow_failure: allow_failure
     end
 end

--- a/railties/test/commands/unused_routes_test.rb
+++ b/railties/test/commands/unused_routes_test.rb
@@ -131,6 +131,22 @@ class Rails::Command::UnusedRoutesTest < ActiveSupport::TestCase
     OUTPUT
   end
 
+  test "controller filter takes precedence over grep" do
+    app_file "config/routes.rb", <<-RUBY
+      Rails.application.routes.draw do
+        get "/one", to: "posts#one"
+        get "/two", to: "users#two"
+      end
+    RUBY
+
+    assert_includes run_unused_routes_command(["-c", "posts", "-g", "users"], allow_failure: true), <<~OUTPUT
+      Found 1 unused route:
+
+      Prefix Verb URI Pattern    Controller#Action
+         one GET  /one(.:format) posts#one
+    OUTPUT
+  end
+
   test "filter by controller no results" do
     app_file "config/routes.rb", <<-RUBY
       Rails.application.routes.draw do


### PR DESCRIPTION
### Motivation / Background

The existing `rails routes` command's output is difficult to read in a large rails application. Long route names, nested controller namespaces, constraints, and wide paths make these rows wrap in a normal terminal, making their fields no longer line up with the headings.

For example, running `bin/rails routes | grep audit_exports` on my local app yields output like this:
```
                                     admin_api_v2_organisation_project_audit_exp
orts POST           /admin/api/v2/organisations/:organisation_id/projects/:proje
ct_id/audit_exports(.:format)                                           admin/ap
i/v2/audit _exports#create
```

Not only are headers removed, it's hard to read, and hard to tell what each string even is.

The command's `-e`/`--expanded` flag ameliorates this somewhat:
```text
--[ Route 1 ]------------------------------
Prefix            | admin_api_v2_organisation_project_audit_exports
Verb              | POST
URI               | /admin/api/v2/organisations/:organisation_id/projects/:project_id/audit_exports(.:format)
Controller#Action | admin/api/v2/audit_exports#create
```

... but this is only useful if the user can reliably select a small number of relevant routes. Using `grep`, `rg` and friends on expanded output is difficult, as expanded output is spread across multiple lines, so getting all of the route metadata _and_ only selecting the route you want difficult.

The classical answer to this is to use the `-g`/`--grep` flag, but it has its own issues in that it actually does two separate things at the same time:
- It treats its argument as a regular expression and searches route metadata such as the route name, verb, declared URI pattern, controller, and action (ie, grepping for its argument)
- It treats the same argument as a possible request path and asks each route whether it could recognise that path (ie, not grepping for its argument)

This often leads to surprising results:
```bash
bin/rails routes -Eg audit_export
```

can return routes whose metadata doesn't contain `audit_export` — anything with a wildcard on the first path segment will be output, and though we only care about endpoints that have `audit_export` in them, we get a whole bunch of other stuff we have to ignore:

```text
[ Routes for application ]
--[ Route 1 ]-------------------------------------------------------------------
Prefix            |
Verb              | GET
URI               | /(*path)(.:format)
Controller#Action | redirect(301, https://status.example.com) {subdomain: "status"}
--[ Route 2 ]-------------------------------------------------------------------
Prefix            |
Verb              | OPTIONS
URI               | /*path(.:format)
Controller#Action | api/root#cors_preflight_check {subdomain: "api"}
--[ Route 3 ]-------------------------------------------------------------------
Prefix            | token
Verb              | GET
URI               | /:token(.:format)
Controller#Action | tokens#show {subdomain: "token"}
--[ Route 4 ]-------------------------------------------------------------------
Prefix            | admin_api_v2_organisation_project_audit_exports
Verb              | POST
URI               | /admin/api/v2/organisations/:organisation_id/projects/:project_id/audit_exports(.:format)
Controller#Action | admin/api/v2/audit_exports#create
--[ Route 5 ]-------------------------------------------------------------------
Prefix            | account_show
Verb              | GET
URI               | /:id(.:format)
Controller#Action | organizations#show {subdomain: ""}

[ Routes for Something::Engine ]
--[ Route 1 ]-------------------------------------------------------------------
Prefix            | delete_item
Verb              | DELETE
URI               | /:id(.:format)
Controller#Action | something/items#destroy
--[ Route 2 ]-------------------------------------------------------------------
Prefix            | item
Verb              | GET
URI               | /:id(/:style)(.:format)
Controller#Action | something/items#show

[ Routes for SomethingElse::Engine ]
--[ Route 1 ]-------------------------------------------------------------------
Prefix            |
Verb              | GET
URI               | /*path(.:format)
Controller#Action | something_else/application#not_found
```

Route 4 is the metadata match the user wanted. The remaining routes appear because they can recognise /audit_export, not because audit_export occurs in their declarations. In a large application, these additional matches can easily overwhelm the relevant result.

None of this would be much of an issue if `rails routes` offered machine-readable output, but at present the only output options are table and expanded, both of which are non-standard and tricky to parse.

### Detail

This PR addresses the issues above by:
- Adding `json` and `tsv` output modes (through `-f`/`--format`), easily parsable by external tooling
- Splitting `--grep`'s functionality into `--search` (look for substrings in routes) and `--recognize` (what routes would match this string). `--grep`'s functionality is left untouched.
- Adds the following filter predicates, each of which can be composed with `--search` as well as each other:
  - `--name`, filtering routes by name
  - `--path`, filtering routes by path
  - `--action`, filtering routes by action
  - `--verb`, filtering routes by HTTP verb
- `--search` and other filter predicates can be further made to only operate on exact string matches using `--exact`, or to use regex matching using `--regex`


### Examples
<details>
<summary>Examples</summary>

#### Searching route metadata

`--search` performs a literal search across route names, verbs, declared paths, controllers, actions, constraints, and source locations. Unlike `--grep`, it doesn't also treat its argument as a possible request path:

```bash
bin/rails routes --search audit_export --format expanded
```

```text
[ Routes for application ]
--[ Route 1 ]-------------------------------------------------------------------
Prefix            | admin_api_v2_organisation_project_audit_exports
Verb              | POST
URI               | /admin/api/v2/organisations/:organisation_id/projects/:project_id/audit_exports(.:format)
Controller#Action | admin/api/v2/audit_exports#create
Source Location   | /app/config/routes.rb:42
```

The wildcard and dynamic routes shown in the motivation aren't included because `audit_export` doesn't occur in their metadata.

#### Recognizing a concrete request path

Request-path recognition is now explicit. Dynamic route segments are matched against the supplied path:

```bash
bin/rails routes \
  --recognize /admin/api/v2/organisations/42/projects/7/audit_exports \
  --verb POST \
  --format expanded
```

```text
[ Routes for application ]
--[ Route 1 ]-------------------------------------------------------------------
Prefix            | admin_api_v2_organisation_project_audit_exports
Verb              | POST
URI               | /admin/api/v2/organisations/:organisation_id/projects/:project_id/audit_exports(.:format)
Controller#Action | admin/api/v2/audit_exports#create
Source Location   | /app/config/routes.rb:42
```

`--recognize` can be combined with the metadata selectors, so `--verb POST` excludes routes which recognize the same path under another HTTP verb.

#### Composing field selectors

Field selectors are combined with AND semantics. For example, this finds only `POST` routes handled by `Admin::Api::V2::AuditExportsController`:

```bash
bin/rails routes \
  --controller Admin::Api::V2::AuditExportsController \
  --verb POST
```

Selectors can target individual route fields:

```bash
bin/rails routes --name audit_export
bin/rails routes --path /audit_exports
bin/rails routes --action create --verb POST
```

By default these perform literal substring matching. `--exact` selects a complete field value:

```bash
bin/rails routes \
  --exact \
  --name admin_api_v2_organisation_project_audit_exports
```

Regular-expression matching must be requested explicitly:

```bash
bin/rails routes \
  --regex \
  --controller '^admin/api/v2/(audit_exports|audit_reports)$' \
  --verb '^POST$'
```

#### Consuming routes as JSON

JSON output exposes route metadata as separate fields rather than requiring callers to parse the human-readable table:

```bash
bin/rails routes \
  --exact \
  --name admin_api_v2_organisation_project_audit_exports \
  --format json |
  jq '.[0]'
```

```json
{
  "name": "admin_api_v2_organisation_project_audit_exports",
  "verb": "POST",
  "path": "/admin/api/v2/organisations/:organisation_id/projects/:project_id/audit_exports(.:format)",
  "controller": "admin/api/v2/audit_exports",
  "action": "create",
  "endpoint": "admin/api/v2/audit_exports#create",
  "constraints": {},
  "source_location": {
    "file": "/app/config/routes.rb",
    "line": 42
  },
  "engine": null
}
```

This can answer questions which aren't directly represented by a `rails routes` option. For example, to count the `POST` routes handled by a controller:

```bash
bin/rails routes \
  --controller Admin::Api::V2::AuditExportsController \
  --verb POST \
  --format json |
  jq 'length'
```

```text
1
```

</details>

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
