### PR TITLE
Harden load schema migrations

### DIFF
--- a/activerecord/lib/active_record/schema.rb
+++ b/activerecord/lib/active_record/schema.rb
@@ -75,7 +75,9 @@ module ActiveRecord
     end
 
     def self.load_schema_migrations(file) # :nodoc:
-      _schema, marker, data = File.read(file).rpartition("__END__\n")
+      # The marker is matched the way Ruby recognizes it, so files with CRLF
+      # line endings or without a trailing newline load too.
+      _schema, marker, data = File.read(file).rpartition(/^__END__\r?$/)
 
       raise ActiveRecordError, "No __END__ found in #{file}" if marker.empty?
 

--- a/activerecord/lib/active_record/schema.rb
+++ b/activerecord/lib/active_record/schema.rb
@@ -89,6 +89,10 @@ module ActiveRecord
         raise ActiveRecordError, "Invalid migration version #{invalid_version.inspect} found after __END__"
       end
 
+      if duplicate_version = versions.tally.find { |_version, count| count > 1 }&.first
+        raise ActiveRecordError, "Duplicate migration version #{duplicate_version.inspect} found after __END__"
+      end
+
       versions -= connection_pool.schema_migration.versions
       connection_pool.schema_migration.create_versions(versions)
     end

--- a/activerecord/test/cases/active_record_schema_test.rb
+++ b/activerecord/test/cases/active_record_schema_test.rb
@@ -171,6 +171,28 @@ class ActiveRecordSchemaTest < ActiveRecord::TestCase
     file.unlink
   end
 
+  def test_schema_load_schema_migrations_rejects_duplicate_versions
+    file = Tempfile.new("schema.rb")
+    file.write <<~RUBY
+      ActiveRecord::Schema.define {}
+      ActiveRecord::Schema.load_schema_migrations(__FILE__)
+      __END__
+      1
+      2
+      1
+    RUBY
+    file.close
+
+    error = assert_raises(ActiveRecord::ActiveRecordError) do
+      ActiveRecord::Schema.load_schema_migrations(file.path)
+    end
+
+    assert_equal "Duplicate migration version \"1\" found after __END__", error.message
+    assert_empty @schema_migration.versions
+  ensure
+    file.unlink
+  end
+
   def test_schema_load_schema_migrations_rejects_non_numeric_versions
     file = Tempfile.new("schema.rb")
     file.write <<~RUBY

--- a/activerecord/test/cases/active_record_schema_test.rb
+++ b/activerecord/test/cases/active_record_schema_test.rb
@@ -127,6 +127,30 @@ class ActiveRecordSchemaTest < ActiveRecord::TestCase
     file.unlink
   end
 
+  def test_schema_load_schema_migrations_with_crlf_line_endings
+    file = Tempfile.new("schema.rb")
+    file.write "ActiveRecord::Schema.define {}\r\nActiveRecord::Schema.load_schema_migrations(__FILE__)\r\n__END__\r\n1\r\n2\r\n"
+    file.close
+
+    ActiveRecord::Schema.load_schema_migrations(file.path)
+
+    assert_equal ["1", "2"], @schema_migration.versions
+  ensure
+    file.unlink
+  end
+
+  def test_schema_load_schema_migrations_with_the_marker_at_the_end_of_file
+    file = Tempfile.new("schema.rb")
+    file.write "ActiveRecord::Schema.define {}\nActiveRecord::Schema.load_schema_migrations(__FILE__)\n__END__"
+    file.close
+
+    ActiveRecord::Schema.load_schema_migrations(file.path)
+
+    assert_empty @schema_migration.versions
+  ensure
+    file.unlink
+  end
+
   def test_schema_load_schema_migrations_skips_versions_already_in_database
     @schema_migration.create_version("1")
 


### PR DESCRIPTION
### Motivation / Background

Follow-up to #58134 (cc @fxn). This hardens the new `ActiveRecord::Schema.load_schema_migrations` against two file shapes it can meet in real projects:

**1. CRLF line endings.** A `db/schema.rb` committed with CRLF line endings executes fine — Ruby itself recognizes the `__END__` marker regardless of line endings — but `load_schema_migrations` then fails with:

```
ActiveRecord::ActiveRecordError: No __END__ found in db/schema.rb
```

even though the marker is visibly present in the file Ruby just ran. The same happens when `__END__` is the last line of the file with no trailing newline, which Ruby also accepts. CRLF bytes reach the loader when the file is committed with CRLF endings on one platform and `db:schema:load` / `db:test:prepare` runs on another.

**2. Duplicate versions.** A version listed twice after `__END__` — say, from a hand-resolved merge conflict in the list, the very scenario this feature aims to mitigate — makes a load into a fresh database fail midway with an adapter-level error:

```
ActiveRecord::RecordNotUnique: SQLite3::ConstraintException: UNIQUE constraint failed: schema_migrations.version
```

When the duplicated version is already present in `schema_migrations`, the duplicate is silently tolerated instead, so fresh and incremental loads currently disagree on the same file.

### Detail

* The `__END__` marker is now matched with Ruby's own line semantics, so files with CRLF line endings, and files where `__END__` is the last line without a trailing newline, load. A file with no marker still raises the same `No __END__ found` error. The version lines themselves were already resilient, since they are stripped.

* The version list is deduplicated before inserting. The `schema_migrations` table acts as a set, so a duplicate entry carries no extra meaning, and fresh and incremental loads now behave the same.

### Additional information

Before this PR, this file (with literal CRLF line endings):

```ruby
ActiveRecord::Schema.define {}
ActiveRecord::Schema.load_schema_migrations(__FILE__)
__END__
20260101000001
```

runs cleanly as Ruby right up to the `load_schema_migrations` call, which then reports that `__END__` is missing.

Happy to turn the dedup into a loud error naming the duplicated version instead, if you'd prefer malformed lists to fail fast — the second commit is standalone so it's easy to adjust or drop.

No CHANGELOG entry since the feature is unreleased and already has one.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
