### PR TITLE
Make Action Cable action methods Ractor-safe

### DIFF
--- a/actioncable/lib/action_cable/channel/base.rb
+++ b/actioncable/lib/action_cable/channel/base.rb
@@ -137,7 +137,7 @@ module ActionCable
               internal_methods).uniq
 
             methods.map!(&:name)
-            methods.to_set
+            methods.to_set.freeze
           end
         end
 

--- a/actioncable/test/channel/base_test.rb
+++ b/actioncable/test/channel/base_test.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "active_support/testing/ractors_assertions"
 require "minitest/mock"
 require "stubs/test_socket"
 require "stubs/room"
 
 class ActionCable::Channel::BaseTest < ActionCable::TestCase
+  include ActiveSupport::Testing::RactorsAssertions
+
   class ActionCable::Channel::Base
     def kick
       @last_action = [ :kick ]
@@ -204,6 +207,16 @@ class ActionCable::Channel::BaseTest < ActionCable::TestCase
   test "actions available on Channel" do
     available_actions = %w(room last_action subscribed unsubscribed toggle_subscribed leave speak subscribed? after_subscribed_ran? get_latest receive chatters topic error_action).to_set
     assert_equal available_actions, ChatChannel.action_methods
+  end
+
+  test "action methods can be accessed from a Ractor" do
+    expected = ChatChannel.action_methods
+
+    actual = on_ractor do
+      ChatChannel.action_methods
+    end
+
+    assert_equal expected, actual
   end
 
   test "invalid action on Channel" do


### PR DESCRIPTION
### Motivation / Background

`ActionCable::Channel::Base.action_methods` memoizes an unfrozen `Set` in a class instance variable. Once populated on the main Ractor, reading that value from a non-main Ractor raises `Ractor::IsolationError`.

This is the Action Cable equivalent of the Abstract Controller issue fixed by #58113.

### Detail

Freeze the computed action-method set so the cached value is shareable across Ractors. Action Cable has no overrides that mutate this set.

A regression test primes the cache on the main Ractor and then reads it from another Ractor.

### Additional information

Verified locally with:

- `actioncable/bin/test test/channel/base_test.rb`
- 225 additional runnable Action Cable tests (Redis and JavaScript package integration tests require local services/tools)
- `bundle exec rubocop actioncable/lib/action_cable/channel/base.rb actioncable/test/channel/base_test.rb`

### Checklist

- [x] This Pull Request is related to one change.
- [x] The commit message describes what changed and why.
- [x] A regression test is included.
- [x] No CHANGELOG entry is included because this is an internal compatibility fix.