### PR TITLE
Add file-reading ImageMagick pseudo-formats to Active Storage argument denylist

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Reject file-reading ImageMagick pseudo-formats (`text:`, `label:`, `caption:`,
+    `pango:`, `msl:`, `ephemeral:`) in Active Storage variant arguments.
+
+    The `unsupported_image_processing_arguments` denylist blocked dangerous
+    command-line options (`-write`, `-set`, etc.) but not input pseudo-formats
+    that read a file's contents into the output image, for example
+    `blob.variant(composite: "text:/etc/passwd")`. These pseudo-formats are now
+    part of the default denylist as a defense-in-depth measure. Passing
+    untrusted arguments to `variant` remains unsafe.
+
+    *Gengyskan*
+
 *   Fix `MirrorService#mirror` losing blob metadata when copying to mirrors.
 
     Mirrored copies on S3, Azure, and GCS were served as `application/octet-stream`

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -157,6 +157,12 @@ module ActiveStorage
           -version
           -write
           -write-mask
+          caption:
+          ephemeral:
+          label:
+          msl:
+          pango:
+          text:
         )
 
         ActiveStorage.variable_content_types = app.config.active_storage.variable_content_types || []

--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -231,6 +231,25 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
     end
   end
 
+  test "variations with a file-reading pseudo-format argument raise UnsupportedImageProcessingArgument" do
+    process_variants_with :mini_magick do
+      blob = create_file_blob(filename: "racecar.jpg")
+      [
+        "text:/etc/passwd",
+        "TEXT:/etc/passwd",
+        "label:@/etc/passwd",
+        "caption:@/etc/passwd",
+        "msl:/tmp/exploit.msl",
+        "pango:@/etc/passwd",
+        "ephemeral:/etc/passwd",
+      ].each do |dangerous_argument|
+        assert_raise(ActiveStorage::Transformers::ImageProcessingTransformer::UnsupportedImageProcessingArgument, "expected #{dangerous_argument} to be rejected") do
+          blob.variant(composite: dangerous_argument).processed
+        end
+      end
+    end
+  end
+
   test "variations with dangerous argument array raise UnsupportedImageProcessingArgument" do
     process_variants_with :mini_magick do
       blob = create_file_blob(filename: "racecar.jpg")


### PR DESCRIPTION
### Summary

`ActiveStorage.unsupported_image_processing_arguments` denylists dangerous ImageMagick **command-line options** (`-write`, `-set`, `-path`, ...), but it does not cover ImageMagick **input pseudo-formats** that read a file's contents into the output image. Because the check in `ImageMagick#validate_arg_string` is a case-insensitive substring match, an argument value such as `text:/etc/passwd` is not currently rejected:

```ruby
# `composite` is on supported_image_processing_methods; the `text:` pseudo-format
# reads the file and renders it into the produced image.
blob.variant(composite: "text:/etc/passwd").processed
```

The same applies to `label:`, `caption:`, `pango:` (render text, and can pull file contents via `@file`), `msl:` (Magick Scripting Language, which can read/write arbitrary files), and `ephemeral:` (reads then deletes a file).

This PR adds those file-reading pseudo-formats to the default denylist and includes a regression test.

### Context

This was raised through the Rails security process. The team's assessment is that the allowlist/denylist is a **defense-in-depth measure, not a security boundary** (the guides document that passing untrusted or user-supplied arguments to `variant` is unsafe), and that extending the denylist to cover file-reading pseudo-formats is worth doing as a hardening/functional improvement via a public PR. This change implements that, and does not claim `variant` is safe for untrusted input.

### Note on matching (happy to adjust)

The existing denylist is matched with `argument.to_s.downcase.include?(bad_arg)`, i.e. an unanchored substring match, so these new entries can over-block legitimate argument values that merely *contain* the substring (for example a caption value containing the word `context:` contains `text:`). This over-blocking is consistent with the current behaviour of the option entries (e.g. `-set`), and it only affects values passed to a `variant` transformation. If you would prefer to avoid the over-block, the pseudo-format entries could instead be anchored to the start of the argument token; I am glad to rework it that way.

### Changed

- `activestorage/lib/active_storage/engine.rb`: add `text:`, `label:`, `caption:`, `pango:`, `msl:`, `ephemeral:` to the default `unsupported_image_processing_arguments`.
- `activestorage/test/models/variant_test.rb`: regression test asserting these raise `UnsupportedImageProcessingArgument`.
- `activestorage/CHANGELOG.md`: entry.
