### PR TITLE
fix exists method with composite primary key

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,23 @@
+*   Raise a helpful error when a composite primary key id is passed to
+    `ActiveRecord::FinderMethods#exists?`.
+
+    An `Array` of composite key values can't be distinguished from
+    `where`-style conditions, so `exists?` now raises a clear `ArgumentError`
+    pointing to `where(...).exists?` instead of the previous cryptic
+    `ArgumentError: Unsupported argument type`.
+
+    ```ruby
+    # Cpk::Book has a composite primary key of [:author_id, :id]
+    Cpk::Book.exists?([1, 2])
+    # => ArgumentError: Composite primary key values aren't supported by
+    #    `exists?`. Use `where(...).exists?` to check for existence by a
+    #    composite primary key.
+    ```
+
+    Fixes #51295.
+
+    *Saleh Alhaddad*
+
 *   Add query predicate hooks for Active Model types.
 
     Types can override `transforms_query_predicates?`, `query_attribute`, and

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -354,6 +354,12 @@ module ActiveRecord
     #   Person.exists?(false)
     #   Person.exists?
     #   Person.where(name: 'Spartacus', rating: 4).exists?
+    #
+    # Checking existence by a composite primary key id is not supported, because
+    # an Array of key values can't be told apart from +where+-style conditions.
+    # Use #where instead:
+    #
+    #   TravelRoute.where(origin: "Ottawa", destination: "London").exists?
     def exists?(conditions = :none)
       return false if @none
 
@@ -441,12 +447,36 @@ module ActiveRecord
 
         case conditions
         when Array, Hash
+          if conditions.is_a?(Array) && composite_primary_key_id?(conditions)
+            raise ArgumentError, <<-MSG.squish
+              Composite primary key values aren't supported by `exists?`.
+              Use `where(...).exists?` to check for existence by a composite primary key.
+            MSG
+          end
           relation.where!(conditions) unless conditions.empty?
         else
           relation.where!(primary_key => conditions) unless conditions == :none
         end
 
         relation
+      end
+
+      # Detects whether an Array passed to #exists? is a composite primary key
+      # id (a single tuple like <tt>[1, 2]</tt>, the wrapped form
+      # <tt>[[1, 2]]</tt>, or several tuples). #exists? cannot disambiguate
+      # these from +where+-style conditions, so they are rejected with a clear
+      # error rather than guessed at. A +where+-style Array leads with the SQL
+      # String (e.g. <tt>["name = ?", "David"]</tt>) and is left untouched.
+      def composite_primary_key_id?(values)
+        return false unless model.composite_primary_key?
+
+        key = model.primary_key_definition
+
+        if key.expects_multiple_ids?(values)
+          values.present?
+        else
+          values.length == key.length && !values.first.is_a?(String)
+        end
       end
 
       def apply_join_dependency(eager_loading: group_values.empty?)

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -2128,6 +2128,30 @@ class FinderTest < ActiveRecord::TestCase
     end
   end
 
+  test "#exists? raises a helpful error when passed a composite primary key id" do
+    book = cpk_books(:cpk_great_author_first_book)
+
+    error = assert_raises(ArgumentError) { Cpk::Book.exists?(book.id) }
+    assert_match(/where/, error.message)
+  end
+
+  test "#exists? raises a helpful error when passed a composite primary key id wrapped in an array" do
+    book = cpk_books(:cpk_great_author_first_book)
+
+    assert_raises(ArgumentError) { Cpk::Book.exists?([book.id]) }
+  end
+
+  test "#exists? raises a helpful error when passed multiple composite primary key ids" do
+    books = [cpk_books(:cpk_great_author_first_book), cpk_books(:cpk_great_author_second_book)]
+
+    assert_raises(ArgumentError) { Cpk::Book.exists?(books.map(&:id)) }
+  end
+
+  test "#exists? still supports where-style array conditions on a composite primary key model" do
+    assert_equal true, Cpk::Book.exists?(["title = ?", "The first book"])
+    assert_equal false, Cpk::Book.exists?(["title = ?", "Nonexistent title"])
+  end
+
   private
     def table_with_custom_primary_key
       yield(Class.new(Toy) do


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `ActiveRecord::FinderMethods#exists?` raised a cryptic, unhelpful error when passed a composite primary key id — the exact array that `find` accepts:

```ruby
class Post < ActiveRecord::Base
  self.primary_key = [:user_id, :account_id]
end

Post.find([1, 1])     # => #<Post user_id: 1, account_id: 1>   ✅
Post.exists?([1, 1])  # 💥 ArgumentError: Unsupported argument type: 1 (Integer)
```

The error gives the user no idea what went wrong or what to do instead. A prior change (#51996) only altered the message; the call still failed with an obscure error.

Rather than have `exists?` *guess* whether an `Array` is a composite id or `where`-style conditions (discussed at length in the review — that heuristic can't reach full parity with `find` for every key shape, e.g. string keys), this PR takes the intermediate approach suggested by `@nvasilevski`: replace the cryptic error with a **clear, actionable one** that points users to `where(...).exists?`. The richer `ActiveRecord::Identifier` API remains the preferred long-term fix, pending core-team direction.

Fixes #51295

### Detail

This Pull Request changes `FinderMethods#construct_relation_for_exists` so that, for a model with a composite primary key, an `Array` argument shaped like a composite id raises a helpful `ArgumentError` instead of the previous cryptic one:

```ruby
Cpk::Book.exists?([1, 2])
# => ArgumentError: Composite primary key values aren't supported by `exists?`.
#    Use `where(...).exists?` to check for existence by a composite primary key.
```

A small private predicate, `composite_primary_key_id?`, detects the composite-id shapes (a single tuple `[1, 2]`, the wrapped form `[[1, 2]]`, or several tuples). It reuses the existing `ActiveRecord::Key` abstraction (`primary_key_definition.expects_multiple_ids?`), the same machinery `find_with_ids` and `include?` rely on.

Crucially, this only affects inputs that **already raised** today. A `where`-style conditions array always begins with a `String` (the SQL fragment, e.g. `["name = ?", x]`); a composite id like `[1, 2]` does not. So conditions arrays are left completely untouched — the change swaps a confusing error for a clear one, and never alters a call that previously worked.

Single-primary-key models are unaffected — the new behavior is gated on `model.composite_primary_key?` — so `exists?([1, 2])` on an ordinary model still raises the original `ArgumentError` (covered by the existing `test_exists` assertion in `finder_test.rb`).

The `exists?` documentation and the Active Record CHANGELOG are updated accordingly.

### Additional information

- No new public API is introduced; no guessing between a composite id and SQL conditions.
- Non-composite-key models are entirely unaffected — the predicate returns early unless `model.composite_primary_key?`.
- `where`-style array conditions (`exists?(["name = ?", x])`) and hash conditions (`exists?(name: "X")`) behave exactly as before — verified against both SQLite and PostgreSQL.
- Tests in `activerecord/test/cases/finder_test.rb` cover: a composite id, the wrapped form, multiple ids (all asserting the clear error), and a regression test asserting `where`-style array conditions still work on a composite-key model.
- Verified locally: the new tests pass (4 runs, 7 assertions), the full `finder_test.rb` passes (283 runs), and `relations_test` and `primary_keys_test` show no regressions. RuboCop reports no offenses.
- Follow-up: the richer `ActiveRecord::Identifier` value object (raised in review) is the preferred long-term direction and would let `exists?` accept a composite id unambiguously; I'm happy to help drive that once the core team weighs in.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.