### PR TITLE
Carry `disabled` and `form` onto a multiple file field's hidden companion input

### DIFF
--- a/actionview/lib/action_view/helpers/tags/file_field.rb
+++ b/actionview/lib/action_view/helpers/tags/file_field.rb
@@ -21,7 +21,7 @@ module ActionView
 
         private
           def hidden_field_for_multiple_file(options)
-            tag_options = { "name" => options["name"], "type" => "hidden", "value" => "" }
+            tag_options = { "name" => options["name"], "type" => "hidden", "value" => "", "disabled" => options["disabled"], "form" => options["form"] }
             tag_options["autocomplete"] = "off" unless ActionView::Base.remove_hidden_field_autocomplete
             tag("input", tag_options)
           end

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -607,6 +607,22 @@ class FormHelperTest < ActionView::TestCase
     end
   end
 
+  def test_file_field_with_multiple_include_hidden_carries_form_attribute
+    ActionView::Base.with(remove_hidden_field_autocomplete: true) do
+      expected = '<input type="hidden" name="import[file][]" value="" form="uploads">' \
+                 '<input id="import_file" multiple="multiple" form="uploads" name="import[file][]" type="file" />'
+      assert_dom_equal expected, file_field("import", "file", multiple: true, include_hidden: true, form: "uploads")
+    end
+  end
+
+  def test_file_field_with_multiple_include_hidden_carries_disabled_attribute
+    ActionView::Base.with(remove_hidden_field_autocomplete: true) do
+      expected = '<input type="hidden" name="import[file][]" value="" disabled="disabled">' \
+                 '<input id="import_file" disabled="disabled" multiple="multiple" name="import[file][]" type="file" />'
+      assert_dom_equal expected, file_field("import", "file", multiple: true, include_hidden: true, disabled: true)
+    end
+  end
+
   def test_file_field_with_direct_upload_when_rails_direct_uploads_url_is_not_defined
     expected = '<input type="file" name="import[file]" id="import_file" />'
     assert_dom_equal expected, file_field("import", "file", direct_upload: true)


### PR DESCRIPTION
### Motivation / Background

A multiple file field with `include_hidden: true` generates a hidden input so that submitting no files sends an empty value. That hidden input currently copies only `name` from the visible control, omitting `disabled` and `form`.

This is the same omission fixed for multiple `select` in #58064. The sibling companion hidden inputs in `check_box` and `select_renderer` already handle both attributes correctly.

### Detail

**Disabled field — before:**

```html
<input name="import[files][]" type="hidden" value="" />
<input multiple="multiple" disabled="disabled" type="file" name="import[files][]" id="import_files" />
```

The enabled hidden input submits `import[files][]=` even though the file control is disabled.

**Disabled field — after:**

```html
<input type="hidden" name="import[files][]" value="" disabled="disabled" />
<input id="import_files" disabled="disabled" multiple="multiple" name="import[files][]" type="file" />
```

**External form — before:**

```html
<input name="import[files][]" type="hidden" value="" />
<input multiple="multiple" form="uploads" type="file" name="import[files][]" id="import_files" />
```

The hidden input does not belong to `uploads`, so submitting the external form without selecting a file sends no `import` parameter.

**External form — after:**

```html
<input type="hidden" name="import[files][]" value="" form="uploads" />
<input id="import_files" multiple="multiple" form="uploads" name="import[files][]" type="file" />
```

The fix mirrors `check_box.rb` and `select_renderer.rb`, which already copy `disabled` and `form` onto their companion hidden inputs.

### Additional information

Confirmed with a real browser (Selenium/Chrome) that a disabled multiple file field submits an empty array, and an external-form file field omits the parameter entirely.

### Checklist

- [x] This Pull Request is related to one change.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added for both the `disabled` and `form` cases.
- [x] No CHANGELOG entry is included because this is a minor bug fix.