### PR TITLE
Test that config.action_dispatch.default_headers set in an initializer is applied

### DIFF
--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -623,6 +623,31 @@ module ApplicationTests
       assert_equal [:password, :foo, "bar"], Rails.application.env_config["action_dispatch.parameter_filter"]
     end
 
+    test "config.action_dispatch.default_headers can be set in an initializer and is applied to responses" do
+      app_file "config/initializers/default_headers.rb", <<-RUBY
+        Rails.application.config.action_dispatch.default_headers = { "X-Custom-Header" => "custom" }
+      RUBY
+
+      app_file "app/controllers/pages_controller.rb", <<-RUBY
+        class PagesController < ApplicationController
+          def index
+            render plain: "OK"
+          end
+        end
+      RUBY
+
+      add_to_config <<-RUBY
+        routes.prepend do
+          get "/pages", to: "pages#index"
+        end
+      RUBY
+
+      app "development"
+
+      get "/pages"
+      assert_equal "custom", last_response.headers["X-Custom-Header"]
+    end
+
     test "filter_parameters is precompiled when config.precompile_filter_parameters is true" do
       filters = [/foo/, :bar, "baz.qux"]
 


### PR DESCRIPTION
### Summary

Adds a regression test asserting that `config.action_dispatch.default_headers`, when set from a `config/initializers/*.rb` file, is applied to responses.

This scenario regressed in released 8.x (see #58145) and — while it is already fixed on `main` by f9c82c3f2a — there was no test guarding the config-propagation timing. Every existing `default_headers` test assigns `ActionDispatch::Response.default_headers` directly on the class, bypassing the railtie/config/initializer path; none boot an app and exercise the initializer timing.

The test replaces the headers hash wholesale in an initializer (rather than mutating it in place), because that is the case that actually breaks when `ActionDispatch::Response` is loaded before `config/initializers` run — in-place mutation happens to survive since it mutates the same object the load hook captured.

### Test plan

```
cd railties
bin/test test/application/configuration_test.rb \
  -i "test_config.action_dispatch.default_headers_can_be_set_in_an_initializer_and_is_applied_to_responses"
```

Passes on `main`. Fails on the code prior to f9c82c3f2a (verified by temporarily reverting the load-hook deferral), so it genuinely guards the fix.

Related to #58145 and #32592.
