### PR TITLE
[8-1-stable] Avoid loading ActionController::Live early in initializer

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Avoid loading `ActionController::Live` early in initializer, and introduce
+    `action_controller_live` load hook.
+
+    *Adrianna Chang*
+
 *   Set the browser binary when preloading the Selenium driver for system tests.
 
     Selenium 4.45 stopped setting it as a side effect of getting the driver path,

--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -433,5 +433,7 @@ module ActionController
           "#{message}\n\n"
         end
       end
+
+      ActiveSupport.run_load_hooks(:action_controller_live, self)
   end
 end

--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -34,7 +34,9 @@ module ActionController
     end
 
     initializer "action_controller.live_streaming_excluded_keys" do |app|
-      ActionController::Live.live_streaming_excluded_keys = app.config.action_controller.live_streaming_excluded_keys
+      ActiveSupport.on_load(:action_controller_live) do
+        ActionController::Live.live_streaming_excluded_keys = app.config.action_controller.live_streaming_excluded_keys
+      end
     end
 
     initializer "action_controller.parameters_config" do |app|

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -4024,6 +4024,7 @@ These are the load hooks you can use in your own code. To hook into the initiali
 | `ActionController::API`              | `action_controller`                  |
 | `ActionController::Base`             | `action_controller_base`             |
 | `ActionController::Base`             | `action_controller`                  |
+| `ActionController::Live`             | `action_controller_live`             |
 | `ActionController::TestCase`         | `action_controller_test_case`        |
 | `ActionDispatch::IntegrationTest`    | `action_dispatch_integration_test`   |
 | `ActionDispatch::Response`           | `action_dispatch_response`           |

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -632,6 +632,31 @@ module ApplicationTests
       assert_equal [:password, :foo, "bar"], Rails.application.env_config["action_dispatch.parameter_filter"]
     end
 
+    test "config.action_dispatch.default_headers can be set in an initializer and is applied to responses" do
+      app_file "config/initializers/default_headers.rb", <<-RUBY
+        Rails.application.config.action_dispatch.default_headers = { "X-Custom-Header" => "custom" }
+      RUBY
+
+      app_file "app/controllers/pages_controller.rb", <<-RUBY
+        class PagesController < ApplicationController
+          def index
+            render plain: "OK"
+          end
+        end
+      RUBY
+
+      add_to_config <<-RUBY
+        routes.prepend do
+          get "/pages", to: "pages#index"
+        end
+      RUBY
+
+      app "development"
+
+      get "/pages"
+      assert_equal "custom", last_response.headers["X-Custom-Header"]
+    end
+
     test "filter_parameters is precompiled when config.precompile_filter_parameters is true" do
       filters = [/foo/, :bar, "baz.qux"]
 


### PR DESCRIPTION
Backports the fix for #58145 to `8-1-stable`.

### The regression

Setting `config.action_dispatch.default_headers = { ... }` (wholesale replacement) from a `config/initializers/*.rb` file is silently ignored on 8.1.2 and 8.1.3 (and 8.0.5+). It works on 7.2, 8.0.0–8.0.4, and 8.1.0–8.1.1.

Cause: the `action_controller.live_streaming_excluded_keys` initializer (added in #56393) eagerly references `ActionController::Live` during `initialize!`, which `require`s `action_dispatch/http/response` and fires the `:action_dispatch_response` load hook **before** `config/initializers` run. The hook then captures the default headers before an initializer can replace them. Full analysis in #58145.

### The fix

Cherry-picks f9c82c3f2a ("Follow up to #56393") from `main`, which wraps the assignment in `ActiveSupport.on_load(:action_controller_live)` so `ActionController::Live` (and thus `ActionDispatch::Response`) is no longer loaded during initialization. Also included is a regression test (#58146 on `main`).

### Note for reviewers

The upstream fix introduces a new public load hook, `:action_controller_live`. I've kept the backport identical to `main` to minimize divergence, but I recognize adding a new documented hook to a stable branch may be more than you'd want in a maintenance release. If you'd prefer, I'm happy to rework this to defer the load **without** exposing/documenting a new public hook. Let me know which you'd like and I'll update — marking this draft in the meantime.

### Test plan

```
cd railties
bin/test test/application/configuration_test.rb \
  -i "test_config.action_dispatch.default_headers_can_be_set_in_an_initializer_and_is_applied_to_responses"
```

Verified: fails on current `8-1-stable`, passes with this change.
