### PR TITLE
Fix test_precompile_shouldn't_use_the_digests_present_in_manifest.json failure

### DIFF
--- a/railties/test/application/sprockets_assets_test.rb
+++ b/railties/test/application/sprockets_assets_test.rb
@@ -314,6 +314,7 @@ module ApplicationTests
       assets = ActiveSupport::JSON.decode(File.read(manifest))
       asset_path = assets["assets"]["application.css"]
 
+      sleep 1
       app_file "app/assets/images/rails.png", "p { url: change }"
 
       precompile!


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `ApplicationTests::SprocketsAssetsTest#test_precompile_shouldn't_use_the_digests_present_in_manifest.json` is flaky on CI:

```
Expected "application-c56ef81d122dffa8b257b0546ba1b09bd2d8b97e4aef881de8db9f760b903af6.css"
to not be equal to "application-c56ef81d122dffa8b257b0546ba1b09bd2d8b97e4aef881de8db9f760b903af6.css".
```

* 2026-07-02 railties (4.0) [rack-3-0]
  https://buildkite.com/rails/rails/builds/130521#019f24ea-6805-4b97-96a2-f774754cf29e
* 2026-07-16 railties [rack-2] (nightly)
  https://buildkite.com/rails/rails-nightly/builds/4552#019f6cba-e4be-4732-b980-bacd627dfc21
* 2026-07-17 railties (3.3)
  https://buildkite.com/rails/rails/builds/131149#019f7040-9396-4972-99b7-06deec0012db

sprockets caches file digests keyed by the file mtime truncated to whole seconds (`Sprockets::Base#file_digest`, rails/sprockets@55c3b563; rails/sprockets@2fefbf4e: "fidelity is already hard coded to 1 second in lots of other spots"). When this test rewrites `app/assets/images/rails.png` in the same second as the initial write, the second precompile reuses the stale cached digest and the `application.css` digest does not change. The two writes are separated only by one precompile run, so the failure becomes more likely as the machine gets faster.

Fixes #50364

### Detail

This Pull Request changes the test to sleep one second before rewriting `app/assets/images/rails.png`, so that the rewrite crosses a second boundary, which is the change detection granularity sprockets documents. sprockets is mature and the one-second granularity is a long-standing design decision, so the test accommodates it. In the scenario the test models, an asset changes between two precompile runs, which does not happen within a single second in practice. Only the speed of the test fits both writes into one second.

Reproduction rate measured by running the test 100 times on an x86_64 Ubuntu 26.04 host (AMD Ryzen 9 7940HS, 16 CPUs, 64 GB RAM) with Ruby 4.0.6:

| Branch | Without the sleep | With the sleep |
| --- | --- | --- |
| main | 47 failures / 100 runs | 0 failures / 100 runs |

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
