### PR TITLE
Harden `rails query --sql` LIMIT handling against strings and comments

### DIFF
--- a/railties/lib/rails/commands/query/query_command.rb
+++ b/railties/lib/rails/commands/query/query_command.rb
@@ -150,9 +150,12 @@ module Rails
         end
 
         def execute_sql(connection:, sql:, page:, per:)
-          unless sql.gsub(/--[^\n]*|\/\*.*?\*\//m, "").match?(/\bLIMIT\b/i)
+          masked = mask_strings_and_comments(sql)
+
+          unless masked.match?(/\bLIMIT\b/i)
             offset = (page - 1) * per
-            sql = "#{sql.rstrip.chomp(';')} LIMIT #{per + 1}"
+            statement_end = masked.rstrip.chomp(";").rstrip.length
+            sql = "#{sql[0, statement_end]} LIMIT #{per + 1}"
             sql += " OFFSET #{offset}" if offset > 0
           end
 
@@ -160,6 +163,20 @@ module Rails
           rows = active_record_result.rows
 
           tabular_result(columns: active_record_result.columns, rows: rows.first(per), sql: sql, truncated: rows.length > per)
+        end
+
+        # String literals, quoted identifiers, and comments are masked out
+        # character for character, so a LIMIT inside them does not count as a
+        # LIMIT clause and cannot hide one, and positions in the masked string
+        # locate the end of the statement in the original. Comments become
+        # spaces so a trailing comment is stripped along with surrounding
+        # whitespace; strings and identifiers become a non-space, non-word
+        # filler so a statement ending in one keeps its length and a LIMIT
+        # keyword directly adjacent to one keeps its word boundary.
+        def mask_strings_and_comments(sql)
+          sql.gsub(/'(?:[^']|'')*'|"(?:[^"]|"")*"|`(?:[^`]|``)*`|--[^\n]*|\/\*.*?\*\//m) do |match|
+            (match.start_with?("--", "/*") ? " " : ".") * match.length
+          end
         end
 
         def execute_expression(expression:, page:, per:)

--- a/railties/test/commands/query_test.rb
+++ b/railties/test/commands/query_test.rb
@@ -260,6 +260,70 @@ class Rails::Command::QueryTest < ActiveSupport::TestCase
     assert_equal 2, data["rows"].length
   end
 
+  test "detects an explicit LIMIT that follows a string containing a comment start" do
+    rails "runner", '3.times { |i| Post.create!(title: "Post #{i}") }'
+
+    data = query_json("--sql", "SELECT * FROM posts WHERE title <> 'a--b' ORDER BY id LIMIT 2")
+
+    assert_equal 2, data["rows"].length
+  end
+
+  test "detects an explicit LIMIT directly adjacent to a string literal" do
+    rails "runner", '3.times { |i| Post.create!(title: "Post #{i}") }'
+
+    data = query_json("--sql", "SELECT * FROM posts WHERE title <> 'a'LIMIT 2")
+
+    assert_equal 2, data["rows"].length
+  end
+
+  test "paginates when a string literal mentions limit" do
+    rails "runner", '4.times { |i| Post.create!(title: "Post #{i}") }'
+
+    sql = "SELECT * FROM posts WHERE title <> 'no limit' ORDER BY id"
+    page1 = query_json("--sql", sql, "--per", "2", "--page", "1")
+    page2 = query_json("--sql", sql, "--per", "2", "--page", "2")
+
+    assert_not_equal page1["rows"], page2["rows"]
+  end
+
+  test "appends LIMIT after a statement ending in a string literal" do
+    rails "runner", '4.times { |i| Post.create!(title: "Post #{i}") }'
+
+    data = query_json("--sql", "SELECT * FROM posts WHERE title <> 'no limit'", "--per", "2")
+
+    assert_equal 2, data["rows"].length
+  end
+
+  test "paginates when a quoted identifier mentions limit" do
+    rails "runner", '4.times { |i| Post.create!(title: "Post #{i}") }'
+
+    sql = %(SELECT title AS "the ""limit""" FROM posts ORDER BY id)
+    page1 = query_json("--sql", sql, "--per", "2", "--page", "1")
+    page2 = query_json("--sql", sql, "--per", "2", "--page", "2")
+
+    assert_not_equal page1["rows"], page2["rows"]
+  end
+
+  test "paginates past a trailing SQL comment" do
+    rails "runner", '4.times { |i| Post.create!(title: "Post #{i}") }'
+
+    sql = "SELECT * FROM posts ORDER BY id -- newest first"
+    page1 = query_json("--sql", sql, "--per", "2", "--page", "1")
+    page2 = query_json("--sql", sql, "--per", "2", "--page", "2")
+
+    assert_not_equal page1["rows"], page2["rows"]
+  end
+
+  test "paginates past a trailing semicolon followed by a comment" do
+    rails "runner", '4.times { |i| Post.create!(title: "Post #{i}") }'
+
+    sql = "SELECT * FROM posts ORDER BY id; -- all posts"
+    page1 = query_json("--sql", sql, "--per", "2", "--page", "1")
+    page2 = query_json("--sql", sql, "--per", "2", "--page", "2")
+
+    assert_not_equal page1["rows"], page2["rows"]
+  end
+
   test "explain shows query plan" do
     data = query_json("explain", "Post.where(status: 0)")
 


### PR DESCRIPTION
### Motivation / Background

Follow-up to #58077, hardening the same check against more statement shapes.

`rails query --sql` appends its own `LIMIT`/`OFFSET` unless the statement already has a `LIMIT`. The check strips comments first, but SQL string literals can still confuse it, and the appended clause can land inside a trailing comment. Three real statement shapes break:

**1. A string containing `--` before a real LIMIT — invalid SQL.**

```console
$ bin/rails query --sql "SELECT * FROM posts WHERE title <> 'a--b' LIMIT 2"
{"error":"SQLite3::SQLException: near \"LIMIT\": syntax error"}
```

The comment stripper consumes from the `--` inside the string to the end of the line, taking the real `LIMIT 2` with it, so a second `LIMIT` is appended.

**2. A string containing the word "limit" — pagination silently disabled.**

```console
$ bin/rails query --sql "SELECT * FROM posts WHERE title <> 'no limit'" --page 2
```

The word inside the string counts as a `LIMIT` clause, so nothing is appended: the entire result is fetched, and every `--page` returns the first page's rows.

**3. A trailing line comment (with or without a semicolon before it) — appended LIMIT swallowed.**

```console
$ bin/rails query --sql "SELECT * FROM posts ORDER BY id -- newest first" --page 2
```

The appended ` LIMIT 101 OFFSET 100` becomes part of the comment, with the same effect: the whole table is fetched and `--page` silently returns page 1 again.

### Detail

String literals, quoted identifiers, and comments are now masked out character for character before looking for a `LIMIT`, so a `LIMIT` inside them neither counts as a clause nor hides a real one. Because the masked string keeps every position, it also locates the end of the statement proper, and the `LIMIT`/`OFFSET` is appended there — before any trailing semicolon or comment instead of inside it. Comments are masked to spaces so a trailing comment is stripped along with surrounding whitespace, while strings and identifiers are masked to a non-space, non-word filler, so a statement ending in a string literal keeps its full length and a `LIMIT` written directly against a closing quote (valid SQL: `... <> 'a'LIMIT 2`) keeps its word boundary.

### Checklist

- [x] 7 new tests, each red on main or on an earlier revision of this branch (2 crashes, 4 page-2-equals-page-1, 1 quote-adjacent `LIMIT`; incl. a `""`-escaped quoted identifier containing the word "limit" and a statement ending in a string literal), green with the fix
- [x] `railties/test/commands/query_test.rb` — 36 runs, 0 failures
- [x] RuboCop clean
- [x] No CHANGELOG (unreleased command)