### PR TITLE
Fix grouped calculation key types when grouping by a column of a table unknown to the schema

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -559,10 +559,16 @@ module ActiveRecord
             end
 
             key_types = group_columns.each_with_object({}) do |(aliaz, col_name), types|
-              types[aliaz] = col_name.try(:type_caster) ||
-                type_for(col_name) do
+              type = col_name.try(:type_caster)
+              if type.nil? || type == Type.default_value
+                # A do-nothing type caster means the column belongs to a table
+                # the schema doesn't know about (e.g. a raw SQL join alias), so
+                # the result set is the only source of type information.
+                type = type_for(col_name) do
                   calculated_data.column_types.fetch(aliaz, Type.default_value)
                 end
+              end
+              types[aliaz] = type
             end
 
             hash_rows = calculated_data.cast_values(key_types).map! do |row|

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -755,6 +755,16 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal({ "active" => 2, "trial" => 2, "suspended" => 1 }, counts)
   end
 
+  def test_should_cast_group_by_keys_from_the_result_set_for_a_column_of_a_table_unknown_to_the_schema
+    counts = Account
+      .joins("JOIN (SELECT tsrange(timestamp '2020-01-01', timestamp '2020-01-02', '[)') AS period) periods ON TRUE")
+      .group("periods.period")
+      .count
+
+    assert_equal [Account.count], counts.values
+    assert_equal [Time.utc(2020, 1, 1)...Time.utc(2020, 1, 2)], counts.keys
+  end if current_adapter?(:PostgreSQLAdapter)
+
   def test_should_count_field_of_root_table_with_conflicting_group_by_column
     expected = { 1 => 2, 2 => 1, 4 => 5, 5 => 3, 7 => 1 }
     assert_equal expected, Post.joins(:comments).group(:post_id).count

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -758,6 +758,16 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal({ "active" => 2, "trial" => 2, "suspended" => 1 }, counts)
   end
 
+  def test_should_cast_group_by_keys_from_the_result_set_for_a_column_of_a_table_unknown_to_the_schema
+    counts = Account
+      .joins("JOIN (SELECT tsrange(timestamp '2020-01-01', timestamp '2020-01-02', '[)') AS period) periods ON TRUE")
+      .group("periods.period")
+      .count
+
+    assert_equal [Account.count], counts.values
+    assert_equal [Time.utc(2020, 1, 1)...Time.utc(2020, 1, 2)], counts.keys
+  end if current_adapter?(:PostgreSQLAdapter)
+
   def test_should_count_field_of_root_table_with_conflicting_group_by_column
     expected = { 1 => 2, 2 => 1, 4 => 5, 5 => 3, 7 => 1 }
     assert_equal expected, Post.joins(:comments).group(:post_id).count


### PR DESCRIPTION
### Motivation / Background

Fixes #48420.

Since 7.0.5, grouping a calculation by a qualified column reference whose table the schema doesn't know about — such as an alias introduced by a string join — returns raw, uncast strings as the result keys on PostgreSQL:

```ruby
Booking
  .joins("JOIN (SELECT tsrange(timestamp '2020-01-01', timestamp '2020-01-02', '[)') AS range) ranges ON TRUE")
  .group("ranges.range")
  .count
# => { "[\"2020-01-01 00:00:00\",\"2020-01-02 00:00:00\")" => 1 }
```

while the same expression grouped directly returns properly cast keys:

```ruby
Booking.group("tsrange(timestamp '2020-01-01', timestamp '2020-01-02', '[)')").count
# => { 2020-01-01 00:00:00 UTC...2020-01-02 00:00:00 UTC => 1 }
```

Before fe3aca1097 (bisected in the issue), both forms were cast from the result set's column types.

### Detail

The group key type is now only taken from the resolved group column when it carries real type information. When the column resolves to a table the schema knows nothing about, the type falls back to the result set's column types, restoring the pre-7.0.5 behavior for such keys.

The case fe3aca1097 fixed is preserved: grouping by a joined table's column that shares its name with a column of the root model still gets its type from the joined model (covered by the existing `test_should_count_field_in_joined_table_with_group_by_when_tables_share_column_names`).

The regression test is PostgreSQL-only because the fallback needs a result set that reports column types; the sqlite3 adapter doesn't provide them, so both branches are indistinguishable there.

### Checklist

- [x] Regression test red on `main`, green with the fix (PostgreSQL):
  - red: `Expected: [2020-01-01...2020-01-02] Actual: ["[\"2020-01-01 00:00:00\",\"2020-01-02 00:00:00\")"]`
- [x] `test/cases/calculations_test.rb`: postgresql 239 runs / sqlite3 237 runs — 0 failures, 0 errors
- [x] No CHANGELOG entry (simple bug fix, per past maintainer guidance — add on request)