### PR TITLE
Pin json below 2.20 in the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,8 @@ gem "bcrypt", "~> 3.1.11", require: false
 gem "terser", ">= 1.1.4", require: false
 
 # Explicitly avoid 1.x that doesn't support Ruby 2.4+
-gem "json", ">= 2.0.0", "!=2.7.0"
+# Pin below 2.20, whose comment deprecation warning fails the strict warnings CI
+gem "json", ">= 2.0.0", "!=2.7.0", "< 2.20"
 
 # Workaround until all supported Ruby versions ship with uri version 0.13.1 or higher.
 gem "uri", ">= 0.13.1", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -731,7 +731,7 @@ DEPENDENCIES
   importmap-rails (>= 1.2.3)
   jbuilder
   jsbundling-rails
-  json (>= 2.0.0, != 2.7.0)
+  json (>= 2.0.0, < 2.20, != 2.7.0)
   kamal (>= 2.1.0)
   launchy
   libxml-ruby


### PR DESCRIPTION
### Motivation / Background

json 2.20.0 deprecates comments in JSON documents, and its deprecation
warning fails the strict warnings CI on this branch.

On main this was addressed by #57832, which passes `allow_comments: true`.
Backporting that change is not an option here: it was merged to 8-0-stable
once (eb5a0633495b70e4484bea0e1562081d1de72de6) and reverted
(fdc6c1c9c1eab99b41b6a53c7bd8cdedbe36c9f0), because on this branch
`ActiveSupport::JSON.decode` takes one argument, so the backported `_load`
passing `allow_comments:` raised `ArgumentError` and broke the JSON message
serializer.

Per https://rubyonrails.org/maintenance, bug fix support for 8.0.x has ended
and only the security fixes window remains, so this branch pins the json gem
in the Gemfile instead.

### Detail

This Pull Request adds `< 2.20` to the existing json requirement in the
Gemfile and updates Gemfile.lock accordingly.

### Additional information

The Gemfile constraint only affects development and CI of Rails itself; it
does not constrain applications using Rails 8.0.x.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
