### PR TITLE
Fix duplicate records when using `create_with` and nested attributes on associations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix duplicated record creation when using nested attributes with `create_with`
+    on an association.
+
+    *Jerome Dalbert*
+
 *   Deprecate the `pk`, `id_value`, and `sequence_name` positional arguments to
     `ActiveRecord::ConnectionAdapters::DatabaseStatements#insert`.
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix duplicated record creation when using nested attributes and `create_with`
+    on an association.
+
+    *Jerome Dalbert*
+
 *   Re-enable PostgreSQL triggers when the block given to `disable_referential_integrity` raises.
 
     On PostgreSQL versions without `NOT ENFORCED` constraints (before 18.4), the

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -218,6 +218,7 @@ module ActiveRecord
         except_from_scope_attributes ||= {}
         skip_assign = [reflection.foreign_key, reflection.type].compact
         assigned_keys = record.changed_attribute_names_to_save
+        assigned_keys += record.assigned_nested_attribute_names
         assigned_keys += except_from_scope_attributes.keys.map(&:to_s)
         attributes = scope_for_create.except!(*(assigned_keys - skip_assign))
         record.send(:_assign_attributes, attributes) if attributes.any?

--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -391,10 +391,15 @@ module ActiveRecord
             def #{association_name}_attributes=(attributes)
               association = association(:#{association_name})
               deprecated_associations_api_guard(association, __method__)
+              (@_assigned_nested_attribute_names ||= []) << "#{association_name}_attributes"
               assign_nested_attributes_for_#{type}_association(:#{association_name}, attributes)
             end
           eoruby
         end
+    end
+
+    def assigned_nested_attribute_names # :nodoc:
+      @_assigned_nested_attribute_names || []
     end
 
     # Returns ActiveRecord::AutosaveAssociation#marked_for_destruction? It's
@@ -407,6 +412,11 @@ module ActiveRecord
     end
 
     private
+      def init_internals
+        super
+        @_assigned_nested_attribute_names = nil
+      end
+
       # Attribute hash keys that should not be assigned as normal attributes.
       # These hash keys are nested attributes implementation details.
       UNASSIGNABLE_KEYS = %w( id _destroy ).freeze

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -237,6 +237,15 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
     end
   end
 
+  def test_should_not_create_duplicates_with_create_with_on_association
+    ship = Ship.create!(name: "Black Pearl")
+    part = ship.parts
+      .create_with(trinkets_attributes: [{ name: "Necklace" }])
+      .find_or_create_by!(name: "Stern")
+
+    assert_equal 1, part.trinkets.count
+  end
+
   def test_updating_models_with_cpk_provided_as_strings
     book = Cpk::Book.create!(id: [1, 2], shop_id: 3)
     book.chapters.create!(id: [1, 3], title: "Title")


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/58155, which is an issue we have encountered at work.

### Motivation / Background

This Pull Request has been created because `some_record.things.create_with(xyz_attributes: [{...}]).find_or_create_by(...)` creates duplicate `xyz` records.

This is happening because internally the same nested attributes are added twice:

1. once when initializing/assigning a general record in `ActiveRecord::Core#initialize` -> `#initialize_internals_callback` -> `ActiveRecord::Scoping#initialize_internals_callback` -> [`#populate_with_current_scope_attributes`](https://github.com/rails/rails/blob/7b36c967dc9a01e616027453d43104af80b06a54/activerecord/lib/active_record/scoping.rb#L50).
2. once when initializing/assigning an association in `ActiveRecord::Associations::CollectionAssociation#build` -> `ActiveRecord::Associations::Association#build_record` -> [`#initialize_attributes`](https://github.com/rails/rails/blob/7b36c967dc9a01e616027453d43104af80b06a54/activerecord/lib/active_record/associations/association.rb#L223).

Normally step 2 shouldn't add attributes again, because the code [excludes](https://github.com/rails/rails/blob/7b36c967dc9a01e616027453d43104af80b06a54/activerecord/lib/active_record/associations/association.rb#L220-L222) `record.changed_attribute_names_to_save`, i.e. attributes added in step 1. But `changed_attribute_names_to_save` only tracks DB columns, not nested attributes (`xyz_attributes` is not a DB column). This means that nested attributes are added a second time, leading to duplicate records.

### Detail

This Pull Request changes step 2's `ActiveRecord::Associations::Association#initialize_attributes` to exclude nested attributes on top of normal attributes. This is done thanks to a new internal method in `ActiveRecord::NestedAttributes` that keeps track of any nested attributes that were previously assigned.

### Additional information

PR https://github.com/rails/rails/pull/33639 fixed a similar [issue](https://github.com/rails/rails/issues/33610), but only at the root level, i.e. `SomeModel.create_with(xyz_attributes: [{...}]).find_or_create_by(...)`. It did not fix the association level.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
