### PR TITLE
Assert @verified directly in the non-StandardError interrupt test

### DIFF
--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -659,7 +659,7 @@ module ActiveRecord
 
         # It can't be reused on the "verified" flag or the recently-used shortcut, so both
         # are cleared and the connection is re-verified before its next use.
-        assert_not_predicate @connection, :verified?
+        assert_not @connection.instance_variable_get(:@verified)
         assert_nil @connection.instance_variable_get(:@last_activity)
       end
 


### PR DESCRIPTION
### Motivation / Background

`ActiveRecord::AdapterConnectionTest#test_a_non-StandardError_interrupt_marks_the_connection_for_re-verification` fails deterministically on 8-0-stable, on every adapter:

```
Expected #<ActiveRecord::ConnectionAdapters::Mysql2Adapter:0x0000000000d5d0 env_name="arunit" role=:writing>
(ActiveRecord::ConnectionAdapters::Mysql2Adapter) to respond to #verified?.
```

- https://buildkite.com/rails/rails/builds/131175 (the backport merge itself)
- https://buildkite.com/rails/rails/builds/131193

The test came in with the backport merge 9241586205 (#57953) and asserts `assert_not_predicate @connection, :verified?`. The `verified?` reader only exists on main; it was introduced by 28638775db ("Preconnect connections that are idle in the pool"), which is not part of 8-0-stable — the branch has the `@verified` instance variable and `verified!`, but no reader. Since minitest 6.0.4, `refute_predicate` asserts `respond_to?` before sending the predicate (minitest/minitest@b12f87f4f8), which reports the failure above; earlier minitest would raise NoMethodError instead, so the test cannot pass on 8-0-stable either way.

### Detail

Read the `@verified` instance variable directly, like the `@last_activity` assertion on the next line. On main, `verified?` is a plain `@verified` reader, so the asserted condition is unchanged.

This keeps the fix on the test side instead of backporting 28638775db or extracting its `verified?` reader into the stable branch.

### Additional information

Verified locally on this branch: before the change, `ARCONN=sqlite3 bin/test test/cases/adapter_test.rb:649` reproduces the same failure; after the change, the test passes on sqlite3 and mysql2, and the full `AdapterConnectionTest` passes on mysql2 (28 runs, 0 failures).

main and 7-2-stable are not affected.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
