### PR TITLE
Fix NodeSource RPM URL in Development Dependencies Install guide [ci skip]

### DIFF
--- a/guides/source/development_dependencies_install.md
+++ b/guides/source/development_dependencies_install.md
@@ -117,7 +117,7 @@ $ sudo dnf install sqlite-devel sqlite-libs mysql-server mysql-devel postgresql-
 # Install Yarn
 # Use this command if you do not have Node.js installed
 # ref: https://github.com/nodesource/distributions#installation-instructions-1
-$ sudo dnf install https://rpm.nodesource.com/pub_20/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm -y
+$ sudo dnf install https://rpm.nodesource.com/pub_20.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm -y
 $ sudo dnf install nodejs -y --setopt=nodesource-nodejs.module_hotfixes=1
 
 # Once you have installed Node.js, install the yarn npm package


### PR DESCRIPTION
### Motivation / Background

The [Fedora and CentOS section of Development Dependencies Install](https://edgeguides.rubyonrails.org/development_dependencies_install.html#fedora-and-centos) installs Node from [`https://rpm.nodesource.com/pub_20/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm`](https://rpm.nodesource.com/pub_20/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm), which returns **404**. The live path is [`…/pub_20.x/…`](https://rpm.nodesource.com/pub_20.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm) (**200**).

### Detail

One path segment: `pub_20` → `pub_20.x` in the NodeSource RPM URL.

### Additional information

N/A

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature. (Documentation-only change.)
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. (Not needed for documentation changes.)