### PR TITLE
Remove default system test lines from Generators guide scaffold samples [ci skip]

### DIFF
--- a/guides/source/generators.md
+++ b/guides/source/generators.md
@@ -370,7 +370,6 @@ $ bin/rails generate scaffold User name:string
       invoke    resource_route
       invoke    test_unit
       create      test/controllers/users_controller_test.rb
-      create      test/system/users_test.rb
       invoke    helper
       create      app/helpers/users_helper.rb
       invoke      test_unit
@@ -517,7 +516,6 @@ $ bin/rails generate scaffold Comment body:text
       invoke    resource_route
       invoke    my_test_unit
       create      test/controllers/comments_controller_test.rb
-      create      test/system/comments_test.rb
       invoke    helper
       create      app/helpers/comments_helper.rb
       invoke      my_test_unit


### PR DESCRIPTION
### Motivation / Background

The Generators guide scaffold samples still show system-test files being created:

```
create      test/system/users_test.rb
```

(and the same for `comments` later in the guide). On main those lines are at `guides/source/generators.md:373` and `:520`.

Against this checkout (`path:` Gemfile from `railties/exe/rails new … --dev`), `bin/rails generate scaffold Widget name:string --pretend` does not emit any `test/system/*` path — controller tests and jbuilder partials appear, system tests do not. Scaffold only generates system tests when `options[:system_tests] == "true"` (`railties/lib/rails/generators/test_unit/scaffold/scaffold_generator.rb`).

### Detail

Remove the two `create test/system/*_test.rb` lines from the scaffold output samples. No other sample drift.

### Additional information

Related generator change: [ea8736b49f](https://github.com/rails/rails/commit/ea8736b49f) / [#56272](https://github.com/rails/rails/pull/56272).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature. (Documentation-only change.)
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. (Not needed for documentation changes.)