### PR TITLE
Move adapter-specific migration compatibility into per-adapter behaviors

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,23 @@
+*   Allow connection adapters to define their own migration version compatibility.
+
+    A connection adapter resolves a migration's declared version
+    (e.g. `Migration[6.1]`) to one of the new subclasses of
+    `ActiveRecord::Migration::CompatibilityBehavior` through its
+    `compatibility_behavior_for(migration_class)` hook; a behavior covers
+    migrations declaring its own version and older, and adjusts schema
+    operations to how that version ran them. The bundled adapters now
+    express their compatibility this way, and a third-party adapter can
+    define its own behaviors, or inherit a bundled adapter's, instead of
+    patching `ActiveRecord::Migration::Compatibility`; adapters that
+    define none get a no-op default and behave as before.
+
+    Subclasses of bundled adapters now inherit the parent's behaviors,
+    which the previous exact-string `adapter_name` checks never applied
+    to subclasses. Review the inherited adjustments and override
+    `compatibility_behavior_for` where they do not fit your database.
+
+    *Yasuo Honda*
+
 *   Add query predicate hooks for Active Model types.
 
     Types can override `transforms_query_predicates?`, `query_attribute`, and

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -7,6 +7,11 @@ require "openssl"
 module ActiveRecord
   module ConnectionAdapters # :nodoc:
     module SchemaStatements
+      def compatibility_behavior_for(migration_class) # :nodoc:
+        ActiveRecord::Migration::CompatibilityBehavior
+      end
+
+
       # Returns a hash of mappings from the abstract data types to the native
       # database types. See TableDefinition#column for details on the recognized
       # abstract data types.

--- a/activerecord/lib/active_record/connection_adapters/mysql/compatibility_behavior.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/compatibility_behavior.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# :markup: markdown
+
+module ActiveRecord
+  module ConnectionAdapters
+    module MySQL
+      module CompatibilityBehavior # :nodoc: all
+        Base = ActiveRecord::Migration::CompatibilityBehavior
+        extend Base::Resolver
+
+        class V7_0 < Base
+          def change_column(table_name, column_name, type, **options)
+            options[:collation] ||= :no_collation
+            super
+          end
+        end
+
+        class V6_1 < V7_0
+        end
+
+        class V6_0 < V6_1
+        end
+
+        class V5_2 < V6_0
+        end
+
+        class V5_1 < V5_2
+          def create_table(table_name, **options)
+            options[:options] = "ENGINE=InnoDB" unless options.key?(:options)
+            super
+          end
+        end
+
+        class V5_0 < V5_1
+          # The framework V5_0 applies default: nil to integer/bigint ids and
+          # runs before this behavior, so MySQL's bigint-without-default is
+          # restored by dropping the injected default back out. The marker
+          # keeps a user-written `default: nil` untouched.
+          def create_table(table_name, **options)
+            if options.delete(:_compat_injected_default) && options[:id] == :bigint
+              options.delete(:default)
+            end
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_record/connection_adapters/mysql/compatibility_behavior"
+
 module ActiveRecord
   module ConnectionAdapters
     module MySQL
@@ -110,6 +112,10 @@ module ActiveRecord
 
         def update_table_definition(table_name, base)
           MySQL::Table.new(table_name, base)
+        end
+
+        def compatibility_behavior_for(migration_class)
+          MySQL::CompatibilityBehavior.for(migration_class)
         end
 
         def create_schema_dumper(options)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/compatibility_behavior.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/compatibility_behavior.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+# :markup: markdown
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module CompatibilityBehavior # :nodoc: all
+        Base = ActiveRecord::Migration::CompatibilityBehavior
+        extend Base::Resolver
+
+        class V7_0 < Base
+          def disable_extension(name, **options)
+            options[:force] = :cascade
+            super
+          end
+
+          def add_foreign_key(from_table, to_table, **options)
+            options[:deferrable] = :immediate if options[:deferrable] == true
+            super
+          end
+        end
+
+        # For Rails <= 6.1, :datetime was aliased to :timestamp on PostgreSQL;
+        # from Rails 7 onwards it resolves to whatever
+        # `PostgreSQLAdapter.datetime_type` is set to.
+        class V6_1 < V7_0
+          def add_column(table_name, column_name, type, **options)
+            type = :timestamp if type.to_sym == :datetime
+            super
+          end
+
+          def change_column(table_name, column_name, type, **options)
+            type = :timestamp if type.to_sym == :datetime
+            super
+          end
+
+          module TableDefinition
+            def new_column_definition(name, type, **options)
+              type = :timestamp if type.to_sym == :datetime
+              super
+            end
+          end
+        end
+
+        class V6_0 < V6_1
+        end
+
+        class V5_2 < V6_0
+        end
+
+        # Runs the real change_column first (`super` reaches V6_1 and then
+        # the base behavior, which executes through the migration), then
+        # applies :default / :null / :comment separately.
+        class V5_1 < V5_2
+          def change_column(table_name, column_name, type, **options)
+            super(table_name, column_name, type, **options.except(:default, :null, :comment))
+            connection.change_column_default(table_name, column_name, options[:default]) if options.key?(:default)
+            connection.change_column_null(table_name, column_name, options[:null], options[:default]) if options.key?(:null)
+            connection.change_column_comment(table_name, column_name, options[:comment]) if options.key?(:comment)
+          end
+        end
+
+        class V5_0 < V5_1
+          def create_table(table_name, **options)
+            if options[:id] == :uuid && !options.key?(:default)
+              options[:default] = "uuid_generate_v4()"
+            end
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_record/connection_adapters/postgresql/compatibility_behavior"
+
 module ActiveRecord
   module ConnectionAdapters
     module PostgreSQL
@@ -1082,6 +1084,10 @@ module ActiveRecord
 
         def update_table_definition(table_name, base) # :nodoc:
           PostgreSQL::Table.new(table_name, base)
+        end
+
+        def compatibility_behavior_for(migration_class) # :nodoc:
+          PostgreSQL::CompatibilityBehavior.for(migration_class)
         end
 
         def create_schema_dumper(options) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/compatibility_behavior.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/compatibility_behavior.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# :markup: markdown
+
+module ActiveRecord
+  module ConnectionAdapters
+    module SQLite3
+      module CompatibilityBehavior # :nodoc: all
+        Base = ActiveRecord::Migration::CompatibilityBehavior
+        extend Base::Resolver
+
+        class V6_0 < Base
+          def add_reference(table_name, ref_name, **options)
+            options[:type] = :integer
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_record/connection_adapters/sqlite3/compatibility_behavior"
+
 module ActiveRecord
   module ConnectionAdapters
     module SQLite3
@@ -120,6 +122,10 @@ module ActiveRecord
 
         def schema_creation # :nodoc
           SQLite3::SchemaCreation.new(self)
+        end
+
+        def compatibility_behavior_for(migration_class)
+          SQLite3::CompatibilityBehavior.for(migration_class)
         end
 
         private

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -850,8 +850,15 @@ module ActiveRecord
       @compatibility_behavior ||= connection.compatibility_behavior_for(self.class).new(self)
     end
 
-    def execute_operation(method, ...) # :nodoc:
-      execution_strategy.send(method, ...)
+    def execute_operation(method, *arguments, **kwargs, &block) # :nodoc:
+      # Logging sits at the execution point so compatibility adjustments
+      # show in the verbose output; table names display as written in the
+      # migration, not as the proper_table_name the operation receives.
+      display_arguments = arguments.dup
+      @written_table_names&.each { |index, name| display_arguments[index] = name }
+      say_with_time("#{method}(#{format_arguments(display_arguments, kwargs)})") do
+        execution_strategy.send(method, *arguments, **kwargs, &block)
+      end
     end
 
     self.verbose = true
@@ -1089,21 +1096,23 @@ module ActiveRecord
     end
 
     def method_missing(method, *arguments, **kwargs, &block)
-      say_with_time "#{method}(#{format_arguments(arguments, kwargs)})" do
-        unless connection.respond_to? :revert
-          unless arguments.empty? || [:execute, :enable_extension, :disable_extension].include?(method)
-            arguments[0] = proper_table_name(arguments.first, table_name_options)
-            if method == :rename_table ||
-              (method == :remove_foreign_key && arguments.second)
-              arguments[1] = proper_table_name(arguments.second, table_name_options)
-            end
+      unless connection.respond_to? :revert
+        unless arguments.empty? || [:execute, :enable_extension, :disable_extension].include?(method)
+          @written_table_names = { 0 => arguments.first }
+          arguments[0] = proper_table_name(arguments.first, table_name_options)
+          if method == :rename_table ||
+            (method == :remove_foreign_key && arguments.second)
+            @written_table_names[1] = arguments.second
+            arguments[1] = proper_table_name(arguments.second, table_name_options)
           end
         end
-        return super unless execution_strategy.respond_to?(method)
-        # A behavior method's `super` lands in the behavior base, which
-        # forwards to execute_operation.
-        compatibility_behavior.public_send(method, *arguments, **kwargs, &block)
       end
+      return super unless execution_strategy.respond_to?(method)
+      # A behavior method's `super` lands in the behavior base, which
+      # forwards to execute_operation.
+      compatibility_behavior.public_send(method, *arguments, **kwargs, &block)
+    ensure
+      @written_table_names = nil
     end
 
     def copy(destination, sources, options = {})

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -608,7 +608,14 @@ module ActiveRecord
         end
       end
 
+      # Ancestors are walked oldest-version-first, so the newest version's
+      # module ends up first in method lookup — the same order the per-class
+      # overrides produced.
       def compatible_table_definition(t)
+        (self.class.ancestors & Compatibility.version_classes).each do |version_class|
+          next unless version_class.const_defined?(:TableDefinition, false)
+          t.singleton_class.prepend(version_class.const_get(:TableDefinition, false))
+        end
         t
       end
     end

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -573,6 +573,7 @@ module ActiveRecord
     autoload :DefaultSchemaVersionsFormatter, "active_record/migration/default_schema_versions_formatter"
     autoload :ExecutionStrategy, "active_record/migration/execution_strategy"
     autoload :DefaultStrategy, "active_record/migration/default_strategy"
+    autoload :CompatibilityBehavior, "active_record/migration/compatibility_behavior"
 
     # This must be defined before the inherited hook, below
     class Current < Migration # :nodoc:
@@ -608,10 +609,18 @@ module ActiveRecord
         end
       end
 
-      # Ancestors are walked oldest-version-first, so the newest version's
-      # module ends up first in method lookup — the same order the per-class
-      # overrides produced.
+      # Behavior modules are prepended before the framework modules and so
+      # resolve after them: the framework adjusts options first and behaviors
+      # run closest to execution, matching migration-level dispatch. Within
+      # the framework the newest version's module resolves first; within
+      # behaviors the oldest version's resolves first, its `super` reaching
+      # the newer ones as in the behavior classes' own inheritance.
+      # `t` is a TableDefinition for create_table and a Table for change_table.
       def compatible_table_definition(t)
+        compatibility_behavior.class.ancestors.reverse_each do |behavior_class|
+          next unless behavior_class <= CompatibilityBehavior && behavior_class.const_defined?(:TableDefinition, false)
+          t.singleton_class.prepend(behavior_class.const_get(:TableDefinition, false))
+        end
         (self.class.ancestors & Compatibility.version_classes).each do |version_class|
           next unless version_class.const_defined?(:TableDefinition, false)
           t.singleton_class.prepend(version_class.const_get(:TableDefinition, false))
@@ -837,6 +846,14 @@ module ActiveRecord
       @execution_strategy ||= (connection.migration_strategy || ActiveRecord.migration_strategy).new(self)
     end
 
+    def compatibility_behavior # :nodoc:
+      @compatibility_behavior ||= connection.compatibility_behavior_for(self.class).new(self)
+    end
+
+    def execute_operation(method, ...) # :nodoc:
+      execution_strategy.send(method, ...)
+    end
+
     self.verbose = true
     # instantiate the delegate object after initialize is defined
     self.delegate = new
@@ -1025,6 +1042,7 @@ module ActiveRecord
     ensure
       @connection = nil
       @execution_strategy = nil
+      @compatibility_behavior = nil
     end
 
     def write(text = "")
@@ -1082,7 +1100,9 @@ module ActiveRecord
           end
         end
         return super unless execution_strategy.respond_to?(method)
-        execution_strategy.send(method, *arguments, **kwargs, &block)
+        # A behavior method's `super` lands in the behavior base, which
+        # forwards to execute_operation.
+        compatibility_behavior.public_send(method, *arguments, **kwargs, &block)
       end
     end
 

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -317,6 +317,7 @@ module ActiveRecord
         def change_column(table_name, column_name, type, **options)
           if connection.adapter_name == "PostgreSQL"
             super(table_name, column_name, type, **options.except(:default, :null, :comment))
+            table_name = proper_table_name(table_name, table_name_options) unless connection.respond_to?(:revert)
             connection.change_column_default(table_name, column_name, options[:default]) if options.key?(:default)
             connection.change_column_null(table_name, column_name, options[:null], options[:default]) if options.key?(:null)
             connection.change_column_comment(table_name, column_name, options[:comment]) if options.key?(:comment)

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -157,52 +157,20 @@ module ActiveRecord
 
         def change_column(table_name, column_name, type, **options)
           options[:_skip_validate_options] = true
-          if connection.adapter_name == "Mysql2" || connection.adapter_name == "Trilogy"
-            options[:collation] ||= :no_collation
-          end
           super
         end
 
         def change_column_null(table_name, column_name, null, default = nil)
           super(table_name, column_name, !!null, default)
         end
-
-        def disable_extension(name, **options)
-          if connection.adapter_name == "PostgreSQL"
-            options[:force] = :cascade
-          end
-          super
-        end
-
-        def add_foreign_key(from_table, to_table, **options)
-          if connection.adapter_name == "PostgreSQL" && options[:deferrable] == true
-            options[:deferrable] = :immediate
-          end
-          super
-        end
       end
 
       class V6_1 < V7_0
-        class PostgreSQLCompat
-          def self.compatible_timestamp_type(type, connection)
-            if connection.adapter_name == "PostgreSQL"
-              # For Rails <= 6.1, :datetime was aliased to :timestamp
-              # See: https://github.com/rails/rails/blob/v6.1.3.2/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L108
-              # From Rails 7 onwards, you can define what :datetime resolves to (the default is still :timestamp)
-              # See `ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.datetime_type`
-              type.to_sym == :datetime ? :timestamp : type
-            else
-              type
-            end
-          end
-        end
-
         def add_column(table_name, column_name, type, **options)
           if type == :datetime
             options[:precision] ||= nil
           end
 
-          type = PostgreSQLCompat.compatible_timestamp_type(type, connection)
           super
         end
 
@@ -211,16 +179,10 @@ module ActiveRecord
             options[:precision] ||= nil
           end
 
-          type = PostgreSQLCompat.compatible_timestamp_type(type, connection)
           super
         end
 
         module TableDefinition
-          def new_column_definition(name, type, **options)
-            type = PostgreSQLCompat.compatible_timestamp_type(type, @conn)
-            super
-          end
-
           def change(name, type, index: nil, **options)
             options[:precision] ||= nil
             super
@@ -256,10 +218,6 @@ module ActiveRecord
         end
 
         def add_reference(table_name, ref_name, **options)
-          if connection.adapter_name == "SQLite"
-            options[:type] = :integer
-          end
-
           options[:_uses_legacy_reference_index_name] = true
           super
         end
@@ -314,25 +272,6 @@ module ActiveRecord
       end
 
       class V5_1 < V5_2
-        def change_column(table_name, column_name, type, **options)
-          if connection.adapter_name == "PostgreSQL"
-            super(table_name, column_name, type, **options.except(:default, :null, :comment))
-            table_name = proper_table_name(table_name, table_name_options) unless connection.respond_to?(:revert)
-            connection.change_column_default(table_name, column_name, options[:default]) if options.key?(:default)
-            connection.change_column_null(table_name, column_name, options[:null], options[:default]) if options.key?(:null)
-            connection.change_column_comment(table_name, column_name, options[:comment]) if options.key?(:comment)
-          else
-            super
-          end
-        end
-
-        def create_table(table_name, **options)
-          if connection.adapter_name == "Mysql2" || connection.adapter_name == "Trilogy"
-            super(table_name, options: "ENGINE=InnoDB", **options)
-          else
-            super
-          end
-        end
       end
 
       class V5_0 < V5_1
@@ -353,16 +292,10 @@ module ActiveRecord
         end
 
         def create_table(table_name, **options)
-          if connection.adapter_name == "PostgreSQL"
-            if options[:id] == :uuid && !options.key?(:default)
-              options[:default] = "uuid_generate_v4()"
-            end
-          end
-
-          unless ["Mysql2", "Trilogy"].include?(connection.adapter_name) && options[:id] == :bigint
-            if [:integer, :bigint].include?(options[:id]) && !options.key?(:default)
-              options[:default] = nil
-            end
+          if [:integer, :bigint].include?(options[:id]) && !options.key?(:default)
+            options[:default] = nil
+            # Marks the injected nil apart from a user-written `default: nil`.
+            options[:_compat_injected_default] = true
           end
 
           # Since 5.1 PostgreSQL adapter uses bigserial type for primary

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -17,6 +17,10 @@ module ActiveRecord
         @version_classes ||= constants.grep(/\AV\d+_\d+\z/).map { |name| const_get(name) }
       end
 
+      def self.version_for(migration_class)
+        migration_class.ancestors.find { |ancestor| version_classes.include?(ancestor) }
+      end
+
       # This file exists to ensure that old migrations run the same way they did before a Rails upgrade.
       # e.g. if you write a migration on Rails 6.1, then upgrade to Rails 7, the migration should do the same thing to your
       # database as it did when you were running Rails 6.1

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -13,6 +13,10 @@ module ActiveRecord
         const_get(name)
       end
 
+      def self.version_classes
+        @version_classes ||= constants.grep(/\AV\d+_\d+\z/).map { |name| const_get(name) }
+      end
+
       # This file exists to ensure that old migrations run the same way they did before a Rails upgrade.
       # e.g. if you write a migration on Rails 6.1, then upgrade to Rails 7, the migration should do the same thing to your
       # database as it did when you were running Rails 6.1
@@ -50,12 +54,6 @@ module ActiveRecord
         end
 
         include RemoveForeignKeyColumnMatch
-
-        private
-          def compatible_table_definition(t)
-            t.singleton_class.prepend(TableDefinition)
-            super
-          end
       end
 
       class V7_2 < V8_0
@@ -178,12 +176,6 @@ module ActiveRecord
           end
           super
         end
-
-        private
-          def compatible_table_definition(t)
-            t.singleton_class.prepend(TableDefinition)
-            super
-          end
       end
 
       class V6_1 < V7_0
@@ -239,12 +231,6 @@ module ActiveRecord
             def raise_on_if_exist_options(options)
             end
         end
-
-        private
-          def compatible_table_definition(t)
-            t.singleton_class.prepend(TableDefinition)
-            super
-          end
       end
 
       class V6_0 < V6_1
@@ -274,12 +260,6 @@ module ActiveRecord
           super
         end
         alias :add_belongs_to :add_reference
-
-        private
-          def compatible_table_definition(t)
-            t.singleton_class.prepend(TableDefinition)
-            super
-          end
       end
 
       class V5_2 < V6_0
@@ -322,11 +302,6 @@ module ActiveRecord
         end
 
         private
-          def compatible_table_definition(t)
-            t.singleton_class.prepend(TableDefinition)
-            super
-          end
-
           def command_recorder
             recorder = super
             recorder.singleton_class.prepend(CommandRecorder)
@@ -414,12 +389,6 @@ module ActiveRecord
           super(table_name, ref_name, type: :integer, **options)
         end
         alias :add_belongs_to :add_reference
-
-        private
-          def compatible_table_definition(t)
-            t.singleton_class.prepend(TableDefinition)
-            super
-          end
       end
 
       class V4_2 < V5_0
@@ -468,11 +437,6 @@ module ActiveRecord
         end
 
         private
-          def compatible_table_definition(t)
-            t.singleton_class.prepend(TableDefinition)
-            super
-          end
-
           def index_name_for_remove(table_name, column_name, options)
             index_name = connection.index_name(table_name, column_name || options)
 

--- a/activerecord/lib/active_record/migration/compatibility_behavior.rb
+++ b/activerecord/lib/active_record/migration/compatibility_behavior.rb
@@ -33,6 +33,12 @@ module ActiveRecord
         @migration = migration
       end
 
+      # Consumed by adapter behaviors; the connection does not know this key.
+      def create_table(*args, **options)
+        options.delete(:_compat_injected_default)
+        super
+      end
+
       private
         attr_reader :migration
 

--- a/activerecord/lib/active_record/migration/compatibility_behavior.rb
+++ b/activerecord/lib/active_record/migration/compatibility_behavior.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# :markup: markdown
+
+module ActiveRecord
+  class Migration
+    class CompatibilityBehavior # :nodoc:
+      module Resolver # :nodoc:
+        # Schema loads resolve like migrations: a versioned
+        # ActiveRecord::Schema[x.y] maps to V<x_y>, and ActiveRecord::Schema
+        # itself maps to Current. A behavior whose version matches therefore
+        # also runs during db:schema:load; check for
+        # ActiveRecord::Schema::Definition inside the behavior when schema
+        # loads must keep the adapter's default behavior.
+        def for(migration_class) # :nodoc:
+          version_class = Compatibility.version_for(migration_class)
+          return CompatibilityBehavior unless version_class
+          # version_pairs is oldest-first; a behavior covers its own version and older.
+          # Pick the lowest defined version >= the migration's, else the no-op base.
+          pair = version_pairs.find { |version, _| version_class <= version }
+          pair ? pair.last : CompatibilityBehavior
+        end
+
+        private
+          def version_pairs
+            @version_pairs ||= constants.grep(/\AV\d+_\d+\z/)
+              .map { |name| [Compatibility.const_get(name, false), const_get(name)] }
+              .sort { |a, b| a.first <=> b.first }
+          end
+      end
+
+      def initialize(migration)
+        @migration = migration
+      end
+
+      private
+        attr_reader :migration
+
+        # `super` from a subclass's operation method lands here and executes
+        # the operation, so behaviors adjust arguments before `super` and run
+        # follow-up work after it.
+        def method_missing(method, ...)
+          migration.execute_operation(method, ...)
+        end
+
+        def respond_to_missing?(method, include_private = false)
+          migration.execution_strategy.respond_to?(method, include_private) || super
+        end
+
+        def connection
+          migration.connection
+        end
+    end
+  end
+end

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -30,8 +30,77 @@ module ActiveRecord
 
       teardown do
         connection.drop_table :testings rescue nil
+        connection.drop_table :behavior_tabledef rescue nil
         ActiveRecord::Migration.verbose = @verbose_was
         @schema_migration.delete_all_versions rescue nil
+      end
+
+      def test_behavior_table_definition_module_is_prepended_generically
+        behavior_class = Class.new(ActiveRecord::Migration::CompatibilityBehavior) do
+          const_set(:TableDefinition, Module.new do
+            def column(name, type, **options)
+              super
+              super(:"#{name}_shadow", type, **options) unless name.to_s.end_with?("_shadow")
+            end
+          end)
+        end
+        namespace = Module.new do
+          const_set(:V7_0, behavior_class)
+          extend ActiveRecord::Migration::CompatibilityBehavior::Resolver
+        end
+
+        connection.stub(:compatibility_behavior_for, ->(klass) { namespace.for(klass) }) do
+          migration = Class.new(ActiveRecord::Migration[7.0]) {
+            def migrate(x)
+              create_table(:behavior_tabledef, force: true) { |t| t.string :name }
+            end
+          }.new
+          ActiveRecord::Migrator.new(:up, [migration], @schema_migration, @internal_metadata).migrate
+        end
+
+        cols = connection.columns(:behavior_tabledef).map(&:name)
+        assert_includes cols, "name"
+        assert_includes cols, "name_shadow"
+      end
+
+      def test_behavior_table_definition_runs_after_framework_compatibility
+        captured = nil
+        table_definition = Module.new do
+          define_method(:column) do |name, type, **options|
+            captured = options.dup
+            super(name, type, **options)
+          end
+        end
+        behavior_class = Class.new(ActiveRecord::Migration::CompatibilityBehavior)
+        behavior_class.const_set(:TableDefinition, table_definition)
+        namespace = Module.new do
+          const_set(:V7_0, behavior_class)
+          extend ActiveRecord::Migration::CompatibilityBehavior::Resolver
+        end
+
+        connection.stub(:compatibility_behavior_for, ->(klass) { namespace.for(klass) }) do
+          migration = Class.new(ActiveRecord::Migration[7.0]) {
+            def migrate(x)
+              create_table(:behavior_tabledef, force: true) { |t| t.string :name }
+            end
+          }.new
+          ActiveRecord::Migrator.new(:up, [migration], @schema_migration, @internal_metadata).migrate
+        end
+
+        assert captured[:_skip_validate_options]
+      end
+
+      def test_third_party_resolver_derives_version_mapping
+        namespace = Module.new do
+          const_set(:V7_0, Class.new(ActiveRecord::Migration::CompatibilityBehavior))
+          const_set(:V6_1, Class.new(const_get(:V7_0)))
+          extend ActiveRecord::Migration::CompatibilityBehavior::Resolver
+        end
+
+        assert_same namespace::V7_0, namespace.for(ActiveRecord::Migration[7.0])
+        assert_same namespace::V6_1, namespace.for(ActiveRecord::Migration[6.1])
+        assert_same namespace::V6_1, namespace.for(ActiveRecord::Migration[5.2])
+        assert_same ActiveRecord::Migration::CompatibilityBehavior, namespace.for(ActiveRecord::Migration[7.1])
       end
 
       def test_migration_doesnt_remove_named_index

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -103,6 +103,37 @@ module ActiveRecord
         assert_same ActiveRecord::Migration::CompatibilityBehavior, namespace.for(ActiveRecord::Migration[7.1])
       end
 
+      def test_verbose_output_shows_executed_arguments
+        behavior_class = Class.new(ActiveRecord::Migration::CompatibilityBehavior) do
+          def add_column(table_name, column_name, type, **options)
+            options[:null] = false
+            super
+          end
+        end
+        namespace = Module.new do
+          const_set(:V7_0, behavior_class)
+          extend ActiveRecord::Migration::CompatibilityBehavior::Resolver
+        end
+
+        migration = Class.new(ActiveRecord::Migration[7.0]) {
+          def migrate(x)
+            add_column :testings, :extra, :string
+          end
+        }.new
+
+        output = capture(:stdout) do
+          ActiveRecord::Migration.verbose = true
+          connection.stub(:compatibility_behavior_for, ->(klass) { namespace.for(klass) }) do
+            ActiveRecord::Migrator.new(:up, [migration], @schema_migration, @internal_metadata).migrate
+          end
+        ensure
+          ActiveRecord::Migration.verbose = false
+        end
+
+        assert_match(/add_column\(:testings, :extra, :string, \{:?null(: |=>)false\}\)/, output)
+        assert connection.column_exists?(:testings, :extra, null: false)
+      end
+
       def test_migration_doesnt_remove_named_index
         connection.add_index :testings, :foo, name: "custom_index_name"
 

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -134,6 +134,30 @@ module ActiveRecord
         assert connection.column_exists?(:testings, :extra, null: false)
       end
 
+      def test_change_column_follow_ups_honor_table_name_prefix_on_5_1
+        skip unless current_adapter?(:PostgreSQLAdapter)
+
+        prefix_was = ActiveRecord::Base.table_name_prefix
+        ActiveRecord::Base.table_name_prefix = "p_"
+        begin
+          connection.create_table :p_testings, force: true do |t|
+            t.string :foo
+          end
+
+          migration = Class.new(ActiveRecord::Migration[5.1]) {
+            def up
+              change_column :testings, :foo, :string, default: "expected"
+            end
+          }.new
+          migration.migrate(:up)
+
+          assert_equal "expected", connection.columns(:p_testings).find { |c| c.name == "foo" }.default
+        ensure
+          ActiveRecord::Base.table_name_prefix = prefix_was
+          connection.drop_table :p_testings rescue nil
+        end
+      end
+
       def test_migration_doesnt_remove_named_index
         connection.add_index :testings, :foo, name: "custom_index_name"
 

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -103,6 +103,63 @@ module ActiveRecord
         assert_same ActiveRecord::Migration::CompatibilityBehavior, namespace.for(ActiveRecord::Migration[7.1])
       end
 
+      def test_behavior_base_strips_the_injected_default_marker
+        captured = nil
+        migration = Object.new
+        migration.define_singleton_method(:execute_operation) do |method, *args, **options|
+          captured = [method, args, options]
+        end
+
+        behavior = ActiveRecord::Migration::CompatibilityBehavior.new(migration)
+        behavior.create_table(:testings, id: :bigint, default: nil, _compat_injected_default: true)
+
+        assert_equal [:create_table, [:testings], { id: :bigint, default: nil }], captured
+      end
+
+      def test_behavior_table_definition_coerces_datetime_on_postgresql
+        skip unless current_adapter?(:PostgreSQLAdapter)
+
+        # With datetime_type switched, an uncoerced :datetime would become
+        # timestamptz — so this fails if the behavior's V6_1::TableDefinition
+        # module stops being prepended or stops coercing.
+        with_postgresql_datetime_type(:timestamptz) do
+          migration = Class.new(ActiveRecord::Migration[6.1]) {
+            def migrate(x)
+              create_table(:behavior_tabledef, force: true) { |t| t.datetime :published_at }
+            end
+          }.new
+          ActiveRecord::Migrator.new(:up, [migration], @schema_migration, @internal_metadata).migrate
+
+          column = connection.columns(:behavior_tabledef).find { |c| c.name == "published_at" }
+          assert_match(/without time zone/, column.sql_type)
+        end
+      end
+
+      def test_third_party_behavior_subclasses_and_inherits
+        skip unless current_adapter?(:PostgreSQLAdapter)
+
+        third_party_v7_0 = Class.new(ActiveRecord::ConnectionAdapters::PostgreSQL::CompatibilityBehavior::V7_0) do
+          def disable_extension(name, **options)
+            options[:custom_marker] = true
+            super
+          end
+        end
+        captured = nil
+        fake_migration = Class.new {
+          define_method(:execute_operation) { |method, *args, **options| captured = [method, args, options] }
+        }.new
+        behavior = third_party_v7_0.new(fake_migration)
+
+        behavior.disable_extension("some_ext")
+        assert_equal :disable_extension, captured[0]
+        assert captured[2][:custom_marker]
+        assert_equal :cascade, captured[2][:force]
+
+        behavior.add_foreign_key("a", "b", deferrable: true)
+        assert_equal :add_foreign_key, captured[0]
+        assert_equal :immediate, captured[2][:deferrable]
+      end
+
       def test_verbose_output_shows_executed_arguments
         behavior_class = Class.new(ActiveRecord::Migration::CompatibilityBehavior) do
           def add_column(table_name, column_name, type, **options)
@@ -1423,6 +1480,20 @@ module LegacyPrimaryKeyTestCases
 
         schema = dump_table_schema "legacy_primary_keys"
         assert_match %r{create_table "legacy_primary_keys", (?!id: :bigint, default: nil)}, schema
+      end
+
+      def test_legacy_bigint_primary_key_with_explicit_nil_default_should_not_be_auto_incremented
+        @migration = Class.new(migration_class) {
+          def change
+            create_table :legacy_primary_keys, id: :bigint, default: nil
+          end
+        }.new
+
+        @migration.migrate(:up)
+
+        legacy_pk = LegacyPrimaryKey.columns_hash["id"]
+        assert_predicate legacy_pk, :bigint?
+        assert_not legacy_pk.auto_increment?
       end
     else
       def test_legacy_bigint_primary_key_should_not_be_auto_incremented

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -461,6 +461,7 @@ class MigrationTest < ActiveRecord::TestCase
         Class.new {
           def create_table; "hi mom!"; end
           def migration_strategy; nil; end
+          def compatibility_behavior_for(_); ActiveRecord::Migration::CompatibilityBehavior; end
         }.new
       end
     }.new
@@ -474,6 +475,7 @@ class MigrationTest < ActiveRecord::TestCase
         Class.new {
           def create_table; end
           def migration_strategy; nil; end
+          def compatibility_behavior_for(_); ActiveRecord::Migration::CompatibilityBehavior; end
         }.new
       end
     }


### PR DESCRIPTION
### Motivation / Background

This Pull Request addresses two limitations in how `ActiveRecord::Migration::Compatibility`
applies adapter-specific behavior through `connection.adapter_name` checks:

- The framework classes provide compatibility only for the combinations of bundled adapters
  and migration versions (e.g. `Migration[6.1]` on PostgreSQL); a third-party adapter has to
  patch them to participate.
- Subclasses of bundled adapters are excluded by the exact-string `adapter_name` checks
  (e.g. `connection.adapter_name == "PostgreSQL"` never matches `CockroachDBAdapter`, which
  reports `"CockroachDB"`) even though they build on the parent adapter's schema statements —
  the CockroachDB adapter patches around exactly this (see Additional information).

Supersedes #57479 and #57480.
[The review of #57479](https://github.com/rails/rails/pull/57479#pullrequestreview-4377334912)
found its runtime inclusion of per-adapter modules into the migration version classes hard to
predict and suggested the strategy pattern. This Pull Request follows that suggestion —
compatibility lives in behavior objects owned by the connection adapter, and the version
classes never change at runtime — which also removes the need for #57480, the conflict
detection for that module inclusion.

### Detail

This Pull Request changes migration version compatibility so that its adapter-specific side
lives in per-adapter behaviors. The new `ActiveRecord::Migration::CompatibilityBehavior`
carries that side: the connection adapter resolves a migration's declared version
(e.g. `Migration[6.1]`) to a behavior class through its
`compatibility_behavior_for(migration_class)` hook, and `Migration#method_missing` routes
every schema operation through the resolved behavior. A connection that does not respond to
the hook gets the no-op base behavior and behaves as before. A behavior class covers migrations
declaring its own version and older; its superclass chain supplies the newer versions'
adjustments. A behavior method adjusts arguments and calls `super`, the same idiom the
framework compatibility classes use; the base behavior executes the operation, so a behavior
can also run follow-up work after `super`. Nested `TableDefinition` modules cover inline
`t.<op>` calls.

The framework `Compatibility::V_X_Y` classes stay adapter-agnostic — no
`connection.adapter_name` checks remain in `compatibility.rb`. Like the rest of the
connection-adapter interface, the extension point is internal (`:nodoc:`); the constraints on
behavior authors are stated in source comments — dispatch is by method name, so a behavior
that overrides an aliased operation such as `add_reference` also re-declares the alias, and
`TableDefinition` modules are picked up from constants on the behavior classes themselves,
not from modules included into them. Versioned schema
loads resolve through the same behaviors — `ActiveRecord::Schema[x.y]` maps to the same
version classes — and a behavior can check `ActiveRecord::Schema::Definition` when schema
loads must keep the adapter's default behavior.

Commits:

1. Compose compatibility TableDefinition modules in Migration::Current
2. Add CompatibilityBehavior: per-adapter migration compatibility plumbing
3. Format verbose migration output at execution time
4. Fix V5_1 change_column follow-ups to honor table_name_prefix
5. Move adapter-specific migration compatibility into per-adapter behaviors

Except for one `Migration[5.1]` fix, migrations produce the same schema and the same verbose
output as before. Verbose messages are now built at the execution point, so options and types
a behavior adjusts show in the output as executed, while table names keep displaying as
written in the migration.

| Case | Before | After |
| --- | --- | --- |
| Old migrations on bundled adapters | `adapter_name` branches in `Compatibility::V_X_Y` | Same schema results via per-adapter behavior chains |
| Verbose migration output | Formatted from the arguments as they arrived | Built at execution: compatibility adjustments show as executed; table names still display as written |
| `Migration[5.1]` `change_column` on PostgreSQL with `table_name_prefix` | The separate `:default`/`:null`/`:comment` statements targeted the unprefixed table | The follow-ups honor the prefix |
| Subclasses of bundled adapters | Excluded by exact-string `adapter_name` checks | Inherit the parent adapter's behavior chain |
| Third-party adapters | Patch `Migration::Compatibility` | Define or inherit a behavior chain via `compatibility_behavior_for` |

A third-party adapter opts in like this:

```ruby
module ActiveRecord
  module ConnectionAdapters
    module OracleEnhanced
      module CompatibilityBehavior
        Base = ActiveRecord::Migration::CompatibilityBehavior
        extend Base::Resolver

        class V8_2 < Base; end

        # A behavior covers migrations declaring its own version and older:
        # Migration[8.1] and earlier keep this adjustment, Migration[8.2]+
        # resolve to the empty V8_2.
        class V8_1 < V8_2
          def add_index(table_name, column_name, **options)
            # adjust options, then execute; follow-up work can run after super
            super
          end
        end
      end

      module SchemaStatements
        def compatibility_behavior_for(migration_class)
          OracleEnhanced::CompatibilityBehavior.for(migration_class)
        end
      end
    end
  end
end
```

### Additional information

The extension point is exercised by three Oracle enhanced adapter PRs whose CI runs against
this branch (all green):

- rsim/oracle-enhanced#2823 — Add CompatibilityBehavior plumbing for per-adapter migration
  compatibility
- rsim/oracle-enhanced#2816 — Default to identity primary keys in Migration[8.2]+
- rsim/oracle-enhanced#2817 — Stop creating a unique constraint for add_index unique: true in
  Migration[8.2]+

activerecord-cockroachdb-adapter re-applies the `:datetime` → `:timestamp` coercion under its
own `adapter_name` by prepending onto `Compatibility::V6_1::PostgreSQLCompat`
([compatibility.rb](https://github.com/cockroachdb/activerecord-cockroachdb-adapter/blob/master/lib/active_record/migration/cockroachdb/compatibility.rb)).
With this Pull Request the patch becomes unnecessary: `CockroachDBAdapter` subclasses
`PostgreSQLAdapter` and now inherits the PostgreSQL behavior chain. It also has to be dropped
once the adapter supports an Active Record release that includes this change, since
`PostgreSQLCompat` no longer exists. I plan to contribute that removal to the adapter.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

Fix #57479
Fix #57480

