### PR TITLE
Generate omakase-compliant routes in the authentication generator

### DIFF
--- a/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
+++ b/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
@@ -40,8 +40,8 @@ module Rails
       end
 
       def configure_authentication_routes
-        route "resources :passwords, param: :token, only: [:new, :create, :edit, :update]"
-        route "resource :session, only: [:new, :create, :destroy]"
+        route "resources :passwords, param: :token, only: [ :new, :create, :edit, :update ]"
+        route "resource :session, only: [ :new, :create, :destroy ]"
       end
 
       def enable_bcrypt

--- a/railties/test/generators/authentication_generator_test.rb
+++ b/railties/test/generators/authentication_generator_test.rb
@@ -105,8 +105,8 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
     end
 
     assert_file "config/routes.rb" do |content|
-      assert_match(/resource :session, only: \[:new, :create, :destroy\]/, content)
-      assert_match(/resources :passwords, param: :token, only: \[:new, :create, :edit, :update\]/, content)
+      assert_match(/resource :session, only: \[ :new, :create, :destroy \]/, content)
+      assert_match(/resources :passwords, param: :token, only: \[ :new, :create, :edit, :update \]/, content)
     end
 
     assert_includes @rails_commands, "generate migration CreateUsers email_address:string!:uniq password_digest:string! --force"


### PR DESCRIPTION
After `bin/rails generate authentication`, a freshly generated app fails its own `bin/rubocop` (and the generated CI lint job) with four `Layout/SpaceInsideArrayLiteralBrackets` offenses in `config/routes.rb`, because the injected routes use unspaced array literals.

With spaced literals the generated app passes RuboCop with zero offenses again, matching the style used across the rest of the generated files. Same class as c67e9dfe19 (https://github.com/rails/rails/pull/50576), which fixed the installed migrations for the same cop.