### PR TITLE
[RF-DOCS] Update the JavaScript in Rails guide

### DIFF
--- a/guides/source/working_with_javascript_in_rails.md
+++ b/guides/source/working_with_javascript_in_rails.md
@@ -20,11 +20,13 @@ After reading this guide, you will know:
 Introduction
 ------------
 
-Rails provides two mechanisms to deliver JavaScript within your application:
-using an [import map](#using-a-javascript-import-map), or a
+ES modules (ESM) is the standard structure for packaging JavaScript
+code in modern applications. Rails provides two mechanisms to
+deliver JavaScript made for ESM: an
+[import map](#using-a-javascript-import-map), or a
 [JavaScript bundler](#using-a-javascript-bundler). Both of these systems
-integrate with the [Asset Pipeline](asset_pipeline.html) to deliver the files to
-the browser.
+integrate with the [Asset Pipeline](asset_pipeline.html) to deliver
+the files to the browser.
 
 The [Turbo](#turbo) and [Stimulus](#stimulus) JavaScript libraries (which are
 part of the [Hotwire](https://hotwired.dev) suite) are included in Rails, and
@@ -42,13 +44,15 @@ It is a JSON object which defines the mapping between the module specifier
 passed to an `import` statement, and the path to the actual file to be imported.
 Here's an example:
 
-```json
+```html
+<script type="importmap" data-turbo-track="reload">
 {
   "imports": {
     "animations": "/scripts/animations.js",
     "utilities": "/scripts/utilities.js"
   }
 }
+</script>
 ```
 
 Scripts can now invoke `import "animations"` or `import "utilities"` and the
@@ -92,7 +96,8 @@ NOTE: All files declared in your `config/importmap.rb` must exist within your
 
 This will create an import map object similar to:
 
-```json
+```html
+<script type="importmap" data-turbo-track="reload">
 {
   "imports": {
     "application": "/assets/application-d8a8613a.js",
@@ -102,6 +107,7 @@ This will create an import map object similar to:
     "controllers": "/assets/controllers/index-ee64e1f1.js"
   }
 }
+</script>
 ```
 
 which is rendered in your HTML document's `<head>` using:
@@ -123,13 +129,15 @@ Using a JavaScript Bundler
 
 You can integrate a JavaScript bundler into Rails using the
 [`jsbundling-rails`](https://github.com/rails/jsbundling-rails) gem. It supports
-a number of builders such as [ESBuild](https://esbuild.github.io/),
+a number of bundlers such as [ESBuild](https://esbuild.github.io/),
 [Rollup](https://rollupjs.org/guide/en/), [Bun](https://bun.sh), and
 [Webpack](https://webpack.js.org/).
 
-This gem requires a JavaScript runtime. For all bundlers except Bun, you'll need
-Node.js and Yarn. For Bun, you'll just need to install that as it is both a
-JavaScript runtime and a bundler.
+`jsbundling-rails` requires a JavaScript runtime. For all bundlers
+except Bun, you'll need Node.js. For Bun, you'll just
+need to install that as it is both a JavaScript runtime and a bundler.
+`jsbundling-rails` will automatically detect the JavaScript bundler, so
+you may use alternatives such as Yarn without additional configuration.
 
 ### Installing Node.js and Yarn
 
@@ -193,9 +201,9 @@ along with Rails server in development. Further information is available in the
 Adding npm Packages
 -------------------
 
-### Vendoring NPM Packages with `importmap-rails`
+### Vendoring npm Packages with `importmap-rails`
 
-When using `importmap-rails`, NPM packages are downloaded into the `vendor`
+When using `importmap-rails`, npm packages are downloaded into the `vendor`
 folder in your app and checked into source control.
 
 Add a package to your application using `bin/importmap pin`:
@@ -209,15 +217,16 @@ your `config/importmap.rb`. You can then import the package in your
 `application.js`:
 
 ```javascript
+// app/javascript/application.js
 import ahoy from "ahoy.js";
 ```
 
 Further information is available in the
 [`importmap-rails` Readme](https://github.com/rails/importmap-rails?tab=readme-ov-file#using-npm-packages-via-javascript-cdns).
 
-### Installing NPM Packages with a JavaScript Bundler
+### Installing npm Packages with a JavaScript Bundler
 
-When using Bun, the Bun package manager installs NPM packages:
+When using Bun, the Bun package manager installs npm packages:
 
 ```bash
 $ bun add ahoy.js
@@ -239,7 +248,7 @@ Choosing Between an Import Map and a JavaScript Bundler
 -------------------------------------------------------
 
 In all new Rails apps, JavaScript is delivered using an import map. The Rails
-team believes that using an import maps reduces complexity, improves developer
+team believes that using an import map reduces complexity, improves developer
 experience, and delivers performance gains.
 
 For many applications, especially those that rely primarily on

--- a/guides/source/working_with_javascript_in_rails.md
+++ b/guides/source/working_with_javascript_in_rails.md
@@ -3,186 +3,369 @@
 Working with JavaScript in Rails
 ================================
 
-This guide covers the options for integrating JavaScript functionality into your Rails application,
-including the options you have for using external JavaScript packages and how to use Turbo with
-Rails.
+This guide covers the integration of JavaScript into your Rails application —
+including the usage of Turbo and Stimulus as well as the installation of
+external JavaScript packages into Rails.
 
 After reading this guide, you will know:
 
-* How to use Rails without the need for a Node.js, Yarn, or a JavaScript bundler.
-* How to create a new Rails application using import maps, Bun, esbuild, Rollup, or Webpack to bundle
-  your JavaScript.
-* What Turbo is, and how to use it.
-* How to use the Turbo HTML helpers provided by Rails.
+- How to use an Import Map to deliver JavaScript in your Rails app.
+- How to integrate JavaScript bundlers like `esbuild` or `rollup` with Rails.
+- What Turbo is and how Rails integrates with it.
+- How to install Stimulus and use it for client-side JavaScript functionality.
+- How to make HTTP requests using JavaScript with the `request.js` library.
 
 --------------------------------------------------------------------------------
 
-Import Maps
------------
+Introduction
+------------
 
-[Import maps](https://github.com/rails/importmap-rails) let you import JavaScript modules using
-logical names that map to versioned files directly from the browser. Import maps are the default
-from Rails 7, allowing anyone to build modern JavaScript applications using most npm packages
-without the need for transpiling or bundling.
+Rails provides two mechanisms to deliver JavaScript within your application:
+using an [import map](#using-a-javascript-import-map), or a
+[JavaScript bundler](#using-a-javascript-bundler). Both of these systems
+integrate with the [Asset Pipeline](asset_pipeline.html) to deliver the files to
+the browser.
 
-Applications using import maps do not need [Node.js](https://nodejs.org/en/) or
-[Yarn](https://yarnpkg.com/) to function. If you plan to use Rails with `importmap-rails` to
-manage your JavaScript dependencies, there is no need to install Node.js or Yarn.
+The [Turbo](#turbo) and [Stimulus](#stimulus) JavaScript libraries (which are
+part of the [Hotwire](https://hotwired.dev) suite) are included in Rails, and
+form the default front-end stack.
 
-When using import maps, no separate build process is required, just start your server with
-`bin/rails server` and you are good to go.
+Using a JavaScript Import Map
+-----------------------------
 
-### Installing importmap-rails
+A JavaScript
+[import map](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap)
+allows JavaScript files to be delivered separately without bundling and still be
+able to reference each other.
 
-Importmap for Rails is automatically included in Rails 7+ for new applications, but you can also install it manually in existing applications:
+It is a JSON object which defines the mapping between the module specifier
+passed to an `import` statement, and the path to the actual file to be imported.
+Here's an example:
+
+```json
+{
+  "imports": {
+    "animations": "/scripts/animations.js",
+    "utilities": "/scripts/utilities.js"
+  }
+}
+```
+
+Scripts can now invoke `import "animations"` or `import "utilities"` and the
+browser will import the corresponding file and the module it contains.
+
+In Rails, the import map is constructed using the
+[importmap-rails](https://github.com/rails/importmap-rails) gem.
+
+This technique doesn't require an additional build step for your JavaScript.
+Your files are delivered as-is, and hence no JavaScript runtime such as Node.js
+is required.
+
+### Installing `importmap-rails`
+
+The `importmap-rails` gem is included by default in all new Rails applications.
+In older applications, you can install it using:
 
 ```bash
 $ bundle add importmap-rails
-```
-
-Run the install task:
-
-```bash
 $ bin/rails importmap:install
 ```
 
-### Adding npm Packages with importmap-rails
+### Declaring JavaScript Files
 
-To add new packages to your import map-powered application, run the `bin/importmap pin` command
-from your terminal:
+All your JavaScript files need to be declared in `config/importmap.rb` so Rails
+knows to include them in the import map object.
 
-```bash
-$ bin/importmap pin react react-dom
+```ruby
+# config/importmap.rb
+
+# Declare JavaScript files from your application
+pin "application"
+pin "utilities"
+
+# Declare all files inside a folder
+pin_all_from "app/javascript/controllers", under: "controllers"
 ```
 
-Then, import the package into `application.js` as usual:
+NOTE: All files declared in your `config/importmap.rb` must exist within your
+[asset pipeline's load paths](asset_pipeline.html#load_paths).
 
-```javascript
-import React from "react"
-import ReactDOM from "react-dom"
+This will create an import map object similar to:
+
+```json
+{
+  "imports": {
+    "application": "/assets/application-d8a8613a.js",
+    "utilities": "/assets/utilities-e8dc057d.js",
+    "controllers/application": "/assets/controllers/application-3affb389.js",
+    "controllers/hello_controller": "/assets/controllers/hello_controller-708796bd.js",
+    "controllers": "/assets/controllers/index-ee64e1f1.js"
+  }
+}
 ```
 
-Adding npm Packages with JavaScript Bundlers
---------------------------------------------
+which is rendered in your HTML document's `<head>` using:
 
-Import maps are the default for new Rails applications, but if you prefer traditional JavaScript
-bundling, you can create new Rails applications with your choice of
-[Bun](https://bun.sh), [esbuild](https://esbuild.github.io/),
-[Webpack](https://webpack.js.org/), or [Rollup.js](https://rollupjs.org/guide/en/).
-
-To use a bundler instead of import maps in a new Rails application, pass the `--javascript` or `-j`
-option to `rails new`:
-
-```bash
-$ rails new my_new_app --javascript=bun
-OR
-$ rails new my_new_app -j bun
+```erb
+<%= javascript_importmap_tags %>
 ```
 
-These bundling options each come with a simple configuration and integration with the asset
-pipeline via the [jsbundling-rails](https://github.com/rails/jsbundling-rails) gem.
+NOTE: You'll notice that the filenames contain a _hash_. This is added by
+[Rails' Asset Pipeline](asset_pipeline.html). It is calculated based on the
+file's contents and used to version the files.
 
-When using a bundling option, use `bin/dev` to start the Rails server and build JavaScript for
-development.
+See the [Asset Pipeline guide](asset_pipeline.html#javascript-import-map) and
+the [`importmap-rails` Readme](https://github.com/rails/importmap-rails) for
+further information.
 
-### Installing a JavaScript Runtime
+Using a JavaScript Bundler
+--------------------------
 
-If you are using esbuild, Rollup.js, or Webpack to bundle your JavaScript in
-your Rails application, Node.js and Yarn must be installed. If you are using
-Bun, then you just need to install Bun as it is both a JavaScript runtime and a bundler.
+You can integrate a JavaScript bundler into Rails using the
+[`jsbundling-rails`](https://github.com/rails/jsbundling-rails) gem. It supports
+a number of builders such as [ESBuild](https://esbuild.github.io/),
+[Rollup](https://rollupjs.org/guide/en/), [Bun](https://bun.sh), and
+[Webpack](https://webpack.js.org/).
 
-#### Installing Bun
+This gem requires a JavaScript runtime. For all bundlers except Bun, you'll need
+Node.js and Yarn. For Bun, you'll just need to install that as it is both a
+JavaScript runtime and a bundler.
 
-Find the installation instructions at the [Bun website](https://bun.sh) and
-verify it’s installed correctly and in your path with the following command:
+### Installing Node.js and Yarn
 
-```bash
-$ bun --version
-```
-
-The version of your Bun runtime should be printed out. If it says something
-like `1.0.0`, Bun has been installed correctly.
-
-If not, you may need to reinstall Bun in the current directory or restart your terminal.
-
-#### Installing Node.js and Yarn
-
-If you are using esbuild, Rollup.js, or Webpack you will need Node.js and Yarn.
-
-Find the installation instructions at the [Node.js website](https://nodejs.org/en/download/) and
-verify it’s installed correctly with the following command:
+Find the installation instructions on the
+[Node.js website](https://nodejs.org/en/download/) and verify it’s installed
+correctly:
 
 ```bash
 $ node --version
+v23.6.1
 ```
 
-The version of your Node.js runtime should be printed out. Make sure it’s greater than `8.16.0`.
-
 To install Yarn, follow the installation instructions at the
-[Yarn website](https://classic.yarnpkg.com/en/docs/install). Running this command should print out
-the Yarn version:
+[Yarn website](https://classic.yarnpkg.com/en/docs/install). Verify it's
+installed using:
 
 ```bash
 $ yarn --version
+1.22.19
 ```
 
-If it says something like `1.22.0`, Yarn has been installed correctly.
+### Installing Bun
 
-Choosing Between Import Maps and a JavaScript Bundler
------------------------------------------------------
+Follow the installation instructions at the [Bun website](https://bun.sh) and
+verify it’s installed:
 
-When you create a new Rails application, you will need to choose between import maps and a
-JavaScript bundling solution. Every application has different requirements, and you should
-consider your requirements carefully before choosing a JavaScript option, as migrating from one
-option to another may be time-consuming for large, complex applications.
+```bash
+$ bun --version
+v1.3.13
+```
 
-Import maps are the default option because the Rails team believes in import maps' potential for
-reducing complexity, improving developer experience, and delivering performance gains.
+### Installing `jsbundling-rails`
 
-For many applications, especially those that rely primarily on the [Hotwire](https://hotwired.dev/)
-stack for their JavaScript needs, import maps will be the right option for the long term. You
-can read more about the reasoning behind making import maps the default in Rails 7
+When creating a new Rails app, setup a JavaScript bundler using the `-j` or
+`--javascript` flag:
+
+```bash
+$ rails new my_new_app -j esbuild
+```
+
+```bash
+$ rails new my_new_app --javascript=esbuild
+```
+
+Add the `jsbundling-rails` gem in an existing Rails app using:
+
+```bash
+$ bundle add jsbundling-rails
+```
+
+Then configure your chosen bundler with:
+
+```bash
+$ bin/rails javascript:install:[bun|esbuild|rollup|webpack]
+```
+
+When using `jsbundling-rails`, use `bin/dev` to start the JavaScript bundler
+along with Rails server in development. Further information is available in the
+[Asset Pipeline guide](asset_pipeline.html#bundling-and-transpiling-javascript).
+
+Adding npm Packages
+-------------------
+
+### Vendoring NPM Packages with `importmap-rails`
+
+When using `importmap-rails`, NPM packages are downloaded into the `vendor`
+folder in your app and checked into source control.
+
+Add a package to your application using `bin/importmap pin`:
+
+```bash
+$ bin/importmap pin ahoy.js
+```
+
+This will download the package into your `vendor` folder and declare them in
+your `config/importmap.rb`. You can then import the package in your
+`application.js`:
+
+```javascript
+import ahoy from "ahoy.js";
+```
+
+Further information is available in the
+[`importmap-rails` Readme](https://github.com/rails/importmap-rails?tab=readme-ov-file#using-npm-packages-via-javascript-cdns).
+
+### Installing NPM Packages with a JavaScript Bundler
+
+When using Bun, the Bun package manager installs NPM packages:
+
+```bash
+$ bun add ahoy.js
+```
+
+See the [Bun documentation](https://bun.com/docs/pm/cli/install) for more
+information.
+
+For all other bundlers, use Yarn to manage your dependencies:
+
+```bash
+$ yarn add ahoy.js
+```
+
+Further details are available in the
+[Yarn documentation](https://yarnpkg.com/getting-started/usage).
+
+Choosing Between an Import Map and a JavaScript Bundler
+-------------------------------------------------------
+
+In all new Rails apps, JavaScript is delivered using an import map. The Rails
+team believes that using an import maps reduces complexity, improves developer
+experience, and delivers performance gains.
+
+For many applications, especially those that rely primarily on
+[Hotwire](https://hotwired.dev/), an import map will be the right option for the
+long term. You can read more about the reasoning behind making import maps the
+default in Rails 7
 [here](https://world.hey.com/dhh/rails-7-will-have-three-great-answers-to-javascript-in-2021-8d68191b).
 
-Other applications may still need a traditional JavaScript bundler. Requirements that indicate
-that you should choose a traditional bundler include:
+However, there may be use cases that call for a JavaScript bundler. Listed below
+are a few considerations where a JavaScript bundler may be more suited to your
+app than an import map:
 
-* If your code requires a transpilation step, such as JSX or TypeScript.
-* If you need to use JavaScript libraries that include CSS or otherwise rely on
+- You cannot serve your assets over HTTP/2.
+- Your code requires a transpilation step, such as JSX or TypeScript.
+- You need to use JavaScript libraries that include CSS or otherwise rely on
   [Webpack loaders](https://webpack.js.org/loaders/).
-* If you are absolutely sure that you need
-  [tree-shaking](https://webpack.js.org/guides/tree-shaking/).
-* If you will install Bootstrap, Bulma, PostCSS, or Dart CSS through the [cssbundling-rails gem](https://github.com/rails/cssbundling-rails). All options provided by this gem except Tailwind and Sass will automatically install `esbuild` for you if you do not specify a different option in `rails new`.
+- Your JavaScript architecture requires
+  [tree-shaking](https://en.wikipedia.org/wiki/Tree_shaking).
+- You're using the
+  [`cssbundling-rails` gem](https://github.com/rails/cssbundling-rails) to
+  manage your CSS.
 
-Turbo
------
+Hotwire
+-------
 
-Whether you choose import maps or a traditional bundler, Rails ships with
-[Turbo](https://turbo.hotwired.dev/) to speed up your application while dramatically reducing the
-amount of JavaScript that you will need to write.
+Rails' default JavaScript stack is [Hotwire](https://hotwired.dev). It is a
+suite of front-end libraries that enable us to build rich, high-fidelity, and
+modern web applications without the complexities of a single-page application.
 
-Turbo lets your server deliver HTML directly as an alternative to the prevailing front-end
-frameworks that reduce the server-side of your Rails application to little more than a JSON API.
+[Turbo][] and [Stimulus][] which are part of the Hotwire suite are automatically
+installed in all new Rails apps.
 
-### Turbo Drive
+This guide primarily covers Rails' integration with Turbo and Stimulus. Consult
+their documentation for detailed usage information:
 
-[Turbo Drive](https://turbo.hotwired.dev/handbook/drive) speeds up page loads by avoiding full-page
-teardowns and rebuilds on every navigation request. Turbo Drive is an improvement on and
-replacement for Turbolinks.
+- [Turbo][]
+- [Stimulus][]
 
-### Turbo Frames
+[Turbo]: https://turbo.hotwired.dev/
+[Stimulus]: https://stimulus.hotwired.dev/
 
-[Turbo Frames](https://turbo.hotwired.dev/handbook/frames) allow predefined parts of a page to be
-updated on request, without impacting the rest of the page’s content.
+### Turbo
 
-You can use Turbo Frames to build in-place editing without any custom JavaScript, lazy load
-content, and create server-rendered, tabbed interfaces with ease.
+Turbo is the nucleus of Hotwire. It consists of 3 parts: [Turbo Drive][], [Turbo
+Frames][], and [Turbo Streams][].
 
-Rails provides HTML helpers to simplify the use of Turbo Frames through the
-[turbo-rails](https://github.com/hotwired/turbo-rails) gem.
+**Turbo Drive** accelerates links and form submissions by making those requests
+using JavaScript and swapping out the document's `<body>` element, eliminating
+the need for full page loads.
 
-Using this gem, you can add a Turbo Frame to your application with the `turbo_frame_tag` helper
-like this:
+**Turbo Frames** allow you to decompose pages into independent contexts where
+navigation and updates can occur without affecting the rest of the page.
+
+**Turbo Streams** are used to make fine-grained, targeted updates to specific
+DOM elements using a range of CRUD actions.
+
+Rails integrates with Turbo via the [`turbo-rails`][] gem. You can use this gem
+to install Turbo in existing applications:
+
+```bash
+$ bundle add turbo-rails
+$ bin/rails turbo:install
+```
+
+See the [Turbo handbook](https://turbo.hotwired.dev/handbook/introduction) for
+more information on how Turbo works and its features.
+
+[Turbo Drive]: https://turbo.hotwired.dev/handbook/drive
+[Turbo Frames]: https://turbo.hotwired.dev/handbook/frames
+[Turbo Streams]: https://turbo.hotwired.dev/handbook/streams
+[`turbo-rails`]: https://github.com/hotwired/turbo-rails
+
+#### Turbo Drive
+
+[Turbo Drive](https://turbo.hotwired.dev/handbook/drive) largely works
+automatically when imported into your HTML document. It offers a few
+configuration options, and the ability to define `data-` attributes and `<meta>`
+tags in your HTML to customize behavior. See the
+[handbook](https://turbo.hotwired.dev/handbook/drive) and
+[reference](https://turbo.hotwired.dev/reference/drive) for further details.
+
+Rails offers view helper methods via the
+[`turbo-rails` gem](https://github.com/hotwired/turbo-rails/tree/main/lib) which
+define `<meta>` tags to customize Turbo Drive on specific pages.
+
+You can
+[control a page's caching behavior](https://turbo.hotwired.dev/handbook/building#opting-out-of-caching)
+by setting a `turbo-cache-control` meta tag.
+
+```erb
+<%# Renders <meta name="turbo-cache-control" content="no-cache"> %>
+<%= turbo_exempts_page_from_cache %>
+
+<%# Renders <meta name="turbo-cache-control" content="no-preview"> %>
+<%= turbo_exempts_page_from_preview %>
+```
+
+Force a
+[full page reload for specific pages](https://turbo.hotwired.dev/reference/attributes#meta-tags)
+with:
+
+```erb
+<%# Renders <meta name="turbo-visit-control" content="reload"> %>
+<%= turbo_page_requires_reload %>
+```
+
+Configure
+[morphing page refreshes](https://turbo.hotwired.dev/handbook/page_refreshes#morphing)
+with:
+
+```erb
+<%= turbo_refreshes_with(method: :morph, scroll: :preserve) %>
+```
+
+View the
+[source code](https://github.com/hotwired/turbo-rails/blob/main/app/helpers/turbo/drive_helper.rb)
+for more details.
+
+#### Turbo Frames
+
+[Turbo Frames](https://turbo.hotwired.dev/handbook/frames) uses a
+`<turbo-frame>` element to isolate parts of a web page into its own navigation
+context, so it can be updated independently from the rest of the page.
+
+The [`turbo-rails`][] gem defines a helper method to simplify the declaration of
+a `<turbo-frame>`:
 
 ```erb
 <%= turbo_frame_tag dom_id(post) do %>
@@ -192,17 +375,50 @@ like this:
 <% end %>
 ```
 
-### Turbo Streams
+All Turbo Frame elements require a unique ID. The
+[`dom_id`](https://api.rubyonrails.org/classes/ActionView/RecordIdentifier.html#method-i-dom_id)
+method calculates an ID based on an Active Record object and is commonly used to
+identify Turbo Frames.
 
-[Turbo Streams](https://turbo.hotwired.dev/handbook/streams) deliver page changes as fragments of
-HTML wrapped in self-executing `<turbo-stream>` elements. Turbo Streams allow you to broadcast
-changes made by other users over WebSockets and update pieces of a page after a form submission
-without requiring a full page load.
+#### Turbo Streams
 
-Rails provides HTML and server-side helpers to simplify the use of Turbo Streams through the
-[turbo-rails](https://github.com/hotwired/turbo-rails) gem.
+[Turbo Streams](https://turbo.hotwired.dev/handbook/streams) are used to perform
+a series of actions (such as `create`, `append`, `remove`, `replace` etc.) on
+specific DOM elements via a `<turbo-stream>` element. As soon as a
+`<turbo-stream>` tag is added to the document, Turbo will execute it and perform
+the action it defines.
 
-Using this gem, you can render Turbo Streams from a controller action:
+[`turbo-rails`][] provides helpers to create HTTP responses consisting of Turbo
+Streams, as well as an integration with
+[Action Cable](action_cable_overview.html) to allow Turbo Streams to be
+delivered via WebSockets.
+
+Render a Turbo Stream in your controller using:
+
+```ruby
+def create
+  @post = Post.new(post_params)
+
+  respond_to do |format|
+    if @post.save
+      format.turbo_stream do
+        # Renders:
+        # <turbo-stream action="prepend" target="posts">
+        #   <template>
+        #     <h2>My New Post</h2>
+        #   </template>
+        # </turbo-stream>
+        render turbo_stream: turbo_stream.prepend("posts", helpers.tag.h2(@post.title))
+      end
+    else
+      format.html { render :new, status: :unprocessable_entity }
+    end
+  end
+end
+```
+
+You can use an ERB template as well. This is useful when defining multiple Turbo
+Streams:
 
 ```ruby
 def create
@@ -218,144 +434,318 @@ def create
 end
 ```
 
-Rails will automatically look for a `.turbo_stream.erb` view file and render that view when found.
+```erb
+<%# create.turbo_stream.erb %>
 
-Turbo Stream responses can also be rendered inline in the controller action:
-
-```ruby
-def create
-  @post = Post.new(post_params)
-
-  respond_to do |format|
-    if @post.save
-      format.turbo_stream { render turbo_stream: turbo_stream.prepend("posts", partial: "post") }
-    else
-      format.html { render :new, status: :unprocessable_entity }
-    end
-  end
-end
+<%= turbo_stream.prepend("posts", partial: "posts/post", locals: { post: @post }) %>
+<%= turbo_stream.replace("posts_title") do %>
+  <%= Post.count %> posts
+<% end %>
 ```
 
-Finally, Turbo Streams can be initiated from a model or a background job using built-in helpers.
-These broadcasts can be used to update content via a WebSocket connection to all users, keeping
-page content fresh and bringing your application to life.
+#### Turbo Streams over Action Cable
 
-To broadcast a Turbo Stream from a model, combine a model callback like this:
+To deliver Turbo Streams over WebSockets, ensure that
+[Action Cable](action_cable_overview.html) is set up in your application and you
+have the [`turbo-rails`][] JavaScript package installed.
 
-```ruby
-class Post < ApplicationRecord
-  after_create_commit { broadcast_append_to("posts") }
-end
-```
-
-With a WebSocket connection set up on the page that should receive the updates like this:
+Turbo Streams can be received over WebSockets by subscribing to broadcasts on a
+_stream_ within a view:
 
 ```erb
 <%= turbo_stream_from "posts" %>
 ```
 
-Replacements for Rails/UJS Functionality
-----------------------------------------
+This will render a `<turbo-cable-stream-source>` tag which opens a WebSocket
+connection and subscribes to a stream called `"posts"`. It will automatically
+execute any Turbo Streams it receives.
 
-Rails 6 shipped with a tool called UJS (Unobtrusive JavaScript). UJS allows
-developers to override the HTTP request method of `<a>` tags, to add confirmation
-dialogs before executing an action, and more. UJS was the default before Rails
-7, but it is now recommended to use Turbo instead.
+Broadcast a Turbo Stream action to this stream using:
 
-### Method
-
-Clicking links always results in an HTTP GET request. If your application is
-[RESTful](https://en.wikipedia.org/wiki/Representational_State_Transfer), some links are in fact
-actions that change data on the server, and should be performed with non-GET
-requests. The `data-turbo-method` attribute allows marking up such links with
-an explicit method such as "post", "put", or "delete".
-
-Turbo will scan `<a>` tags in your application for the `turbo-method` data attribute and use the
-specified method when present, overriding the default GET action.
-
-For example:
-
-```erb
-<%= link_to "Delete post", post_path(post), data: { turbo_method: "delete" } %>
+```ruby
+Turbo::StreamsChannel.broadcast_action_to(
+  "posts",
+  action: :append,
+  target: "posts",
+  partial: "posts/post",
+  locals: { post: post }
+)
 ```
 
-This generates:
+There are helper methods to broadcast the stock Turbo Stream actions. The above
+snippet can be rewritten as:
 
-```html
-<a data-turbo-method="delete" href="...">Delete post</a>
+```ruby
+Turbo::StreamsChannel.broadcast_append_to(
+  "posts",
+  target: "posts",
+  partial: "posts/post",
+  locals: { post: post }
+)
 ```
 
-An alternative to changing the method of a link with `data-turbo-method` is to use Rails
-`button_to` helper. For accessibility reasons, actual buttons and forms are preferable for any
-non-GET action.
+You can also broadcast a Turbo Stream template containing multiple actions:
 
-### Confirmations
-
-You can ask for an extra confirmation from the user by adding a `data-turbo-confirm`
-attribute on links and forms. On link click or form submit, the user will be
-presented with a JavaScript `confirm()` dialog containing the attribute's text.
-If the user chooses to cancel, the action doesn't take place.
-
-For example, with the `link_to` helper:
-
-```erb
-<%= link_to "Delete post", post_path(post), data: { turbo_method: "delete", turbo_confirm: "Are you sure?" } %>
+```ruby
+Turbo::StreamsChannel.broadcast_render_to(
+  "posts",
+  template: "posts/create"
+)
 ```
 
-Which generates:
+or broadcast a `refresh` action which is useful for morphing:
 
-```html
-<a href="..." data-turbo-confirm="Are you sure?" data-turbo-method="delete">Delete post</a>
+```ruby
+Turbo::StreamsChannel.broadcast_refresh_to("posts")
 ```
 
-When the user clicks on the "Delete post" link, they will be presented with an
-"Are you sure?" confirmation dialog.
+All the above examples render templates and broadcast them synchronously. They
+can be offloaded to a background job to improve performance by using the `later`
+version of the methods such as `broadcast_append_later_to`.
 
-The attribute can also be used with the `button_to` helper, however it must be
-added to the form that the `button_to` helper renders internally:
+```ruby
+# enqueues a `Turbo::Streams::ActionBroadcastJob`
+Turbo::StreamsChannel.broadcast_append_later_to(
+  "posts",
+  target: "posts",
+  partial: "posts/post",
+  locals: { post: post }
+)
 
-```erb
-<%= button_to "Delete post", post, method: :delete, form: { data: { turbo_confirm: "Are you sure?" } } %>
+# enqueues a `Turbo::Streams::BroadcastJob`
+Turbo::StreamsChannel.broadcast_render_later_to(
+  "posts",
+  template: "posts/create"
+)
 ```
 
-### Ajax Requests
+Check out the
+[source code](https://github.com/hotwired/turbo-rails/blob/main/app/channels/turbo/streams/broadcasts.rb)
+for all available helpers.
 
-When making non-GET requests from JavaScript, the `X-CSRF-Token` header is required.
-Without this header, requests won't be accepted by Rails.
+In addition to this, the gem provides a
+[`Broadcastable`](https://github.com/hotwired/turbo-rails/blob/main/app/models/concerns/turbo/broadcastable.rb)
+concern which is included in Active Record. It applies Rails conventions to
+succinctly broadcast model-specific Turbo Streams. Some example use cases are:
 
-NOTE: This token is required by Rails to prevent Cross-Site Request Forgery (CSRF) attacks. Read more in the [security guide](security.html#cross-site-request-forgery-csrf).
+```ruby
+@post = Post.first
 
-[Rails Request.JS](https://github.com/rails/request.js) encapsulates the logic
-of adding the request headers that are required by Rails. Just
-import the `FetchRequest` class from the package and instantiate it
-passing the request method, url, options, then call `await request.perform()`
-and do what you need with the response.
+# Turbo Stream actions are implicitly broadcast to
+# the model object's stream. To subscribe to an individual
+# model's stream, you'd use:
+#
+# <%= turbo_stream_from @post %>
 
-For example:
+# Broadcasts an `append` action containing the partial
+# `posts/post` targeted at the DOM ID `posts`.
+@post.broadcast_append
+@post.broadcast_append_later
 
-```javascript
-import { FetchRequest } from '@rails/request.js'
+# The update action targets the specific model's HTML element (`dom_id(@post)`).
+# In this case, it will target the DOM ID `post_1`. The content
+# will be the partial `posts/post`.
+@post.broadcast_update
+@post.broadcast_update_later
 
-....
+# The remove action targets the specific model's HTML element (`dom_id(@post)`).
+# In this case, it will target the DOM ID `post_1`.
+@post.broadcast_remove
+@post.broadcast_remove_later
 
-async function myMethod () {
-  const request = new FetchRequest('post', 'http://localhost:3000/posts', {
-    body: JSON.stringify({ name: 'Request.JS' })
-  })
-  const response = await request.perform()
-  if (response.ok) {
-    const body = await response.text
+# The partial can be explicitly defined if required.
+@post.broadcast_append(partial: "posts/post", locals: { post: @post })
+@post.broadcast_append_later(partial: "posts/post", locals: { post: @post })
+
+# Broadcast to a specific stream
+@post.broadcast_append_to("posts")
+@post.broadcast_append_later_to("posts")
+```
+
+The `broadcasts_to` method configures a model to emit Turbo Streams on creation,
+update, and deletion to the supplied stream name:
+
+```ruby
+class Post < ApplicationRecord
+  broadcasts_to ->(post) { post.model_name.plural }
+end
+```
+
+The above snippet is equivalent to:
+
+```ruby
+class Post < ApplicationRecord
+  after_create_commit  -> { broadcast_append_later_to("posts", target: "posts", partial: "posts/post") }
+  after_update_commit  -> { broadcast_replace_later_to("posts", target: dom_id(self), partial: "posts/post") }
+  after_destroy_commit -> { broadcast_remove_to("posts", target: dom_id(self)) }
+end
+```
+
+Use `broadcasts` to emit Turbo Streams to an inferred stream name:
+
+```ruby
+class Post < ApplicationRecord
+  broadcasts
+end
+```
+
+This can be expanded as:
+
+```ruby
+class Post < ApplicationRecord
+  after_create_commit  -> { broadcast_append_later_to("posts", target: "posts", partial: "posts/post") }
+  after_update_commit  -> { broadcast_replace_later_to(self, target: dom_id(self), partial: "posts/post") }
+  after_destroy_commit -> { broadcast_remove_to(self, target: dom_id(self)) }
+end
+```
+
+Use `broadcasts_refreshes` to emit a Turbo Stream to `refresh` the page whenever
+the model changes:
+
+```ruby
+class Post < ApplicationRecord
+  broadcasts_refreshes
+end
+```
+
+The above code is equivalent to:
+
+```ruby
+class Post < ApplicationRecord
+  after_create_commit  -> { broadcast_refresh_later_to("posts") }
+  after_update_commit  -> { broadcast_refresh_later_to(dom_id(self)) }
+  after_destroy_commit -> { broadcast_refresh_to(dom_id(self)) }
+end
+```
+
+See the
+[source code](https://github.com/hotwired/turbo-rails/blob/main/app/models/concerns/turbo/broadcastable.rb)
+and inline RDoc comments for all available helpers and options.
+
+### Stimulus
+
+[Stimulus][] is a lightweight library to manipulate HTML with reusable pieces of
+JavaScript logic encapsulated in a JavaScript _controller_.
+
+Stimulus has an HTML-centric way of writing JavaScript. The markup is connected
+to the controller using a range of `data-` attributes.
+
+Here's an example of a Stimulus controller:
+
+```js
+// hello_controller.js
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [ "name", "output" ]
+
+  greet() {
+    this.outputTarget.textContent =
+      `Hello, ${this.nameTarget.value}!`
   }
 }
 ```
 
-When using another library to make Ajax calls, it is necessary to add the
-security token as a default header yourself. To get the token, have a look at
-`<meta name='csrf-token' content='THE-TOKEN'>` tag printed by
-[`csrf_meta_tags`][] in your application view. You could do something like:
+The above controller uses _targets_, which are named references to elements in
+its HTML scope, to grab an input's value and display a greeting. The `greet()`
+action reads the `name` _target_ and writes it into the `output` _target_.
 
-```javascript
-document.head.querySelector("meta[name=csrf-token]")?.content
+It can be attached to the DOM via the `data-controller` attribute:
+
+```html
+<div data-controller="hello">
+  <input data-hello-target="name" type="text">
+
+  <button data-action="click->hello#greet">Greet</button>
+
+  <span data-hello-target="output"> </span>
+</div>
 ```
 
-[`csrf_meta_tags`]: https://api.rubyonrails.org/classes/ActionView/Helpers/CsrfHelper.html#method-i-csrf_meta_tags
+Refer to the Stimulus
+[handbook](https://stimulus.hotwired.dev/handbook/introduction) and
+[reference](https://stimulus.hotwired.dev/reference/controllers) for complete
+usage information.
+
+Rails integrates with Stimulus via the [`stimulus-rails`][] gem, which provides
+a generator to create Stimulus controllers:
+
+```bash
+# Generates app/javascript/controllers/hello_controller.js
+$ bin/rails generate stimulus hello
+```
+
+```js
+// app/javascript/controllers/hello_controller.js
+
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="hello"
+export default class extends Controller {
+  connect() {}
+}
+```
+
+It also contains a _task_ which you can use to install Stimulus in an existing
+application:
+
+```bash
+$ bin/rails stimulus:install
+```
+
+[`stimulus-rails`]: https://github.com/hotwired/stimulus-rails
+
+### `request.js`
+
+Rails protects against
+[CSRF attacks](security.html#cross-site-request-forgery-csrf) by
+[validating non-`GET` requests with a token](security.html#required-security-token).
+The [`request.js`](https://github.com/rails/request.js) library automatically
+adds the CSRF token to HTTP requests, making it easier to trigger HTTP requests
+using JavaScript.
+
+This library is maintained by the Rails team but it isn't included in Rails by
+default, so you'll need to install it:
+
+```bash
+$ bundle add requestjs-rails
+$ bin/rails requestjs:install
+```
+
+Here's an example of a Stimulus controller that uses `request.js` to make a
+`POST` request:
+
+```js
+import { post } from "@rails/request.js"
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [ "input" ]
+
+  async fetchSuggestions() {
+    const response = await post("/users/suggestions", {
+      body: JSON.stringify({
+        input: this.inputTarget.value
+      })
+    })
+
+    if (response.ok) {
+      // Do something with the response
+    }
+  }
+}
+```
+
+`request.js` will automatically activate JavaScript responses which have a
+`content-type` response header of `application/javascript` or
+`application/ecmascript`. It will also automatically execute Turbo Stream
+responses.
+
+See the [Readme](https://github.com/rails/request.js) for advanced usage and
+further installation information.
+
+NOTE: Prior to Rails 7, a JavaScript library called Rails UJS was used to
+enhance Rails on the front-end. This library has now been removed from Rails,
+and all its functionality has been replaced by Turbo, Stimulus, and request.js.
+You can find information about Rails UJS in an
+[older version of the guides](/v6.1/working_with_javascript_in_rails.html#unobtrusive-javascript).

--- a/guides/source/working_with_javascript_in_rails.md
+++ b/guides/source/working_with_javascript_in_rails.md
@@ -48,8 +48,8 @@ Here's an example:
 <script type="importmap" data-turbo-track="reload">
 {
   "imports": {
-    "animations": "/scripts/animations.js",
-    "utilities": "/scripts/utilities.js"
+    "animations": "/assets/scripts/animations.js",
+    "utilities": "/assets/scripts/utilities.js"
   }
 }
 </script>
@@ -226,12 +226,26 @@ $ bin/importmap pin ahoy.js
 ```
 
 This will download the package into your `vendor` folder and declare them in
-your `config/importmap.rb`. You can then import the package in your
-`application.js`:
+your `config/importmap.rb`. You can then import the package wherever required:
 
 ```javascript
 // app/javascript/application.js
+
 import ahoy from "ahoy.js";
+```
+
+Or in a Stimulus controller:
+
+```js
+import { Controller } from "@hotwired/stimulus"
+import ahoy from "ahoy.js";
+
+// Connects to data-controller="ahoy"
+export default class extends Controller {
+  connect() {
+    ahoy.trackView()
+  }
+}
 ```
 
 Further information is available in the

--- a/guides/source/working_with_javascript_in_rails.md
+++ b/guides/source/working_with_javascript_in_rails.md
@@ -9,6 +9,7 @@ external JavaScript packages into Rails.
 
 After reading this guide, you will know:
 
+- The techniques to deliver and integrate JavaScript with Rails.
 - How to use an Import Map to deliver JavaScript in your Rails app.
 - How to integrate JavaScript bundlers like `esbuild` or `rollup` with Rails.
 - What Turbo is and how Rails integrates with it.
@@ -20,17 +21,36 @@ After reading this guide, you will know:
 Introduction
 ------------
 
-ES modules (ESM) is the standard structure for packaging JavaScript
-code in modern applications. Rails provides two mechanisms to
-deliver JavaScript made for ESM: an
-[import map](#using-a-javascript-import-map), or a
-[JavaScript bundler](#using-a-javascript-bundler). Both of these systems
-integrate with the [Asset Pipeline](asset_pipeline.html) to deliver
-the files to the browser.
+Rails applications typically deliver server-rendered HTML to the browser. In this
+setup, JavaScript is used mainly to add a layer of user interactivity over the HTML
+document.
 
-The [Turbo](#turbo) and [Stimulus](#stimulus) JavaScript libraries (which are
-part of the [Hotwire](https://hotwired.dev) suite) are included in Rails, and
-form the default front-end stack.
+JavaScript files can be delivered individually using an import map, or bundled together
+and shipped as a single file. This guide will cover the pros and cons of each approach,
+as well as Rails' default JavaScript stack composed of [Turbo](#turbo)
+and [Stimulus](#stimulus) (which are part of the [Hotwire](https://hotwired.dev) suite).
+
+NOTE: Rails can also be [used in API-mode](api_app.html) where it speaks JSON or XML,
+but in such a setup, the front-end JavaScript application is usually transmitted independently
+from the Rails app. As such, this guide covers the usage of JavaScript for server-rendered
+applications only.
+
+Modern JavaScript has a standard structure for packaging called
+[ECMAScript modules (ESM)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules).
+Rails provides two mechanisms to deliver JavaScript written for ESM: an
+[import map](#using-a-javascript-import-map), or a
+[JavaScript bundler](#using-a-javascript-bundler).
+
+Legacy JavaScript applications may use another structure such as
+[`CommonJS`](https://en.wikipedia.org/wiki/CommonJS). In such setups, JavaScript
+needs to be compiled and bundled into a single file before transmission to the browser.
+Common bundlers for this approach include [Babel](https://babeljs.io)
+and [Webpack](https://webpack.js.org), but Rails doesn't integrate tightly with these
+tools. You can, however, [deliver pre-built or bespoke JavaScript files](#delivering-bespoke-javascript-files)
+using Rails.
+
+Rails uses the [Asset Pipeline](asset_pipeline.html) to deliver all assets,
+including JavaScript files, to the browser.
 
 Using a JavaScript Import Map
 -----------------------------
@@ -210,6 +230,36 @@ $ bin/rails javascript:install:[bun|esbuild|rollup|webpack]
 When using `jsbundling-rails`, use `bin/dev` to start the JavaScript bundler
 along with Rails server in development. Further information is available in the
 [Asset Pipeline guide](asset_pipeline.html#bundling-and-transpiling-javascript).
+
+Delivering Bespoke JavaScript Files
+-----------------------------------
+
+You may wish to use Rails to deliver a pre-built or bespoke JavaScript file. This is useful
+if your JavaScript application doesn't use ESM, or requires a bundler such as
+[Babel](https://babeljs.io) which isn't natively supported within Rails.
+
+You can reference any JavaScript files in the
+[asset pipeline's load path](asset_pipeline.html#load_paths) using `javascript_include_tag`:
+
+```erb
+<%= javascript_include_tag "application" %>
+```
+
+which will render
+
+```html
+<script src="/assets/application-5bcb24fe.js"></script>
+```
+
+A common setup in this case would be to write your built JavaScript files to `app/assets/builds`
+(which is in the asset pipeline's load path), and load them into your HTML document
+using `javascript_include_tag`.
+
+Configuring your chosen bundler within Rails is out of scope for this guide. All supported bundlers
+are designed to work with ESM and are covered in the previous
+section: [Using a JavaScript Bundler](#using-a-javascript-bundler).
+
+NOTE: Files within `app/assets/builds` are excluded from source control by default.
 
 Adding npm Packages
 -------------------

--- a/guides/source/working_with_javascript_in_rails.md
+++ b/guides/source/working_with_javascript_in_rails.md
@@ -84,8 +84,8 @@ knows to include them in the import map object.
 # config/importmap.rb
 
 # Declare JavaScript files from your application
-pin "application"
-pin "utilities"
+pin "application" # app/javascript/application.js
+pin "utilities"   # app/javascript/utilities.js
 
 # Declare all files inside a folder
 pin_all_from "app/javascript/controllers", under: "controllers"
@@ -115,6 +115,19 @@ which is rendered in your HTML document's `<head>` using:
 ```erb
 <%= javascript_importmap_tags %>
 ```
+
+It's worth reiterating that the import map only defines the mapping
+between a module specifier and a file. It doesn't execute or import any code.
+As part of the above declaration, Rails also renders:
+
+```
+<script type="module">import "application"</script>
+```
+
+This is the default entry-point for your JavaScript application
+(located at `app/javascript/application.js`). Use this file to import
+additional JavaScript files such as your Stimulus controllers or
+the `utilities` file shown in the above examples.
 
 NOTE: You'll notice that the filenames contain a _hash_. This is added by
 [Rails' Asset Pipeline](asset_pipeline.html). It is calculated based on the


### PR DESCRIPTION
### Motivation / Background

Update the JavaScript in Rails guide. 

### Detail

A summary of the key changes:

* Improve the narrative flow regarding import-map and JavaScript bundlers.
* Simplify and compress the section comparing the usage of a bundler to an import map.
* Add a detailed section on Hotwire and information regarding the integration with Rails using `turbo-rails` and `stimulus-rails`.
* Add a section about `request.js`.

### Additional information

#### Internal Audit

The heading 'Adding npm Packages to Javascript bundlers' -> could change this to 'Using Javascript Bundlers' to make it a bit more general.

"The version of your Node.js runtime should be printed out. Make sure it’s greater than 8.16.0." -> Node.js 8 reached end of life a while ago it looks like - maybe we should bump this a bit to 'Make sure it's greater than 18'?

Section 4.1 -> maybe this Turbo Drive part could be put into a NOTE block somewhere else rather than being its own section?

Section 5.1 -> I think the heading 'method' is potentially too vague. What if we changed this to 'Overriding HTTP Methods'?

We could tidy up the AJAX request example - the function call has a space before the () which we can remove and I think it's worth potentially showing that after the 
    const body = await response.text
line the function would continue to go on further, e.g. "// do something with body" or just "...."

Some extra content that we could include in this guide:
- Stimulus? Feels like if we're giving a bit of an overview on Turbo we should also touch on Stimulus?
- Any more recently released Turbo features (perhaps 8 onwards - I'm thinking maybe morphing (https://turbo.hotwired.dev/handbook/page_refreshes)
- Worth mentioning Propshaft in relation to the asset pipeline, or maybe as its own sub-heading? https://github.com/rails/propshaft
- Maybe a troubleshooting section to help developers with Turbo might be useful!

The first three sections: "Import maps", "Adding npm Packages with JavaScript Bundlers" and "Choosing Between Import Maps and a JavaScript Bundler" are all about adding JavaScript to an application. Maybe combine these into a single "Adding npm Packages" section. Then it's also clear to skip this section if you already have JavaScript packages installed in your application.

Turbo
- This section title is not very clear for someone who doesn't know what Turbo is. Maybe something like "Speeding up Navigation with Turbo", "Faster Navigation with Turbo"?
- The Turbo-Drive section could probably be expanded on? At least explain how it's installed It would also be nice to explain some of the Turbo drive helpers?
http://www.rubydoc.info/gems/turbo-rails/2.0.23/Turbo/DriveHelper
- The same thing applies to the Turbo-Frame section.
http://www.rubydoc.info/gems/turbo-rails/2.0.23/Turbo/FramesHelper
- The Turbo-Broadcasts are mentioned in the Turbo-Streams section, but seem to miss a header.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
