### PR TITLE
Let dump_schema_migrations_sort_by be :reverse by default

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -8,16 +8,9 @@
     which can be overridden per database, using the new `dump_schema_migrations`
     database configuration option.
 
-    The versions are listed in lexicographic order by default, but this can be
-    changed to reduce the likelihood of merge conflicts:
-
-    ```ruby
-    config.active_record.dump_schema_migrations_sort_by = \
-      ->(version) { version.reverse }
-
-    # Same, via to_proc.
-    config.active_record.dump_schema_migrations_sort_by = :reverse
-    ```
+    Versions are ordered by their reversed strings by default, to help avoid
+    merge conflicts, but `dump_schema_migrations_sort_by` gives you a way to
+    customize this.
 
     `ActiveRecord.dump_schema_migrations` is false by default.
 

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -462,7 +462,7 @@ module ActiveRecord
   # Specifies the proc used to order versions when dumping the +schema_migrations+
   # table in the +:ruby+ format.
   singleton_class.attr_accessor :dump_schema_migrations_sort_by
-  self.dump_schema_migrations_sort_by = :itself
+  self.dump_schema_migrations_sort_by = :reverse
 
   ##
   # :singleton-method: verify_foreign_keys_for_fixtures

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -42,7 +42,7 @@ module ActiveRecord
     config.active_record.use_legacy_signed_id_verifier = :generate_and_verify
     config.active_record.deprecated_associations_options = { mode: :warn, backtrace: false }
     config.active_record.dump_schema_migrations = false
-    config.active_record.dump_schema_migrations_sort_by = :itself
+    config.active_record.dump_schema_migrations_sort_by = :reverse
 
     config.active_record.queues = ActiveSupport::InheritableOptions.new
 

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -61,7 +61,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
       dump_all_table_schema
     end
 
-    expected_versions = versions.map(&:to_s).sort
+    expected_versions = versions.map(&:to_s).sort_by(&:reverse)
     expected = [
       "ActiveRecord::Schema.load_schema_migrations(__FILE__)",
       "__END__",
@@ -84,19 +84,19 @@ class SchemaDumperTest < ActiveRecord::TestCase
 
     versions = ActiveRecord::Base.connection_pool.migration_context.migrations.map(&:version)
     versions_seen_by_sorter = []
-    sort_by_reversed_string = ->(version) {
+    sort_by_version = ->(version) {
       versions_seen_by_sorter << version
-      version.reverse
+      version
     }
 
     @schema_migration.delete_all_versions
     @schema_migration.create_versions(versions.map(&:to_s))
 
     ActiveRecord.dump_schema_migrations = true
-    ActiveRecord.dump_schema_migrations_sort_by = sort_by_reversed_string
+    ActiveRecord.dump_schema_migrations_sort_by = sort_by_version
     output = dump_all_table_schema
 
-    expected_versions = versions.map(&:to_s).sort_by(&:reverse)
+    expected_versions = versions.map(&:to_s).sort
     expected = [
       "ActiveRecord::Schema.load_schema_migrations(__FILE__)",
       "__END__",

--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -1503,18 +1503,23 @@ The dump includes only versions with an existing migration file, so projects
 that prune old migrations keep the table in sync automatically just by
 regenerating the schema with `bin/rails db:schema:dump`.
 
-By default, versions are ordered lexicographically. You can customize this to
-reduce the likelihood of merge conflicts:
+By default, versions are ordered by their reversed strings to help avoid merge
+conflicts, but this can be customized:
 
 ```ruby
-config.active_record.dump_schema_migrations_sort_by = \
-  ->(version) { version.reverse }
+# Linear order.
+config.active_record.dump_schema_migrations_sort_by = :itself
 
-# Same, via to_proc.
-config.active_record.dump_schema_migrations_sort_by = :reverse
+# Hash-based ordering.
+require "digest/md5"
+
+config.active_record.dump_schema_migrations_sort_by = ->(version) {
+  Digest::MD5.hexdigest(version)
+}
 ```
 
-The proc is called with a string as argument.
+The value has to be a proc (or respond to `to_proc`) which is called with a
+string as argument.
 
 Please note that the order of the versions does not matter for Active Record,
 the `schema_migrations` table acts as a set.

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1311,18 +1311,23 @@ the `schema_migrations` table. This can be overridden per database by setting
 #### `config.active_record.dump_schema_migrations_sort_by`
 
 When `config.active_record.dump_schema_migrations` is enabled, migration
-versions are listed in lexicographical order by default, but this option allows
-you to change that to reduce the likelihood of merge conflicts:
+versions are ordered by their reversed strings by default, to help avoid merge
+conflicts. This option provides a way to configure that:
 
 ```ruby
-config.active_record.dump_schema_migrations_sort_by = \
-  ->(version) { version.reverse }
+# Linear order.
+config.active_record.dump_schema_migrations_sort_by = :itself
 
-# Same, via to_proc.
-config.active_record.dump_schema_migrations_sort_by = :reverse
+# Hash-based order.
+require "digest/md5"
+
+config.active_record.dump_schema_migrations_sort_by = ->(version) {
+  Digest::MD5.hexdigest(version)
+}
 ```
 
-The proc is called with a string as argument.
+The value has to be a proc (or respond to `to_proc`) which is called with a
+string as argument.
 
 Please note that the order of the versions does not matter for Active Record,
 the `schema_migrations` table acts as a set.

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2121,17 +2121,17 @@ module ApplicationTests
       assert ActiveRecord.dump_schema_migrations
     end
 
-    test "config.active_record.dump_schema_migrations_sort_by is :itself by default" do
-      app "development"
-
-      assert_equal :itself, ActiveRecord.dump_schema_migrations_sort_by
-    end
-
-    test "config.active_record.dump_schema_migrations_sort_by can be configured" do
-      add_to_config "config.active_record.dump_schema_migrations_sort_by = :reverse"
+    test "config.active_record.dump_schema_migrations_sort_by is :reverse by default" do
       app "development"
 
       assert_equal :reverse, ActiveRecord.dump_schema_migrations_sort_by
+    end
+
+    test "config.active_record.dump_schema_migrations_sort_by can be configured" do
+      add_to_config "config.active_record.dump_schema_migrations_sort_by = :itself"
+      app "development"
+
+      assert_equal :itself, ActiveRecord.dump_schema_migrations_sort_by
     end
 
     test "config.active_record.verbose_query_logs is false by default in development" do


### PR DESCRIPTION
#58134 implemented the ability to dump `schema_migrations` in `db/schema.rb`, and as a trade-off chose to dump the table in lexicographic order by default.

Well, after merging and sleeping on it for a few days, I believe that default (which I called "painful") is wrong and we are on time to get it right.

What is going to trigger enabling this? I expect that to be merge conflicts. So, if you provide something with that in mind, it is coherent to address the use case right out of the box. You should not need to realize ordering is customizable and that doing that extra step is what you generally want.

I am thinking that POLS would apply if this dumping was what Rails did by default, but it is not, you have to opt in. If you opt in and the docs tell you which is the default ordering, you should be good.

Now, in the unlikely (?) case that you opt in and also want a linear order, you have a way to accomplish that.