### PR TITLE
Disable Content-Security-Policy on the built-in health check

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Disable the Content-Security-Policy header on the built-in health check (`/up`).
+
+    Since the response body is fixed and controlled by the framework, applying
+    the app's configured `style-src` policy to it could cause browsers to
+    reject its inline `style` attribute and log a CSP violation when a human
+    visits `/up` directly.
+
+    *madogiwa0124*
+
 *   Don't filter nonexistent i18n paths on initialize. This negatively impacts
     applications with lots of translation files.
 

--- a/railties/lib/rails/health_controller.rb
+++ b/railties/lib/rails/health_controller.rb
@@ -34,7 +34,14 @@ module Rails
   # where your application is being restarted due to a third-party service going
   # bad. Ideally, you should design your application to handle those outages
   # gracefully.
+  #
+  # The response body is fixed and entirely controlled by the framework, so
+  # this controller disables the app's Content-Security-Policy rather than
+  # inheriting it, which would otherwise make browsers reject the inline
+  # +style+ attribute used to color the page.
   class HealthController < ActionController::Base
+    content_security_policy false
+
     rescue_from(Exception) { render_down }
 
     def show

--- a/railties/test/application/content_security_policy_test.rb
+++ b/railties/test/application/content_security_policy_test.rb
@@ -211,6 +211,27 @@ module ApplicationTests
       assert_policy "default-src 'self' https:", report_only: true
     end
 
+    test "rails health check endpoint does not set a content security policy" do
+      app_file "config/initializers/content_security_policy.rb", <<-RUBY
+        Rails.application.config.content_security_policy do |p|
+          p.default_src :self, :https
+        end
+      RUBY
+
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          get "up" => "rails/health#show", as: :rails_health_check
+        end
+      RUBY
+
+      app("development")
+
+      get "/up"
+      assert_equal 200, last_response.status
+      assert_nil last_response.headers["Content-Security-Policy"]
+      assert_nil last_response.headers["Content-Security-Policy-Report-Only"]
+    end
+
     test "global content security policy added to rack app" do
       app_file "config/initializers/content_security_policy.rb", <<-RUBY
         Rails.application.config.content_security_policy do |p|


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `Rails::HealthController` (the built-in `/up` health check) triggers a Content-Security-Policy violation in the browser.

It renders its status using an inline `style` attribute. When an application configures a `style-src` Content-Security-Policy that doesn't allow `unsafe-inline` (the default suggested in `config/initializers/content_security_policy.rb`), visiting `/up` in a browser triggers a CSP violation in the console.

https://github.com/rails/rails/blob/160577bb9acc2f6d17e66b2d4aeb1392fcd690cf/railties/lib/rails/generators/rails/app/templates/config/initializers/content_security_policy.rb.tt#L7-L17

Since CSP is enforced by the browser, this doesn't affect infrastructure-level health checks such as load balancers, `curl`, or Kamal.

Because the response body is entirely fixed by the framework, I concluded that disabling CSP on `Rails::HealthController` itself is the right approach, rather than having applications loosen their CSP configuration.

### Detail

This Pull Request adds `content_security_policy false` to `Rails::HealthController` to disable CSP for it, the same mechanism already used by `Rails::MailersController`.

- Adds an integration test in `railties/test/application/content_security_policy_test.rb` that configures a global `style-src` CSP and asserts `/up` returns 200 with no `Content-Security-Policy` / `Content-Security-Policy-Report-Only` header.
- Adds a note to the `Rails::HealthController` rdoc comment explaining why CSP is disabled.
- Adds a CHANGELOG entry to `railties/CHANGELOG.md`.

### Checklist

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG files are updated.
