### PR TITLE
Refactor template lookup details handling

### DIFF
--- a/actionmailer/lib/action_mailer.rb
+++ b/actionmailer/lib/action_mailer.rb
@@ -107,5 +107,5 @@ autoload :Mime, "action_dispatch/http/mime_type"
 ActiveSupport.on_load(:action_view) do
   ActionView::Base.default_formats ||= Mime.symbols
   ActionView::Template.mime_types_implementation = Mime
-  ActionView::LookupContext::DetailsKey.clear
+  ActionView::LookupContext.clear
 end

--- a/actionpack/lib/action_controller/metal/implicit_render.rb
+++ b/actionpack/lib/action_controller/metal/implicit_render.rb
@@ -35,8 +35,9 @@ module ActionController
     include BasicImplicitRender
 
     def default_render
-      if template_exists?(action_name.to_s, _prefixes, variants: request.variant)
-        render
+      lookup_context.variants = request.variant if request.variant.present?
+      if (template = lookup_context.find(action_name.to_s, _prefixes))
+        render(template: template)
       elsif any_templates?(action_name.to_s, _prefixes)
         message = "#{self.class.name}\##{action_name} is missing a template " \
           "for this request format and variant.\n" \

--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -163,5 +163,5 @@ autoload :Mime, "action_dispatch/http/mime_type"
 ActiveSupport.on_load(:action_view) do
   ActionView::Base.default_formats ||= Mime.symbols
   ActionView::Template.mime_types_implementation = Mime
-  ActionView::LookupContext::DetailsKey.clear
+  ActionView::LookupContext.clear
 end

--- a/actionpack/test/controller/mime/respond_to_test.rb
+++ b/actionpack/test/controller/mime/respond_to_test.rb
@@ -336,7 +336,7 @@ class RespondToControllerTest < ActionController::TestCase
     Mime::Type.register("text/x-mobile", :mobile)
     Mime::Type.register("application/fancy-xml", :fancy_xml)
     Mime::Type.register("text/html; fragment", :html_fragment)
-    ActionView::LookupContext::DetailsKey.clear
+    ActionView::LookupContext.clear
   end
 
   def teardown
@@ -345,7 +345,7 @@ class RespondToControllerTest < ActionController::TestCase
     Mime::Type.unregister(:mobile)
     Mime::Type.unregister(:fancy_xml)
     Mime::Type.unregister(:html_fragment)
-    ActionView::LookupContext::DetailsKey.clear
+    ActionView::LookupContext.clear
   end
 
   def test_html_fragment

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -354,11 +354,11 @@ module TemplateModificationHelper
       key = name + ".erb"
       original = hash[key]
       hash[key] = "#{original} Modified!"
-      ActionView::LookupContext::DetailsKey.clear
+      ActionView::LookupContext.clear
       yield
     ensure
       hash[key] = original
-      ActionView::LookupContext::DetailsKey.clear
+      ActionView::LookupContext.clear
     end
 end
 

--- a/actionview/lib/action_view/cache_expiry.rb
+++ b/actionview/lib/action_view/cache_expiry.rb
@@ -52,7 +52,7 @@ module ActionView
 
       private
         def reload!
-          ActionView::LookupContext::DetailsKey.clear
+          ActionView::LookupContext.clear
         end
 
         def build_watcher

--- a/actionview/lib/action_view/digestor.rb
+++ b/actionview/lib/action_view/digestor.rb
@@ -1,13 +1,27 @@
 # frozen_string_literal: true
 
+require "concurrent/map"
 require "action_view/dependency_tracker"
 
 module ActionView
   class Digestor
     MUTEX = Mutex.new
     private_constant :MUTEX
+    @cache = Concurrent::Map.new
 
     class << self
+      def cache(details_key)
+        @cache[details_key] ||= Concurrent::Map.new
+      end
+
+      def digest_caches
+        @cache.values
+      end
+
+      def clear_cache
+        @cache.clear
+      end
+
       # Supported options:
       #
       # * <tt>name</tt>         - Template name

--- a/actionview/lib/action_view/layouts.rb
+++ b/actionview/lib/action_view/layouts.rb
@@ -284,7 +284,7 @@ module ActionView
         silence_redefinition_of_method(:_layout)
 
         prefixes = /\blayouts/.match?(_implied_layout_name) ? [] : ["layouts"]
-        default_behavior = "lookup_context.find('#{_implied_layout_name}', #{prefixes.inspect}, false, keys, { formats: formats }) || super"
+        default_behavior = "lookup_context.find('#{_implied_layout_name}', #{prefixes.inspect}, false, keys, lookup_context.details_for(formats: formats)) || super"
         name_clause = if name
           default_behavior
         else

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -107,7 +107,7 @@ module ActionView
       end
 
       def digest_cache
-        @digest_cache ||= DetailsKey.digest_cache(to_h)
+        @digest_cache ||= DetailsKey.digest_cache(to_cache_key)
       end
 
       def merge(options)
@@ -154,6 +154,10 @@ module ActionView
             rank(variants, value)
           end
         end
+
+        def to_cache_key
+          [locale, Template.normalized_formats(formats) || formats, variants, handlers].freeze
+        end
     end
 
     class DetailsKey # :nodoc:
@@ -162,8 +166,8 @@ module ActionView
       @details_keys = Concurrent::Map.new
       @digest_cache = Concurrent::Map.new
 
-      def self.digest_cache(details)
-        @digest_cache[details_cache_key(details)] ||= Concurrent::Map.new
+      def self.digest_cache(key)
+        @digest_cache[key] ||= Concurrent::Map.new
       end
 
       def self.details_cache_key(details)

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -107,7 +107,7 @@ module ActionView
       end
 
       def digest_cache
-        @digest_cache ||= DetailsKey.digest_cache(to_cache_key)
+        @digest_cache ||= Digestor.cache(to_cache_key)
       end
 
       def merge(options)
@@ -164,11 +164,6 @@ module ActionView
       alias :eql? :equal?
 
       @details_keys = Concurrent::Map.new
-      @digest_cache = Concurrent::Map.new
-
-      def self.digest_cache(key)
-        @digest_cache[key] ||= Concurrent::Map.new
-      end
 
       def self.details_cache_key(details)
         @details_keys.fetch(details) do
@@ -188,11 +183,7 @@ module ActionView
         end
         ActionView::LookupContext.reset_view_context_class
         @details_keys.clear
-        @digest_cache.clear
-      end
-
-      def self.digest_caches
-        @digest_cache.values
+        Digestor.clear_cache
       end
     end
 

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -19,6 +19,12 @@ module ActionView
       [:locale, :formats, :variants, :handlers]
     end
 
+    def self.clear
+      ActionView::PathRegistry.all_resolvers.each(&:clear_cache)
+      reset_view_context_class
+      Digestor.clear_cache
+    end
+
     class Details
       def initialize(locale: nil, formats: nil, variants: nil, handlers: nil)
         @locale   = locale   && Array(locale)
@@ -158,16 +164,6 @@ module ActionView
         def to_cache_key
           [locale, Template.normalized_formats(formats) || formats, variants, handlers].freeze
         end
-    end
-
-    class DetailsKey # :nodoc:
-      def self.clear
-        ActionView::PathRegistry.all_resolvers.each do |resolver|
-          resolver.clear_cache
-        end
-        ActionView::LookupContext.reset_view_context_class
-        Digestor.clear_cache
-      end
     end
 
     def self.reset_view_context_class

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -15,10 +15,6 @@ module ActionView
   class LookupContext # :nodoc:
     attr_accessor :prefixes
 
-    def self.registered_details
-      [:locale, :formats, :variants, :handlers]
-    end
-
     def self.clear
       ActionView::PathRegistry.all_resolvers.each(&:clear_cache)
       reset_view_context_class
@@ -184,35 +180,36 @@ module ActionView
     module ViewPaths
       attr_reader :view_paths
 
-      def find(name, prefixes = [], partial = false, keys = [], options = {})
+      def find(name, prefixes = [], partial = false, keys = [], details = @details)
         name, prefixes = normalize_name(name, prefixes)
-        @view_paths.find(name, prefixes, partial, detail_args_for(options), @cache, keys)
+        @view_paths.find(name, prefixes, partial, details, @cache, keys)
       end
 
-      def find!(name, prefixes = [], partial = false, keys = [], options = {})
+      def find!(name, prefixes = [], partial = false, keys = [], details = @details)
         name, prefixes = normalize_name(name, prefixes)
-        @view_paths.find!(name, prefixes, partial, detail_args_for(options), @cache, keys)
+        @view_paths.find!(name, prefixes, partial, details, @cache, keys)
       end
 
-      def find_all(name, prefixes = [], partial = false, keys = [], options = {})
+      def find_all(name, prefixes = [], partial = false, keys = [], details = @details)
         name, prefixes = normalize_name(name, prefixes)
-        @view_paths.find_all(name, prefixes, partial, detail_args_for(options), @cache, keys)
+        @view_paths.find_all(name, prefixes, partial, details, @cache, keys)
       end
 
       def exists?(name, prefixes = [], partial = false, keys = [], **options)
         name, prefixes = normalize_name(name, prefixes)
-        @view_paths.exists?(name, prefixes, partial, detail_args_for(options), @cache, keys)
+        @view_paths.exists?(name, prefixes, partial, details_for(options), @cache, keys)
       end
       alias :template_exists? :exists?
 
       def any?(name, prefixes = [], partial = false)
         name, prefixes = normalize_name(name, prefixes)
-        @view_paths.exists?(name, prefixes, partial, detail_args_for_any, @cache, [])
+        @view_paths.exists?(name, prefixes, partial, details_for_any, @cache, [])
       end
       alias :any_templates? :any?
 
-      def any_formats?(name, prefixes = [], partial = false, keys = [], options = {})
-        exists?(name, prefixes, partial, keys, **options, formats: default_formats)
+      def any_formats?(name, prefixes = [], partial = false, keys = [], details = @details)
+        name, prefixes = normalize_name(name, prefixes)
+        @view_paths.exists?(name, prefixes, partial, details.merge(formats: default_formats), @cache, keys)
       end
 
       def append_view_paths(paths)
@@ -221,6 +218,15 @@ module ActionView
 
       def prepend_view_paths(paths)
         @view_paths = build_view_paths(paths + @view_paths.to_a)
+      end
+
+      # Resolves the Details to look up with from the render options (e.g.
+      # <tt>formats: :json</tt> passed to #render): the context's own Details
+      # when there are no relevant overrides, otherwise a copy with them layered
+      # on. Renderers call this once and then flow the resulting Details straight
+      # through find/find_all.
+      def details_for(options)
+        @details.merge(options)
       end
 
     private
@@ -234,14 +240,8 @@ module ActionView
         end
       end
 
-      # Compute details hash and key according to user options (e.g. passed from #render).
-      def detail_args_for(options) # :doc:
-        return @details if options.empty? # most common path.
-        @details.merge(options)
-      end
-
-      def detail_args_for_any
-        @detail_args_for_any ||= Details.new(variants: :any)
+      def details_for_any
+        @details_for_any ||= Details.new(variants: :any)
       end
 
       # Fix when prefix is specified as part of the template name

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -15,43 +15,121 @@ module ActionView
   class LookupContext # :nodoc:
     attr_accessor :prefixes
 
-    singleton_class.attr_accessor :default_procs
-    self.default_procs = {}.freeze
-
     def self.registered_details
-      self.default_procs.keys
+      [:locale, :formats, :variants, :handlers]
     end
 
-    def self.register_detail(name, &block)
-      self.default_procs = self.default_procs.merge(name => block).freeze
+    class Details
+      def initialize(locale: nil, formats: nil, variants: nil, handlers: nil)
+        @locale   = locale   && Array(locale)
+        @formats  = formats  && Array(formats)
+        @variants = variants == :any ? :any : variants && Array(variants)
+        @handlers = handlers && Array(handlers)
+      end
 
-      Accessors.define_method(:"default_#{name}", &block)
-      Accessors.module_eval <<-METHOD, __FILE__, __LINE__ + 1
-        def #{name}
-          @details[:#{name}] || []
+      attr_reader :html_fallback_for_js
+
+      def locale
+        @locale ||= default_locale
+      end
+
+      def locale=(value)
+        value = value.present? ? Array(value) : default_locale
+        return if value == @locale
+        @locale = value
+        @digest_cache = nil
+      end
+
+      def formats
+        @formats ||= default_formats
+      end
+
+      def formats=(values)
+        if values
+          values = values.dup
+          values.concat(default_formats) if values.delete "*/*"
+          values.uniq!
+
+          Template.validate_formats(values)
+
+          if (values.length == 1) && (values[0] == :js)
+            values << :html
+            @html_fallback_for_js = true
+          end
         end
 
-        def #{name}=(value)
-          value = value.present? ? Array(value) : default_#{name}
-          _set_detail(:#{name}, value) if value != @details[:#{name}]
+        values = values.presence || default_formats
+        return if values == @formats
+        @formats = values
+        @digest_cache = nil
+      end
+
+      def variants
+        @variants ||= default_variants
+      end
+
+      def variants=(value)
+        value = value.present? ? Array(value) : default_variants
+        return if value == @variants
+        @variants = value
+        @digest_cache = nil
+      end
+
+      def handlers
+        @handlers ||= default_handlers
+      end
+
+      def handlers=(value)
+        value = value.present? ? Array(value) : default_handlers
+        return if value == @handlers
+        @handlers = value
+        @digest_cache = nil
+      end
+
+      def default_locale
+        locales = [I18n.locale]
+        locales.concat(I18n.fallbacks[I18n.locale]) if I18n.respond_to? :fallbacks
+        locales << I18n.default_locale
+        locales.uniq!
+        locales
+      end
+
+      def default_formats
+        ActionView::Base.default_formats || [:html, :text, :js, :css, :xml, :json]
+      end
+
+      def default_variants
+        []
+      end
+
+      def default_handlers
+        Template::Handlers.extensions
+      end
+
+      def digest_cache
+        @digest_cache ||= DetailsKey.digest_cache(to_h)
+      end
+
+      def merge(options)
+        return self if [:locale, :formats, :variants, :handlers].freeze.none? { |key| options[key] }
+        self.class.new(
+          locale:   options[:locale]   || locale,
+          formats:  options[:formats]  || formats,
+          variants: options[:variants] || variants,
+          handlers: options[:handlers] || handlers,
+        )
+      end
+
+      def to_h
+        { locale: locale, formats: formats, variants: variants, handlers: handlers }
+      end
+
+      private
+        def initialize_copy(other)
+          @digest_cache = nil
+          super
         end
-      METHOD
     end
-
-    # Holds accessors for the registered details.
-    module Accessors # :nodoc:
-    end
-
-    register_detail(:locale) do
-      locales = [I18n.locale]
-      locales.concat(I18n.fallbacks[I18n.locale]) if I18n.respond_to? :fallbacks
-      locales << I18n.default_locale
-      locales.uniq!
-      locales
-    end
-    register_detail(:formats) { ActionView::Base.default_formats || [:html, :text, :js, :css,  :xml, :json] }
-    register_detail(:variants) { [] }
-    register_detail(:handlers) { Template::Handlers.extensions }
 
     class DetailsKey # :nodoc:
       alias :eql? :equal?
@@ -103,28 +181,9 @@ module ActionView
     @view_context_mutex = Mutex.new
     ActiveSupport.on_load(:action_view) { ActionView::LookupContext.view_context_class }
 
-    # Add caching behavior on top of Details.
-    module DetailsCache
-      attr_accessor :cache
-
-      def disable_cache
-        old_value, @cache = @cache, false
-        yield
-      ensure
-        @cache = old_value
-      end
-
-    private
-      def _set_detail(key, value) # :doc:
-        @details = @details.dup if @digest_cache
-        @digest_cache = nil
-        @details[key] = value
-      end
-    end
-
     # Helpers related to template lookup using the lookup context information.
     module ViewPaths
-      attr_reader :view_paths, :html_fallback_for_js
+      attr_reader :view_paths
 
       def find(name, prefixes = [], partial = false, keys = [], options = {})
         name, prefixes = normalize_name(name, prefixes)
@@ -178,24 +237,12 @@ module ActionView
 
       # Compute details hash and key according to user options (e.g. passed from #render).
       def detail_args_for(options) # :doc:
-        return @details if options.empty? # most common path.
-        @details.merge(options)
+        return @details.to_h if options.empty? # most common path.
+        @details.merge(options).to_h
       end
 
       def detail_args_for_any
-        @detail_args_for_any ||= begin
-          details = {}
-
-          LookupContext.registered_details.each do |k|
-            if k == :variants
-              details[k] = :any
-            else
-              details[k] = LookupContext.default_procs[k].call
-            end
-          end
-
-          details
-        end
+        @detail_args_for_any ||= Details.new(variants: :any).to_h
       end
 
       # Fix when prefix is specified as part of the template name
@@ -218,59 +265,52 @@ module ActionView
       end
     end
 
-    include Accessors
-    include DetailsCache
     include ViewPaths
 
+    attr_accessor :cache
+
     def initialize(view_paths, details = {}, prefixes = [])
-      @digest_cache = nil
+      # Load ActionView::Base so its on_load(:action_view) hooks run before we
+      # resolve any templates (e.g. template handler registration).
+      _ = ActionView::Base
       @cache = true
       @prefixes = prefixes
 
-      @details = initialize_details({}, details)
+      @details = if details.is_a?(Details)
+        details
+      else
+        Details.new(
+          locale:   details[:locale],
+          formats:  details[:formats],
+          variants: details[:variants],
+          handlers: details[:handlers],
+        )
+      end
+
+
       @view_paths = build_view_paths(view_paths)
     end
 
-    def digest_cache
-      @digest_cache ||= DetailsKey.digest_cache(@details)
+    delegate :formats, :formats=, :variants, :variants=, :handlers, :handlers=,
+             :html_fallback_for_js, :default_formats, :digest_cache, to: :@details
+
+    def disable_cache
+      old_value, @cache = @cache, false
+      yield
+    ensure
+      @cache = old_value
     end
 
     def with_prepended_formats(formats)
       details = @details.dup
-      details[:formats] = formats
+      details.formats = formats
 
       self.class.new(@view_paths, details, @prefixes)
     end
 
-    def initialize_details(target, details)
-      LookupContext.registered_details.each do |k|
-        target[k] = details[k] || LookupContext.default_procs[k].call
-      end
-      target
-    end
-    private :initialize_details
-
-    # Override formats= to expand ["*/*"] values and automatically
-    # add :html as fallback to :js.
-    def formats=(values)
-      if values
-        values = values.dup
-        values.concat(default_formats) if values.delete "*/*"
-        values.uniq!
-
-        Template.validate_formats(values)
-
-        if (values.length == 1) && (values[0] == :js)
-          values << :html
-          @html_fallback_for_js = true
-        end
-      end
-      super(values)
-    end
-
     # Override locale to return a symbol instead of array.
     def locale
-      @details[:locale].first
+      @details.locale.first
     end
 
     # Overload locale= to also set the I18n.locale. If the current I18n.config object responds
@@ -282,7 +322,7 @@ module ActionView
         config.locale = value
       end
 
-      super(default_locale)
+      @details.locale = @details.default_locale
     end
   end
 end

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -161,28 +161,11 @@ module ActionView
     end
 
     class DetailsKey # :nodoc:
-      alias :eql? :equal?
-
-      @details_keys = Concurrent::Map.new
-
-      def self.details_cache_key(details)
-        @details_keys.fetch(details) do
-          if formats = details[:formats]
-            if normalized = Template.normalized_formats(formats)
-              details = details.dup
-              details[:formats] = normalized
-            end
-          end
-          @details_keys[details] ||= TemplateDetails::Requested.new(**details)
-        end
-      end
-
       def self.clear
         ActionView::PathRegistry.all_resolvers.each do |resolver|
           resolver.clear_cache
         end
         ActionView::LookupContext.reset_view_context_class
-        @details_keys.clear
         Digestor.clear_cache
       end
     end

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -120,6 +120,15 @@ module ActionView
         )
       end
 
+      def template_rank(template)
+        d = template.details
+        format  = rank(formats, d.format)     or return
+        locale  = rank(self.locale, d.locale) or return
+        variant = variant_rank(d.variant)     or return
+        handler = rank(handlers, d.handler)   or return
+        [format, locale, variant, handler]
+      end
+
       def to_h
         { locale: locale, formats: formats, variants: variants, handlers: handlers }
       end
@@ -128,6 +137,22 @@ module ActionView
         def initialize_copy(other)
           @digest_cache = nil
           super
+        end
+
+        def rank(requested, value)
+          if requested
+            requested.index(value) || (requested.size if value.nil?)
+          elsif value.nil?
+            0
+          end
+        end
+
+        def variant_rank(value)
+          if variants == :any
+            value.nil? ? 0 : 1
+          else
+            rank(variants, value)
+          end
         end
     end
 
@@ -237,12 +262,12 @@ module ActionView
 
       # Compute details hash and key according to user options (e.g. passed from #render).
       def detail_args_for(options) # :doc:
-        return @details.to_h if options.empty? # most common path.
-        @details.merge(options).to_h
+        return @details if options.empty? # most common path.
+        @details.merge(options)
       end
 
       def detail_args_for_any
-        @detail_args_for_any ||= Details.new(variants: :any).to_h
+        @detail_args_for_any ||= Details.new(variants: :any)
       end
 
       # Fix when prefix is specified as part of the template name

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -107,13 +107,6 @@ module ActionView
     module DetailsCache
       attr_accessor :cache
 
-      # Calculate the details key. Remove the handlers from calculation to improve performance
-      # since the user cannot modify it explicitly.
-      def details_key # :nodoc:
-        @details_key ||= DetailsKey.details_cache_key(@details) if @cache
-      end
-
-      # Temporary skip passing the details_key forward.
       def disable_cache
         old_value, @cache = @cache, false
         yield
@@ -123,9 +116,8 @@ module ActionView
 
     private
       def _set_detail(key, value) # :doc:
-        @details = @details.dup if @digest_cache || @details_key
+        @details = @details.dup if @digest_cache
         @digest_cache = nil
-        @details_key = nil
         @details[key] = value
       end
     end
@@ -136,33 +128,28 @@ module ActionView
 
       def find(name, prefixes = [], partial = false, keys = [], options = {})
         name, prefixes = normalize_name(name, prefixes)
-        details, details_key = detail_args_for(options)
-        @view_paths.find(name, prefixes, partial, details, details_key, keys)
+        @view_paths.find(name, prefixes, partial, detail_args_for(options), @cache, keys)
       end
 
       def find!(name, prefixes = [], partial = false, keys = [], options = {})
         name, prefixes = normalize_name(name, prefixes)
-        details, details_key = detail_args_for(options)
-        @view_paths.find!(name, prefixes, partial, details, details_key, keys)
+        @view_paths.find!(name, prefixes, partial, detail_args_for(options), @cache, keys)
       end
 
       def find_all(name, prefixes = [], partial = false, keys = [], options = {})
         name, prefixes = normalize_name(name, prefixes)
-        details, details_key = detail_args_for(options)
-        @view_paths.find_all(name, prefixes, partial, details, details_key, keys)
+        @view_paths.find_all(name, prefixes, partial, detail_args_for(options), @cache, keys)
       end
 
       def exists?(name, prefixes = [], partial = false, keys = [], **options)
         name, prefixes = normalize_name(name, prefixes)
-        details, details_key = detail_args_for(options)
-        @view_paths.exists?(name, prefixes, partial, details, details_key, keys)
+        @view_paths.exists?(name, prefixes, partial, detail_args_for(options), @cache, keys)
       end
       alias :template_exists? :exists?
 
       def any?(name, prefixes = [], partial = false)
         name, prefixes = normalize_name(name, prefixes)
-        details, details_key = detail_args_for_any
-        @view_paths.exists?(name, prefixes, partial, details, details_key, [])
+        @view_paths.exists?(name, prefixes, partial, detail_args_for_any, @cache, [])
       end
       alias :any_templates? :any?
 
@@ -191,16 +178,8 @@ module ActionView
 
       # Compute details hash and key according to user options (e.g. passed from #render).
       def detail_args_for(options) # :doc:
-        return @details, details_key if options.empty? # most common path.
-        user_details = @details.merge(options)
-
-        if @cache
-          details_key = DetailsKey.details_cache_key(user_details)
-        else
-          details_key = nil
-        end
-
-        [user_details, details_key]
+        return @details if options.empty? # most common path.
+        @details.merge(options)
       end
 
       def detail_args_for_any
@@ -215,11 +194,7 @@ module ActionView
             end
           end
 
-          if @cache
-            [details, DetailsKey.details_cache_key(details)]
-          else
-            [details, nil]
-          end
+          details
         end
       end
 
@@ -248,7 +223,6 @@ module ActionView
     include ViewPaths
 
     def initialize(view_paths, details = {}, prefixes = [])
-      @details_key = nil
       @digest_cache = nil
       @cache = true
       @prefixes = prefixes

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -39,7 +39,7 @@ module ActionView
         value = value.present? ? Array(value) : default_locale
         return if value == @locale
         @locale = value
-        @digest_cache = nil
+        @ranks = @digest_cache = nil
       end
 
       def formats
@@ -63,7 +63,7 @@ module ActionView
         values = values.presence || default_formats
         return if values == @formats
         @formats = values
-        @digest_cache = nil
+        @ranks = @digest_cache = nil
       end
 
       def variants
@@ -74,7 +74,7 @@ module ActionView
         value = value.present? ? Array(value) : default_variants
         return if value == @variants
         @variants = value
-        @digest_cache = nil
+        @ranks = @digest_cache = nil
       end
 
       def handlers
@@ -85,7 +85,7 @@ module ActionView
         value = value.present? ? Array(value) : default_handlers
         return if value == @handlers
         @handlers = value
-        @digest_cache = nil
+        @ranks = @digest_cache = nil
       end
 
       def default_locale
@@ -123,11 +123,12 @@ module ActionView
       end
 
       def template_rank(template)
+        format_idx, locale_idx, variant_idx, handler_idx = ranks
         d = template.details
-        format  = rank(formats, d.format)     or return
-        locale  = rank(self.locale, d.locale) or return
-        variant = variant_rank(d.variant)     or return
-        handler = rank(handlers, d.handler)   or return
+        format  = format_idx[d.format]   or return
+        locale  = locale_idx[d.locale]   or return
+        variant = variant_idx[d.variant] or return
+        handler = handler_idx[d.handler] or return
         [format, locale, variant, handler]
       end
 
@@ -141,20 +142,26 @@ module ActionView
           super
         end
 
-        def rank(requested, value)
-          if requested
-            requested.index(value) || (requested.size if value.nil?)
-          elsif value.nil?
-            0
+        ANY_HASH = Hash.new(1).merge!(nil => 0).freeze
+
+        def ranks
+          @ranks ||= self.class.intern_ranks(formats, locale, variants, handlers)
+        end
+
+        def self.intern_ranks(formats, locale, variants, handlers)
+          cache = ActiveSupport::Ractors.store_if_absent(:action_view_details_ranks) { Concurrent::Map.new }
+          cache.compute_if_absent([formats, locale, variants, handlers].freeze) do
+            [
+              build_idx(formats),
+              build_idx(locale),
+              variants == :any ? ANY_HASH : build_idx(variants),
+              build_idx(handlers),
+            ].freeze
           end
         end
 
-        def variant_rank(value)
-          if variants == :any
-            value.nil? ? 0 : 1
-          else
-            rank(variants, value)
-          end
+        def self.build_idx(requested)
+          [*requested, nil].each_with_index.to_h.freeze
         end
 
         def to_cache_key

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -132,6 +132,15 @@ module ActionView
         [format, locale, variant, handler]
       end
 
+      # Same match semantics as +template_rank+ without computing a rank and skips the ranks cache.
+      def template_match?(template)
+        d = template.details
+        (d.format.nil? || formats.include?(d.format)) &&
+          (d.locale.nil? || locale.include?(d.locale)) &&
+          (variants == :any || d.variant.nil? || variants.include?(d.variant)) &&
+          (d.handler.nil? || handlers.include?(d.handler))
+      end
+
       def to_h
         { locale: locale, formats: formats, variants: variants, handlers: handlers }
       end

--- a/actionview/lib/action_view/path_set.rb
+++ b/actionview/lib/action_view/path_set.rb
@@ -38,12 +38,16 @@ module ActionView # :nodoc:
     end
 
     def find(path, prefixes, partial, details, cache, locals)
-      find_all(path, prefixes, partial, details, cache, locals).first
+      search_combinations(prefixes) do |resolver, prefix|
+        template = resolver.find(path, prefix, partial, details, cache, locals)
+        return template if template
+      end
+      nil
     end
 
     def find!(path, prefixes, partial, details, cache, locals)
       find(path, prefixes, partial, details, cache, locals) ||
-        raise(MissingTemplate.new(self, path, prefixes, partial, details, cache, locals))
+        raise(MissingTemplate.new(self, path, prefixes, partial, details.to_h, cache, locals))
     end
 
     def find_all(path, prefixes, partial, details, cache, locals)

--- a/actionview/lib/action_view/path_set.rb
+++ b/actionview/lib/action_view/path_set.rb
@@ -37,25 +37,25 @@ module ActionView # :nodoc:
       PathSet.new(paths + array)
     end
 
-    def find(path, prefixes, partial, details, details_key, locals)
-      find_all(path, prefixes, partial, details, details_key, locals).first
+    def find(path, prefixes, partial, details, cache, locals)
+      find_all(path, prefixes, partial, details, cache, locals).first
     end
 
-    def find!(path, prefixes, partial, details, details_key, locals)
-      find(path, prefixes, partial, details, details_key, locals) ||
-        raise(MissingTemplate.new(self, path, prefixes, partial, details, details_key, locals))
+    def find!(path, prefixes, partial, details, cache, locals)
+      find(path, prefixes, partial, details, cache, locals) ||
+        raise(MissingTemplate.new(self, path, prefixes, partial, details, cache, locals))
     end
 
-    def find_all(path, prefixes, partial, details, details_key, locals)
+    def find_all(path, prefixes, partial, details, cache, locals)
       search_combinations(prefixes) do |resolver, prefix|
-        templates = resolver.find_all(path, prefix, partial, details, details_key, locals)
+        templates = resolver.find_all(path, prefix, partial, details, cache, locals)
         return templates unless templates.empty?
       end
       []
     end
 
-    def exists?(path, prefixes, partial, details, details_key, locals)
-      find_all(path, prefixes, partial, details, details_key, locals).any?
+    def exists?(path, prefixes, partial, details, cache, locals)
+      find_all(path, prefixes, partial, details, cache, locals).any?
     end
 
     private

--- a/actionview/lib/action_view/path_set.rb
+++ b/actionview/lib/action_view/path_set.rb
@@ -59,7 +59,10 @@ module ActionView # :nodoc:
     end
 
     def exists?(path, prefixes, partial, details, cache, locals)
-      find_all(path, prefixes, partial, details, cache, locals).any?
+      search_combinations(prefixes) do |resolver, prefix|
+        return true if resolver.find(path, prefix, partial, details, cache, locals)
+      end
+      false
     end
 
     private

--- a/actionview/lib/action_view/renderer/abstract_renderer.rb
+++ b/actionview/lib/action_view/renderer/abstract_renderer.rb
@@ -154,20 +154,6 @@ module ActionView
     end
 
     private
-      NO_DETAILS = {}.freeze
-
-      def extract_details(options) # :doc:
-        details = nil
-        LookupContext.registered_details.each do |key|
-          value = options[key]
-
-          if value
-            (details ||= {})[key] = Array(value)
-          end
-        end
-        details || NO_DETAILS
-      end
-
       def prepend_formats(formats) # :doc:
         formats = Array(formats)
         return if formats.empty? || @lookup_context.html_fallback_for_js

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -240,7 +240,7 @@ module ActionView
       super(lookup_context)
       @options = options
       @locals  = @options[:locals] || {}
-      @details = extract_details(@options)
+      @details = @lookup_context.details_for(@options)
     end
 
     def render(partial, context, block)

--- a/actionview/lib/action_view/renderer/template_renderer.rb
+++ b/actionview/lib/action_view/renderer/template_renderer.rb
@@ -3,7 +3,7 @@
 module ActionView
   class TemplateRenderer < AbstractRenderer # :nodoc:
     def render(context, options, &block)
-      @details = extract_details(options)
+      @details = @lookup_context.details_for(options)
       template = determine_template(options, &block)
 
       prepend_formats(template.format)

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -57,8 +57,8 @@ module ActionView
     end
 
     # Normalizes the arguments and passes it on to find_templates.
-    def find_all(name, prefix = nil, partial = false, details = {}, key = nil, locals = [])
-      _find_all(name, prefix, partial, details, key, locals)
+    def find_all(name, prefix = nil, partial = false, details = {}, cache = false, locals = [])
+      _find_all(name, prefix, partial, details, cache, locals)
     end
 
     def built_templates # :nodoc:
@@ -72,7 +72,7 @@ module ActionView
     end
 
   private
-    def _find_all(name, prefix, partial, details, key, locals)
+    def _find_all(name, prefix, partial, details, cache, locals)
       find_templates(name, prefix, partial, details, locals)
     end
 
@@ -128,12 +128,12 @@ module ActionView
     end
 
     private
-      def _find_all(name, prefix, partial, details, key, locals)
-        requested_details = key || TemplateDetails::Requested.new(**details)
-        cache = key ? @unbound_templates : Concurrent::Map.new
+      def _find_all(name, prefix, partial, details, cache, locals)
+        requested_details = TemplateDetails::Requested.new(**details)
+        store = cache ? @unbound_templates : Concurrent::Map.new
 
         unbound_templates =
-          cache.compute_if_absent(TemplatePath.virtual(name, prefix, partial)) do
+          store.compute_if_absent(TemplatePath.virtual(name, prefix, partial)) do
             path = TemplatePath.build(name, prefix, partial)
             unbound_templates_from_path(path)
           end

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -3,6 +3,7 @@
 require "pathname"
 require "active_support/core_ext/class"
 require "active_support/core_ext/module/attribute_accessors"
+require "active_support/core_ext/string/access"
 require "action_view/template"
 require "concurrent/map"
 
@@ -56,9 +57,15 @@ module ActionView
     def clear_cache
     end
 
-    # Normalizes the arguments and passes it on to find_templates.
+    # Returns every matching template. The only multi-template caller is
+    # ActionMailer multipart; view rendering resolves via #find.
     def find_all(name, prefix = nil, partial = false, details = {}, cache = false, locals = [])
       _find_all(name, prefix, partial, details, cache, locals)
+    end
+
+    # Returns the single best-matching template.
+    def find(name, prefix = nil, partial = false, details = {}, cache = false, locals = [])
+      _find(name, prefix, partial, details, cache, locals)
     end
 
     def built_templates # :nodoc:
@@ -74,6 +81,10 @@ module ActionView
   private
     def _find_all(name, prefix, partial, details, cache, locals)
       find_templates(name, prefix, partial, details, locals)
+    end
+
+    def _find(name, prefix, partial, details, cache, locals)
+      find_all(name, prefix, partial, details, cache, locals).first
     end
 
     delegate :caching?, to: :class
@@ -129,17 +140,23 @@ module ActionView
 
     private
       def _find_all(name, prefix, partial, details, cache, locals)
-        requested_details = TemplateDetails::Requested.new(**details)
-        store = cache ? @unbound_templates : Concurrent::Map.new
+        unbound_templates = unbound_templates_for(name, prefix, partial, cache)
 
-        unbound_templates =
-          store.compute_if_absent(TemplatePath.virtual(name, prefix, partial)) do
-            path = TemplatePath.build(name, prefix, partial)
-            unbound_templates_from_path(path)
-          end
-
-        filter_and_sort_by_details(unbound_templates, requested_details).map do |unbound_template|
+        filter_and_sort_by_details(unbound_templates, details).map do |unbound_template|
           unbound_template.bind_locals(locals)
+        end
+      end
+
+      def _find(name, prefix, partial, details, cache, locals)
+        unbound_templates = unbound_templates_for(name, prefix, partial, cache)
+
+        find_best_by_details(unbound_templates, details)&.bind_locals(locals)
+      end
+
+      def unbound_templates_for(name, prefix, partial, cache)
+        store = cache ? @unbound_templates : Concurrent::Map.new
+        store.compute_if_absent(TemplatePath.virtual(name, prefix, partial)) do
+          unbound_templates_from_path(TemplatePath.build(name, prefix, partial))
         end
       end
 
@@ -177,18 +194,25 @@ module ActionView
         end
       end
 
-      def filter_and_sort_by_details(templates, requested_details)
-        filtered_templates = templates.select do |template|
-          template.details.matches?(requested_details)
+      def filter_and_sort_by_details(templates, details)
+        ranked = templates.filter_map do |template|
+          rank = details.template_rank(template)
+          [rank, template] if rank
         end
 
-        if filtered_templates.count > 1
-          filtered_templates.sort_by! do |template|
-            template.details.sort_key_for(requested_details)
+        ranked.sort_by!(&:first).map!(&:last)
+      end
+
+      def find_best_by_details(templates, details)
+        best = best_rank = nil
+        templates.each do |template|
+          rank = details.template_rank(template) or next
+          if best_rank.nil? || (rank <=> best_rank) < 0
+            best = template
+            best_rank = rank
           end
         end
-
-        filtered_templates
+        best
       end
 
       # Safe glob within @path

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -204,6 +204,11 @@ module ActionView
       end
 
       def find_best_by_details(templates, details)
+        if templates.size == 1
+          template = templates.first
+          return details.template_match?(template) ? template : nil
+        end
+
         best = best_rank = nil
         templates.each do |template|
           rank = details.template_rank(template) or next

--- a/actionview/lib/action_view/template_details.rb
+++ b/actionview/lib/action_view/template_details.rb
@@ -33,22 +33,6 @@ module ActionView
       @variant = variant
     end
 
-    def matches?(requested)
-      requested.formats_idx[@format] &&
-        requested.locale_idx[@locale] &&
-        requested.variants_idx[@variant] &&
-        requested.handlers_idx[@handler]
-    end
-
-    def sort_key_for(requested)
-      [
-        requested.formats_idx[@format],
-        requested.locale_idx[@locale],
-        requested.variants_idx[@variant],
-        requested.handlers_idx[@handler]
-      ]
-    end
-
     def handler_class
       Template.handler_for_extension(handler)
     end

--- a/actionview/lib/action_view/template_details.rb
+++ b/actionview/lib/action_view/template_details.rb
@@ -2,28 +2,6 @@
 
 module ActionView
   class TemplateDetails # :nodoc:
-    class Requested
-      attr_reader :locale_idx, :handlers_idx, :formats_idx, :variants_idx
-
-      ANY_HASH = Hash.new(1).merge(nil => 0).freeze
-
-      def initialize(locale:, handlers:, formats:, variants:)
-        @locale_idx   = build_idx_hash(locale)
-        @handlers_idx = build_idx_hash(handlers)
-        @formats_idx  = build_idx_hash(formats)
-        if variants == :any
-          @variants_idx = ANY_HASH
-        else
-          @variants_idx = build_idx_hash(variants)
-        end
-      end
-
-      private
-        def build_idx_hash(arr)
-          [*arr, nil].each_with_index.to_h.freeze
-        end
-    end
-
     attr_reader :locale, :handler, :format, :variant
 
     def initialize(locale, handler, format, variant)

--- a/actionview/test/actionpack/controller/layout_test.rb
+++ b/actionview/test/actionpack/controller/layout_test.rb
@@ -19,12 +19,12 @@ module TemplateHandlerHelper
   def with_template_handler(*extensions, handler)
     ActionView::Template.register_template_handler(*extensions, handler)
     ActionController::Base.view_paths.paths.each(&:clear_cache)
-    ActionView::LookupContext::DetailsKey.clear
+    ActionView::LookupContext.clear
     yield
   ensure
     ActionView::Template.unregister_template_handler(*extensions)
     ActionController::Base.view_paths.paths.each(&:clear_cache)
-    ActionView::LookupContext::DetailsKey.clear
+    ActionView::LookupContext.clear
   end
 end
 

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -1510,11 +1510,11 @@ class RenderTest < ActionController::TestCase
 
   def with_annotations_enabled
     ActionView::Base.annotate_rendered_view_with_filenames = true
-    ActionView::LookupContext::DetailsKey.clear
+    ActionView::LookupContext.clear
     yield
   ensure
     ActionView::Base.annotate_rendered_view_with_filenames = false
-    ActionView::LookupContext::DetailsKey.clear
+    ActionView::LookupContext.clear
   end
 
   def test_template_annotations

--- a/actionview/test/actionpack/controller/view_paths_test.rb
+++ b/actionview/test/actionpack/controller/view_paths_test.rb
@@ -30,7 +30,7 @@ class ViewLoadPathsTest < ActionController::TestCase
   end
 
   def setup
-    ActionView::LookupContext::DetailsKey.clear
+    ActionView::LookupContext.clear
 
     @controller = TestController.new
     @request  = ActionController::TestRequest.create(@controller.class)

--- a/actionview/test/activerecord/render_partial_with_record_identification_test.rb
+++ b/actionview/test/activerecord/render_partial_with_record_identification_test.rb
@@ -54,7 +54,7 @@ class RenderPartialWithRecordIdentificationTest < ActiveRecordTestCase
 
   def setup
     super
-    ActionView::LookupContext::DetailsKey.clear
+    ActionView::LookupContext.clear
   end
 
   def test_rendering_partial_with_has_many_and_belongs_to_association

--- a/actionview/test/template/compiled_templates_test.rb
+++ b/actionview/test/template/compiled_templates_test.rb
@@ -14,7 +14,7 @@ class CompiledTemplatesTest < ActiveSupport::TestCase
 
   def teardown
     super
-    ActionView::LookupContext::DetailsKey.clear
+    ActionView::LookupContext.clear
   end
 
   def test_template_with_nil_erb_return

--- a/actionview/test/template/digestor_test.rb
+++ b/actionview/test/template/digestor_test.rb
@@ -23,7 +23,7 @@ class TemplateDigestorTest < ActionView::TestCase
     @cwd     = Dir.pwd
     @tmp_dir = Dir.mktmpdir
 
-    ActionView::LookupContext::DetailsKey.clear
+    ActionView::LookupContext.clear
     FileUtils.cp_r FixtureFinder::FIXTURES_DIR, @tmp_dir
     Dir.chdir @tmp_dir
   end

--- a/actionview/test/template/log_subscriber_test.rb
+++ b/actionview/test/template/log_subscriber_test.rb
@@ -21,7 +21,7 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
     @old_logger = ActionView::LogSubscriber.logger
     ActionView::LogSubscriber.logger = @logger
 
-    ActionView::LookupContext::DetailsKey.clear
+    ActionView::LookupContext.clear
 
     view_paths = ActionController::Base.view_paths
 

--- a/actionview/test/template/lookup_context_test.rb
+++ b/actionview/test/template/lookup_context_test.rb
@@ -127,28 +127,6 @@ class LookupContextTest < ActiveSupport::TestCase
     end
   end
 
-  test "generates a new details key for each details hash" do
-    keys = []
-    keys << @lookup_context.details_key
-    assert_equal 1, keys.uniq.size
-
-    @lookup_context.locale = :da
-    keys << @lookup_context.details_key
-    assert_equal 2, keys.uniq.size
-
-    @lookup_context.locale = :en
-    keys << @lookup_context.details_key
-    assert_equal 2, keys.uniq.size
-
-    @lookup_context.formats = [:html]
-    keys << @lookup_context.details_key
-    assert_equal 3, keys.uniq.size
-
-    @lookup_context.formats = nil
-    keys << @lookup_context.details_key
-    assert_equal 3, keys.uniq.size
-  end
-
   test "uses details as part of cache key" do
     fixtures = {
       "test/_foo.erb" => "Foo",

--- a/actionview/test/template/lookup_context_test.rb
+++ b/actionview/test/template/lookup_context_test.rb
@@ -214,8 +214,7 @@ class TestMissingTemplate < ActiveSupport::TestCase
 
   test "if a single prefix is passed as a string and the lookup fails, MissingTemplate accepts it" do
     e = assert_raise ActionView::MissingTemplate do
-      details = { handlers: [], formats: [], variants: [], locale: [] }
-      @lookup_context.view_paths.find!("foo", "parent", true, details, nil, [])
+      @lookup_context.find!("foo", "parent", true)
     end
     assert_match %r{Missing partial parent/_foo with .*\n\nSearched in:\n  \* "/Path/to/views"\n}, e.message
   end

--- a/actionview/test/template/lookup_context_test.rb
+++ b/actionview/test/template/lookup_context_test.rb
@@ -6,7 +6,7 @@ require "abstract_controller/rendering"
 class LookupContextTest < ActiveSupport::TestCase
   def setup
     @lookup_context = build_lookup_context(FIXTURE_LOAD_PATH, {})
-    ActionView::LookupContext::DetailsKey.clear
+    ActionView::LookupContext.clear
   end
 
   def build_lookup_context(paths, details)

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -845,7 +845,7 @@ class FrozenStringLiteralEnabledViewRenderTest < ActiveSupport::TestCase
   include RenderTestCases
 
   def setup
-    ActionView::LookupContext::DetailsKey.clear
+    ActionView::LookupContext.clear
 
     @previous_frozen_literal = ActionView::Template.frozen_string_literal
     ActionView::Template.frozen_string_literal = true
@@ -871,7 +871,7 @@ class CachedViewRenderTest < ActiveSupport::TestCase
 
   # Ensure view path cache is primed
   def setup
-    ActionView::LookupContext::DetailsKey.clear
+    ActionView::LookupContext.clear
     view_paths = ActionController::Base.view_paths
     assert_equal ActionView::FileSystemResolver, view_paths.first.class
     setup_view(view_paths)
@@ -909,7 +909,7 @@ class LazyViewRenderTest < ActiveSupport::TestCase
   # Test the same thing as above, but make sure the view path
   # is not eager loaded
   def setup
-    ActionView::LookupContext::DetailsKey.clear
+    ActionView::LookupContext.clear
     path = ActionView::FileSystemResolver.new(FIXTURE_LOAD_PATH)
     view_paths = ActionView::PathSet.new([path])
     assert_equal ActionView::FileSystemResolver.new(FIXTURE_LOAD_PATH), view_paths.first
@@ -962,7 +962,7 @@ class CachedCollectionViewRenderTest < ActiveSupport::TestCase
 
   # Ensure view path cache is primed
   setup do
-    ActionView::LookupContext::DetailsKey.clear
+    ActionView::LookupContext.clear
 
     view_paths = ActionController::Base.view_paths
     assert_equal ActionView::FileSystemResolver, view_paths.first.class

--- a/actionview/test/template/resolver_shared_tests.rb
+++ b/actionview/test/template/resolver_shared_tests.rb
@@ -102,17 +102,17 @@ module ResolverSharedTests
   def test_found_template_is_cached
     with_file "test/hello_world.html.erb", "Hello HTML!"
 
-    a = context.find("hello_world", "test", false, [], {})
-    b = context.find("hello_world", "test", false, [], {})
+    a = context.find("hello_world", "test", false, [])
+    b = context.find("hello_world", "test", false, [])
     assert_same a, b
   end
 
   def test_different_templates_when_cache_disabled
     with_file "test/hello_world.html.erb", "Hello HTML!"
 
-    a = context.find("hello_world", "test", false, [], {})
-    b = context.disable_cache { context.find("hello_world", "test", false, [], {}) }
-    c = context.find("hello_world", "test", false, [], {})
+    a = context.find("hello_world", "test", false, [])
+    b = context.disable_cache { context.find("hello_world", "test", false, []) }
+    c = context.find("hello_world", "test", false, [])
 
     # disable_cache should give us a new object
     assert_not_same a, b
@@ -124,8 +124,8 @@ module ResolverSharedTests
   def test_same_template_from_different_details_is_same_object
     with_file "test/hello_world.html.erb", "Hello HTML!"
 
-    a = context.find("hello_world", "test", false, [], locale: [:en])
-    b = context.find("hello_world", "test", false, [], locale: [:fr])
+    a = context.find("hello_world", "test", false, [], ActionView::LookupContext::Details.new(locale: [:en]))
+    b = context.find("hello_world", "test", false, [], ActionView::LookupContext::Details.new(locale: [:fr]))
     assert_same a, b
   end
 
@@ -133,8 +133,8 @@ module ResolverSharedTests
     with_file "test/hello_world.text.erb", "Generic plain text!"
     with_file "test/hello_world.fr.text.erb", "Texte en Francais!"
 
-    en = context.find_all("hello_world", "test", false, [], locale: [:en])
-    fr = context.find_all("hello_world", "test", false, [], locale: [:fr])
+    en = context.find_all("hello_world", "test", false, [], ActionView::LookupContext::Details.new(locale: [:en]))
+    fr = context.find_all("hello_world", "test", false, [], ActionView::LookupContext::Details.new(locale: [:fr]))
 
     assert_equal 1, en.size
     assert_equal 2, fr.size
@@ -188,18 +188,18 @@ module ResolverSharedTests
     with_file "test/hello_world.html+tricorder.erb", "Hello Spock!"
     with_file "test/hello_world.html+lcars.erb", "Hello Geordi!"
 
-    tricorder = context.find("hello_world", "test", false, [], { variants: [:tricorder] })
-    lcars = context.find("hello_world", "test", false, [], { variants: [:lcars] })
+    tricorder = context.find("hello_world", "test", false, [], ActionView::LookupContext::Details.new(variants: [:tricorder]))
+    lcars = context.find("hello_world", "test", false, [], ActionView::LookupContext::Details.new(variants: [:lcars]))
 
     assert_equal "Hello Spock!", tricorder.source
     assert_equal "tricorder", tricorder.variant
     assert_equal "Hello Geordi!", lcars.source
     assert_equal "lcars", lcars.variant
 
-    templates = context.find_all("hello_world", "test", false, [], { variants: [:tricorder, :lcars] })
+    templates = context.find_all("hello_world", "test", false, [], ActionView::LookupContext::Details.new(variants: [:tricorder, :lcars]))
     assert_equal [tricorder, lcars], templates
 
-    templates = context.find_all("hello_world", "test", false, [], { variants: [:lcars, :tricorder] })
+    templates = context.find_all("hello_world", "test", false, [], ActionView::LookupContext::Details.new(variants: [:lcars, :tricorder]))
     assert_equal [lcars, tricorder], templates
   end
 
@@ -230,13 +230,13 @@ module ResolverSharedTests
   def test_returns_no_results_with_dot
     with_file "test/hello_world.html.erb", "Hello html!"
 
-    assert_empty context.find_all("hello_world.html", "test", false, [], {})
+    assert_empty context.find_all("hello_world.html", "test", false, [])
   end
 
   def test_finds_template_with_lowdash_format
     with_file "test/hello_world.es_AR.text.erb", "Texto simple!"
 
-    es_ar = context.find_all("hello_world", "test", false, [], locale: [:es_AR])
+    es_ar = context.find_all("hello_world", "test", false, [], ActionView::LookupContext::Details.new(locale: [:es_AR]))
 
     assert_equal 1, es_ar.size
 
@@ -247,7 +247,7 @@ module ResolverSharedTests
     I18n.backend.store_translations(:en_customer1, { hello: "hello" })
     with_file "test/hello_world.en_customer1.text.erb", "Good day, world."
 
-    templates = context.find_all("hello_world", "test", false, [], locale: [:en_customer1])
+    templates = context.find_all("hello_world", "test", false, [], ActionView::LookupContext::Details.new(locale: [:en_customer1]))
 
     assert_equal 1, templates.size
     assert_equal "Good day, world.", templates[0].source
@@ -258,8 +258,8 @@ module ResolverSharedTests
   def test_strict_locals_reuses_same_template
     with_file "test/hello_world.html.erb", %q{<%# locals: (message: "hello")%>\n<%= message %>}
 
-    template = context.find_all("hello_world", "test", false, [:message], {})[0]
-    template2 = context.find_all("hello_world", "test", false, [], {})[0]
+    template = context.find_all("hello_world", "test", false, [:message])[0]
+    template2 = context.find_all("hello_world", "test", false, [])[0]
 
     assert_same template, template2
 

--- a/actionview/test/template/resolver_shared_tests.rb
+++ b/actionview/test/template/resolver_shared_tests.rb
@@ -22,7 +22,7 @@ module ResolverSharedTests
   def test_can_find_with_no_extensions
     with_file "test/hello_world", "Hello default!"
 
-    templates = resolver.find_all("hello_world", "test", false, locale: [:en], formats: [:html], variants: [:phone], handlers: [:erb])
+    templates = resolver.find_all("hello_world", "test", false, ActionView::LookupContext::Details.new(locale: [:en], formats: [:html], variants: [:phone], handlers: [:erb]))
     assert_equal 1, templates.size
     assert_equal "Hello default!",   templates[0].source
     assert_equal "test/hello_world", templates[0].virtual_path
@@ -34,7 +34,7 @@ module ResolverSharedTests
   def test_can_find_with_just_handler
     with_file "test/hello_world.erb", "Hello erb!"
 
-    templates = resolver.find_all("hello_world", "test", false, locale: [:en], formats: [:html], variants: [:phone], handlers: [:erb])
+    templates = resolver.find_all("hello_world", "test", false, ActionView::LookupContext::Details.new(locale: [:en], formats: [:html], variants: [:phone], handlers: [:erb]))
     assert_equal 1, templates.size
     assert_equal "Hello erb!",   templates[0].source
     assert_equal "test/hello_world", templates[0].virtual_path
@@ -46,7 +46,7 @@ module ResolverSharedTests
   def test_can_find_with_format_and_handler
     with_file "test/hello_world.text.builder", "Hello plain text!"
 
-    templates = resolver.find_all("hello_world", "test", false, locale: [:en], formats: [:html, :text], variants: [:phone], handlers: [:erb, :builder])
+    templates = resolver.find_all("hello_world", "test", false, ActionView::LookupContext::Details.new(locale: [:en], formats: [:html, :text], variants: [:phone], handlers: [:erb, :builder]))
     assert_equal 1, templates.size
     assert_equal "Hello plain text!", templates[0].source
     assert_equal "test/hello_world",  templates[0].virtual_path
@@ -58,7 +58,7 @@ module ResolverSharedTests
   def test_can_find_with_variant_format_and_handler
     with_file "test/hello_world.html+phone.erb", "Hello plain text!"
 
-    templates = resolver.find_all("hello_world", "test", false, locale: [:en], formats: [:html], variants: [:phone], handlers: [:erb])
+    templates = resolver.find_all("hello_world", "test", false, ActionView::LookupContext::Details.new(locale: [:en], formats: [:html], variants: [:phone], handlers: [:erb]))
     assert_equal 1, templates.size
     assert_equal "Hello plain text!", templates[0].source
     assert_equal "test/hello_world",  templates[0].virtual_path
@@ -70,7 +70,7 @@ module ResolverSharedTests
   def test_can_find_with_any_variant_format_and_handler
     with_file "test/hello_world.html+phone.erb", "Hello plain text!"
 
-    templates = resolver.find_all("hello_world", "test", false, locale: [:en], formats: [:html], variants: :any, handlers: [:erb])
+    templates = resolver.find_all("hello_world", "test", false, ActionView::LookupContext::Details.new(locale: [:en], formats: [:html], variants: :any, handlers: [:erb]))
     assert_equal 1, templates.size
     assert_equal "Hello plain text!", templates[0].source
     assert_equal "test/hello_world",  templates[0].virtual_path
@@ -83,7 +83,7 @@ module ResolverSharedTests
     dir = "test +()[]{}"
     with_file "#{dir}/hello_world", "Hello funky path!"
 
-    templates = resolver.find_all("hello_world", dir, false, locale: [:en], formats: [:html], variants: [:phone], handlers: [:erb])
+    templates = resolver.find_all("hello_world", dir, false, ActionView::LookupContext::Details.new(locale: [:en], formats: [:html], variants: [:phone], handlers: [:erb]))
     assert_equal 1, templates.size
     assert_equal "Hello funky path!", templates[0].source
     assert_equal "#{dir}/hello_world", templates[0].virtual_path
@@ -92,10 +92,10 @@ module ResolverSharedTests
   def test_doesnt_find_template_with_wrong_details
     with_file "test/hello_world.html.erb", "Hello plain text!"
 
-    templates = resolver.find_all("hello_world", "test", false, locale: [], formats: [:xml], variants: :any, handlers: [:builder])
+    templates = resolver.find_all("hello_world", "test", false, ActionView::LookupContext::Details.new(locale: [], formats: [:xml], variants: :any, handlers: [:builder]))
     assert_equal 0, templates.size
 
-    templates = resolver.find_all("hello_world", "test", false, locale: [], formats: [:xml], variants: :any, handlers: [:erb])
+    templates = resolver.find_all("hello_world", "test", false, ActionView::LookupContext::Details.new(locale: [], formats: [:xml], variants: :any, handlers: [:erb]))
     assert_equal 0, templates.size
   end
 
@@ -150,7 +150,7 @@ module ResolverSharedTests
     with_file "test/hello_world.html.erb", "Hello HTML!"
     with_file "test/hello_world.json.builder", "Hello JSON!"
 
-    templates = resolver.find_all("hello_world", "test", false, locale: [], formats: [:json, :html], variants: :any, handlers: [:erb, :builder])
+    templates = resolver.find_all("hello_world", "test", false, ActionView::LookupContext::Details.new(locale: [], formats: [:json, :html], variants: :any, handlers: [:erb, :builder]))
 
     assert_equal 2, templates.size
     assert_equal "Hello JSON!", templates[0].source
@@ -163,7 +163,7 @@ module ResolverSharedTests
     with_file "test/hello_world.html.erb", "Hello HTML!"
     with_file "test/hello_world.json.builder", "Hello JSON!"
 
-    templates = resolver.find_all("hello_world", "test", false, locale: [], formats: [:html, :json], variants: :any, handlers: [:erb, :builder])
+    templates = resolver.find_all("hello_world", "test", false, ActionView::LookupContext::Details.new(locale: [], formats: [:html, :json], variants: :any, handlers: [:erb, :builder]))
 
     assert_equal 2, templates.size
     assert_equal "Hello HTML!", templates[0].source
@@ -175,7 +175,7 @@ module ResolverSharedTests
   def test_templates_with_variant
     with_file "test/hello_world.html+mobile.erb", "Hello HTML!"
 
-    templates = resolver.find_all("hello_world", "test", false, locale: [], formats: [:html, :json], variants: :any, handlers: [:erb, :builder])
+    templates = resolver.find_all("hello_world", "test", false, ActionView::LookupContext::Details.new(locale: [], formats: [:html, :json], variants: :any, handlers: [:erb, :builder]))
 
     assert_equal 1, templates.size
     assert_equal "Hello HTML!", templates[0].source
@@ -206,7 +206,7 @@ module ResolverSharedTests
   def test_templates_no_format_with_variant
     with_file "test/hello_world+mobile.erb", "Hello HTML!"
 
-    templates = resolver.find_all("hello_world", "test", false, locale: [], formats: [:html, :json], variants: :any, handlers: [:erb, :builder])
+    templates = resolver.find_all("hello_world", "test", false, ActionView::LookupContext::Details.new(locale: [], formats: [:html, :json], variants: :any, handlers: [:erb, :builder]))
 
     assert_equal 1, templates.size
     assert_equal "Hello HTML!", templates[0].source
@@ -218,7 +218,7 @@ module ResolverSharedTests
   def test_templates_no_format_or_handler_with_variant
     with_file "test/hello_world+mobile", "Hello HTML!"
 
-    templates = resolver.find_all("hello_world", "test", false, locale: [], formats: [:html, :json], variants: :any, handlers: [:erb, :builder])
+    templates = resolver.find_all("hello_world", "test", false, ActionView::LookupContext::Details.new(locale: [], formats: [:html, :json], variants: :any, handlers: [:erb, :builder]))
 
     assert_equal 1, templates.size
     assert_equal "Hello HTML!", templates[0].source

--- a/actionview/test/template/streaming_render_test.rb
+++ b/actionview/test/template/streaming_render_test.rb
@@ -7,7 +7,7 @@ end
 
 class SetupFiberedBase < ActiveSupport::TestCase
   def setup
-    ActionView::LookupContext::DetailsKey.clear
+    ActionView::LookupContext.clear
 
     view_paths = ActionController::Base.view_paths
 

--- a/actionview/test/template/structured_event_subscriber_test.rb
+++ b/actionview/test/template/structured_event_subscriber_test.rb
@@ -12,7 +12,7 @@ module ActionView
     def setup
       super
 
-      ActionView::LookupContext::DetailsKey.clear
+      ActionView::LookupContext.clear
 
       view_paths = ActionController::Base.view_paths
 

--- a/actionview/test/template/test_case_test.rb
+++ b/actionview/test/template/test_case_test.rb
@@ -26,7 +26,7 @@ module ActionView
 
     module SharedTests
       def setup
-        ActionView::LookupContext::DetailsKey.clear
+        ActionView::LookupContext.clear
         super
       end
 

--- a/actionview/test/template/testing/fixture_resolver_test.rb
+++ b/actionview/test/template/testing/fixture_resolver_test.rb
@@ -5,13 +5,13 @@ require "abstract_unit"
 class FixtureResolverTest < ActiveSupport::TestCase
   def test_should_return_empty_list_for_unknown_path
     resolver = ActionView::FixtureResolver.new()
-    templates = resolver.find_all("path", "arbitrary", false, locale: [], formats: [:html], variants: [], handlers: [])
+    templates = resolver.find_all("path", "arbitrary", false, ActionView::LookupContext::Details.new(locale: [], formats: [:html], variants: [], handlers: []))
     assert_equal [], templates, "expected an empty list of templates"
   end
 
   def test_should_return_template_for_declared_path
     resolver = ActionView::FixtureResolver.new("arbitrary/path.erb" => "this text")
-    templates = resolver.find_all("path", "arbitrary", false, locale: [], formats: [:html], variants: [], handlers: [:erb])
+    templates = resolver.find_all("path", "arbitrary", false, ActionView::LookupContext::Details.new(locale: [], formats: [:html], variants: [], handlers: [:erb]))
     assert_equal 1, templates.size, "expected one template"
     assert_equal "this text",      templates.first.source
     assert_equal "arbitrary/path", templates.first.virtual_path
@@ -20,7 +20,7 @@ class FixtureResolverTest < ActiveSupport::TestCase
 
   def test_should_match_templates_with_variants
     resolver = ActionView::FixtureResolver.new("arbitrary/path.html+variant.erb" => "this text")
-    templates = resolver.find_all("path", "arbitrary", false, locale: [], formats: [:html], variants: [:variant], handlers: [:erb])
+    templates = resolver.find_all("path", "arbitrary", false, ActionView::LookupContext::Details.new(locale: [], formats: [:html], variants: [:variant], handlers: [:erb]))
     assert_equal 1, templates.size, "expected one template"
     assert_equal "this text",       templates.first.source
     assert_equal "arbitrary/path",  templates.first.virtual_path
@@ -30,8 +30,8 @@ class FixtureResolverTest < ActiveSupport::TestCase
 
   def test_should_match_locales
     resolver = ActionView::FixtureResolver.new("arbitrary/path.erb" => "this text", "arbitrary/path.fr.erb" => "ce texte")
-    en = resolver.find_all("path", "arbitrary", false, locale: [:en], formats: [:html], variants: [], handlers: [:erb])
-    fr = resolver.find_all("path", "arbitrary", false, locale: [:fr], formats: [:html], variants: [], handlers: [:erb])
+    en = resolver.find_all("path", "arbitrary", false, ActionView::LookupContext::Details.new(locale: [:en], formats: [:html], variants: [], handlers: [:erb]))
+    fr = resolver.find_all("path", "arbitrary", false, ActionView::LookupContext::Details.new(locale: [:fr], formats: [:html], variants: [], handlers: [:erb]))
 
     assert_equal 1, en.size
     assert_equal 2, fr.size
@@ -43,10 +43,10 @@ class FixtureResolverTest < ActiveSupport::TestCase
 
   def test_should_return_all_variants_for_any
     resolver = ActionView::FixtureResolver.new("arbitrary/path.html.erb" => "this html", "arbitrary/path.html+variant.erb" => "this text")
-    templates = resolver.find_all("path", "arbitrary", false, locale: [], formats: [:html], variants: [], handlers: [:erb])
+    templates = resolver.find_all("path", "arbitrary", false, ActionView::LookupContext::Details.new(locale: [], formats: [:html], variants: [], handlers: [:erb]))
     assert_equal 1, templates.size, "expected one template"
     assert_equal "this html", templates.first.source
-    templates = resolver.find_all("path", "arbitrary", false, locale: [], formats: [:html], variants: :any, handlers: [:erb])
+    templates = resolver.find_all("path", "arbitrary", false, ActionView::LookupContext::Details.new(locale: [], formats: [:html], variants: :any, handlers: [:erb]))
     assert_equal 2, templates.size, "expected all templates"
   end
 end

--- a/activesupport/lib/active_support/ractors.rb
+++ b/activesupport/lib/active_support/ractors.rb
@@ -117,6 +117,17 @@ module ActiveSupport
         def shareable_lambda(...)
           Ractor.shareable_lambda(...)
         end
+
+        # Returns the value stored under +key+ in the current Ractor's local
+        # storage, running +block+ to compute and store it on first access, by
+        # delegating to +Ractor.store_if_absent+. Concurrent threads in the
+        # same Ractor initialize the value only once.
+        #
+        # On Ruby versions without +Ractor+ support there are no non-main
+        # Ractors, so this shim stores the value in a process-wide map.
+        def store_if_absent(key, &block)
+          Ractor.store_if_absent(key, &block)
+        end
       else
         def main?
           Ractor.current == Ractor.main
@@ -140,6 +151,13 @@ module ActiveSupport
 
         def shareable_lambda(self: nil, &block)
           block
+        end
+
+        require "concurrent/map"
+        LOCAL_STORAGE = Concurrent::Map.new # :nodoc:
+
+        def store_if_absent(key, &block)
+          LOCAL_STORAGE.compute_if_absent(key, &block)
         end
       end
     end

--- a/activesupport/test/ractors_test.rb
+++ b/activesupport/test/ractors_test.rb
@@ -18,6 +18,16 @@ class RactorsTest < ActiveSupport::TestCase
     assert_not value
   end
 
+  def test_store_if_absent_computes_once_and_returns_the_stored_value
+    calls = 0
+    first  = ActiveSupport::Ractors.store_if_absent(:as_ractors_test_once) { calls += 1; +"value" }
+    second = ActiveSupport::Ractors.store_if_absent(:as_ractors_test_once) { calls += 1; +"other" }
+
+    assert_equal "value", first
+    assert_same first, second
+    assert_equal 1, calls
+  end
+
   if RUBY_VERSION >= "4.0"
     def test_on_main_runs_block_on_main_ractor
       value = Ractor.new do
@@ -185,6 +195,16 @@ class RactorsTest < ActiveSupport::TestCase
       end
     ensure
       ActiveSupport::Ractors.unshareable_proc_action = old
+    end
+
+    def test_store_if_absent_is_ractor_local
+      main_value = ActiveSupport::Ractors.store_if_absent(:as_ractors_test_local) { "main" }
+      worker_value = Ractor.new do
+        ActiveSupport::Ractors.store_if_absent(:as_ractors_test_local) { "worker" }
+      end.value
+
+      assert_equal "main", main_value
+      assert_equal "worker", worker_value
     end
   end
 end

--- a/railties/test/application/per_request_digest_cache_test.rb
+++ b/railties/test/application/per_request_digest_cache_test.rb
@@ -62,7 +62,7 @@ class PerRequestDigestCacheTest < ActiveSupport::TestCase
   end
 
   test "template digests are cleared before a request" do
-    assert_called(ActionView::LookupContext::DetailsKey, :clear, times: 2) do
+    assert_called(ActionView::LookupContext, :clear, times: 2) do
       get "/customers"
       assert_equal 200, last_response.status
     end

--- a/railties/test/application/per_request_digest_cache_test.rb
+++ b/railties/test/application/per_request_digest_cache_test.rb
@@ -56,7 +56,7 @@ class PerRequestDigestCacheTest < ActiveSupport::TestCase
     get "/customers"
     assert_equal 200, last_response.status
 
-    values = ActionView::LookupContext::DetailsKey.digest_caches.first.values
+    values = ActionView::Digestor.digest_caches.first.values
     assert_equal [ "ddb451d2c1b2374caa676005893bb776" ], values
     assert_equal %w(david dingus), last_response.body.split.map(&:strip)
   end


### PR DESCRIPTION
Currently template lookup uses a ranking against an interned `TemplateDetails::Requested` object that precomputes an index hash per details axis (locale, formats, variants, handlers).
Those interned objects live in a process-wide `Concurrent::Map` (`LookupContext::DetailsKey`) and exist to make template ranking a few hash lookups.
But this interning/caching is one of the things that prevents template lookup from being Ractor-shareable.

This branch replaces the interner with a `LookupContext::Details` value object created per request; additional instances are created when a `render` call specifies more details (e.g. `render "partial", locale: :en`).
Without the interned object, ranking initially fell back to `Array#index` on the axis arrays, which can be slower, however:
* a dedicated single-template resolver path (`Resolver#_find`, building on the `find`/`find!` split in #57783) finds the best match in one pass instead of materialising the whole matching set and sorting it.
* in most cases there are very few candidates, I checked mastodon, lobsters, rubygems.org, for a given virtual path, there's often only one template (most cases where there's more than one template are mailers).
* I improved the implicit render path to find and then render a template in one pass, instead of checking for the existence of any matching template, then scanning them again to find the best match.

After review, the last two commits bring back cheap ranking: the per-axis index hashes are memoized in a Ractor-local cache (via a new `ActiveSupport::Ractors.store_if_absent` helper), and a virtual path with a single candidate skips ranking entirely.

On the warmed hot path, allocations drop for every `find`: from 9 to 5 for the common single-template lookup (one file per virtual path, the majority of real templates), and from 16 to 7 when a virtual path has several format/locale/variant siblings.
That common single-template lookup is ~15% faster, with or without YJIT.
With a few templates for a virtual path it's 1.4–2x faster.
Ranking many variations of one virtual path stays faster than main under YJIT even at 80 variations; without YJIT it's ~10–20% slower at 40–80 variations (both added to the benchmark), far beyond any real app.
`find_all`, whose only caller is ActionMailer multipart, is ~10–20% slower and allocates one more object.

<details>
<summary>Benchmark</summary>

```ruby
# frozen_string_literal: true
require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"
  gem "rails", path: "."
  gem "benchmark-ips"
end

require "action_view"
require "action_dispatch/http/mime_type"
require "benchmark/ips"
require "tmpdir"
require "fileutils"

RubyVM::YJIT.enable if defined?(RubyVM::YJIT) && !ENV["NO_YJIT"]

ActionView::Template.mime_types_implementation = Mime
ActionView::Base.default_formats ||= Mime.symbols

DIR = Dir.mktmpdir("lookup-bench")
at_exit { FileUtils.remove_entry(DIR) }

def write(rel, body = "x")
  path = File.join(DIR, rel)
  FileUtils.mkdir_p(File.dirname(path))
  File.write(path, body)
end

# home/dashboard, home/_widget: one template per virtual path (the common case).
write "home/dashboard.html.erb",   "DASH html"
write "home/_widget.html.erb",     "WIDGET html"
# posts/show: 7 variations on one virtual path (format / locale / variant).
write "posts/show.html.erb",       "SHOW html"
write "posts/show.en.html.erb",    "SHOW en html"
write "posts/show.text.erb",       "SHOW text"
write "posts/show.js.erb",         "SHOW js"
write "posts/show.css.erb",        "SHOW css"
write "posts/show.xml.builder",    "xml.show"
write "posts/show.html+phone.erb", "SHOW phone"
# posts/_item: partial, 2 formats.
write "posts/_item.html.erb",      "ITEM html"
write "posts/_item.text.erb",      "ITEM text"
# notifier/welcome: mailer action, 2 formats (find_all returns both parts).
write "notifier/welcome.html.erb", "WELCOME html"
write "notifier/welcome.text.erb", "WELCOME text"
# posts/mega, posts/giga: pathological virtual paths with 40 and 80 on-disk
# variations. Far more than any real app (one file per virtual path is the norm);
# they exercise the per-candidate ranking scan at its worst.
write "posts/mega.html.erb",       "MEGA html"
write "posts/mega.en.html.erb",    "MEGA en html"
locales = (("aa".."zz").to_a - %w[en js]) # 2-letter codes the path parser reads as locales
locales.first(38).each { |code| write "posts/mega.#{code}.html.erb", "MEGA #{code}" }
write "posts/giga.html.erb",       "GIGA html"
write "posts/giga.en.html.erb",    "GIGA en html"
locales.first(78).each { |code| write "posts/giga.#{code}.html.erb", "GIGA #{code}" }

resolver = ActionView::FileSystemResolver.new(DIR)
handlers = ActionView::Template::Handlers.extensions

# action / partial rendering: caching on, single html format.
html = ActionView::LookupContext.new(
  [resolver], { formats: [:html], locale: [:en], variants: [], handlers: handlers }
)
# mailer: html + text; find_all returns both parts.
multi = ActionView::LookupContext.new(
  [resolver], { formats: [:html, :text], locale: [:en], variants: [], handlers: handlers }
)

SCENARIOS = {
  "find action (1 candidate, 1 match)"   => -> { html.find("dashboard", ["home"], false, []) },
  "find partial (1 candidate, 1 match)"  => -> { html.find("widget", ["home"], true, []) },
  "find action (7 candidates, 2 match)"  => -> { html.find("show", ["posts"], false, []) },
  "find action (40 candidates, 2 match)" => -> { html.find("mega", ["posts"], false, []) },
  "find action (80 candidates, 2 match)" => -> { html.find("giga", ["posts"], false, []) },
  "find partial (2 candidates, 1 match)" => -> { html.find("item", ["posts"], true, []) },
  "find_all mailer (2 formats, 2 match)" => -> { multi.find_all("welcome", ["notifier"], false, []) },
  # Includes the once-per-request setup the other scenarios exclude:
  # context construction and the first-lookup ranking-cache hit.
  "new context + find action (1 candidate, 1 match)" => -> {
    ActionView::LookupContext.new(
      [resolver], { formats: [:html], locale: [:en], variants: [], handlers: handlers }
    ).find("dashboard", ["home"], false, [])
  },
}.freeze

version = begin
  require "action_view/gem_version"
  ActionView.gem_version.to_s
rescue LoadError
  "?"
end
sha = `git rev-parse --short HEAD 2>/dev/null`.strip
yjit = (defined?(RubyVM::YJIT) && RubyVM::YJIT.enabled?) ? "YJIT" : "no-YJIT"
puts
puts "ActionView #{version}  ruby #{RUBY_VERSION} #{yjit}#{sha.empty? ? "" : "  @#{sha}"}"

hold_dir = __dir__ + "/tmp/lookup-details/#{yjit.downcase}"
FileUtils.mkdir_p(hold_dir)

SCENARIOS.each_with_index do |(name, blk), i|
  Benchmark.ips do |x|
    x.config(time: 10, warmup: 2)
    x.report("#{name}  @#{sha}", &blk)
    x.save!(File.join(hold_dir, "scenario_#{i}.json"))
    x.compare!(order: :baseline)
  end
end

def alloc_per_call(iters)
  GC.start
  GC.disable
  before = GC.stat(:total_allocated_objects)
  iters.times { yield }
  after = GC.stat(:total_allocated_objects)
  GC.enable
  (after - before).fdiv(iters)
end

exit
puts
puts "allocations per call (GC.stat(:total_allocated_objects)):"
SCENARIOS.each do |name, blk|
  puts "  %-50s %6.2f" % [name, alloc_per_call(300_000, &blk)]
end
```
</details>

Speedup vs main (`@bbcb19cdcd` = 1.0, higher is better), from the results below:

```mermaid
xychart-beta
    title "Speedup vs main - YJIT (bars: Linux x86-64, line: macOS arm64)"
    x-axis [find 1, partial 1, find 7, find 40, find 80, partial 2, find_all 2, new ctx]
    y-axis "speedup vs main" 0 --> 2.5
    bar [1.17, 1.18, 2.09, 1.68, 1.48, 1.14, 0.82, 2.31]
    line [1.19, 1.16, 1.74, 1.33, 1.10, 1.14, 0.86, 2.28]
    line [1, 1, 1, 1, 1, 1, 1, 1]
```

```mermaid
xychart-beta
    title "Speedup vs main - no YJIT (bars: Linux x86-64, line: macOS arm64)"
    x-axis [find 1, partial 1, find 7, find 40, find 80, partial 2, find_all 2, new ctx]
    y-axis "speedup vs main" 0 --> 2.5
    bar [1.15, 1.15, 1.49, 1.02, 0.90, 1.09, 0.93, 1.74]
    line [1.16, 1.16, 1.38, 0.88, 0.82, 1.05, 0.88, 1.74]
    line [1, 1, 1, 1, 1, 1, 1, 1]
```

<details>
<summary>Results (Ruby 4.0.6)</summary>

Base `@bbcb19cdcd`, the refactor `@e26dfc8c03`, and the refactor plus the
Ractor-local ranking cache and single-candidate fast path `@33475c55d3`,
compared in one benchmark-ips cross-run.

### Linux x86-64

#### With YJIT:

```
ActionView 8.2.0.alpha  ruby 4.0.6 YJIT  @33475c55d3
ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +YJIT +PRISM [x86_64-linux]
Warming up --------------------------------------
find action (1 candidate, 1 match)  @33475c55d3    28.625k i/100ms
Calculating -------------------------------------
find action (1 candidate, 1 match)  @33475c55d3    282.520k (± 4.0%) i/s    (3.54 μs/i) -      2.834M in  10.030698s

Comparison:
find action (1 candidate, 1 match)  @bbcb19cdcd:   241018.9 i/s
find action (1 candidate, 1 match)  @33475c55d3:   282520.2 i/s - 1.17x  faster
find action (1 candidate, 1 match)  @e26dfc8c03:   253967.1 i/s - same-ish: difference falls within error

ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +YJIT +PRISM [x86_64-linux]
Warming up --------------------------------------
find partial (1 candidate, 1 match)  @33475c55d3    26.945k i/100ms
Calculating -------------------------------------
find partial (1 candidate, 1 match)  @33475c55d3    282.848k (± 3.8%) i/s    (3.54 μs/i) -      2.829M in  10.002643s

Comparison:
find partial (1 candidate, 1 match)  @bbcb19cdcd:   239708.4 i/s
find partial (1 candidate, 1 match)  @33475c55d3:   282847.7 i/s - 1.18x  faster
find partial (1 candidate, 1 match)  @e26dfc8c03:   252378.2 i/s - same-ish: difference falls within error

ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +YJIT +PRISM [x86_64-linux]
Warming up --------------------------------------
find action (7 candidates, 2 match)  @33475c55d3    18.279k i/100ms
Calculating -------------------------------------
find action (7 candidates, 2 match)  @33475c55d3    188.306k (± 2.2%) i/s    (5.31 μs/i) -      1.901M in  10.095332s

Comparison:
find action (7 candidates, 2 match)  @bbcb19cdcd:    89905.0 i/s
find action (7 candidates, 2 match)  @33475c55d3:   188306.4 i/s - 2.09x  faster
find action (7 candidates, 2 match)  @e26dfc8c03:   167448.6 i/s - 1.86x  faster

ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +YJIT +PRISM [x86_64-linux]
Warming up --------------------------------------
find action (40 candidates, 2 match)  @33475c55d3    11.481k i/100ms
Calculating -------------------------------------
find action (40 candidates, 2 match)  @33475c55d3    117.342k (± 2.1%) i/s    (8.52 μs/i) -      1.183M in  10.077789s

Comparison:
find action (40 candidates, 2 match)  @bbcb19cdcd:    69672.2 i/s
find action (40 candidates, 2 match)  @33475c55d3:   117341.5 i/s - 1.68x  faster
find action (40 candidates, 2 match)  @e26dfc8c03:    94726.4 i/s - 1.36x  faster

ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +YJIT +PRISM [x86_64-linux]
Warming up --------------------------------------
find action (80 candidates, 2 match)  @33475c55d3     8.054k i/100ms
Calculating -------------------------------------
find action (80 candidates, 2 match)  @33475c55d3     81.837k (± 2.0%) i/s   (12.22 μs/i) -    821.508k in  10.038398s

Comparison:
find action (80 candidates, 2 match)  @bbcb19cdcd:    55349.4 i/s
find action (80 candidates, 2 match)  @33475c55d3:    81836.6 i/s - 1.48x  faster
find action (80 candidates, 2 match)  @e26dfc8c03:    63125.5 i/s - 1.14x  faster

ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +YJIT +PRISM [x86_64-linux]
Warming up --------------------------------------
find partial (2 candidates, 1 match)  @33475c55d3    25.118k i/100ms
Calculating -------------------------------------
find partial (2 candidates, 1 match)  @33475c55d3    262.464k (± 2.6%) i/s    (3.81 μs/i) -      2.637M in  10.048597s

Comparison:
find partial (2 candidates, 1 match)  @bbcb19cdcd:   231024.9 i/s
find partial (2 candidates, 1 match)  @33475c55d3:   262463.5 i/s - 1.14x  faster
find partial (2 candidates, 1 match)  @e26dfc8c03:   246401.7 i/s - same-ish: difference falls within error

ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +YJIT +PRISM [x86_64-linux]
Warming up --------------------------------------
find_all mailer (2 formats, 2 match)  @33475c55d3     7.621k i/100ms
Calculating -------------------------------------
find_all mailer (2 formats, 2 match)  @33475c55d3     77.084k (± 1.6%) i/s   (12.97 μs/i) -    777.342k in  10.084400s

Comparison:
find_all mailer (2 formats, 2 match)  @bbcb19cdcd:    93904.6 i/s
find_all mailer (2 formats, 2 match)  @33475c55d3:    77083.6 i/s - 1.22x  slower
find_all mailer (2 formats, 2 match)  @e26dfc8c03:    73714.5 i/s - 1.27x  slower

ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +YJIT +PRISM [x86_64-linux]
Warming up --------------------------------------
new context + find action (1 candidate, 1 match)  @33475c55d3    16.072k i/100ms
Calculating -------------------------------------
new context + find action (1 candidate, 1 match)  @33475c55d3    164.284k (± 2.5%) i/s    (6.09 μs/i) -      1.655M in  10.076574s

Comparison:
new context + find action (1 candidate, 1 match)  @bbcb19cdcd:    71049.6 i/s
new context + find action (1 candidate, 1 match)  @33475c55d3:   164283.6 i/s - 2.31x  faster
new context + find action (1 candidate, 1 match)  @e26dfc8c03:   153851.5 i/s - 2.17x  faster


allocations per call (GC.stat(:total_allocated_objects)):
  find action (1 candidate, 1 match)                   5.00
  find partial (1 candidate, 1 match)                  5.00
  find action (7 candidates, 2 match)                  7.00
  find action (40 candidates, 2 match)                 7.00
  find action (80 candidates, 2 match)                 7.00
  find partial (2 candidates, 1 match)                 6.00
  find_all mailer (2 formats, 2 match)                17.00
  new context + find action (1 candidate, 1 match)    15.00
```

#### Without YJIT:

```
ActionView 8.2.0.alpha  ruby 4.0.6 no-YJIT  @33475c55d3
ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux]
Warming up --------------------------------------
find action (1 candidate, 1 match)  @33475c55d3    12.904k i/100ms
Calculating -------------------------------------
find action (1 candidate, 1 match)  @33475c55d3    125.293k (± 3.8%) i/s    (7.98 μs/i) -      1.265M in  10.093114s

Comparison:
find action (1 candidate, 1 match)  @bbcb19cdcd:   109269.9 i/s
find action (1 candidate, 1 match)  @33475c55d3:   125292.5 i/s - 1.15x  faster
find action (1 candidate, 1 match)  @e26dfc8c03:   104721.5 i/s - same-ish: difference falls within error

ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux]
Warming up --------------------------------------
find partial (1 candidate, 1 match)  @33475c55d3    12.932k i/100ms
Calculating -------------------------------------
find partial (1 candidate, 1 match)  @33475c55d3    125.825k (± 2.1%) i/s    (7.95 μs/i) -      1.267M in  10.072204s

Comparison:
find partial (1 candidate, 1 match)  @bbcb19cdcd:   109489.1 i/s
find partial (1 candidate, 1 match)  @33475c55d3:   125825.1 i/s - 1.15x  faster
find partial (1 candidate, 1 match)  @e26dfc8c03:   104457.8 i/s - same-ish: difference falls within error

ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux]
Warming up --------------------------------------
find action (7 candidates, 2 match)  @33475c55d3     7.147k i/100ms
Calculating -------------------------------------
find action (7 candidates, 2 match)  @33475c55d3     71.690k (± 2.2%) i/s   (13.95 μs/i) -    721.847k in  10.068993s

Comparison:
find action (7 candidates, 2 match)  @bbcb19cdcd:    48144.1 i/s
find action (7 candidates, 2 match)  @33475c55d3:    71690.1 i/s - 1.49x  faster
find action (7 candidates, 2 match)  @e26dfc8c03:    55322.0 i/s - 1.15x  faster

ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux]
Warming up --------------------------------------
find action (40 candidates, 2 match)  @33475c55d3     2.820k i/100ms
Calculating -------------------------------------
find action (40 candidates, 2 match)  @33475c55d3     27.870k (± 1.7%) i/s   (35.88 μs/i) -    279.180k in  10.017109s

Comparison:
find action (40 candidates, 2 match)  @bbcb19cdcd:    27334.1 i/s
find action (40 candidates, 2 match)  @33475c55d3:    27870.3 i/s - same-ish: difference falls within error
find action (40 candidates, 2 match)  @e26dfc8c03:    19312.7 i/s - 1.42x  slower

ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux]
Warming up --------------------------------------
find action (80 candidates, 2 match)  @33475c55d3     1.638k i/100ms
Calculating -------------------------------------
find action (80 candidates, 2 match)  @33475c55d3     16.313k (± 1.3%) i/s   (61.30 μs/i) -    163.800k in  10.041368s

Comparison:
find action (80 candidates, 2 match)  @bbcb19cdcd:    18155.1 i/s
find action (80 candidates, 2 match)  @33475c55d3:    16312.5 i/s - 1.11x  slower
find action (80 candidates, 2 match)  @e26dfc8c03:    10987.7 i/s - 1.65x  slower

ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux]
Warming up --------------------------------------
find partial (2 candidates, 1 match)  @33475c55d3    11.778k i/100ms
Calculating -------------------------------------
find partial (2 candidates, 1 match)  @33475c55d3    113.226k (± 2.5%) i/s    (8.83 μs/i) -      1.142M in  10.090101s

Comparison:
find partial (2 candidates, 1 match)  @bbcb19cdcd:   104076.9 i/s
find partial (2 candidates, 1 match)  @33475c55d3:   113226.4 i/s - 1.09x  faster
find partial (2 candidates, 1 match)  @e26dfc8c03:    96634.1 i/s - 1.08x  slower

ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux]
Warming up --------------------------------------
find_all mailer (2 formats, 2 match)  @33475c55d3     5.043k i/100ms
Calculating -------------------------------------
find_all mailer (2 formats, 2 match)  @33475c55d3     51.264k (± 1.9%) i/s   (19.51 μs/i) -    514.386k in  10.034127s

Comparison:
find_all mailer (2 formats, 2 match)  @bbcb19cdcd:    54903.5 i/s
find_all mailer (2 formats, 2 match)  @33475c55d3:    51263.7 i/s - 1.07x  slower
find_all mailer (2 formats, 2 match)  @e26dfc8c03:    44323.5 i/s - 1.24x  slower

ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux]
Warming up --------------------------------------
new context + find action (1 candidate, 1 match)  @33475c55d3     7.372k i/100ms
Calculating -------------------------------------
new context + find action (1 candidate, 1 match)  @33475c55d3     74.064k (± 3.4%) i/s   (13.50 μs/i) -    744.572k in  10.053110s

Comparison:
new context + find action (1 candidate, 1 match)  @bbcb19cdcd:    42496.3 i/s
new context + find action (1 candidate, 1 match)  @33475c55d3:    74063.8 i/s - 1.74x  faster
new context + find action (1 candidate, 1 match)  @e26dfc8c03:    65984.9 i/s - 1.55x  faster


allocations per call (GC.stat(:total_allocated_objects)):
  find action (1 candidate, 1 match)                   5.00
  find partial (1 candidate, 1 match)                  5.00
  find action (7 candidates, 2 match)                  7.00
  find action (40 candidates, 2 match)                 7.00
  find action (80 candidates, 2 match)                 7.00
  find partial (2 candidates, 1 match)                 6.00
  find_all mailer (2 formats, 2 match)                17.00
  new context + find action (1 candidate, 1 match)    15.00
```

### macOS arm64

#### With YJIT:

```
ActionView 8.2.0.alpha  ruby 4.0.6 YJIT  @33475c55d3
ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +YJIT +PRISM [arm64-darwin25]
Warming up --------------------------------------
find action (1 candidate, 1 match)  @33475c55d3   174.625k i/100ms
Calculating -------------------------------------
find action (1 candidate, 1 match)  @33475c55d3      1.763M (± 2.6%) i/s  (567.27 ns/i) -     17.637M in  10.005027s

Comparison:
find action (1 candidate, 1 match)  @bbcb19cdcd:  1484810.7 i/s
find action (1 candidate, 1 match)  @33475c55d3:  1762826.3 i/s - 1.19x  faster
find action (1 candidate, 1 match)  @e26dfc8c03:  1491586.2 i/s - same-ish: difference falls within error

ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +YJIT +PRISM [arm64-darwin25]
Warming up --------------------------------------
find partial (1 candidate, 1 match)  @33475c55d3   171.248k i/100ms
Calculating -------------------------------------
find partial (1 candidate, 1 match)  @33475c55d3      1.704M (± 4.1%) i/s  (586.96 ns/i) -     17.125M in  10.051595s

Comparison:
find partial (1 candidate, 1 match)  @bbcb19cdcd:  1467503.8 i/s
find partial (1 candidate, 1 match)  @33475c55d3:  1703689.8 i/s - 1.16x  faster
find partial (1 candidate, 1 match)  @e26dfc8c03:  1532728.3 i/s - 1.04x  faster

ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +YJIT +PRISM [arm64-darwin25]
Warming up --------------------------------------
find action (7 candidates, 2 match)  @33475c55d3   105.921k i/100ms
Calculating -------------------------------------
find action (7 candidates, 2 match)  @33475c55d3      1.080M (± 2.1%) i/s  (925.66 ns/i) -     10.804M in  10.000735s

Comparison:
find action (7 candidates, 2 match)  @bbcb19cdcd:   622218.5 i/s
find action (7 candidates, 2 match)  @33475c55d3:  1080314.8 i/s - 1.74x  faster
find action (7 candidates, 2 match)  @e26dfc8c03:   910954.1 i/s - 1.46x  faster

ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +YJIT +PRISM [arm64-darwin25]
Warming up --------------------------------------
find action (40 candidates, 2 match)  @33475c55d3    52.397k i/100ms
Calculating -------------------------------------
find action (40 candidates, 2 match)  @33475c55d3    524.952k (± 0.9%) i/s    (1.90 μs/i) -      5.292M in  10.081099s

Comparison:
find action (40 candidates, 2 match)  @bbcb19cdcd:   393303.9 i/s
find action (40 candidates, 2 match)  @33475c55d3:   524952.4 i/s - 1.33x  faster
find action (40 candidates, 2 match)  @e26dfc8c03:   396531.0 i/s - same-ish: difference falls within error

ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +YJIT +PRISM [arm64-darwin25]
Warming up --------------------------------------
find action (80 candidates, 2 match)  @33475c55d3    32.302k i/100ms
Calculating -------------------------------------
find action (80 candidates, 2 match)  @33475c55d3    321.893k (± 1.1%) i/s    (3.11 μs/i) -      3.230M in  10.035022s

Comparison:
find action (80 candidates, 2 match)  @bbcb19cdcd:   291887.5 i/s
find action (80 candidates, 2 match)  @33475c55d3:   321892.7 i/s - 1.10x  faster
find action (80 candidates, 2 match)  @e26dfc8c03:   235359.0 i/s - 1.24x  slower

ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +YJIT +PRISM [arm64-darwin25]
Warming up --------------------------------------
find partial (2 candidates, 1 match)  @33475c55d3   156.264k i/100ms
Calculating -------------------------------------
find partial (2 candidates, 1 match)  @33475c55d3      1.596M (± 1.9%) i/s  (626.76 ns/i) -     16.095M in  10.087818s

Comparison:
find partial (2 candidates, 1 match)  @bbcb19cdcd:  1405026.0 i/s
find partial (2 candidates, 1 match)  @33475c55d3:  1595507.8 i/s - 1.14x  faster
find partial (2 candidates, 1 match)  @e26dfc8c03:  1445358.2 i/s - 1.03x  faster

ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +YJIT +PRISM [arm64-darwin25]
Warming up --------------------------------------
find_all mailer (2 formats, 2 match)  @33475c55d3    57.960k i/100ms
Calculating -------------------------------------
find_all mailer (2 formats, 2 match)  @33475c55d3    578.147k (± 2.5%) i/s    (1.73 μs/i) -      5.796M in  10.025124s

Comparison:
find_all mailer (2 formats, 2 match)  @bbcb19cdcd:   673871.9 i/s
find_all mailer (2 formats, 2 match)  @33475c55d3:   578147.5 i/s - 1.17x  slower
find_all mailer (2 formats, 2 match)  @e26dfc8c03:   531645.5 i/s - 1.27x  slower

ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +YJIT +PRISM [arm64-darwin25]
Warming up --------------------------------------
new context + find action (1 candidate, 1 match)  @33475c55d3   106.986k i/100ms
Calculating -------------------------------------
new context + find action (1 candidate, 1 match)  @33475c55d3      1.079M (± 2.4%) i/s  (926.55 ns/i) -     10.806M in  10.011926s

Comparison:
new context + find action (1 candidate, 1 match)  @bbcb19cdcd:   473828.1 i/s
new context + find action (1 candidate, 1 match)  @33475c55d3:  1079271.5 i/s - 2.28x  faster
new context + find action (1 candidate, 1 match)  @e26dfc8c03:   961453.2 i/s - 2.03x  faster
```

#### Without YJIT:

```
ActionView 8.2.0.alpha  ruby 4.0.6 no-YJIT  @33475c55d3
ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [arm64-darwin25]
Warming up --------------------------------------
find action (1 candidate, 1 match)  @33475c55d3    92.680k i/100ms
Calculating -------------------------------------
find action (1 candidate, 1 match)  @33475c55d3    939.638k (± 2.1%) i/s    (1.06 μs/i) -      9.453M in  10.060637s

Comparison:
find action (1 candidate, 1 match)  @bbcb19cdcd:   808279.2 i/s
find action (1 candidate, 1 match)  @33475c55d3:   939638.3 i/s - 1.16x  faster
find action (1 candidate, 1 match)  @e26dfc8c03:   745204.4 i/s - 1.08x  slower

ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [arm64-darwin25]
Warming up --------------------------------------
find partial (1 candidate, 1 match)  @33475c55d3    94.132k i/100ms
Calculating -------------------------------------
find partial (1 candidate, 1 match)  @33475c55d3    951.001k (± 1.1%) i/s    (1.05 μs/i) -      9.601M in  10.096171s

Comparison:
find partial (1 candidate, 1 match)  @bbcb19cdcd:   823367.1 i/s
find partial (1 candidate, 1 match)  @33475c55d3:   951000.5 i/s - 1.16x  faster
find partial (1 candidate, 1 match)  @e26dfc8c03:   763902.4 i/s - 1.08x  slower

ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [arm64-darwin25]
Warming up --------------------------------------
find action (7 candidates, 2 match)  @33475c55d3    54.027k i/100ms
Calculating -------------------------------------
find action (7 candidates, 2 match)  @33475c55d3    536.835k (± 2.0%) i/s    (1.86 μs/i) -      5.403M in  10.063994s

Comparison:
find action (7 candidates, 2 match)  @bbcb19cdcd:   388079.3 i/s
find action (7 candidates, 2 match)  @33475c55d3:   536834.6 i/s - 1.38x  faster
find action (7 candidates, 2 match)  @e26dfc8c03:   397872.8 i/s - same-ish: difference falls within error

ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [arm64-darwin25]
Warming up --------------------------------------
find action (40 candidates, 2 match)  @33475c55d3    19.773k i/100ms
Calculating -------------------------------------
find action (40 candidates, 2 match)  @33475c55d3    185.374k (± 4.2%) i/s    (5.39 μs/i) -      1.859M in  10.026534s

Comparison:
find action (40 candidates, 2 match)  @bbcb19cdcd:   211223.2 i/s
find action (40 candidates, 2 match)  @33475c55d3:   185374.3 i/s - 1.14x  slower
find action (40 candidates, 2 match)  @e26dfc8c03:   136005.5 i/s - 1.55x  slower

ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [arm64-darwin25]
Warming up --------------------------------------
find action (80 candidates, 2 match)  @33475c55d3    11.347k i/100ms
Calculating -------------------------------------
find action (80 candidates, 2 match)  @33475c55d3    111.537k (± 3.6%) i/s    (8.97 μs/i) -      1.123M in  10.071613s

Comparison:
find action (80 candidates, 2 match)  @bbcb19cdcd:   136075.2 i/s
find action (80 candidates, 2 match)  @33475c55d3:   111536.6 i/s - 1.22x  slower
find action (80 candidates, 2 match)  @e26dfc8c03:    75205.2 i/s - 1.81x  slower

ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [arm64-darwin25]
Warming up --------------------------------------
find partial (2 candidates, 1 match)  @33475c55d3    77.743k i/100ms
Calculating -------------------------------------
find partial (2 candidates, 1 match)  @33475c55d3    825.261k (± 5.1%) i/s    (1.21 μs/i) -      8.319M in  10.079846s

Comparison:
find partial (2 candidates, 1 match)  @bbcb19cdcd:   784565.9 i/s
find partial (2 candidates, 1 match)  @33475c55d3:   825260.7 i/s - same-ish: difference falls within error
find partial (2 candidates, 1 match)  @e26dfc8c03:   719421.4 i/s - 1.09x  slower

ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [arm64-darwin25]
Warming up --------------------------------------
find_all mailer (2 formats, 2 match)  @33475c55d3    41.453k i/100ms
Calculating -------------------------------------
find_all mailer (2 formats, 2 match)  @33475c55d3    387.733k (± 5.4%) i/s    (2.58 μs/i) -      3.897M in  10.049640s

Comparison:
find_all mailer (2 formats, 2 match)  @bbcb19cdcd:   441569.5 i/s
find_all mailer (2 formats, 2 match)  @33475c55d3:   387733.5 i/s - 1.14x  slower
find_all mailer (2 formats, 2 match)  @e26dfc8c03:   356685.3 i/s - 1.24x  slower

ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [arm64-darwin25]
Warming up --------------------------------------
new context + find action (1 candidate, 1 match)  @33475c55d3    50.205k i/100ms
Calculating -------------------------------------
new context + find action (1 candidate, 1 match)  @33475c55d3    571.554k (± 3.0%) i/s    (1.75 μs/i) -      5.723M in  10.013702s

Comparison:
new context + find action (1 candidate, 1 match)  @bbcb19cdcd:   329033.1 i/s
new context + find action (1 candidate, 1 match)  @33475c55d3:   571553.9 i/s - 1.74x  faster
new context + find action (1 candidate, 1 match)  @e26dfc8c03:   515961.4 i/s - 1.57x  faster
```

</details>
