### PR TITLE
Fix stale route recognition after clearing a route set

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Fix route recognition still matching routes that were removed by redrawing
+    a route set as empty.
+
+    `Journey::Routes#clear` did not invalidate the memoized recognition data
+    (`ast` / `simulator`); only `add_route` did. After `RouteSet#draw` cleared
+    the set, a draw block that added no routes left the stale recognition data
+    in place, so previously drawn routes were still recognized.
+
+    *Kenta Ishizaki*
+
 *   Deprecate `ActionDispatch::Cookies::HTTP_HEADER`.
 
     Use `Rack::SET_COOKIE` instead.

--- a/actionpack/lib/action_dispatch/journey/routes.rb
+++ b/actionpack/lib/action_dispatch/journey/routes.rb
@@ -40,6 +40,7 @@ module ActionDispatch
         routes.clear
         anchored_routes.clear
         custom_routes.clear
+        clear_cache!
       end
 
       def partition_route(route)

--- a/actionpack/test/dispatch/routing/route_set_test.rb
+++ b/actionpack/test/dispatch/routing/route_set_test.rb
@@ -30,6 +30,25 @@ module ActionDispatch
         assert_not_empty @set
       end
 
+      class FooController < ActionController::Base
+      end
+
+      test "recognize_path does not recognize routes removed by a redraw" do
+        controller = "action_dispatch/routing/route_set_test/foo"
+
+        draw do
+          get "foo", to: "action_dispatch/routing/route_set_test/foo#index"
+        end
+
+        assert_equal({ controller: controller, action: "index" }, @set.recognize_path("/foo"))
+
+        draw { }
+
+        assert_raises ActionController::RoutingError do
+          @set.recognize_path("/foo")
+        end
+      end
+
       test "URL helpers are added when route is added" do
         draw do
           get "foo", to: SimpleApp.new("foo#index")

--- a/actionpack/test/journey/routes_test.rb
+++ b/actionpack/test/journey/routes_test.rb
@@ -25,6 +25,16 @@ module ActionDispatch
         assert_equal 0, routes.length
       end
 
+      def test_clear_clears_the_cached_ast_and_simulator
+        mapper.get "/foo(/:id)", to: "foo#bar", as: "aaron"
+        simulator = routes.simulator
+
+        routes.clear
+
+        assert_empty routes.ast.children
+        assert_not_same simulator, routes.simulator
+      end
+
       def test_ast
         mapper.get "/foo(/:id)", to: "foo#bar", as: "aaron"
         ast = routes.ast


### PR DESCRIPTION
### Motivation / Background

This Pull Request fixes stale route recognition after a route set is redrawn with no routes.

`ActionDispatch::Journey::Routes#clear` removes the routes but never invalidates the memoized recognition data (`ast` / `simulator`); `add_route` is the only place that calls `clear_cache!`. Since `RouteSet#draw` calls `clear!` before evaluating the block, a draw block that ends up adding **zero** routes leaves the previously built simulator in place, and recognition keeps matching routes that no longer exist in the set:

```ruby
routes.draw { get "/foo", to: "foo#index" }
routes.recognize_path("/foo") # warms the simulator memo
routes.draw { }               # clears the set, adds nothing

routes.routes.size            # => 0
routes.recognize_path("/foo") # => { controller: "foo", action: "index" } — stale!
```

Because the cache is rebuilt as soon as any route is added, the bug only surfaces when a redraw results in an empty route set *and* recognition had already run beforehand — which makes it order-dependent and confusing to track down in test suites that redraw application routes per example. (I originally hit this as a seed-dependent failure in the [doorkeeper-openid_connect](https://github.com/doorkeeper-gem/doorkeeper-openid_connect) test suite, where a routing spec drew a configuration whose routes were all skipped.)

### Detail

This Pull Request changes `Journey::Routes#clear` to also call `clear_cache!`, mirroring what `add_route` already does, so the memoized `ast` / `simulator` are rebuilt from the (now empty) route table on next access.

Tests:

* `test/journey/routes_test.rb`: after `clear`, the memoized AST is rebuilt empty and the simulator is not the cached instance.
* `test/dispatch/routing/route_set_test.rb`: end-to-end reproduction — a route recognized via `recognize_path` must raise `ActionController::RoutingError` after the set is redrawn empty.

Both tests fail without the one-line fix and pass with it.

### Additional information

* The empty-`ast` code path is already exercised today (recognition against a freshly created, empty `RouteSet` builds the simulator from an empty `Nodes::Or`), so rebuilding the cache from an empty table introduces no new state.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.