### PR TITLE
Silence `Time.rfc3339` redefinition warning on Ruby 4.1.0dev

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -6,6 +6,7 @@ require "active_support/time_with_zone"
 require "active_support/core_ext/time/zones"
 require "active_support/core_ext/date_and_time/calculations"
 require "active_support/core_ext/date/calculations"
+require "active_support/core_ext/module/redefine_method"
 require "active_support/core_ext/module/remove_method"
 
 class Time
@@ -58,6 +59,8 @@ class Time
     ruby2_keywords :at_with_coercion
     alias_method :at_without_coercion, :at
     alias_method :at, :at_with_coercion
+
+    silence_redefinition_of_method :rfc3339
 
     # Creates a +Time+ instance from an RFC 3339 string.
     #


### PR DESCRIPTION
### Motivation / Background

Ruby master added `Time.rfc3339` via [ruby/time#59](https://github.com/ruby/time/pull/59) (synced to ruby/ruby in [ruby/ruby@6c9f9f5c6118](https://github.com/ruby/ruby/commit/6c9f9f5c6118)). Active Support defines a singleton method of the same name, so loading `active_support/core_ext/time/calculations.rb` now emits a redefinition warning, which `tools/strict_warnings.rb` turns into an error. Every rails-nightly job that loads `active_support/test_case` aborts before running any test:

```
/rails/activesupport/lib/active_support/core_ext/time/calculations.rb:69: warning: method redefined; discarding old rfc3339
/usr/local/lib/ruby/4.1.0+4/time.rb:657: warning: previous definition of rfc3339 was here
/rails/tools/strict_warnings.rb:42:in 'RailsStrictWarnings#warn': /rails/activesupport/lib/active_support/core_ext/time/calculations.rb:69: warning: method redefined; discarding old rfc3339 (RailsStrictWarnings::WarningError)
```

https://buildkite.com/rails/rails-nightly/builds/4564#019f8154-590a-4568-b7c6-7b31021f4286/L1318

### Detail

This Pull Request adds `silence_redefinition_of_method :rfc3339` before the definition, following the existing pattern used for `Date#to_time`, `Date#xmlschema`, and `Time#to_time`. Active Support keeps its current behavior on every Ruby version and CI runs again.

### Additional information

The two methods share a name but not semantics, and simply replacing the implementation with Ruby's fails the `Time.rfc3339` tests. An assertion failure aborts the rest of its test method, so a single run of `test_rfc3339_parse` only reports the first divergence and the later assertions never run. With Active Support's definition made conditional (`unless ::Time.respond_to?(:rfc3339)`) and `test_rfc3339_parse` split into one test per input, matching the granularity of the `TimeZone#rfc3339` tests (https://github.com/yahonda/rails/tree/split-test-rfc3339-parse), all the divergences show up in one run on Ruby master:

```
$ ruby -v
ruby 4.1.0dev (2026-07-21T11:03:46Z master 812738f940) +PRISM [x86_64-linux]
$ cd activesupport && bundle exec ruby -Ilib -Itest test/core_ext/time_ext_test.rb -i "/rfc3339_parse/"

.FFF

  1) Failure:
TimeExtCalculationsTest#test_rfc3339_parse_with_missing_offset [test/core_ext/time_ext_test.rb:1340]:
ArgumentError expected but nothing was raised.

  2) Failure:
TimeExtCalculationsTest#test_rfc3339_parse_with_missing_time [test/core_ext/time_ext_test.rb:1336]:
--- expected
+++ actual
@@ -1 +1 @@
-"invalid date"
+"invalid xmlschema format: \"1999-12-31\""

  3) Failure:
TimeExtCalculationsTest#test_rfc3339_parse_with_invalid_string [test/core_ext/time_ext_test.rb:1352]:
--- expected
+++ actual
@@ -1 +1 @@
-"invalid date"
+"invalid xmlschema format: \"foobar\""

4 runs, 13 assertions, 3 failures, 0 errors, 0 skips
```

The first failure is the behavior change: Ruby accepts a timestamp without an offset and returns a local time, while Active Support raises `ArgumentError`:

```
$ TZ=America/New_York ruby -v -rtime -e 'p Time.rfc3339("1999-12-31T19:00:00")'
ruby 4.1.0dev (2026-07-21T11:03:46Z master 812738f940) +PRISM [x86_64-linux]
1999-12-31 19:00:00 -0500
```

```ruby
require "bundler/inline"

gemfile do
  source "https://rubygems.org"
  gem "activesupport", github: "rails/rails", require: false
end

require "active_support"
require "active_support/core_ext/time"
p Time.rfc3339("1999-12-31T19:00:00")
```

```
$ ruby -v
ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux]
$ TZ=America/New_York ruby rfc3339.rb
/home/yahonda/.local/share/mise/installs/ruby/4.0.6/lib/ruby/gems/4.0.0/bundler/gems/rails-ee7a9866854a/activesupport/lib/active_support/core_ext/time/calculations.rb:72:in 'Time.rfc3339': invalid date (ArgumentError)

      raise ArgumentError, "invalid date" if parts.empty?
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	from rfc3339.rb:10:in '<main>'
```

The other two failures differ only in the `ArgumentError` message.

Context:

- Ruby's rfc3339 is xmlschema under another name: per ruby/time#59, `Time#rfc3339` "is an alias to #xmlschema and is just for consistency", and `Time.rfc3339` differs from `Time.xmlschema` only in accepting a space separator and requiring a four digit year, so it inherits `Time.xmlschema`'s leniency.
- Active Support's method was introduced in 08e05d4a49 to enforce the offset: "The `Time.xmlschema` and consequently its alias `iso8601` accepts timestamps without a offset in contravention of the RFC 3339 standard."
- `Time.rfc3339("1999-12-31T19:00:00Z")` returns a `utc?` time in Ruby and a `+00:00` offset time (`utc?` returns `false`) in Active Support. Nothing in the test suite asserts this, so delegating to Ruby's method would change it without any test failing.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
