### PR TITLE
Locate Action Text attachables in bulk

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Locate attachables in bulk when extracting or rendering rich text content
+
+    `ActionText::Content` previously resolved each attachment's SGID with an
+    individual query, so rendering content with N attachments cost N queries.
+    Attachables are now located in bulk, one query per model class, memoised
+    per content instance. This also fixes quadratic query growth when saving
+    rich text with many attachments, where each attachment's `record`
+    presence validation re-renders the body.
+
+    *Olly Headey*
+
 *   Dispatch all Active Storage `direct-upload:`-prefixed events
 
     Add support for `direct-upload:before-blob-request` and `direct-upload:before-storage-request`.

--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Locate attachables in bulk when extracting or rendering rich text content
+
+    `ActionText::Content` previously resolved each attachment's SGID with an
+    individual query, so rendering content with N attachments cost N queries.
+    Attachables are now located in bulk, one query per model class, memoised
+    per content instance. This also fixes quadratic query growth when saving
+    rich text with many attachments, where each attachment's `record`
+    presence validation re-renders the body.
+
+    *Olly Headey*
+
 *   Add alternative text to Action Text attachments.
 
     Attachments could only be described by their caption, which is always shown

--- a/actiontext/lib/action_text/attachable.rb
+++ b/actiontext/lib/action_text/attachable.rb
@@ -46,6 +46,39 @@ module ActionText
         record || raise(ActiveRecord::RecordNotFound)
       end
 
+      # Locates multiple attachables in bulk, one query per model class, and
+      # returns them as a hash keyed by SGID. SGIDs that cannot be parsed or
+      # located are omitted:
+      #
+      #     attachable = Person.create! name: "Javan"
+      #     sgid = attachable.attachable_sgid
+      #     ActionText::Attachable.from_attachable_sgids([sgid, "missing"])
+      #     # => { sgid => person }
+      def from_attachable_sgids(sgids)
+        gids_by_sgid = Array(sgids).uniq.each_with_object({}) do |sgid, hash|
+          if gid = SignedGlobalID.parse(sgid, for: LOCATOR_NAME)
+            hash[sgid] = gid
+          end
+        end
+
+        records = GlobalID::Locator.locate_many(gids_by_sgid.values, ignore_missing: true)
+
+        # +locate_many+ returns the located records in the same order as the
+        # GIDs it was given, omitting any that couldn't be found. Walk the GIDs
+        # and located records in lockstep, only advancing the record pointer
+        # when it matches the current GID, so unlocatable SGIDs are skipped.
+        attachables_by_sgid = {}
+        index = 0
+        gids_by_sgid.each do |sgid, gid|
+          record = records[index]
+          if record && gid.model_id.to_s == record.id.to_s && record.class <= gid.model_class
+            attachables_by_sgid[sgid] = record
+            index += 1
+          end
+        end
+        attachables_by_sgid
+      end
+
       private
         def attachable_from_sgid(sgid)
           from_attachable_sgid(sgid)

--- a/actiontext/lib/action_text/content.rb
+++ b/actiontext/lib/action_text/content.rb
@@ -86,7 +86,7 @@ module ActionText
     #     content.attachables # => [attachable]
     def attachables
       @attachables ||= attachment_nodes.map do |node|
-        ActionText::Attachable.from_node(node)
+        attachable_for_node(node)
       end
     end
 
@@ -215,8 +215,24 @@ module ActionText
       end
 
       def attachment_for_node(node, with_full_attributes: true)
-        attachment = ActionText::Attachment.from_node(node)
+        attachment = ActionText::Attachment.from_node(node, attachable_for_node(node))
         with_full_attributes ? attachment.with_full_attributes : attachment
+      end
+
+      def attachable_for_node(node)
+        sgid = node["sgid"]
+
+        if sgid.present? && attachables_by_sgid.key?(sgid)
+          attachables_by_sgid[sgid]
+        else
+          ActionText::Attachable.from_node(node)
+        end
+      end
+
+      def attachables_by_sgid
+        @attachables_by_sgid ||= ActionText::Attachable.from_attachable_sgids(
+          attachment_nodes.filter_map { |node| node["sgid"].presence }
+        )
       end
 
       def attachment_gallery_for_node(node)

--- a/actiontext/lib/action_text/content.rb
+++ b/actiontext/lib/action_text/content.rb
@@ -87,7 +87,7 @@ module ActionText
     #     content.attachables # => [attachable]
     def attachables
       @attachables ||= attachment_nodes.map do |node|
-        ActionText::Attachable.from_node(node)
+        attachable_for_node(node)
       end
     end
 
@@ -214,8 +214,24 @@ module ActionText
       end
 
       def attachment_for_node(node, with_full_attributes: true)
-        attachment = ActionText::Attachment.from_node(node)
+        attachment = ActionText::Attachment.from_node(node, attachable_for_node(node))
         with_full_attributes ? attachment.with_full_attributes : attachment
+      end
+
+      def attachable_for_node(node)
+        sgid = node["sgid"]
+
+        if sgid.present? && attachables_by_sgid.key?(sgid)
+          attachables_by_sgid[sgid]
+        else
+          ActionText::Attachable.from_node(node)
+        end
+      end
+
+      def attachables_by_sgid
+        @attachables_by_sgid ||= ActionText::Attachable.from_attachable_sgids(
+          attachment_nodes.filter_map { |node| node["sgid"].presence }
+        )
       end
 
       def attachment_gallery_for_node(node)

--- a/actiontext/test/unit/content_test.rb
+++ b/actiontext/test/unit/content_test.rb
@@ -39,6 +39,44 @@ class ActionText::ContentTest < ActiveSupport::TestCase
     assert_equal attachable, attachment.attachable
   end
 
+  test "extracts attachables in bulk with one query per model class" do
+    blobs = 4.times.map { create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg") }
+    html = blobs.map { |blob| %Q(<action-text-attachment sgid="#{blob.attachable_sgid}"></action-text-attachment>) }.join
+
+    content = ActionText::Content.new(html)
+    assert_queries_count(1) do
+      assert_equal blobs, content.attachables
+    end
+  end
+
+  test "resolves attachables once per content instance across renders" do
+    blobs = 4.times.map { create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg") }
+    html = blobs.map { |blob| %Q(<action-text-attachment sgid="#{blob.attachable_sgid}"></action-text-attachment>) }.join
+
+    content = ActionText::Content.new(html)
+    assert_queries_count(1) do
+      content.to_plain_text
+    end
+    assert_queries_count(0) do
+      content.to_plain_text
+      content.attachables
+    end
+  end
+
+  test "extracts attachables when some cannot be located" do
+    first = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+    destroyed = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+    last = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+    html = [ first, destroyed, last ].map { |blob| %Q(<action-text-attachment sgid="#{blob.attachable_sgid}"></action-text-attachment>) }.join
+    destroyed.destroy!
+
+    attachables = content_from_html(html).attachables
+
+    assert_equal first, attachables.first
+    assert_kind_of ActionText::Attachables::MissingAttachable, attachables.second
+    assert_equal last, attachables.third
+  end
+
   test "extracts remote image attachables" do
     html = '<action-text-attachment content-type="image" url="http://example.com/cat.jpg" width="100" height="100" caption="Captioned"></action-text-attachment>'
 


### PR DESCRIPTION
### Summary

Rendering Action Text content resolves every attachment's SGID with its own query, so a post with N images costs N queries.

On save it is quadratic. Each attachment's `record` presence validation calls `RichText#blank?`, which re-renders the whole body, and every render re-resolves every attachment. A 20-image post issues around 450 queries.

This resolves attachables in bulk through `GlobalID::Locator.locate_many`, one query per model class, memoised per `Content` instance. The same post drops to a handful.

Preloading is not a workaround: `with_rich_text_body_and_embeds` loads the Active Storage associations, but rendering still resolves each SGID one at a time.

### Approach

`ActionText::Attachable.from_attachable_sgids` is the bulk counterpart to `from_attachable_sgid`, returning `{ sgid => attachable }`. It goes through `GlobalID::Locator`, so signature verification, custom locators and STI base-class SGIDs behave as before. Anything it cannot resolve falls back to the existing `Attachable.from_node` chain, leaving behaviour unchanged.

### Tests

Query counts for N attachments, memoisation across renders, and correct ordering when some attachables cannot be located.

Found in production on [Pagecord](https://pagecord.com), where saving photo-heavy posts spiked the query count.
