### PR TITLE
[ci-skip][doc] Fix missing user destroy action in sign up guide

### DIFF
--- a/guides/source/sign_up_and_settings.md
+++ b/guides/source/sign_up_and_settings.md
@@ -1158,6 +1158,8 @@ class Store::UsersController < Store::BaseController
   end
 
   def destroy
+    @user.destroy
+    redirect_to store_users_path, status: :see_other, notice: "User has been deleted."
   end
 
   private


### PR DESCRIPTION
### Motivation / Background

In the section [8.2. Users Controller & Views](https://guides.rubyonrails.org/sign_up_and_settings.html#users-controller-views), The `Store::UsersController#destroy` action in the **Sign Up and Settings** guide appears to be empty.

The guide includes a delete button and states that:

> This gives admins the ability to read, update, and destroy users in the database.

But the empty action only loads the selected user through `set_user`. It does not delete the user or redirect after the request.

The example also allows an administrator to select their own account for deletion, which could remove the account associated with the current session.

### Detail

With this Pull Request, i'm trying to implement the missing `Store::UsersController#destroy`.

The action deletes the selected user and redirects to the users index with a `303 See Other` response and a confirmation notice.

### Additional information

This is a documentation-only change to:

`guides/source/sign_up_and_settings.md`

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
