### PR TITLE
Remove unused EMPTY_BINARY_STRING constant

### DIFF
--- a/activesupport/lib/active_support/cache/coder.rb
+++ b/activesupport/lib/active_support/cache/coder.rb
@@ -74,7 +74,6 @@ module ActiveSupport
 
       private
         SIGNATURE = "\x00\x11".b.freeze
-        EMPTY_BINARY_STRING = "".b.freeze
 
         OBJECT_DUMP_TYPE = 0x01
 


### PR DESCRIPTION
Rubydex reports no references to this constant, and repository-wide code search confirms that it is never read.

EMPTY_BINARY_STRING was added by d51ad367e2 on February 4, 2026 as part of better cache deserialization error handling. That change did not use the constant, and no later change introduced a use, so it has been dead since it was added.