### PR TITLE
Remove unused UriEncoder constants

### DIFF
--- a/actionpack/lib/action_dispatch/journey/router/utils.rb
+++ b/actionpack/lib/action_dispatch/journey/router/utils.rb
@@ -41,7 +41,6 @@ module ActionDispatch
         class UriEncoder # :nodoc:
           ENCODE   = "%%%02X"
           US_ASCII = Encoding::US_ASCII
-          UTF_8    = Encoding::UTF_8
           EMPTY    = (+"").force_encoding(US_ASCII).freeze
           DEC2HEX  = (0..255).map { |i| (ENCODE % i).force_encoding(US_ASCII).freeze }.freeze
 
@@ -49,8 +48,6 @@ module ActionDispatch
           DIGIT = "0-9"
           UNRESERVED = "#{ALPHA}#{DIGIT}\\-\\._~".freeze
           SUB_DELIMS = "!\\$&'\\(\\)\\*\\+,;="
-
-          ESCAPED  = /%[a-zA-Z0-9]{2}/
 
           FRAGMENT = /[^#{UNRESERVED}#{SUB_DELIMS}:@\/?]/
           SEGMENT  = /[^#{UNRESERVED}#{SUB_DELIMS}:@]/


### PR DESCRIPTION
UriEncoder is an internal, nodoc class, and its UTF_8 and ESCAPED constants have no remaining references.

Both constants were added by a61792574d on April 20, 2014 for UriEncoder#unescape_uri: UTF_8 selected the output encoding and ESCAPED matched encoded bytes. They became dead in dfc5e80e0f on February 13, 2025, when unescape_uri was removed in favor of CGI.unescape.