### PR TITLE
Preserve the declared parent order when dumping PostgreSQL `INHERITS` options

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -230,6 +230,7 @@ module ActiveRecord
             WHERE child.relname = #{scope[:name]}
               AND child.relkind IN (#{scope[:type]})
               AND n.nspname = #{scope[:schema]}
+            ORDER BY i.inhseqno
           SQL
         end
 

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -1018,7 +1018,7 @@ class SchemaCreateTableOptionsTest < ActiveRecord::PostgreSQLTestCase
       t.string :kind
     end
 
-    options = "INHERITS (transportation_modes, vehicles)"
+    options = "INHERITS (vehicles, transportation_modes)"
 
     @connection.create_table "trains", options: options
 


### PR DESCRIPTION
### Motivation / Background

The `INHERITS` clause was dumped in whatever order PG returned the parents, which in general isn't stable and should not be relied on. In other words, the schema dump is not deterministic.

### Detail

The solution is to order by `inhseqno` so the dump matches the order the table was declared with.

### Additional information

The issue is repoducible e.g. via [`pg_disorder`](https://github.com/viralpraxis/pg_disorder) extension.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
