### PR TITLE
Remove unused Journey::GTG::MatchData

### DIFF
--- a/actionpack/lib/action_dispatch/journey/gtg/simulator.rb
+++ b/actionpack/lib/action_dispatch/journey/gtg/simulator.rb
@@ -5,14 +5,6 @@
 module ActionDispatch
   module Journey # :nodoc:
     module GTG # :nodoc:
-      class MatchData # :nodoc:
-        attr_reader :memos
-
-        def initialize(memos)
-          @memos = memos
-        end
-      end
-
       class Simulator # :nodoc:
         STATIC_TOKENS = Array.new(64)
         STATIC_TOKENS[".".ord] = "."


### PR DESCRIPTION
Journey::GTG::MatchData is an internal, nodoc class with no remaining constructor or constant references.

The class entered Action Pack in 56fee39c39 on December 19, 2012 when Journey moved under Action Dispatch. It became dead in 845aabbcd3 on May 22, 2017, when the unused Simulator#simulate method and its MatchData.new call were removed.