### PR TITLE
Raise ConfigurationFile::FormatError for invalid YAML

### DIFF
--- a/activerecord/lib/active_record/fixture_set/file.rb
+++ b/activerecord/lib/active_record/fixture_set/file.rb
@@ -53,7 +53,7 @@ module ActiveRecord
             data = ActiveSupport::ConfigurationFile.parse(@file, freeze: true, context:
               ActiveRecord::FixtureSet::RenderContext.create_subclass.new.get_binding)
             data ? validate(data).to_a : []
-          rescue RuntimeError => error
+          rescue ActiveSupport::ConfigurationFile::FormatError => error
             raise Fixture::FormatError, error.message
           end
         end

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Raise `ActiveSupport::ConfigurationFile::FormatError` when parsing malformed YAML.
+
+    *Nikita Vasilevsky*
+
 *   Preserve sub-second precision when subtracting a `DateTime` from a `Time`.
 
     `Time - DateTime` converted both sides via `to_f`, so microsecond-level

--- a/activesupport/lib/active_support/configuration_file.rb
+++ b/activesupport/lib/active_support/configuration_file.rb
@@ -27,7 +27,7 @@ module ActiveSupport
         YAML.unsafe_load(source, **options) || {}
       end
     rescue Psych::SyntaxError => error
-      raise "YAML syntax error occurred while parsing #{@content_path}. " \
+      raise FormatError, "YAML syntax error occurred while parsing #{@content_path}. " \
             "Please note that YAML must be consistently indented using spaces. Tabs are not allowed. " \
             "Error: #{error.message}"
     end

--- a/activesupport/test/configuration_file_test.rb
+++ b/activesupport/test/configuration_file_test.rb
@@ -38,4 +38,17 @@ class ConfigurationFileTest < ActiveSupport::TestCase
       assert_equal({ "ok" => 42 }, data)
     end
   end
+
+  test "raises FormatError for malformed YAML" do
+    Tempfile.create do |file|
+      file.write("foo: bar: baz\n")
+      file.flush
+
+      error = assert_raises(ActiveSupport::ConfigurationFile::FormatError) do
+        ActiveSupport::ConfigurationFile.parse(file.path)
+      end
+
+      assert_match "YAML syntax error", error.message
+    end
+  end
 end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2825,7 +2825,7 @@ module ApplicationTests
           key: foo:
       RUBY
 
-      error = assert_raises RuntimeError do
+      error = assert_raises ActiveSupport::ConfigurationFile::FormatError do
         app "development"
       end
       assert_match "YAML syntax error occurred while parsing", error.message


### PR DESCRIPTION
`ActiveSupport::ConfigurationFile::FormatError` is currently defined but never raised. Malformed YAML is instead reraised using a string, which produces a generic `RuntimeError`.

The exception was introduced with `ActiveSupport::ConfigurationFile` in ef7599fe91. The discussion in #38067 indicates that it was intended to represent configuration-file parsing failures: a reviewer explicitly approved extracting `ConfigurationFile::FormatError`, and the original implementation raised it. The final landing retained the exception declaration but continued raising a string.

This changes malformed-YAML handling to raise the dedicated `FormatError`, retaining its existing `StandardError` hierarchy.

Active Record's fixture loader previously rescued `RuntimeError` to translate these parsing failures into `ActiveRecord::Fixture::FormatError`. It now rescues `ActiveSupport::ConfigurationFile::FormatError` explicitly, preserving that behavior while narrowing the rescue to the error it intends to handle.

### Alternative

We could remove remove the unused `FormatError` declaration and preserve the generic `RuntimeError` behavior. That would be the smaller dead-code cleanup, but the history of #38067 suggests the dedicated exception was intended to be used rather than removed.
