### PR TITLE
Remove unused SAFE_FETCH_SITES constant

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -604,11 +604,6 @@ module ActionController # :nodoc:
 
       AUTHENTICITY_TOKEN_LENGTH = 32
 
-      # Safe values for Sec-Fetch-Site header that indicate the request
-      # originated from the same site.
-      SAFE_FETCH_SITES = %w[ same-origin same-site ].freeze
-      private_constant :SAFE_FETCH_SITES
-
       # Returns true or false if a request is verified. The verification method
       # depends on the configured `forgery_protection_verification_strategy`:
       #


### PR DESCRIPTION
SAFE_FETCH_SITES is private and has no remaining references.

It was added by f5a1915f1d on December 12, 2025 for Sec-Fetch-Site based CSRF protection. It became dead in 4a3bf76371 on January 12, 2026, when SAFE_FETCH_SITES.include? was replaced with explicit case branches for same-origin and same-site.