### PR TITLE
Evaluate nested attributes `reject_if` proc in the context of the record

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   Evaluate the `accepts_nested_attributes_for` `:reject_if` proc in the
+    context of the owner record. This matches how `Symbol` reject_if
+    callbacks and other proc options such as validation `:if`/`:unless`
+    conditions already behave.
+
+    ```ruby
+    class Member < ActiveRecord::Base
+      has_many :posts
+      accepts_nested_attributes_for :posts,
+        reject_if: proc { |attributes| attributes["author_id"] != id }
+    end
+    ```
+
+    The attributes hash is still passed to the proc as its argument, so procs
+    that only use their argument are unaffected. Procs that relied on `self`
+    pointing at the definition context need to be updated.
+
+    *Oliver Garcia*
+
 *   Add query predicate hooks for Active Model types.
 
     Types can override `transforms_query_predicates?`, `query_attribute`, and

--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -150,6 +150,16 @@ module ActiveRecord
     #   member.posts.first.title # => 'Kari, the awesome Ruby documentation browser!'
     #   member.posts.second.title # => 'The egalitarian assumption of the modern citizen'
     #
+    # The +:reject_if+ proc is evaluated in the context of the owner record,
+    # so +self+ refers to that record and you can call its methods from within
+    # the proc:
+    #
+    #   class Member < ActiveRecord::Base
+    #     has_many :posts
+    #     accepts_nested_attributes_for :posts,
+    #       reject_if: proc { |attributes| attributes['author_id'] != id }
+    #   end
+    #
     # Alternatively, +:reject_if+ also accepts a symbol for using methods:
     #
     #   class Member < ActiveRecord::Base
@@ -598,6 +608,10 @@ module ActiveRecord
       # rejected by calling the reject_if Symbol or Proc (if defined).
       # The reject_if option is defined by +accepts_nested_attributes_for+.
       #
+      # Both a Symbol and a Proc are evaluated in the context of the record
+      # instance, so +self+ refers to the record and its methods and other
+      # attributes are available from within the callback.
+      #
       # Returns false if there is a +destroy_flag+ on the attributes.
       def call_reject_if(association_name, attributes)
         return false if will_be_destroyed?(association_name, attributes)
@@ -606,7 +620,7 @@ module ActiveRecord
         when Symbol
           method(callback).arity == 0 ? send(callback) : send(callback, attributes)
         when Proc
-          callback.call(attributes)
+          instance_exec(attributes, &callback)
         end
       end
 

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -116,6 +116,18 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
     assert_difference("Ship.count") { pirate.save! }
   end
 
+  def test_reject_if_proc_is_evaluated_in_the_context_of_the_record
+    Pirate.accepts_nested_attributes_for :ship, reject_if: proc { |attributes| catchphrase != "Aye" }
+
+    accepting_pirate = Pirate.new(catchphrase: "Aye")
+    accepting_pirate.ship_attributes = { name: "Black Pearl" }
+    assert_difference("Ship.count") { accepting_pirate.save! }
+
+    rejecting_pirate = Pirate.new(catchphrase: "Nay")
+    rejecting_pirate.ship_attributes = { name: "Flying Dutchman" }
+    assert_no_difference("Ship.count") { rejecting_pirate.save! }
+  end
+
   def test_reject_if_with_indifferent_keys
     Pirate.accepts_nested_attributes_for :ship, reject_if: proc { |attributes| attributes[:name].blank? }
 


### PR DESCRIPTION
### Motivation / Background

`accepts_nested_attributes_for` accepts a `:reject_if` callback as either a `Symbol` or a `Proc`. The two forms do not run in the same context, which is surprising and undocumented.
Example:

```ruby
class Component < ActiveRecord::Base
  has_many :details

  # Symbol form — works: `self` is the record instance
  accepts_nested_attributes_for :details, reject_if: :only_accepted
  def only_accepted(attributes)
    attributes["describable_id"] != component_id
  end
end
```

the `Symbol` form works because it is dispatched with `send` against the record, so `self` is the record and `component_id` resolves to the instance's method.

The equivalent `Proc` form does **not** work:

```ruby
accepts_nested_attributes_for :details,
  reject_if: ->(attributes) { attributes["describable_id"] != component_id }
```

The proc literal is written in the class body, so at definition time `self` is the **class**. `call_reject_if` invoked it with `Proc#call`,  so `component_id` is sent to the class instead of the record and the record's attributes and methods are unreachable. There was no supported way to reach the instance from inside the proc.

This is also inconsistent with the rest of Rails: proc conditions such as validation `:if`/`:unless` are evaluated against the record instance via `ActiveSupport::Callbacks` (`instance_exec`).

### Detail

This Pull Request changes `ActiveRecord::NestedAttributes#call_reject_if` to evaluate a `Proc` reject_if with `instance_exec` instead of `Proc#call`:

```ruby
when Proc
  instance_exec(attributes, &callback)
```

`self` inside the proc is now the record being saved, while the attributes hash is still passed as the block argument. The change aligns the `Proc` branch with both the `Symbol` branch and the proc `:if`/`:unless` conditions used elsewhere in Rails.

Documentation (the `accepts_nested_attributes_for` API docs and the `:reject_if` option description) has been updated to state that the callback is evaluated in the context of the owner record, with an example.

**Behavior change / backward compatibility:** procs that only use their block argument are unaffected. Procs that relied on `self` pointing at the definition context (e.g. calling a class method or referencing the class) will now see the record as `self` and need to be updated. This is the Active Record CHANGELOG.

### Additional information

- All existing `nested_attributes` tests pass, including the `Symbol` reject_if cases and `reject_if: proc(&:empty?)`.
- The added test references an instance-only attribute (`catchphrase`) bare inside the proc, so it raises `NameError` on the current code and passes with the fix.
- Test runs (sqlite3):
  - `activerecord/test/cases/nested_attributes_test.rb` — 171 runs, 0 failures
  - `activerecord/test/cases/nested_attributes_with_callbacks_test.rb` — 10 runs, 0 failures
- `bundle exec rubocop` reports no offenses on the changed files.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
