### PR TITLE
Remove unused ThreadMonitor#mon_try_enter method

### DIFF
--- a/activesupport/lib/active_support/concurrency/thread_monitor.rb
+++ b/activesupport/lib/active_support/concurrency/thread_monitor.rb
@@ -26,14 +26,6 @@ module ActiveSupport
       end
 
       private
-        def mon_try_enter
-          if @owner != Thread.current
-            return false unless @mutex.try_lock
-            @owner = Thread.current
-          end
-          @count += 1
-        end
-
         def mon_enter
           @mutex.lock if @owner != Thread.current
           @owner = Thread.current


### PR DESCRIPTION
Commit 51d4feaabc replaced ThreadLoadInterlockAwareMonitor with ThreadMonitor and carried this helper over from the old implementation. The removed LoadInterlockAwareMonitorMixin had called mon_try_enter, while ThreadMonitor#synchronize calls mon_enter directly, so the helper became unused in that commit.