### PR TITLE
Remove unused ParamBuilder#new_depth_limit method

### DIFF
--- a/actionpack/lib/action_dispatch/http/param_builder.rb
+++ b/actionpack/lib/action_dispatch/http/param_builder.rb
@@ -164,10 +164,6 @@ module ActionDispatch
         ActiveSupport::HashWithIndifferentAccess.new
       end
 
-      def new_depth_limit(param_depth_limit)
-        self.class.new @params_class, param_depth_limit
-      end
-
       def params_hash_type?(obj)
         Hash === obj
       end


### PR DESCRIPTION
The method was copied from Rack::QueryParser when ParamBuilder was introduced in ce5f1817bc, but Rails never added Rack's caller or an equivalent depth-limit setter. It has therefore been unused since its introduction.