### PR TITLE
Remove unused Redis cache serialize_entries methods

### DIFF
--- a/activesupport/lib/active_support/cache/deprecated_redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/deprecated_redis_cache_store.rb
@@ -457,12 +457,6 @@ module ActiveSupport
           end
         end
 
-        def serialize_entries(entries, **options)
-          entries.transform_values do |entry|
-            serialize_entry(entry, **options)
-          end
-        end
-
         def change_counter(key, amount, options)
           redis.then do |c|
             c = c.node_for(key) if c.is_a?(Redis::Distributed)

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -440,12 +440,6 @@ module ActiveSupport
           end
         end
 
-        def serialize_entries(entries, **options)
-          entries.transform_values do |entry|
-            serialize_entry(entry, **options)
-          end
-        end
-
         def change_counter(key, amount, options)
           redis.node_for(key).with do |c|
             expires_in = options[:expires_in]


### PR DESCRIPTION
RedisCacheStore#serialize_entries was introduced in f9a8646d81 for the mapped_mset write path. Commit f9fce850da replaced that path with per-entry pipelined writes, leaving the helper without a caller.

The unused helper was later copied into DeprecatedRedisCacheStore by the rename in 79b357bd89. Remove it from both implementations.