### PR TITLE
Inspect nested attribute `id` in `RecordNotFound` message

### DIFF
--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -621,7 +621,7 @@ module ActiveRecord
 
       def raise_nested_attributes_record_not_found!(association_name, record_id)
         model = self.class._reflect_on_association(association_name).klass.name
-        raise RecordNotFound.new("Couldn't find #{model} with ID=#{record_id} for #{self.class.name} with ID=#{id}",
+        raise RecordNotFound.new("Couldn't find #{model} with ID=#{record_id.inspect} for #{self.class.name} with ID=#{id}",
                                  model, "id", record_id)
       end
 

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -317,6 +317,13 @@ class TestNestedAttributesOnAHasOneAssociation < ActiveRecord::TestCase
     assert_equal "Couldn't find Ship with ID=1234567890 for Pirate with ID=#{@pirate.id}", exception.message
   end
 
+  def test_should_inspect_the_id_in_the_RecordNotFound_message
+    exception = assert_raise ActiveRecord::RecordNotFound do
+      @pirate.ship_attributes = { id: "\e[31mHello World!\e[0m" }
+    end
+    assert_equal "Couldn't find Ship with ID=\"\\e[31mHello World!\\e[0m\" for Pirate with ID=#{@pirate.id}", exception.message
+  end
+
   def test_should_take_a_hash_with_string_keys_and_update_the_associated_model
     @pirate.reload.ship_attributes = { "id" => @ship.id, "name" => "Davy Jones Gold Dagger" }
 


### PR DESCRIPTION
### Motivation / Background

`ActiveRecord::NestedAttributes#raise_nested_attributes_record_not_found!` interpolates the user-controlled `id` from nested params directly into the `RecordNotFound` message:

    raise RecordNotFound.new("Couldn't find #{model} with ID=#{record_id} for #{self.class.name} with ID=#{id}", ...)

`record_id` comes straight from `posts_attributes[].id` and is not escaped. Rails maps `RecordNotFound` to a generic `404` and never renders this message, so this is not exploitable through the framework itself. The risk is limited to an application that logs the message: an `id` carrying ANSI escape sequences is interpreted when the log is later viewed in a terminal, which lets an attacker forge, recolor, or hide log output.

This is the same class of issue as [CVE-2025-55193](https://github.com/advisories/GHSA-76r7-hhxj-r776), which added `.inspect` to the ids in the `RecordNotFound` messages raised by `find` in `core.rb` and `finder_methods.rb`. That fix missed the nested attributes call site.

### Detail

This change calls `.inspect` on `record_id` before interpolating it. String ids are now quoted and their control bytes are escaped to inert text, while integer ids are unchanged.

For example, a nested `id` of `"\e[31mHello\e[0m"` (containing raw ANSI escape bytes) previously passed through to the message verbatim, where a terminal viewing the log would interpret it. It now renders as the quoted, inert literal `ID="\e[31mHello\e[0m"`.

### Additional information

The second interpolation, `#{id}`, is the parent record's own persisted primary key rather than reflected request input, so it is left unchanged, consistent with the parent fix in dd6fcc43.

HackerOne user ylchen originally reported this behavior. The report was closed as informative because it was not exploitable.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
