### PR TITLE
Remove unused V6_0::ReferenceDefinition

### DIFF
--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -248,12 +248,6 @@ module ActiveRecord
       end
 
       class V6_0 < V6_1
-        class ReferenceDefinition < ConnectionAdapters::ReferenceDefinition
-          def index_options(table_name)
-            as_options(index)
-          end
-        end
-
         module TableDefinition
           def references(*args, **options)
             options[:_uses_legacy_reference_index_name] = true


### PR DESCRIPTION
Rubydex and Ruby LSP find no references to the compatibility class. The remaining ReferenceDefinition.new calls are lexically defined in ActiveRecord::ConnectionAdapters and therefore resolve ConnectionAdapters::ReferenceDefinition, even when V6_0::TableDefinition prepends its references method and calls super.

V6_0::ReferenceDefinition was added by e8437a68f6 on October 30, 2020 and was then constructed directly by the Rails 6.0 references and add_reference compatibility overrides. It became dead in 7c5a8fc759f on March 14, 2022, when those constructors were replaced by the _uses_legacy_reference_index_name option followed by super.