### PR TITLE
Remove unused Redis cache default options

### DIFF
--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -46,12 +46,6 @@ module ActiveSupport
     #     cache.read("greeting")                 # => nil
     #
     class RedisCacheStore < Store
-      DEFAULT_REDIS_OPTIONS = {
-        connect_timeout:    1,
-        read_timeout:       1,
-        write_timeout:      1,
-      }.freeze
-
       DEFAULT_ERROR_HANDLER = -> (method:, returning:, exception:) do
         if logger
           logger.error { "RedisCacheStore: #{method} failed, returned #{returning.inspect}: #{exception.class}: #{exception.message}" }


### PR DESCRIPTION
DEFAULT_REDIS_OPTIONS was added in 9f8ec35352 on 2017-11-13 as part of the built-in Redis cache store. It became unused in 5843a7b7f2 on 2026-06-01, when the redis-client migration removed build_redis_distributed_client and build_redis_client, its last in-file callers. RedisClient now supplies the same timeout defaults itself.

DeprecatedRedisCacheStore has a separate, still-used DEFAULT_REDIS_OPTIONS constant; this change leaves it intact.
