### PR TITLE
Deprecate Cookies::HTTP_HEADER constant

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Deprecate `ActionDispatch::Cookies::HTTP_HEADER`.
+
+    Use `Rack::SET_COOKIE` instead.
+
+    *Nikita Vasilevsky*
+
 *   Fix `ActionController::Live` streams hanging on client disconnect.
 
     `ActionController::Live::Buffer#abort` cleared the streaming queue but never

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -194,7 +194,12 @@ module ActionDispatch
   #     `:lax`.
   #
   class Cookies
-    HTTP_HEADER   = "Set-Cookie"
+    include ActiveSupport::Deprecation::DeprecatedConstantAccessor
+
+    deprecate_constant :HTTP_HEADER, "Rack::SET_COOKIE",
+      deprecator: ActionDispatch.deprecator,
+      message: "ActionDispatch::Cookies::HTTP_HEADER is deprecated and will be removed in Rails 9.0. Use Rack::SET_COOKIE instead."
+
     GENERATOR_KEY = "action_dispatch.key_generator"
     SIGNED_COOKIE_SALT = "action_dispatch.signed_cookie_salt"
     ENCRYPTED_COOKIE_SALT = "action_dispatch.encrypted_cookie_salt"

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -94,6 +94,12 @@ class CookiesMiddlewareTest < ActiveSupport::TestCase
 
     assert_equal "foo=bar; path=/", headers["set-cookie"]
   end
+
+  def test_http_header_constant_is_deprecated
+    assert_deprecated(/ActionDispatch::Cookies::HTTP_HEADER is deprecated/, ActionDispatch.deprecator) do
+      assert_equal Rack::SET_COOKIE, ActionDispatch::Cookies::HTTP_HEADER
+    end
+  end
 end
 
 class CookiesTest < ActionController::TestCase


### PR DESCRIPTION
HTTP_HEADER was added in d3e62fc57c on 2010-05-18 so the cookie middleware could normalize the Set-Cookie header after it stopped wrapping responses in Rack::Response. It became unused in 706fb10ad5 on 2023-01-21, when Rack 2 and Rack 3 compatibility required cookie handling to move back to Rack::Response.

The constant is published in the API documentation and has an external consumer, so preserve it through the deprecation cycle rather than removing it directly. Rack::SET_COOKIE is the canonical replacement.

