### PR TITLE
Deprecate RedisCacheStore::DEFAULT_REDIS_OPTIONS

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Deprecate `ActiveSupport::Cache::RedisCacheStore::DEFAULT_REDIS_OPTIONS`.
+
+    The `redis-client` implementation no longer reads this constant. Pass
+    timeout options to `RedisCacheStore` or a configured `RedisClient` instead.
+
+    *Nikita Vasilevsky*
+
 *   Add `#this_quarter?` to Date/Time.
 
     It returns true if the date/time falls within the current quarter.

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -12,6 +12,7 @@ rescue LoadError
 end
 
 require "redis-client"
+require "active_support/deprecation"
 require "active_support/core_ext/array/wrap"
 require "active_support/core_ext/hash/slice"
 require "active_support/core_ext/numeric/time"
@@ -46,11 +47,15 @@ module ActiveSupport
     #     cache.read("greeting")                 # => nil
     #
     class RedisCacheStore < Store
-      DEFAULT_REDIS_OPTIONS = {
-        connect_timeout:    1,
-        read_timeout:       1,
-        write_timeout:      1,
-      }.freeze
+      DEFAULT_REDIS_OPTIONS = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(
+        {
+          connect_timeout: 1,
+          read_timeout: 1,
+          write_timeout: 1,
+        }.freeze,
+        "ActiveSupport::Cache::RedisCacheStore::DEFAULT_REDIS_OPTIONS is deprecated and will be removed in Rails 9.0. Pass timeout options to RedisCacheStore or a configured RedisClient instead.",
+        ActiveSupport.deprecator,
+      )
 
       DEFAULT_ERROR_HANDLER = -> (method:, returning:, exception:) do
         if logger

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -37,6 +37,13 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       assert_equal "redis://localhost:6379", @cache.redis.config.server_url
     end
 
+    test "default Redis options constant is deprecated" do
+      options = assert_deprecated(/RedisCacheStore::DEFAULT_REDIS_OPTIONS is deprecated/, ActiveSupport.deprecator) do
+        ActiveSupport::Cache::RedisCacheStore::DEFAULT_REDIS_OPTIONS.to_h
+      end
+      assert_equal({ connect_timeout: 1, read_timeout: 1, write_timeout: 1 }, options)
+    end
+
     test "no URLs uses Redis client with default settings" do
       @cache = ActiveSupport::Cache::RedisCacheStore.new(url: [])
       assert_equal 1, @cache.redis.connect_timeout


### PR DESCRIPTION
DEFAULT_REDIS_OPTIONS was added in 9f8ec35352 on 2017-11-13 as part of the built-in Redis cache store. It became unused in 5843a7b7f2 on 2026-06-01, when the redis-client migration removed its last in-file callers.

The constant is published in the API documentation and may have external consumers, so preserve its value through a deprecation cycle rather than removing it directly. Applications can pass timeout options to RedisCacheStore or a configured RedisClient instead.