### PR TITLE
Remove unused Routing::HTTP_METHODS constant

### DIFF
--- a/actionpack/lib/action_dispatch/routing.rb
+++ b/actionpack/lib/action_dispatch/routing.rb
@@ -255,8 +255,5 @@ module ActionDispatch
     end
     autoload :UrlFor
     autoload :PolymorphicRoutes
-
-    SEPARATORS = %w( / . ? ).freeze # :nodoc:
-    HTTP_METHODS = [:get, :head, :post, :patch, :put, :delete, :options].freeze # :nodoc:
   end
 end

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -178,7 +178,7 @@ module ActionDispatch
           @path = Journey::Path::Pattern.new(ast, @requirements, JOINED_SEPARATORS, @anchor)
         end
 
-        JOINED_SEPARATORS = SEPARATORS.join # :nodoc:
+        JOINED_SEPARATORS = "/.?" # :nodoc:
 
         def make_route(name, precedence)
           Journey::Route.new(name: name, app: application, path: path, constraints: conditions,


### PR DESCRIPTION
HTTP_METHODS was added in dcaa074abf on 2007-05-26 to enumerate verbs when reporting method-not-allowed routing errors. It became unused in 588225f885 on 2009-12-11, when that fallback was removed as too much of a hack.

Routing implementation details were excluded from RDoc in c10bf8205c on 2010-03-31, and the constant remains explicitly :nodoc: with no Rails callers. Remove the stale internal list.
