### PR TITLE
Remove unused test methods

### DIFF
--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -63,9 +63,6 @@ class ActionPackAssertionsController < ActionController::Base
     render plain: "Mr. #{params[:name]}"
   end
 
-  def render_url
-    render html: "<div>#{url_for(action: 'flash_me', only_path: true)}</div>"
-  end
 
   def render_text_with_custom_content_type
     render body: "Hello!", content_type: Mime[:rss]

--- a/actionpack/test/controller/new_base/render_layout_test.rb
+++ b/actionpack/test/controller/new_base/render_layout_test.rb
@@ -27,9 +27,6 @@ module ControllerLayouts
     def layout_false
       render layout: false
     end
-
-    def builder_override
-    end
   end
 
   class ImplicitNameController < ::ApplicationController

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -223,11 +223,6 @@ class RedirectController < ActionController::Base
   end
 
   def rescue_errors(e) raise e end
-
-  private
-    def dashboard_url(id, message)
-      url_for action: "dashboard", params: { "id" => id, "message" => message }
-    end
 end
 
 class RedirectTest < ActionController::TestCase

--- a/actionpack/test/controller/resources_test.rb
+++ b/actionpack/test/controller/resources_test.rb
@@ -1433,13 +1433,6 @@ class ResourcesTest < ActionController::TestCase
       assert_equal expected, actual, "Error on route: #{route}(#{options.inspect})"
     end
 
-    def assert_resource_methods(expected, resource, action_method, method)
-      assert_equal expected.length, resource.send("#{action_method}_methods")[method].size, "#{resource.send("#{action_method}_methods")[method].inspect}"
-      expected.each do |action|
-        assert_includes resource.send("#{action_method}_methods")[method], action,
-          "#{method} not in #{action_method} methods: #{resource.send("#{action_method}_methods")[method].inspect}"
-      end
-    end
 
     def assert_resource_allowed_routes(controller, options, shallow_options, allowed, not_allowed, path = controller)
       shallow_path = "#{path}/#{shallow_options[:id]}"

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -137,13 +137,7 @@ class TestCaseTest < ActionController::TestCase
       send_file(__FILE__)
     end
 
-    def redirect_to_same_controller
-      redirect_to controller: "test", action: "test_uri", id: 5
-    end
 
-    def redirect_to_different_controller
-      redirect_to controller: "fail", id: 5
-    end
 
     def create
       head :created, location: "/resource"

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -240,10 +240,6 @@ class CookiesTest < ActionController::TestCase
       head :ok
     end
 
-    def set_cookie_with_domain_all_as_string
-      cookies[:user_name] = { value: "rizwanreza", domain: "all" }
-      head :ok
-    end
 
     def set_cookie_with_domain_proc
       cookies[:user_name] = { value: "braindeaf", domain: proc { ".sub.www.nextangle.com" } }
@@ -260,10 +256,6 @@ class CookiesTest < ActionController::TestCase
       head :ok
     end
 
-    def delete_cookie_with_domain_all_as_string
-      cookies.delete(:user_name, domain: "all")
-      head :ok
-    end
 
     def set_cookie_with_domain_and_tld
       cookies[:user_name] = { value: "rizwanreza", domain: :all, tld_length: 2 }

--- a/actionpack/test/dispatch/request/url_encoded_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/url_encoded_params_parsing_test.rb
@@ -5,7 +5,7 @@ require "abstract_unit"
 class UrlEncodedParamsParsingTest < ActionDispatch::IntegrationTest
   class TestController < ActionController::Base
     class << self
-      attr_accessor :last_request_parameters, :last_request_type
+      attr_accessor :last_request_parameters
     end
 
     def parse

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -68,10 +68,6 @@ class TestController < ActionController::Base
     render "test/hello_world"
   end
 
-  def render_hello_world_with_last_modified_set
-    response.last_modified = Date.new(2008, 10, 10).to_time
-    render "test/hello_world"
-  end
 
   # :ported: compatibility
   def render_hello_world_with_forward_slash
@@ -228,10 +224,6 @@ class TestController < ActionController::Base
     # let's just rely on the template
   end
 
-  # :ported:
-  def blank_response
-    render plain: " "
-  end
 
   # :ported:
   def layout_test
@@ -300,9 +292,6 @@ class TestController < ActionController::Base
     end
   end
 
-  def render_action_hello_world_as_symbol
-    render action: :hello_world
-  end
 
   def layout_test_with_different_layout
     render action: "hello_world", layout: "standard"
@@ -564,9 +553,6 @@ class TestController < ActionController::Base
     render partial: "customer", collection: []
   end
 
-  def partial_collection_shorthand_with_different_types_of_records_with_counter
-    partial_collection_shorthand_with_different_types_of_records
-  end
 
   def missing_partial
     render partial: "thisFileIsntHere"
@@ -592,10 +578,6 @@ class TestController < ActionController::Base
     render partial: "hash_greeting", collection: [ { first_name: "Pratik" }, { first_name: "Amy" } ], locals: { greeting: "Hola" }
   end
 
-  def partial_with_implicit_local_assignment
-    @customer = Customer.new("Marcel")
-    render partial: "customer"
-  end
 
   def render_call_to_partial_with_layout
     render action: "calling_partial_with_layout"

--- a/activejob/test/cases/continuation_test.rb
+++ b/activejob/test/cases/continuation_test.rb
@@ -760,11 +760,4 @@ class ActiveJob::TestContinuation < ActiveSupport::TestCase
 
     assert_equal [ "step_one", "step_two", "step_three", "step_four" ], IsolatedStepsJob.items
   end
-
-  private
-    def capture_info_stdout(&block)
-      ActiveJob::Base.logger.with(level: :info) do
-        capture(:stdout, &block)
-      end
-    end
 end

--- a/activejob/test/support/integration/test_case_helpers.rb
+++ b/activejob/test/support/integration/test_case_helpers.rb
@@ -44,9 +44,6 @@ module TestCaseHelpers
       job_file(id).exist?
     end
 
-    def continuable_job_started(id = @id)
-      job_file("#{id}.started").exist?
-    end
 
     def job_data(id)
       Marshal.load(File.binread(job_file(id)))

--- a/activerecord/test/cases/encryption/envelope_encryption_key_provider_test.rb
+++ b/activerecord/test/cases/encryption/envelope_encryption_key_provider_test.rb
@@ -41,9 +41,4 @@ class ActiveRecord::Encryption::EnvelopeEncryptionKeyProviderTest < ActiveRecord
 
     assert_encryptor_works_with @key_provider
   end
-
-  private
-    def assert_multiple_primary_keys
-      assert Rails.app.credentials.dig(:active_record_encryption, :primary_key).length > 1
-    end
 end

--- a/activerecord/test/cases/encryption/helper.rb
+++ b/activerecord/test/cases/encryption/helper.rb
@@ -38,14 +38,6 @@ module ActiveRecord::Encryption
       assert_equal expected_value, model.read_attribute_before_type_cast(attribute_name)
     end
 
-    def assert_encrypted_record(model)
-      encrypted_attributes = model.class.encrypted_attributes.find_all { |attribute_name| model.send(attribute_name).present? }
-      assert_not encrypted_attributes.empty?, "The model has no encrypted attributes with content to check (they are all blank)"
-
-      encrypted_attributes.each do |attribute_name|
-        assert_encrypted_attribute model, attribute_name, model.send(attribute_name)
-      end
-    end
 
     def assert_encryptor_works_with(key_provider)
       encryptor = ActiveRecord::Encryption::Encryptor.new
@@ -67,10 +59,6 @@ module ActiveRecord::Encryption
         ActiveRecord::Encryption.with_encryption_context key_provider: key_provider, &block
       end
 
-      def with_envelope_encryption(&block)
-        @envelope_encryption_key_provider ||= ActiveRecord::Encryption::EnvelopeEncryptionKeyProvider.new
-        with_key_provider @envelope_encryption_key_provider, &block
-      end
 
       def create_unencrypted_book_ignoring_case(name:)
         book = ActiveRecord::Encryption.without_encryption do

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -427,15 +427,6 @@ class TransactionTest < ActiveRecord::TestCase
     assert_not_predicate Topic.find(2), :approved?, "Second should have been unapproved"
   end
 
-  def transaction_with_return
-    Topic.transaction do
-      @first.approved  = true
-      @second.approved = false
-      @first.save
-      @second.save
-      return
-    end
-  end
 
   def transaction_with_shallow_return
     Topic.transaction do

--- a/activesupport/test/callbacks_test.rb
+++ b/activesupport/test/callbacks_test.rb
@@ -201,9 +201,7 @@ module CallbacksTest
     before_save Proc.new { |r| r.history << "b00m" }, if: :yes, unless: :yes
 
     def yes; true; end
-    def other_yes; true; end
     def no; false; end
-    def other_no; false; end
 
     def save
       run_callbacks :save

--- a/activesupport/test/deprecation_test.rb
+++ b/activesupport/test/deprecation_test.rb
@@ -855,12 +855,6 @@ class DeprecationTest < ActiveSupport::TestCase
       deprecator.warn
     end
 
-    def with_rails_application_deprecators(&block)
-      application = Struct.new(:deprecators).new(ActiveSupport::Deprecation::Deprecators.new)
-      rails = Struct.new(:application).new(application)
-      rails.application.deprecators[:deprecator] = @deprecator
-      stub_const(Object, :Rails, rails, &block)
-    end
 
     def deprecator_with_messages
       klass = Class.new(ActiveSupport::Deprecation)

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -64,9 +64,6 @@ module TestHelpers
       end
     end
 
-    def framework_path
-      RAILS_FRAMEWORK_ROOT
-    end
 
     def rails_root
       app_path


### PR DESCRIPTION
# TL;DR

Remove 24 unused methods and accessors from Rails' test-only code.

This is safe as a test-only cleanup: every changed file is under a component's `test/` tree, no production code changes, Rubydex resolves no references to any removed declaration, and the affected component tests pass.

# Context

Rubydex found method declarations in the test suite with no references. I then checked each candidate repo-wide and reviewed its surrounding code and history. Dynamic Ruby entry points were excluded, including callback symbols, controller actions built through interpolation, protocol implementations, generated attribute methods, and nested-form writers such as `comments_attributes=`, `tags_attributes=`, and `post_attributes=` that `fields_for` probes through `respond_to?`.

The final batch contains only declarations whose callers were removed or which were introduced without a caller.

## How each declaration became unused

### Action Pack

- `ActionPackAssertionsController#render_url`: its last `get :render_url` caller was removed by [`2ff60e8648`](https://github.com/rails/rails/commit/2ff60e86486141b5a5aae6e1a0a7521fbd85a269) while deleting deprecated tag support.
- `ControllerLayouts::ImplicitController#builder_override`: added by the 2009 new-base test port in [`69fd669165`](https://github.com/rails/rails/commit/69fd66916566f402620cc385689c36f61deb6ba1) without a route or test caller; later similarly named form-builder tests are unrelated.
- `RedirectController#dashboard_url`: originally named `dashbord_url`; its only caller was removed with deprecated `redirect_to(:symbol, *args)` support in [`f770165cc2`](https://github.com/rails/rails/commit/f770165cc23a44ac329b5b1fbd47376a6c2e3f11). The spelling fix in [`1825c2b6c5`](https://github.com/rails/rails/commit/1825c2b6c5fc873172552fe6f999174e34ad4e17) renamed the unused method but added no caller.
- `ResourcesTest#assert_resource_methods`: all calls were removed with the deprecated `RouteSet` API in [`b3eb26a161`](https://github.com/rails/rails/commit/b3eb26a161acb23781e55fc6c37b948f160cd9b5), leaving the helper behind.
- `TestCaseTest::TestController#redirect_to_same_controller` and `#redirect_to_different_controller`: their `follow_redirect` tests were removed with the broken functional-test implementation in [`db58391079`](https://github.com/rails/rails/commit/db5839107951b000633fa8405f78e5c315b6656a).
- `CookiesTest::TestController#set_cookie_with_domain_all_as_string` and `#delete_cookie_with_domain_all_as_string`: introduced in [`f7dbf388bd`](https://github.com/rails/rails/commit/f7dbf388bd867cba7a66abf44affb09960ccb4c1) as fixture actions but never wired to a test; the feature tests use the existing symbol-domain actions instead.
- `UrlEncodedParamsParsingTest::TestController.last_request_type`: copied into the URL-encoded parsing fixture by [`18cb0493d1`](https://github.com/rails/rails/commit/18cb0493d1ec1990a45000b1f3e6d9714a849690); the multipart-specific assignment, reset, and assertion were removed in [`5a43908c74`](https://github.com/rails/rails/commit/5a43908c7414996354ca427354d98d789e0210e7), leaving only the accessor.

### Action View

- `TestController#render_hello_world_with_last_modified_set` and `#blank_response`: their request callers were removed when ETag and conditional GET behavior moved to middleware in [`74dd8a3681`](https://github.com/rails/rails/commit/74dd8a3681c6984ea35c879f88c6a87521b58ec2).
- `TestController#render_action_hello_world_as_symbol`: its caller was dropped during the render-test merge in [`a200c67611`](https://github.com/rails/rails/commit/a200c67611ed3bb2d276a9a1d1eb67b5c926f22a); a separate same-named integration fixture was later added and removed, but did not reference this declaration.
- `TestController#partial_collection_shorthand_with_different_types_of_records_with_counter`: introduced in [`9cc478a254`](https://github.com/rails/rails/commit/9cc478a2547bec5b72fa2a4b36b2f8e627373a74) without a route or test caller.
- `TestController#partial_with_implicit_local_assignment`: its test and request were removed with deprecated implicit instance-variable assignment in [`7aa730440c`](https://github.com/rails/rails/commit/7aa730440c2143051b46c0857e637100f9367628).

### Active Job

- `ActiveJob::TestContinuation#capture_info_stdout`: introduced by the continuation tests in [`0ac3fba6ee`](https://github.com/rails/rails/commit/0ac3fba6ee5f7d1680024a4925eee6069095487b) without a caller.
- `TestCaseHelpers#continuable_job_started`: its last assertion was removed with the deprecated Sidekiq Active Job adapter in [`10c24f2481`](https://github.com/rails/rails/commit/10c24f2481c55a8f215f7a0dcfa4126a702f5b82).

### Active Record

- `EnvelopeEncryptionKeyProviderTest#assert_multiple_primary_keys`: extracted as `assert_multiple_master_keys` in [`638a92f734`](https://github.com/rails/rails/commit/638a92f7344963c7e42eeb84eb816e4592bda7e4) without a caller, then renamed in [`28145c3cee`](https://github.com/rails/rails/commit/28145c3ceefb35ae3df22f90ca7ea7c1eef0d340); it remained unused.
- `EncryptionHelpers#assert_encrypted_record`: its only callers were mass-encryption tests removed in [`c41b354bf0`](https://github.com/rails/rails/commit/c41b354bf065c9e59d65abbaeb22897f95ab47c0).
- `EncryptionHelpers#with_envelope_encryption`: its last inherited caller was the storage performance test removed with the encryption performance suite in [`3e7ba58439`](https://github.com/rails/rails/commit/3e7ba58439a434be5e6894993370a8cef403303e).
- `TransactionTest#transaction_with_return`: its call was removed when Rails dropped the deprecated rollback-on-`return` behavior in [`eccc6061f4`](https://github.com/rails/rails/commit/eccc6061f4f3abdfdeb9a363987a898418d9498f); the still-used shallow-return helper remains.

### Active Support

- `CallbacksTest::ConditionalPerson#other_yes` and `#other_no`: the callback rewrite in [`21e7b84621`](https://github.com/rails/rails/commit/21e7b8462113fc7c0fd1882dcc2bf7225de67b1a) removed the condition arrays that referenced these methods while retaining the declarations.
- `DeprecationTest#with_rails_application_deprecators`: all six callers were removed with deprecated `ActiveSupport::Deprecation` instance delegation in [`c682bf2641`](https://github.com/rails/rails/commit/c682bf26417f2a88b0efa46499e94dcf45955f4f).

### Railties

- `TestHelpers::Paths#framework_path`: its final initializer load-path tests were removed in [`4f6d6f7031`](https://github.com/rails/rails/commit/4f6d6f7031a88b647814fc0154e6b69b636dc912); the shared path helper remained unused.
