### PR TITLE
Restore unregistered tests

### DIFF
--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -322,7 +322,7 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
     assert_equal "turkey", session["xmas"]
   end
 
-  def session_does_not_exist
+  def test_session_does_not_exist
     process :nothing
     assert_empty session
   end

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -1151,7 +1151,7 @@ class FinderTest < ActiveRecord::TestCase
     end
   end
 
-  def first_with_at_least_query_constraints
+  def test_first_with_at_least_query_constraints
     ordered_edge = Class.new(Edge) do
       query_constraints "source_id"
     end

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -276,7 +276,7 @@ class PrimaryKeysTest < ActiveRecord::TestCase
     assert_not_predicate klass, :composite_primary_key?
   end
 
-  def composite_primary_key_is_false_for_a_non_cpk_model
+  def test_composite_primary_key_is_false_for_a_non_cpk_model
     assert_not_predicate Dashboard, :composite_primary_key?
   end
 
@@ -506,7 +506,7 @@ class CompositePrimaryKeyTest < ActiveRecord::TestCase
     assert_equal(["shop_id", "id"], Cpk::Order.primary_key)
   end
 
-  def composite_primary_key_is_true_for_a_cpk_model
+  def test_composite_primary_key_is_true_for_a_cpk_model
     assert_predicate Cpk::Book, :composite_primary_key?
   end
 

--- a/railties/test/generators/authentication_generator_test.rb
+++ b/railties/test/generators/authentication_generator_test.rb
@@ -152,7 +152,7 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
     assert_no_file "test/models/user_test.rb"
   end
 
-  def mailer_preview_is_skipped_if_test_framework_is_given
+  def test_mailer_preview_is_skipped_if_test_framework_is_given
     generator([destination_root], ["-t", "rspec"])
 
     run_generator_instance
@@ -160,7 +160,7 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
     assert_no_file "test/mailers/previews/passwords_mailer_preview.rb"
   end
 
-  def session_test_helper_is_skipped_if_test_framework_is_given
+  def test_session_test_helper_is_skipped_if_test_framework_is_given
     generator([destination_root], ["-t", "rspec"])
 
     run_generator_instance


### PR DESCRIPTION
Register six tests that were missing the `test_` prefix.

Minitest discovers methods matching `/^test_/`. These methods contain assertions, have no callers, and therefore never ran.