### PR TITLE
Remove unused Journey methods

### DIFF
--- a/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
+++ b/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
@@ -54,10 +54,6 @@ module ActionDispatch
           @memos[idx]
         end
 
-        def eclosure(t)
-          Array(t)
-        end
-
         def move(t, full_string, token, start_index, token_matches_default)
           return [] if t.empty?
 
@@ -194,13 +190,6 @@ module ActionDispatch
           else
             raise ArgumentError, "unknown symbol: %s" % sym.class
           end
-        end
-
-        def states
-          ss = @string_states.keys + @string_states.values.flat_map(&:values)
-          ps = @stdparam_states.keys + @stdparam_states.values
-          rs = @regexp_states.keys + @regexp_states.values.flat_map(&:values)
-          (ss + ps + rs).uniq
         end
 
         def transitions

--- a/actionpack/lib/action_dispatch/journey/nodes/node.rb
+++ b/actionpack/lib/action_dispatch/journey/nodes/node.rb
@@ -105,7 +105,6 @@ module ActionDispatch
         def literal?; false; end
         def terminal?; false; end
         def star?; false; end
-        def cat?; false; end
         def group?; false; end
       end
 
@@ -191,7 +190,6 @@ module ActionDispatch
       end
 
       class Cat < Binary # :nodoc:
-        def cat?; true; end
         def type; :CAT; end
       end
 


### PR DESCRIPTION
## Summary

Remove unused public methods from internal Journey classes:

- `ActionDispatch::Journey::GTG::TransitionTable#eclosure`
- `ActionDispatch::Journey::GTG::TransitionTable#states`
- `ActionDispatch::Journey::Nodes::Node#cat?`
- `ActionDispatch::Journey::Nodes::Cat#cat?`

## Context

Rubydex found no resolved references for these methods. There are also no exact string or symbol references, and Ruby LSP reports only their definitions.

The history explains how they became unused:

- `eclosure` supported `NFA::Simulator`; commit [`639f5fda30`](https://github.com/rails/rails/commit/639f5fda302ad6b5d535cf393161e4e77ea5050b) removed that simulator in 2020 and left the GTG compatibility method behind.
- `states` arrived with the Journey integration in [`56fee39c39`](https://github.com/rails/rails/commit/56fee39c392788314c44a575b3fd66e16a50c8b5), but has no Rails caller. DOT rendering uses `transitions` and `accepting_states` instead.
- `cat?` identified concatenation nodes without `is_a?` checks. Commit [`0011e098a1`](https://github.com/rails/rails/commit/0011e098a14fae16fb13cfd9a50659909a645d63) removed its last caller when custom-route regex alteration became unnecessary.
