### PR TITLE
Remove unused Journey endpoints reader

### DIFF
--- a/actionpack/lib/action_dispatch/journey/gtg/builder.rb
+++ b/actionpack/lib/action_dispatch/journey/gtg/builder.rb
@@ -10,7 +10,7 @@ module ActionDispatch
       class Builder # :nodoc:
         DUMMY_END_NODE = Nodes::Dummy.new
 
-        attr_reader :root, :ast, :endpoints
+        attr_reader :root, :ast
 
         def initialize(root)
           @root      = root


### PR DESCRIPTION
Remove unused `ActionDispatch::Journey::GTG::Builder#endpoints`.

It was added when Journey was integrated into Action Dispatch in [`56fee39c39`](https://github.com/rails/rails/commit/56fee39c392788314c44a575b3fd66e16a50c8b5) in 2012. It has never been assigned or called in Rails, so the reader has always returned `nil`.