### PR TITLE
Remove unused HABTM reflection storage

### DIFF
--- a/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
@@ -16,7 +16,6 @@ module ActiveRecord::Associations::Builder # :nodoc:
           attr_accessor :left_model
           attr_accessor :name
           attr_accessor :table_name_resolver
-          attr_accessor :left_reflection
           attr_accessor :right_reflection
         end
 
@@ -33,7 +32,6 @@ module ActiveRecord::Associations::Builder # :nodoc:
 
         def self.add_left_association(name, options)
           belongs_to name, required: false, **options
-          self.left_reflection = _reflect_on_association(name)
         end
 
         def self.add_right_association(name, options)


### PR DESCRIPTION
Remove unused `left_reflection` storage from the internal HABTM join model.

It was added in [`d3089adb1a`](https://github.com/rails/rails/commit/d3089adb1a76d0d0446e914e972cf3ef49964333) in 2013 and used by `middle_options` to populate `:source`. Commit [`b30a23f53b`](https://github.com/rails/rails/commit/b30a23f53b52e59d31358f7b80385ee5c2ba3afe) removed that read in 2019, leaving only the unused assignment.