### PR TITLE
Remove unused TemplateDetails readers

### DIFF
--- a/actionview/lib/action_view/template_details.rb
+++ b/actionview/lib/action_view/template_details.rb
@@ -3,17 +3,11 @@
 module ActionView
   class TemplateDetails # :nodoc:
     class Requested
-      attr_reader :locale, :handlers, :formats, :variants
       attr_reader :locale_idx, :handlers_idx, :formats_idx, :variants_idx
 
       ANY_HASH = Hash.new(1).merge(nil => 0).freeze
 
       def initialize(locale:, handlers:, formats:, variants:)
-        @locale = locale
-        @handlers = handlers
-        @formats = formats
-        @variants = variants
-
         @locale_idx   = build_idx_hash(locale)
         @handlers_idx = build_idx_hash(handlers)
         @formats_idx  = build_idx_hash(formats)


### PR DESCRIPTION
Remove unused raw detail readers and backing instance variables from `ActionView::TemplateDetails::Requested`.

They were added in [`f8f9a085cc`](https://github.com/rails/rails/commit/f8f9a085ccf5930a38d7866ab7b7d6532881521e) in 2021 and used by template matching and sorting. The follow-up index refactor in [`eac19fea2b`](https://github.com/rails/rails/commit/eac19fea2b31f7d5c887fb3aacfc5c8a2e094e5e) switched every consumer to the `*_idx` values, leaving the original readers and instance variables unused.