### PR TITLE
Stop filtering i18n paths on initialize

### DIFF
--- a/activesupport/lib/active_support/i18n_railtie.rb
+++ b/activesupport/lib/active_support/i18n_railtie.rb
@@ -49,7 +49,7 @@ module I18n
         case setting
         when :railties_load_path
           reloadable_paths = value
-          app.config.i18n.load_path.unshift(*value.flat_map(&:existent))
+          app.config.i18n.load_path.unshift(*value.flat_map(&:expanded_files))
         when :load_path
           I18n.load_path += value
         when :raise_on_missing_translations

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Don't filter nonexistent i18n paths on initialize. This negatively impacts
+    applications with lots of translation files.
+
+    *Gannon McGibbon*
+
 *   Validate subcommand in `rails plugin` command.
 
     `rails plugin foo bar` silently ignored the invalid subcommand "foo"

--- a/railties/lib/rails/paths.rb
+++ b/railties/lib/rails/paths.rb
@@ -232,11 +232,15 @@ module Rails
         expanded.select { |d| File.directory?(d) }
       end
 
+      def expanded_files
+        expanded.select { |file| !File.extname(file).empty? }
+      end
+
       alias to_a expanded
 
       private
         def files_in(path)
-          files = Dir.glob(@glob, base: path)
+          files = Dir.glob(@glob, base: path, sort: false)
           files -= @exclude if @exclude
           files.map! { |file| File.join(path, file) }
           files.sort

--- a/railties/test/paths_test.rb
+++ b/railties/test/paths_test.rb
@@ -315,4 +315,14 @@ class PathsIntegrationTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test "expanded_files filters out directories" do
+    Dir.mktmpdir do |dir|
+      root = Rails::Paths::Root.new(dir)
+      root.add "without/config/locales", glob: "**/*.{rb,yml}"
+      without = root["without/config/locales"]
+      assert_equal [File.join(dir, "without", "config", "locales")], without.expanded
+      assert_equal [], without.expanded_files
+    end
+  end
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because i18n loading is slow. the approach of filtering nonexistent translations doesn't work at scale. Apps with thousands of files are significantly slowed down by these file stat checks. It is easier to defer the filtering to when we reload, where we actually need to filter.

While we're here, I also stopped sorting in globs because this is done by Ruby to ensure consistent sorting across platforms.

### Detail

This Pull Request changes path globbing and i18n initializing to do less redundant work.

This cuts i18n loading in my application from 400ms to ~250ms. I expect it to improve other path globbing workflows too:


```rb
$LOAD_PATH.unshift(File.expand_path("railties/lib", __dir__))
require "rails/paths"
require "tmpdir"
require "fileutils"
require "benchmark/ips"

GLOB = "**/*.{rb,yml}"
RAILTIE = File.expand_path("activesupport/lib/active_support/i18n_railtie.rb", __dir__)
RESULTS = File.join(Dir.tmpdir, "rails_i18n_bench.json")

filter_method = File.read(RAILTIE)[/load_path\.unshift\(\*value\.flat_map\(&:(\w+)\)\)/, 1].to_sym

tmp = Dir.mktmpdir("locales_bench")
begin
  locales = File.join(tmp, "config", "locales")
  FileUtils.mkdir_p(locales)
  2000.times { |i| File.write(File.join(locales, "loc#{i}.yml"), "en: {}\n") }
  %w[en es fr models views mailers].each do |sub|
    dir = File.join(locales, sub)
    FileUtils.mkdir_p(dir)
    300.times { |i| File.write(File.join(dir, "f#{i}.yml"), "en: {}\n") }
    50.times  { |i| File.write(File.join(dir, "r#{i}.rb"), "x") }
  end

  root = Rails::Paths::Root.new(tmp)
  root.add "config/locales", glob: GLOB
  path = root["config/locales"]

  puts "checkout method: #{filter_method}  files: #{path.expanded.size}"

  Benchmark.ips do |x|
    x.config(time: 3, warmup: 1)
    x.hold!(RESULTS)
    x.report("main")   { path.public_send(filter_method) }
    x.report("branch") { path.public_send(filter_method) }
    x.compare!
  end
ensure
  FileUtils.rm_rf(tmp)
end

```

```
ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [arm64-darwin25]
Warming up --------------------------------------
              branch    12.000 i/100ms
Calculating -------------------------------------
              branch    119.204 (± 1.7%) i/s    (8.39 ms/i) -    360.000 in   3.021312s

Comparison:
              branch:      119.2 i/s
                main:       74.8 i/s - 1.59x  slower
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
