### PR TITLE
Handle missing credential params in the authentication generator's SessionsController

### DIFF
--- a/railties/lib/rails/generators/rails/authentication/templates/app/controllers/sessions_controller.rb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/controllers/sessions_controller.rb.tt
@@ -6,7 +6,7 @@ class SessionsController < ApplicationController
   end
 
   def create
-    if user = User.authenticate_by(params.permit(:email_address, :password))
+    if user = User.authenticate_by(params.permit(:email_address, :password).with_defaults(email_address: "", password: ""))
       start_new_session_for user
       redirect_to after_authentication_url
     else

--- a/railties/lib/rails/generators/test_unit/authentication/templates/test/controllers/sessions_controller_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/authentication/templates/test/controllers/sessions_controller_test.rb.tt
@@ -22,6 +22,13 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_nil cookies[:session_id]
   end
 
+  test "create without a password param" do
+    post session_path, params: { email_address: @user.email_address }
+
+    assert_redirected_to new_session_path
+    assert_nil cookies[:session_id]
+  end
+
   test "destroy" do
     sign_in_as(@user)
 


### PR DESCRIPTION
### Motivation / Background

The `SessionsController` generated by `rails generate authentication` passes
`params.permit(:email_address, :password)` directly to `User.authenticate_by`.
`authenticate_by` raises `ArgumentError` when it receives no password (or no
identifier) argument, so any login request that omits either key responds
with a 500:

```
$ rails new demo && cd demo
$ bin/rails generate authentication && bin/rails db:prepare
$ curl -i -X POST -d "email_address=user@example.com" localhost:3000/session
# => 500 Internal Server Error
# ArgumentError: One or more password arguments are required
```

A public login endpoint routinely receives malformed requests (bots probing
the endpoint, scripted clients, broken forms). `authenticate_by`'s
`ArgumentError` is designed to flag programmer mistakes such as a misspelled
attribute name — but here the keys come from untrusted request params, so
their absence is user input, not a programming error. Each such request
currently surfaces as an exception in error trackers.

#55166 attempted to harden these templates with `params.expect`, but was
closed because `expect` returns an array for flat keys, which
`authenticate_by` cannot take.

### Detail

Defaults both keys to an empty string:

```ruby
User.authenticate_by(params.permit(:email_address, :password).with_defaults(email_address: "", password: ""))
```

`authenticate_by` short-circuits blank passwords before touching the
database (the timing-safe behavior added in #43958), and a blank identifier
finds no user — so malformed requests now follow the same
"Try another email address or password." redirect as any failed login.
Behavior for well-formed requests is unchanged.

Also adds a test to the generated `SessionsControllerTest` covering the
missing-password case. Against the current template it errors with the
`ArgumentError` above; with this change it passes.

### Additional information

Verified by generating an app, running the generated controller tests
against the stock template (new test errors), then against the patched
template (all green). `railties/test/generators/authentication_generator_test.rb`
passes.

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated.
* [x] CHANGELOG not updated (minor bug fix, per contributing guide).
