### PR TITLE
Reject blank passwords in the authentication generator's PasswordsController

### DIFF
--- a/railties/lib/rails/generators/rails/authentication/templates/app/controllers/passwords_controller.rb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/controllers/passwords_controller.rb.tt
@@ -22,7 +22,9 @@ class PasswordsController < ApplicationController
   end
 
   def update
-    if @user.update(params.permit(:password, :password_confirmation))
+    if params[:password].blank?
+      redirect_to edit_password_path(params[:token]), alert: "Password can't be blank."
+    elsif @user.update(params.permit(:password, :password_confirmation))
       @user.sessions.destroy_all
       redirect_to new_session_path, notice: "Password has been reset."
     else

--- a/railties/lib/rails/generators/test_unit/authentication/templates/test/controllers/passwords_controller_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/authentication/templates/test/controllers/passwords_controller_test.rb.tt
@@ -62,6 +62,17 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
     assert_notice "Passwords did not match"
   end
 
+  test "update with a blank password" do
+    token = @user.password_reset_token
+    assert_no_changes -> { @user.reload.password_digest } do
+      put password_path(token), params: { password: "", password_confirmation: "" }
+      assert_redirected_to edit_password_path(token)
+    end
+
+    follow_redirect!
+    assert_notice "Password can't be blank"
+  end
+
   private
     def assert_notice(text)
       assert_select "div", /#{text}/


### PR DESCRIPTION
### Motivation / Background

Submitting the password reset form generated by `rails generate authentication`
with both fields left blank takes the success path: every session is
destroyed, the user sees "Password has been reset." — and the password was
never changed.

```
$ rails new demo && cd demo
$ bin/rails generate authentication && bin/rails db:prepare
# request a reset token, then:
$ curl -i -X PUT -d "password=&password_confirmation=" localhost:3000/passwords/<token>
# => 302 to /session/new, flash: "Password has been reset."
# password_digest unchanged, all sessions destroyed
```

This happens because `has_secure_password` deliberately ignores an
empty-string assignment (so that "leave the field blank to keep the current
password" works in profile forms), which means no validation ever sees the
blank value: the digest is untouched, the confirmation check is skipped via
`allow_blank`, and `@user.update` succeeds vacuously. The user is then told
their password was reset, cannot sign in with what they typed, and — since
#54524 — has had every other session terminated as well.

### Detail

Rejects a blank password up front and re-renders the form with a
"Password can't be blank." alert, mirroring the existing
non-matching-confirmation failure path:

```ruby
def update
  if params[:password].blank?
    redirect_to edit_password_path(params[:token]), alert: "Password can't be blank."
  elsif @user.update(params.permit(:password, :password_confirmation))
    ...
```

Also adds a test to the generated `PasswordsControllerTest` asserting the
digest does not change and the request redirects back to the edit form.
Against the current template it fails (the request redirects to the success
path); with this change it passes.

### Additional information

Verified by generating an app, running the generated controller tests
against the stock template (new test fails), then against the patched
template (all green). `railties/test/generators/authentication_generator_test.rb`
passes.

Note: a `nil` password (e.g. `"password": null` from a JSON client) is
already handled — assigning `nil` clears the digest and the model's
digest-presence validation rejects the update. Only the empty string slips
through, which is exactly what an empty form submission sends.

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated.
* [x] CHANGELOG not updated (minor bug fix, per contributing guide).
