### PR TITLE
Generate an omakase-compliant config/ci.rb when steps are skipped

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/ci.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/ci.rb.tt
@@ -7,7 +7,6 @@ CI.run do
 <% unless options.skip_rubocop? -%>
     step "Style: Ruby", "bin/rubocop"
 <% end -%>
-
 <% unless options.skip_bundler_audit? -%>
     step "Security: Gem audit", "bin/bundler-audit"
 <% end -%>
@@ -20,8 +19,8 @@ CI.run do
 <% unless options.skip_brakeman? -%>
     step "Security: Brakeman code analysis", "bin/brakeman --quiet --no-pager --exit-on-warn --exit-on-error"
 <% end -%>
-
 <% unless options[:skip_test] -%>
+
     group "Tests" do
       step "Tests: Rails", "bin/rails test"
 <% unless options.skip_active_record? -%>


### PR DESCRIPTION
After `bin/rails new --skip-test`, a freshly generated app fails its own `bin/rubocop` (and the "Style: Ruby" step of the generated `bin/ci`) with a `Layout/EmptyLinesAroundBlockBody` offense in `config/ci.rb`, because the blank line separating the security checks from the test group is left behind at the end of the "Checks" group when no test group is generated:

```
config/ci.rb:12:1: C: [Correctable] Layout/EmptyLinesAroundBlockBody: Extra empty line detected at block body end.
```

With this change the separator blank lines are only emitted when there is a step on both sides, so every combination of `--skip-rubocop` / `--skip-bundler-audit` / `--skip-javascript` / `--skip-brakeman` / `--skip-test` renders a `config/ci.rb` that passes RuboCop with zero offenses. The only change to the default output is that the blank line between the Brakeman step and the "Tests" group is gone.

Same class as #58164, which fixed the routes injected by the authentication generator so that a fresh app passes its own RuboCop again.