### PR TITLE
Prevent render_to_string from changing content type

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Fix `render_to_string` changing the content type of a subsequent render.
+
+    Renderers such as the JSON renderer set the response content type while
+    producing their body. `render_to_string` now restores the original
+    `Content-Type` header after rendering.
+
+    *Nikita Vasilevsky*
+
 *   Deprecate `ActionDispatch::Cookies::HTTP_HEADER`.
 
     Use `Rack::SET_COOKIE` instead.

--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -182,7 +182,14 @@ module ActionController
     # instead of setting `self.response_body`.
     #--
     # Override render_to_string because body can now be set to a Rack body.
+    #
+    # Renderers such as +:json+ set the response's +Content-Type+ as a side
+    # effect. Since +render_to_string+ only returns a string and must not mutate
+    # the response, snapshot and restore the +Content-Type+ header around the
+    # render so the leaked type does not carry over to a subsequent +render+.
     def render_to_string(*)
+      rendering_response = response
+      original_content_type = rendering_response&.get_header(ActionDispatch::Response::CONTENT_TYPE)
       result = super
       if result.respond_to?(:each)
         string = +""
@@ -190,6 +197,14 @@ module ActionController
         string
       else
         result
+      end
+    ensure
+      if rendering_response
+        if original_content_type
+          rendering_response.set_header(ActionDispatch::Response::CONTENT_TYPE, original_content_type)
+        else
+          rendering_response.delete_header(ActionDispatch::Response::CONTENT_TYPE)
+        end
       end
     end
 

--- a/actionpack/test/controller/render_to_string_test.rb
+++ b/actionpack/test/controller/render_to_string_test.rb
@@ -24,11 +24,6 @@ class RenderToStringTest < ActionController::TestCase
       render plain: render_to_string(json: "[]")
     end
 
-    def test_render_json_render_to_string
-      get :render_json_render_to_string
-      assert_equal "[]", @response.body
-    end
-
     def render_plain_text_response_with_inline_template_and_xml_format
       render_to_string(inline: "<language>Ruby</language>", formats: [:xml])
       render plain: "Hello"
@@ -54,8 +49,9 @@ class RenderToStringTest < ActionController::TestCase
     assert_equal "application/json", @response.media_type
   end
 
-  def render_json_render_to_string
-    render plain: render_to_string(json: "[]")
+  def test_render_json_render_to_string
+    get :render_json_render_to_string
+    assert_equal "[]", @response.body
     assert_equal "text/plain", @response.media_type
   end
 


### PR DESCRIPTION
Preserve the response Content-Type header around render_to_string so renderers such as JSON cannot affect a subsequent render.

Repair and register the regression test, which never ran: one half was misplaced as an instance method inside the controller class and the other was misnamed on the test case (missing the `test_` prefix), so neither was collected by the runner. Merge them into a single `test_render_json_render_to_string` that asserts both the body and the `text/plain` media type.