### PR TITLE
Remove unused `WhereClause#referenced_columns`

### DIFF
--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -116,12 +116,6 @@ module ActiveRecord
       protected
         attr_reader :predicates
 
-        def referenced_columns
-          hash = {}
-          each_attributes { |attr, node| hash[attr] = node }
-          hash
-        end
-
       private
         def each_attributes
           predicates.each do |node|


### PR DESCRIPTION
`WhereClause#referenced_columns` has been unused since c313d9161360 removed its only caller, `predicates_unreferenced_by`, together with the deprecated support for passing `rewhere` to `ActiveRecord::Relation#merge`.