### PR TITLE
Flatten block content inside links in Action Text markdown conversion

### DIFF
--- a/actiontext/lib/action_text/markdown_conversion.rb
+++ b/actiontext/lib/action_text/markdown_conversion.rb
@@ -193,10 +193,16 @@ module ActionText
       def visit_a(node, child_values)
         inner = join_children(child_values)
         if (href = node["href"]) && Rails::HTML::Sanitizer.allowed_uri?(href)
-          "[#{inner}](#{encode_href(href)})"
+          "[#{flatten_to_inline(inner)}](#{encode_href(href)})"
         else
           inner
         end
+      end
+
+      def flatten_to_inline(text)
+        return text unless text.match?(/[\r\n]/)
+
+        text.gsub(/[\r\n]+/, " ")
       end
 
       def visit_tr(node, child_values)

--- a/actiontext/test/unit/markdown_conversion_test.rb
+++ b/actiontext/test/unit/markdown_conversion_test.rb
@@ -593,6 +593,128 @@ class ActionText::MarkdownConversionTest < ActiveSupport::TestCase
     assert_converted_to("click here", '<a href="&#10;javascript:alert(1)">click here</a>')
   end
 
+  test "<a> tags preserve boundary whitespace in link text" do
+    assert_converted_to(
+      "before[ link ](/x)after",
+      'before<a href="/x"> link </a>after'
+    )
+  end
+
+  test "<a> tags containing <pre> are flattened into an inline code span" do
+    assert_converted_to(
+      "[``` puts 1 ``` ](https://example.com)",
+      '<a href="https://example.com"><pre>puts 1</pre></a>'
+    )
+  end
+
+  test "<a> tags containing multiline <pre> are flattened into an inline code span" do
+    assert_converted_to(
+      "[``` line one line two ``` ](https://example.com)",
+      "<a href=\"https://example.com\"><pre>line one\nline two</pre></a>"
+    )
+  end
+
+  test "<a> tags containing <pre> with backticks are flattened into an inline code span" do
+    assert_converted_to(
+      "[```` a ``` b ```` ](https://example.com)",
+      '<a href="https://example.com"><pre>a ``` b</pre></a>'
+    )
+  end
+
+  test "<a> tags containing <p> are flattened into link text" do
+    assert_converted_to(
+      "[text ](https://example.com)",
+      '<a href="https://example.com"><p>text</p></a>'
+    )
+  end
+
+  test "<a> tags containing multiple <p> are flattened into link text" do
+    assert_converted_to(
+      "[one two ](https://example.com)",
+      '<a href="https://example.com"><p>one</p><p>two</p></a>'
+    )
+  end
+
+  test "<a> tags containing <h1> are flattened into link text" do
+    assert_converted_to(
+      "[# heading ](https://example.com)",
+      '<a href="https://example.com"><h1>heading</h1></a>'
+    )
+  end
+
+  test "<a> tags containing <blockquote> are flattened into link text" do
+    assert_converted_to(
+      "[> quoted ](https://example.com)",
+      '<a href="https://example.com"><blockquote>quoted</blockquote></a>'
+    )
+  end
+
+  test "<a> tags containing <ul> are flattened into link text" do
+    assert_converted_to(
+      "[- item ](https://example.com)",
+      '<a href="https://example.com"><ul><li>item</li></ul></a>'
+    )
+  end
+
+  test "<a> tags containing <ul> with multiple items are flattened into link text" do
+    assert_converted_to(
+      "[- one - two ](https://example.com)",
+      '<a href="https://example.com"><ul><li>one</li><li>two</li></ul></a>'
+    )
+  end
+
+  test "<a> tags containing <ol> are flattened into link text" do
+    assert_converted_to(
+      "[1. item ](https://example.com)",
+      '<a href="https://example.com"><ol><li>item</li></ol></a>'
+    )
+  end
+
+  test "<a> tags containing <pre> with CRLF line endings are flattened into an inline code span" do
+    assert_converted_to(
+      "[``` line one line two ``` ](https://example.com)",
+      "<a href=\"https://example.com\"><pre>line one\r\nline two</pre></a>"
+    )
+  end
+
+  test "<a> tags containing <pre> with CR line endings are flattened into an inline code span" do
+    assert_converted_to(
+      "[``` line one line two ``` ](https://example.com)",
+      "<a href=\"https://example.com\"><pre>line one\rline two</pre></a>"
+    )
+  end
+
+  test "<a> tags containing <pre> with CR line endings from an HTML4-parsed fragment are flattened" do
+    fragment = Nokogiri::HTML4.fragment("<a href=\"https://example.com\"><pre>line one\rline two</pre></a>")
+    assert_equal "[``` line one line two ``` ](https://example.com)", ActionText::MarkdownConversion.node_to_markdown(fragment)
+  end
+
+  test "<a> tags containing <pre> with CRLF line endings from an HTML4-parsed fragment are flattened" do
+    fragment = Nokogiri::HTML4.fragment("<a href=\"https://example.com\"><pre>line one\r\nline two</pre></a>")
+    assert_equal "[``` line one line two ``` ](https://example.com)", ActionText::MarkdownConversion.node_to_markdown(fragment)
+  end
+
+  test "<a> tags containing <br> are flattened into link text" do
+    assert_converted_to(
+      "[one two](https://example.com)",
+      '<a href="https://example.com">one<br>two</a>'
+    )
+  end
+
+  test "<a> tags with javascript: href containing <p> pass through content without flattening" do
+    assert_converted_to(
+      "one\n\ntwo",
+      '<a href="javascript:alert(1)"><p>one</p><p>two</p></a>'
+    )
+  end
+
+  test "<a> tags without href containing <p> pass through content without flattening" do
+    assert_converted_to(
+      "one\n\ntwo",
+      "<a><p>one</p><p>two</p></a>"
+    )
+  end
+
   test "<table> with <thead> is converted to markdown table" do
     assert_converted_to(
       "| Name | Age |\n| --- | --- |\n| Alice | 30 |",


### PR DESCRIPTION
### Motivation / Background

`ActionText::Content#to_markdown` produces invalid CommonMark when a block-level element is nested inside an `<a>`. HTML allows an anchor to wrap block-level content because `<a>` has a transparent content model, but CommonMark defines link text as ["a sequence of zero or more inline elements"](https://spec.commonmark.org/0.31.2/#links), so there is no Markdown representation of a link whose text is a block.

The problem lives in `visit_a` in `actiontext/lib/action_text/markdown_conversion.rb`, which assumes its children produce inline output:

    "[#{inner}](#{encode_href(href)})"

The block visitors violate that assumption: `visit_pre` emits a fenced code block, and `visit_p`, `visit_blockquote`, the heading visitors, and the list visitors all append a paragraph-separating blank line. A blank line inside link text severs the link, because Markdown resolves block structure before it parses inline links.

### Detail

CommonMark provides no way to encode a block-level element inside a link, so the best the conversion can do is approximate the intent of the original HTML. This change keeps the link and degrades its contents to inline text.

`visit_a` now flattens its children's joined output onto a single line, replacing each run of newlines with a space, before wrapping it in link syntax. When the anchor does not produce a link because the `href` is missing or disallowed, the content passes through unchanged with its block structure intact.

For example, `<a href="https://example.com"><pre>puts 1</pre></a>` previously produced

    [```
    puts 1
    ```

    ](https://example.com)

in which the fenced code block and the blank line sever the link. Now it produces

    [``` puts 1 ``` ](https://example.com)

which is a valid inline code span inside a valid link, and renders as a link whose text is the code `puts 1`. Other block elements flatten the same way, keeping their markers as literal link text: `<a href="https://example.com"><h1>heading</h1></a>` produces `[# heading ](https://example.com)`.

### Additional information

`to_markdown` is unreleased, added in [#56858](https://github.com/rails/rails/pull/56858), so this is not a behavior change for any released version and no CHANGELOG entry is needed.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
