### PR TITLE
Pass scheme to token authentication block in http_atthentication

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   Allow HTTP token authentication to require specific authentication schemes.
+
+    Pass `scheme:` to `authenticate_or_request_with_http_token` (and the other
+    token authentication methods) with a scheme name, or an array of names, to
+    require one of those schemes and use them in the `WWW-Authenticate`
+    challenge:
+
+    ```ruby
+    authenticate_or_request_with_http_token(scheme: ["Bearer", "DPoP"]) do |token, options, scheme|
+      # ...
+    end
+    ```
+
+    Any scheme name can be required. Without `scheme:`, `Token`, `Bearer`, and
+    `DPoP` are accepted. The request's scheme is yielded to the authentication
+    block as a downcased symbol in an optional third argument.
+
+    *Chad Cole*
+
 *   Fix route recognition still matching routes that were removed by redrawing
     a route set as empty.
 

--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -425,34 +425,43 @@ module ActionController
     #
     #     RewriteRule ^(.*)$ dispatch.fcgi [E=X-HTTP_AUTHORIZATION:%{HTTP:Authorization},QSA,L]
     module Token
+      SCHEMES = ["Token", "Bearer", "DPoP"].freeze
       TOKEN_KEY = "token="
-      TOKEN_REGEX = /^(Token|Bearer)\s+/i
+      # Matches an RFC 9110 auth-scheme (a `token`: ALPHA / DIGIT / tchar symbols).
+      AUTH_SCHEME_REGEX = /^([0-9A-Za-z!#$%&'*+\-.^_`|~]+)\s+/
       AUTHN_PAIR_DELIMITERS = /(?:,|;|\t)/
       extend self
 
       module ControllerMethods
-        # Authenticate using an HTTP Bearer token, or otherwise render an HTTP header
-        # requesting the client to send a Bearer token. For the authentication to be
+        # Authenticate using an HTTP token, or otherwise render an HTTP header
+        # requesting the client to send a token. For the authentication to be
         # considered successful, `login_procedure` must not return a false value.
         # Typically, the authenticated user is returned.
         #
+        # The optional `scheme` restricts authentication to that scheme (or any of
+        # them, when given an array) and uses it verbatim for the WWW-Authenticate
+        # response header. Any scheme name can be required. When no `scheme` is
+        # given, `"Token"`, `"Bearer"`, and `"DPoP"` are accepted. The request's
+        # authentication scheme is yielded as a downcased symbol in an optional
+        # third argument to `login_procedure`.
+        #
         # See ActionController::HttpAuthentication::Token for example usage.
-        def authenticate_or_request_with_http_token(realm = "Application", message = nil, content_type = nil, &login_procedure)
-          authenticate_with_http_token(&login_procedure) || request_http_token_authentication(realm, message, content_type)
+        def authenticate_or_request_with_http_token(realm = "Application", message = nil, content_type = nil, scheme: nil, &login_procedure)
+          authenticate_with_http_token(scheme:, &login_procedure) || request_http_token_authentication(realm, message, content_type, scheme:)
         end
 
-        # Authenticate using an HTTP Bearer token. Returns the return value of
+        # Authenticate using an HTTP token. Returns the return value of
         # `login_procedure` if a token is found. Returns `nil` if no token is found.
         #
         # See ActionController::HttpAuthentication::Token for example usage.
-        def authenticate_with_http_token(&login_procedure)
-          Token.authenticate(self, &login_procedure)
+        def authenticate_with_http_token(scheme: nil, &login_procedure)
+          Token.authenticate(self, scheme:, &login_procedure)
         end
 
-        # Render an HTTP header requesting the client to send a Bearer token for
+        # Render an HTTP header requesting the client to send a token for
         # authentication.
-        def request_http_token_authentication(realm = "Application", message = nil, content_type = nil)
-          Token.authentication_request(self, realm, message, content_type)
+        def request_http_token_authentication(realm = "Application", message = nil, content_type = nil, scheme: nil)
+          Token.authentication_request(self, realm, message, content_type, scheme:)
         end
       end
 
@@ -465,22 +474,30 @@ module ActionController
       # #### Parameters
       #
       # *   `controller` - ActionController::Base instance for the current request.
+      # *   `scheme` - Optional authentication scheme (or array of schemes) to
+      #     allow. Defaults to `SCHEMES`.
       # *   `login_procedure` - Proc to call if a token is present. The Proc should
-      #     take two arguments:
+      #     take two or three arguments:
       #
-      #         authenticate(controller) { |token, options| ... }
+      #         authenticate(controller) { |token, options, scheme| ... }
       #
+      #     The third argument contains the downcased authentication scheme from the
+      #     request, e.g. `:token`, `:bearer`, or `:dpop`.
       #
-      def authenticate(controller, &login_procedure)
-        token, options = token_and_options(controller.request)
-        unless token.blank?
-          login_procedure.call(token, options)
+      def authenticate(controller, scheme: nil, &login_procedure)
+        request = controller.request
+        request_scheme = normalize_scheme(request.authorization.to_s[AUTH_SCHEME_REGEX, 1])
+        schemes = normalize_schemes(scheme.presence || SCHEMES)
+
+        token, options = token_and_options(request)
+        unless token.blank? || !schemes.include?(request_scheme)
+          login_procedure.call(token, options, request_scheme)
         end
       end
 
       # Parses the token and options out of the token Authorization header. The value
-      # for the Authorization header is expected to have the prefix `"Token"` or
-      # `"Bearer"`. If the header looks like this:
+      # for the Authorization header is expected to have the scheme name as a prefix,
+      # for example `"Token"`, `"Bearer"` or `"DPoP"`. If the header looks like this:
       #
       #     Authorization: Token token="abc", nonce="def"
       #
@@ -495,7 +512,7 @@ module ActionController
       #
       def token_and_options(request)
         authorization_request = request.authorization.to_s
-        if authorization_request[TOKEN_REGEX]
+        if authorization_request[AUTH_SCHEME_REGEX]
           params = token_params_from authorization_request
           [params.shift[1], Hash[params].with_indifferent_access]
         end
@@ -519,7 +536,7 @@ module ActionController
       # the standardized `,`, `;`, or `\t` delimiters defined in
       # `AUTHN_PAIR_DELIMITERS`.
       def raw_params(auth)
-        _raw_params = auth.sub(TOKEN_REGEX, "").split(AUTHN_PAIR_DELIMITERS).map(&:strip)
+        _raw_params = auth.sub(AUTH_SCHEME_REGEX, "").split(AUTHN_PAIR_DELIMITERS).map(&:strip)
         _raw_params.reject!(&:empty?)
 
         if !_raw_params.first&.start_with?(TOKEN_KEY)
@@ -553,12 +570,26 @@ module ActionController
       #
       # *   `controller` - ActionController::Base instance for the outgoing response.
       # *   `realm` - String realm to use in the header.
+      # *   `scheme` - Optional authentication scheme (or array of schemes) to use
+      #     in the header, verbatim. Multiple schemes are emitted as separate
+      #     challenges. Defaults to `"Token"`.
       #
-      def authentication_request(controller, realm, message = nil, content_type = nil)
+      def authentication_request(controller, realm, message = nil, content_type = nil, scheme: nil)
+        schemes = Array(scheme).presence || ["Token"]
         message ||= "HTTP Token: Access denied.\n"
-        controller.headers["WWW-Authenticate"] = %(Token realm="#{realm.tr('"', "")}")
+        challenges = schemes.map { |s| %(#{s} realm="#{realm.tr('"', "")}") }
+        controller.headers["WWW-Authenticate"] = challenges.join(", ")
         controller.__send__ :render, plain: message, status: :unauthorized, content_type: content_type
       end
+
+      private
+        def normalize_schemes(schemes)
+          Array(schemes).map { |scheme| normalize_scheme(scheme) }
+        end
+
+        def normalize_scheme(scheme)
+          scheme&.to_s&.downcase&.to_sym
+        end
     end
   end
 end

--- a/actionpack/test/controller/http_token_authentication_test.rb
+++ b/actionpack/test/controller/http_token_authentication_test.rb
@@ -7,9 +7,24 @@ class HttpTokenAuthenticationTest < ActionController::TestCase
     before_action :authenticate, only: :index
     before_action :authenticate_with_request, only: :display
     before_action :authenticate_long_credentials, only: :show
+    before_action :authenticate_dpop, only: :dpop
+    before_action :authenticate_bearer_or_dpop, only: :bearer_or_dpop
+    before_action :authenticate_private_token, only: :private_token
 
     def index
       render plain: "Hello Secret"
+    end
+
+    def dpop
+      render plain: "Hello #{@authentication_scheme}"
+    end
+
+    def bearer_or_dpop
+      render plain: "Hello #{@authentication_scheme}"
+    end
+
+    def private_token
+      render plain: "Hello #{@authentication_scheme}"
     end
 
     def display
@@ -38,6 +53,27 @@ class HttpTokenAuthenticationTest < ActionController::TestCase
       def authenticate_long_credentials
         authenticate_or_request_with_http_token do |token, options|
           token == "1234567890123456789012345678901234567890" && options[:algorithm] == "test"
+        end
+      end
+
+      def authenticate_dpop
+        authenticate_or_request_with_http_token(scheme: "DPoP") do |token, _, scheme|
+          @authentication_scheme = scheme
+          token == "lifo"
+        end
+      end
+
+      def authenticate_bearer_or_dpop
+        authenticate_or_request_with_http_token(scheme: ["Bearer", "DPoP"]) do |token, _, scheme|
+          @authentication_scheme = scheme
+          token == "lifo"
+        end
+      end
+
+      def authenticate_private_token
+        authenticate_or_request_with_http_token(scheme: "PrivateToken") do |token, _, scheme|
+          @authentication_scheme = scheme
+          token == "lifo"
         end
       end
   end
@@ -105,8 +141,60 @@ class HttpTokenAuthenticationTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "successful authentication request with DPoP" do
+    @request.env["HTTP_AUTHORIZATION"] = "DPoP lifo"
+    get :index
+
+    assert_response :success
+  end
+
+  test "DPoP authentication request without credentials" do
+    get :dpop
+
+    assert_response :unauthorized
+    assert_equal 'DPoP realm="Application"', @response.headers["WWW-Authenticate"]
+  end
+
+  test "authentication can be restricted to DPoP" do
+    @request.env["HTTP_AUTHORIZATION"] = "Bearer lifo"
+    get :dpop
+
+    assert_response :unauthorized
+    assert_equal 'DPoP realm="Application"', @response.headers["WWW-Authenticate"]
+  end
+
+  test "successful authentication when restricted to DPoP" do
+    @request.env["HTTP_AUTHORIZATION"] = "DPoP lifo"
+    get :dpop
+
+    assert_response :success
+    assert_equal "Hello dpop", @response.body
+  end
+
+  test "authentication can be restricted to multiple schemes" do
+    @request.env["HTTP_AUTHORIZATION"] = "Token lifo"
+    get :bearer_or_dpop
+
+    assert_response :unauthorized
+    assert_equal 'Bearer realm="Application", DPoP realm="Application"', @response.headers["WWW-Authenticate"]
+  end
+
+  test "successful authentication with any of multiple schemes" do
+    @request.env["HTTP_AUTHORIZATION"] = "Bearer lifo"
+    get :bearer_or_dpop
+
+    assert_response :success
+    assert_equal "Hello bearer", @response.body
+
+    @request.env["HTTP_AUTHORIZATION"] = "DPoP lifo"
+    get :bearer_or_dpop
+
+    assert_response :success
+    assert_equal "Hello dpop", @response.body
+  end
+
   test "successful authentication request with case-insensitive scheme" do
-    ["bearer lifo", "BEARER lifo", "token lifo", "TOKEN lifo"].each do |header|
+    ["bearer lifo", "BEARER lifo", "token lifo", "TOKEN lifo", "dpop lifo", "DPOP lifo"].each do |header|
       @request.env["HTTP_AUTHORIZATION"] = header
       get :index
 
@@ -139,6 +227,36 @@ class HttpTokenAuthenticationTest < ActionController::TestCase
     assert_equal "Authentication Failed\n", @response.body
     assert_equal "application/json", @response.media_type
     assert_equal 'Token realm="SuperSecret"', @response.headers["WWW-Authenticate"]
+  end
+
+  test "authenticate ignores the scheme argument for two-parameter blocks" do
+    controller = Struct.new(:request).new(sample_request("token"))
+
+    result = ActionController::HttpAuthentication::Token.authenticate(controller) { |token, options| token }
+
+    assert_equal "token", result
+  end
+
+  test "authentication rejects unknown schemes by default" do
+    @request.env["HTTP_AUTHORIZATION"] = "Basic lifo"
+    get :index
+
+    assert_response :unauthorized
+  end
+
+  test "authentication can require a custom scheme" do
+    @request.env["HTTP_AUTHORIZATION"] = "PrivateToken lifo"
+    get :private_token
+
+    assert_response :success
+    assert_equal "Hello privatetoken", @response.body
+  end
+
+  test "custom scheme challenge uses the scheme name verbatim" do
+    get :private_token
+
+    assert_response :unauthorized
+    assert_equal 'PrivateToken realm="Application"', @response.headers["WWW-Authenticate"]
   end
 
   test "token_and_options returns correct token" do


### PR DESCRIPTION

This Pull Request has been created because Rails drops token scheme information in http_authentication

### Detail

This Pull Request changes action controller's token authentication to allow `scheme` to be passed into the block used by controllers to perform token based authentication. 

For example, in `authenticate_or_request_with_http_token` and the other token authentication methods, `scheme` is yielded to the authentication block as a normalized symbol in an optional third argument.

Additionally, this PR adds support to allow controllers to require a certain scheme. When the scheme requirement is not met, the controller can now respond with the appropriate RFC 9110 WWW-Authenticate challenge.

The impetus for this is adding the `DPoP` scheme. The DPoP spec (RFC 9449) requires that controllers validate scheme specific details like a proof header.

To do this cleanly, it makes sense for the rails layer to forward the token scheme to the application layer.

Note that this commit does not implement the DPoP RFC, just allows the token scheme in authentication.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
