### PR TITLE
Carry `form` and `disabled` onto a multiple `file_field`'s hidden field

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Carry `form` and `disabled` onto a multiple `file_field`'s hidden field.
+
+    A multiple file field with `include_hidden: true` renders a companion empty
+    hidden input so that clearing all files still submits a blank value. That
+    hidden input now mirrors the file field's `form` and `disabled` attributes,
+    matching `check_box` and multiple `select`.
+
+    *Said Kaldybaev*
+
 *   Extract `current_page?`, `button_to`, and `link_to` methods to
     `ActionView::Helpers::NavigationHelper`
 

--- a/actionview/lib/action_view/helpers/tags/file_field.rb
+++ b/actionview/lib/action_view/helpers/tags/file_field.rb
@@ -21,7 +21,7 @@ module ActionView
 
         private
           def hidden_field_for_multiple_file(options)
-            tag_options = { "name" => options["name"], "type" => "hidden", "value" => "" }
+            tag_options = options.slice("name", "disabled", "form").merge!("type" => "hidden", "value" => "")
             tag_options["autocomplete"] = "off" unless ActionView::Base.remove_hidden_field_autocomplete
             tag("input", tag_options)
           end

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -607,6 +607,18 @@ class FormHelperTest < ActionView::TestCase
     end
   end
 
+  def test_file_field_with_multiple_include_hidden_carries_form
+    expected = '<input type="hidden" name="import[file][]" value="" autocomplete="off" form="my_form">' \
+               '<input id="import_file" multiple="multiple" name="import[file][]" type="file" form="my_form" />'
+    assert_dom_equal expected, file_field("import", "file", multiple: true, include_hidden: true, form: "my_form")
+  end
+
+  def test_file_field_with_multiple_include_hidden_carries_disabled
+    expected = '<input type="hidden" name="import[file][]" value="" autocomplete="off" disabled="disabled">' \
+               '<input id="import_file" multiple="multiple" name="import[file][]" type="file" disabled="disabled" />'
+    assert_dom_equal expected, file_field("import", "file", multiple: true, include_hidden: true, disabled: true)
+  end
+
   def test_file_field_with_direct_upload_when_rails_direct_uploads_url_is_not_defined
     expected = '<input type="file" name="import[file]" id="import_file" />'
     assert_dom_equal expected, file_field("import", "file", direct_upload: true)


### PR DESCRIPTION
### Summary

A multiple `file_field` rendered with `include_hidden: true` produces two elements: the `<input type="file">` itself and a companion empty hidden `<input>` (so that clearing every selected file still submits a blank value). The file input honored `form:` and `disabled:`, but the hidden field did not:

```erb
<%= file_field :import, :file, multiple: true, include_hidden: true, form: "my_form" %>
```

Before:

```html
<input type="hidden" name="import[file][]" value="" autocomplete="off">
<input type="file" multiple="multiple" name="import[file][]" id="import_file" form="my_form">
```

After:

```html
<input type="hidden" name="import[file][]" value="" autocomplete="off" form="my_form">
<input type="file" multiple="multiple" name="import[file][]" id="import_file" form="my_form">
```

When the file field lives outside the `<form>` it targets via the `form` attribute, the browser only submits the hidden field if it is associated with that form too. Without it, clearing all files no longer sends an empty value. The same applies to `disabled:` — a disabled file input must not still submit an empty value from an enabled hidden companion.

### Why this is correct

This matches the sibling hidden-field companions, which already carry `form` and `disabled`:

- `check_box` — slices `"name", "disabled", "form"` onto its hidden field
- multiple `select` — carries `disabled` and `form` onto its hidden field (#58064)

The multiple `file_field` hidden field was the only one omitting them. The change is purely additive: when neither option is given the attributes are absent and the tag helper omits them, so existing output is unchanged.