### PR TITLE
Preserve sub-second precision when subtracting a `DateTime` from a `Time`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Preserve sub-second precision when subtracting a `DateTime` from a `Time`.
+
+    `Time - DateTime` converted both sides via `to_f`, so microsecond-level
+    `DateTime` values lost precision. The difference is now computed from exact
+    rational timestamps, matching `Time.at(DateTime)` and
+    `ActiveSupport::TimeWithZone - DateTime`.
+
+    *Said Kaldybaev*
+
 *   Deprecate `ActiveSupport::Cache::RedisCacheStore::DEFAULT_REDIS_OPTIONS`.
 
     The `redis-client` implementation no longer reads this constant. Pass

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -313,7 +313,14 @@ class Time
   # are coerced into values that Time#- will recognize
   def minus_with_coercion(other)
     other = other.comparable_time if other.respond_to?(:comparable_time)
-    other.is_a?(DateTime) ? to_f - other.to_f : minus_without_coercion(other)
+    if other.is_a?(DateTime)
+      # Prefer an exact rational difference: Float (to_f) cannot represent every
+      # microsecond, so sub-second DateTime values lost precision (same class of
+      # issue as Time.at with DateTime).
+      to_r - other.to_i - other.sec_fraction
+    else
+      minus_without_coercion(other)
+    end
   end
   alias_method :minus_without_coercion, :-
   alias_method :-, :minus_with_coercion # rubocop:disable Lint/DuplicateMethods

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -1268,6 +1268,14 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal 86_400.0, Time.utc(2000, 1, 2) - DateTime.civil(2000, 1, 1)
   end
 
+  def test_minus_with_datetime_sub_second_precision
+    dt = DateTime.civil(2000, 1, 1, 0, 0, Rational(1, 1_000_000), "+0") # .000001s
+    assert_equal Rational(999_999, 1_000_000), Time.utc(2000, 1, 1, 0, 0, 1) - dt
+
+    dt = DateTime.civil(2000, 1, 1, 0, 0, Rational(123_457, 1_000_000), "+0")
+    assert_equal Rational(876_543, 1_000_000), Time.utc(2000, 1, 1, 0, 0, 1) - dt
+  end
+
   def test_time_created_with_local_constructor_cannot_represent_times_during_hour_skipped_by_dst
     with_env_tz "US/Eastern" do
       # On Apr 2 2006 at 2:00AM in US, clocks were moved forward to 3:00AM.


### PR DESCRIPTION
### Summary

`Time - DateTime` (ActiveSupport layers this on top of `Time#-`) converted both sides via `Float` (`to_f`). A `Float` cannot represent every microsecond exactly, so the resulting difference was wrong for roughly half of all sub-second `DateTime` values.

### Before / After

```ruby
t  = Time.utc(2000, 1, 1, 0, 0, 1)
dt = DateTime.civil(2000, 1, 1, 0, 0, Rational(1, 1_000_000), "+0") # .000001s
t - dt
# before => 0.9999990463256836
# after  => (999999/1000000)

dt = DateTime.civil(2000, 1, 1, 0, 0, Rational(123_457, 1_000_000), "+0")
t - dt
# before => 0.8765430450439453
# after  => (876543/1000000)
```

Whole-second differences are unchanged (`Time.utc(2000, 1, 2) - DateTime.civil(2000, 1, 1)` is still `86400`).

### Why this is correct

- It brings `Time - DateTime` in line with the sibling paths that already use exact rational timestamps: `Time.at(DateTime)` (#58085) and `ActiveSupport::TimeWithZone - DateTime` (via `getutc`).
- The exact fractional second on a `DateTime` is `datetime.to_i + datetime.sec_fraction`; subtracting that from `time.to_r` preserves every microsecond.
- Existing whole-second coverage continues to pass; new assertions lock the sub-second contract.