### PR TITLE
Remove unused parameter

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Remove unused `rest` parameter from merge and merge!
+
+    *Aaron Patterson*
+
 *   Support dumping `schema_migrations` in `db/schema.rb`.
 
     When the new `ActiveRecord.dump_schema_migrations` flag is true, `:ruby`

--- a/activerecord/lib/active_record/relation/spawn_methods.rb
+++ b/activerecord/lib/active_record/relation/spawn_methods.rb
@@ -30,17 +30,17 @@ module ActiveRecord
     #
     # For conditions that exist in both relations, those from <tt>other</tt> will take precedence.
     # To find the intersection of two relations, use QueryMethods#and.
-    def merge(other, *rest)
+    def merge(other)
       if other.is_a?(Array)
         records & other
       elsif other
-        spawn.merge!(other, *rest)
+        spawn.merge!(other)
       else
         raise ArgumentError, "invalid argument: #{other.inspect}."
       end
     end
 
-    def merge!(other, *rest) # :nodoc:
+    def merge!(other) # :nodoc:
       if other.is_a?(Hash)
         Relation::HashMerger.new(self, other).merge
       elsif other.is_a?(Relation)


### PR DESCRIPTION
Since we removed rewhere support in
c313d9161360f4539afeb36cc8353ad29ba6bef3, the *rest parameter has been unused. This commit removes the parameter