### PR TITLE
Remove unused ConnectionPool#remove_from_maintenance method

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -992,8 +992,8 @@ module ActiveRecord
 
         # Directly check a specific connection out of the pool. Skips callbacks.
         #
-        # The connection must later either #return_from_maintenance or
-        # #remove_from_maintenance, or the pool will hang.
+        # The connection must later be returned with #return_from_maintenance, or
+        # the pool will hang.
         def checkout_for_maintenance(conn)
           synchronize do
             @maintaining += 1
@@ -1019,15 +1019,6 @@ module ActiveRecord
           end
         end
 
-        # Remove a connection from the pool after it has been checked out for
-        # maintenance. It will be automatically replaced with a new connection if
-        # necessary.
-        def remove_from_maintenance(conn)
-          synchronize do
-            @maintaining -= 1
-            remove conn
-          end
-        end
 
         #--
         # this is unfortunately not concurrent


### PR DESCRIPTION
`ConnectionPool#remove_from_maintenance` was added in [`5eab03f7b0`](https://github.com/rails/rails/commit/5eab03f7b0e8a12871bbe3929a5297491915f586) alongside `checkout_for_maintenance` and `return_from_maintenance`. No maintenance path ever called it; `sequential_maintenance` has always returned borrowed connections through `return_from_maintenance`.

This removes one half of a documented private pair that Rails never wired up. If a future maintenance flow needs to discard a borrowed connection, the implementation remains in Git history and can be restored alongside its first caller and focused tests.

Remove the method and update `checkout_for_maintenance`'s documentation to describe the path Rails uses.
