### PR TITLE
Remove unused test runner path helper

### DIFF
--- a/railties/lib/rails/commands/test/test_command.rb
+++ b/railties/lib/rails/commands/test/test_command.rb
@@ -67,7 +67,7 @@ module Rails
       end
 
       private
-        EXACT_TEST_ARGUMENT_PATTERN = /^-n|^--name\b|#{Rails::TestUnit::Runner::PATH_ARGUMENT_PATTERN}/
+        EXACT_TEST_ARGUMENT_PATTERN = %r{^-n|^--name\b|^(?!/.+/$)[.\w]*[/\\]}
 
         def run_prepare_task
           Rails::Command::RakeCommand.perform("test:prepare", [], {})

--- a/railties/lib/rails/test_unit/runner.rb
+++ b/railties/lib/rails/test_unit/runner.rb
@@ -24,7 +24,6 @@ module Rails
 
     class Runner
       TEST_FOLDERS = [:models, :helpers, :channels, :controllers, :mailers, :integration, :jobs, :mailboxes].freeze
-      PATH_ARGUMENT_PATTERN = %r"^(?!/.+/$)[.\w]*[/\\]"
       mattr_reader :filters, default: []
       mattr_reader :load_test_files, default: false
 
@@ -125,9 +124,6 @@ module Rails
             arg.start_with?("/") && arg.end_with?("/")
           end
 
-          def path_argument?(arg)
-            PATH_ARGUMENT_PATTERN.match?(arg)
-          end
 
           def list_tests(patterns)
             tests = Rake::FileList[patterns.any? ? patterns : default_test_glob]


### PR DESCRIPTION
[`b1589fa7d9`](https://github.com/rails/rails/commit/b1589fa7d9feac53ad2b957a240a88d0f8288244) removed the `path_argument?` guard from `extract_filters`, leaving the private method uncalled.

`PATH_ARGUMENT_PATTERN` remained in use only to construct `TestCommand::EXACT_TEST_ARGUMENT_PATTERN`. Inline the regexp there so the obsolete helper and its dedicated constant can be removed together.
