### PR TITLE
Remove unused Active Record internals

### DIFF
--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -18,7 +18,6 @@ module ActiveRecord
       def reset
         super
         @target = nil
-        @future_target = nil
       end
 
       # Implements the writer method, e.g. foo.bar= for Foo.belongs_to :bar

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -1161,13 +1161,13 @@ module ActiveRecord
           # <tt>synchronize { conn.lease }</tt> in this method, but by leaving it to <tt>@available.poll</tt>
           # and +try_to_checkout_new_connection+ we can piggyback on +synchronize+ sections
           # of the said methods and avoid an additional +synchronize+ overhead.
-          if conn = @available.poll || try_to_queue_for_background_connection(checkout_timeout) || try_to_checkout_new_connection
+          if conn = @available.poll || try_to_queue_for_background_connection || try_to_checkout_new_connection
             conn
           else
             reap
             # Retry after reaping, which may return an available connection,
             # remove an inactive connection, or both
-            if conn = @available.poll || try_to_queue_for_background_connection(checkout_timeout) || try_to_checkout_new_connection
+            if conn = @available.poll || try_to_queue_for_background_connection || try_to_checkout_new_connection
               conn
             else
               @available.poll(checkout_timeout)
@@ -1189,7 +1189,7 @@ module ActiveRecord
         # If background connections are available, this method will block and
         # return a connection. If no background connections are available, it
         # will immediately return +nil+.
-        def try_to_queue_for_background_connection(checkout_timeout)
+        def try_to_queue_for_background_connection
           return unless @maintaining > 0
 
           synchronize do

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -1358,14 +1358,6 @@ module ActiveRecord
         def build_statement_pool
         end
 
-        # Builds the result object.
-        #
-        # This is an internal hook to make possible connection adapters to build
-        # custom result objects with connection-specific data.
-        def build_result(columns:, rows:, column_types: nil)
-          ActiveRecord::Result.new(columns, rows, column_types)
-        end
-
         # Perform any necessary initialization upon the newly-established
         # @raw_connection -- this is the place to modify the adapter's
         # connection settings, run queries to configure any application-global

--- a/activerecord/lib/active_record/connection_adapters/pool_config.rb
+++ b/activerecord/lib/active_record/connection_adapters/pool_config.rb
@@ -6,7 +6,7 @@ module ActiveRecord
       include MonitorMixin
 
       attr_reader :db_config, :role, :shard, :connection_descriptor
-      attr_writer :schema_reflection, :server_version
+      attr_writer :schema_reflection
 
       def schema_reflection
         @schema_reflection ||= SchemaReflection.new(db_config.lazy_schema_cache_path)

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -1145,14 +1145,6 @@ module ActiveRecord
         end
       end
 
-      def source_options
-        source_reflection.options
-      end
-
-      def through_options
-        through_reflection.options
-      end
-
       def check_validity!
         return if @validated
 

--- a/activerecord/lib/active_record/relation/from_clause.rb
+++ b/activerecord/lib/active_record/relation/from_clause.rb
@@ -10,10 +10,6 @@ module ActiveRecord
         @name = name
       end
 
-      def merge(other)
-        self
-      end
-
       def empty?
         value.nil?
       end

--- a/activerecord/lib/active_record/type/hash_lookup_type_map.rb
+++ b/activerecord/lib/active_record/type/hash_lookup_type_map.rb
@@ -3,7 +3,7 @@
 module ActiveRecord
   module Type
     class HashLookupTypeMap # :nodoc:
-      def initialize(parent = nil)
+      def initialize
         @mapping = {}
         @cache = Concurrent::Map.new do |h, key|
           h.fetch_or_store(key, Concurrent::Map.new)


### PR DESCRIPTION
Follow-up to the recent unused-code cleanups (#58214, #58197, #58208). Each commit removes one piece of dead code, verified with repo-wide greps (including dynamic dispatch, `send`, and symbol references):

<details>

* **`FromClause#merge`** — unused since 45955aed00 replaced the generic clause-merge loop in `Relation::Merger` with explicit where/having merges and a replacement rule for the from clause.
* **`checkout_timeout` parameter of `try_to_queue_for_background_connection`** — unused since the method was introduced in 5eab03f7b0; the wait is intentionally unbounded (see the comment in the method body).
* **`parent` parameter of `HashLookupTypeMap#initialize`** — unused since cf7db80fe1 decoupled `HashLookupTypeMap` from `TypeMap`; no caller passes an argument.
* **`TransactionState#fully_committed?`, `#fully_rolledback?`, `#fully_completed?`, `#nullify!`** — the first two lost their last callers in 77f7b2df3a, `fully_completed?` in 8180c39610, and `nullify!` in 6c745b0c51. Only `nullify!`'s own unit test still called it, so that test is removed as well. The `:fully_committed`/`:fully_rolledback` states themselves are still set and consumed through `committed?`/`rolledback?`.
* **Write-only `@future_target` in `SingularAssociation#reset`** — never read since it was added in fe92250a5c.
* **Dead store to `@_query_constraints_list`** — 767cd52e76 renamed the memo to `@query_constraints_list` but left this reset behind in the `inherited` hook. Since instance variables are not inherited in Ruby, the subclass never sees the parent's memo either way, so the line can simply be deleted.
* **`ThroughReflection#source_options` and `#through_options`** — their last callers were removed in 500b1df43e and 65843e1acc.
* **`server_version` writer on `PoolConfig`** — its last callers were removed in 6b1515aeb9; tests reset the memo via `instance_variable_set`.
* **`AbstractAdapter#build_result`** — its last callers were removed in fd24e5bfc9 when the adapters moved to the `cast_result` path. Its comment described it as a hook for adapters to build custom result objects, but no framework code has invoked it since, so an adapter overriding it today gets nothing. Happy to drop this commit if you'd rather keep it as an extension point.

</details>