### PR TITLE
Remove unused Active Support internals

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -240,7 +240,7 @@ module ActiveSupport
           new chain.name, filter, kind, options, chain.config
         end
 
-        attr_accessor :kind, :name
+        attr_reader :kind, :name
         attr_reader :chain_config, :filter
 
         def initialize(name, filter, kind, options, chain_config)

--- a/activesupport/lib/active_support/continuous_integration/group.rb
+++ b/activesupport/lib/active_support/continuous_integration/group.rb
@@ -75,7 +75,7 @@ module ActiveSupport
         def execute_task(type, title, payload)
           case type
           when :step  then execute_step(title, payload)
-          when :group then execute_group(title, payload)
+          when :group then execute_group(payload)
           end
         end
 
@@ -96,7 +96,7 @@ module ActiveSupport
           success
         end
 
-        def execute_group(name, block)
+        def execute_group(block)
           all_success = true
           TaskCollector.new(&block).tasks.each do |type, title, payload|
             unless execute_task(type, title, payload)

--- a/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
@@ -133,7 +133,6 @@ module ActiveSupport
       def initialize(old_const, new_const, deprecator, message: "#{old_const} is deprecated! Use #{new_const} instead.")
         Kernel.require "active_support/inflector/methods"
 
-        @old_const = old_const
         @new_const = new_const
         @deprecator = deprecator
         @message = message

--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -237,7 +237,7 @@ module ActiveSupport
       class Handle
         include FanoutIteration
 
-        def initialize(notifier, name, id, groups, payload) # :nodoc:
+        def initialize(name, id, groups, payload) # :nodoc:
           @name = name
           @id = id
           @payload = payload
@@ -298,7 +298,7 @@ module ActiveSupport
         if groups.empty?
           NullHandle
         else
-          Handle.new(self, name, id, groups, payload)
+          Handle.new(name, id, groups, payload)
         end
       end
 

--- a/activesupport/lib/active_support/ordered_hash.rb
+++ b/activesupport/lib/active_support/ordered_hash.rb
@@ -22,10 +22,6 @@ module ActiveSupport
   # +ActiveSupport::OrderedHash+ is namespaced to prevent conflicts
   # with other implementations.
   class OrderedHash < ::Hash # :nodoc:
-    def to_yaml_type
-      "!tag:yaml.org,2002:omap"
-    end
-
     def encode_with(coder)
       coder.represent_seq "!omap", map { |k, v| { k => v } }
     end

--- a/activesupport/lib/active_support/subscriber.rb
+++ b/activesupport/lib/active_support/subscriber.rb
@@ -36,7 +36,6 @@ module ActiveSupport
         @namespace  = namespace
         @subscriber = subscriber
         @notifier   = notifier
-        @inherit_all = inherit_all
 
         subscribers << subscriber
 

--- a/activesupport/lib/active_support/testing/parallelization/server.rb
+++ b/activesupport/lib/active_support/testing/parallelization/server.rb
@@ -46,7 +46,7 @@ module ActiveSupport
           @worker_pids[worker_id] = worker_pid
         end
 
-        def stop_worker(worker_id, worker_pid)
+        def stop_worker(worker_id)
           @active_workers.delete(worker_id)
           @worker_pids.delete(worker_id)
         end

--- a/activesupport/lib/active_support/testing/parallelization/worker.rb
+++ b/activesupport/lib/active_support/testing/parallelization/worker.rb
@@ -31,7 +31,7 @@ module ActiveSupport
             set_process_title("(stopping)")
 
             run_cleanup
-            @queue.stop_worker(@id, Process.pid)
+            @queue.stop_worker(@id)
           end
         end
 

--- a/activesupport/test/parallelization/server_test.rb
+++ b/activesupport/test/parallelization/server_test.rb
@@ -12,7 +12,7 @@ class ServerTest < ActiveSupport::TestCase
     server.start_worker("worker-1", 1234)
     assert server.active_workers?
 
-    server.stop_worker("worker-1", 1234)
+    server.stop_worker("worker-1")
     assert_not server.active_workers?
   end
 


### PR DESCRIPTION
Follow-up to the recent unused-code cleanups (#58214, #58193). Each commit removes one piece of dead code, verified with repo-wide greps (including dynamic dispatch, `send`, and symbol references):

<details>

* **`notifier` parameter of `Fanout::Handle#initialize`** — unused since 3ce38ae35c hoisted group construction into `build_handle`. The constructor is `:nodoc:`; handles are only obtained through `build_handle`.
* **`name` parameter of `ContinuousIntegration::Group#execute_group`** — unused since the method was introduced in 10db73a0b6.
* **`worker_pid` parameter of `Testing::Parallelization::Server#stop_worker`** — unused since it was introduced in 5399166e86. Worker pids are recorded in `start_worker` and both maps are cleaned up by `worker_id` here, so the pid argument never participates.
* **Write-only `@old_const` in `DeprecatedConstantProxy`** — unread since 7da8d76206 folded the warning text into the `message:` keyword default.
* **Write-only `@inherit_all` in `Subscriber.attach_to`** — never read since it was introduced in 387aa8c373; the method only uses the local.
* **`OrderedHash#to_yaml_type`** — a Syck serialization hook. Syck was removed in Ruby 2.0; Psych uses `encode_with`, which is defined right below it.
* **`Callback#kind=` and `#name=`** — the writers have no callers, so the accessors are demoted to readers (same shape as #58198).

</details>