### PR TITLE
Remove unused Action Pack internals

### DIFF
--- a/actionpack/lib/action_controller/metal/params_wrapper.rb
+++ b/actionpack/lib/action_controller/metal/params_wrapper.rb
@@ -186,10 +186,6 @@ module ActionController
     end
 
     module ClassMethods
-      def _set_wrapper_options(options)
-        self._wrapper_options = Options.from_hash(options)
-      end
-
       # Sets the name of the wrapper key, or the model which `ParamsWrapper` would use
       # to determine the attribute names from.
       #

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -202,7 +202,6 @@ module ActionController
       @id = id
       @data = stringify_keys(session)
       @loaded = true
-      @initially_empty = @data.empty?
     end
 
     def exists?

--- a/actionpack/lib/action_dispatch/journey/path/pattern.rb
+++ b/actionpack/lib/action_dispatch/journey/path/pattern.rb
@@ -142,10 +142,6 @@ module ActionDispatch
             Array.new(length - 1) { |i| self[i + 1] }
           end
 
-          def named_captures
-            @names.zip(captures).to_h
-          end
-
           def [](x)
             idx = @offsets[x - 1] + x
             @match[idx]

--- a/actionpack/lib/action_dispatch/journey/route.rb
+++ b/actionpack/lib/action_dispatch/journey/route.rb
@@ -123,10 +123,6 @@ module ActionDispatch
         path.names
       end
 
-      def required_keys
-        required_parts + required_defaults.keys
-      end
-
       def score(supplied_keys)
         path.required_names.each do |k|
           return -1 unless supplied_keys.include?(k)

--- a/actionpack/lib/action_dispatch/middleware/debug_locks.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_locks.rb
@@ -39,7 +39,7 @@ module ActionDispatch
       if req.get?
         path = req.path_info.chomp("/")
         if path == @path
-          return render_details(req)
+          return render_details
         end
       end
 
@@ -47,7 +47,7 @@ module ActionDispatch
     end
 
     private
-      def render_details(req)
+      def render_details
         owners = ActiveSupport::Dependencies.interlock.raw_state do |raw_owners|
           # The Interlock itself comes to a complete halt as long as this block is
           # executing. That gives us a more consistent picture of everything, but creates

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -830,7 +830,7 @@ module ActionDispatch
         [URI(path_info).path, generator.params.except(:_recall).keys]
       end
 
-      def generate(route_name, options, recall = {}, method_name = nil)
+      def generate(route_name, options, recall = {})
         Generator.new(route_name, options, recall, self).generate
       end
       private :generate

--- a/actionpack/lib/action_dispatch/testing/assertions/response.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/response.rb
@@ -86,11 +86,6 @@ module ActionDispatch
       end
 
       private
-        # Proxy to to_param if the object will respond to it.
-        def parameterize(value)
-          value.respond_to?(:to_param) ? value.to_param : value
-        end
-
         def normalize_argument_to_redirection(fragment)
           if Regexp === fragment
             fragment

--- a/actionpack/test/controller/params_wrapper_test.rb
+++ b/actionpack/test/controller/params_wrapper_test.rb
@@ -6,7 +6,7 @@ module Admin; class User; end; end
 
 module ParamsWrapperTestHelp
   def with_default_wrapper_options(&block)
-    @controller.class._set_wrapper_options(format: [:json])
+    @controller.class._wrapper_options = ActionController::ParamsWrapper::Options.from_hash(format: [:json])
     @controller.class.inherited(@controller.class)
     yield
   end

--- a/actionpack/test/journey/path/pattern_test.rb
+++ b/actionpack/test/journey/path/pattern_test.rb
@@ -268,15 +268,6 @@ module ActionDispatch
           assert_equal "rss", match[2]
         end
 
-        def test_named_captures
-          path = path_from_string "/books(/:action(.:format))"
-
-          uri = "/books/list.rss"
-          match = path =~ uri
-          named_captures = { "action" => "list", "format" => "rss" }
-          assert_equal named_captures, match.named_captures
-        end
-
         def test_requirements_for_missing_keys_check
           name_regex = /test/
 


### PR DESCRIPTION
Follow-up to the recent unused-code cleanups (#58214, #58195, #58196). Each commit removes one piece of dead code, verified with repo-wide greps (including dynamic dispatch, `send`, and symbol references):

<details>

* **`method_name` parameter of `RouteSet#generate`** — unused since 437ab2031e moved `UrlGenerationError` construction out of this method. Both callers pass three arguments. Same shape as #58214, in the same subsystem.
* **`req` parameter of `DebugLocks#render_details`** — unused since the middleware was introduced in 04b4a0666b.
* **`Journey::Route#required_keys`** — no caller since Journey was merged into Action Pack; the formatter uses `required_parts` and `required_defaults` directly.
* **`ResponseAssertions#parameterize`** — its last caller was removed in c3aaba0180.
* **Write-only `@initially_empty` in `TestSession`** — never read since it was added in f2c66ce392. (Checked against rack and rack-session: unlike `default_session`, this is not a Rack hook.)
* **`ParamsWrapper._set_wrapper_options`** — `wrap_parameters` assigns `_wrapper_options` directly, and the helper has had no caller outside its own test setup since it was introduced in 95ec448580. The test now sets the class attribute directly.
* **`Journey::Path::Pattern::MatchData#named_captures`** — nothing outside its own unit test calls it; the test is removed with it.

</details>