### PR TITLE
Remove unused Active Model internals

### DIFF
--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -241,7 +241,7 @@ module ActiveModel
         call_args = []
         call_args << parameters if parameters
 
-        define_call(code_generator, method_name, target_name, mangled_name, parameters, call_args, namespace: :alias_attribute, as: method_name)
+        define_call(code_generator, target_name, mangled_name, parameters, call_args, namespace: :alias_attribute, as: method_name)
       end
 
       # Is +new_name+ an alias?
@@ -430,7 +430,7 @@ module ActiveModel
           #   attribute :title
           namespace = :"#{namespace}_#{proxy_target}"
 
-          define_call(code_generator, name, proxy_target, mangled_name, parameters, call_args, namespace: namespace, as: as)
+          define_call(code_generator, proxy_target, mangled_name, parameters, call_args, namespace: namespace, as: as)
         end
 
         def build_mangled_name(name)
@@ -443,7 +443,7 @@ module ActiveModel
           mangled_name
         end
 
-        def define_call(code_generator, name, target_name, mangled_name, parameters, call_args, namespace:, as:)
+        def define_call(code_generator, target_name, mangled_name, parameters, call_args, namespace:, as:)
           code_generator.define_cached_method(mangled_name, as: as, namespace: namespace) do |batch|
             body = if CALL_COMPILABLE_REGEXP.match?(target_name)
               "self.#{target_name}(#{call_args.join(", ")})"

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -572,7 +572,7 @@ module ActiveModel
         # to allocate an object on each call to the attribute method.
         # Making it frozen means that it doesn't get duped when used to
         # key the @attributes in read_attribute.
-        def self.define_attribute_accessor_method(owner, attr_name, writer: false)
+        def self.define_attribute_accessor_method(attr_name, writer: false)
           method_name = "#{attr_name}#{'=' if writer}"
           if attr_name.ascii_only? && DEF_SAFE_NAME.match?(attr_name)
             yield method_name, "'#{attr_name}'"

--- a/activemodel/lib/active_model/attributes.rb
+++ b/activemodel/lib/active_model/attributes.rb
@@ -95,7 +95,7 @@ module ActiveModel
       private
         def define_method_attribute=(canonical_name, owner:, as: canonical_name)
           ActiveModel::AttributeMethods::AttrNames.define_attribute_accessor_method(
-            owner, canonical_name, writer: true,
+            canonical_name, writer: true,
           ) do |temp_method_name, attr_name_expr|
             owner.define_cached_method(temp_method_name, as: "#{as}=", namespace: :active_model) do |batch|
               batch <<

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -460,10 +460,6 @@ module ActiveModel
     end
 
   private
-    def validation_context=(context)
-      context_for_validation.context = context
-    end
-
     def context_for_validation
       @context_for_validation ||= ValidationContext.new
     end

--- a/activemodel/lib/active_model/validations/confirmation.rb
+++ b/activemodel/lib/active_model/validations/confirmation.rb
@@ -10,7 +10,7 @@ module ActiveModel
 
       def validate_each(record, attribute, value)
         unless (confirmed = record.public_send("#{attribute}_confirmation")).nil?
-          unless confirmation_value_equal?(record, attribute, value, confirmed)
+          unless confirmation_value_equal?(value, confirmed)
             human_attribute_name = record.class.human_attribute_name(attribute)
             record.errors.add(:"#{attribute}_confirmation", :confirmation, **options.except(:case_sensitive).merge!(attribute: human_attribute_name))
           end
@@ -28,7 +28,7 @@ module ActiveModel
           end)
         end
 
-        def confirmation_value_equal?(record, attribute, value, confirmed)
+        def confirmation_value_equal?(value, confirmed)
           if !options[:case_sensitive] && value.is_a?(String)
             value.casecmp(confirmed) == 0
           else

--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -10,7 +10,7 @@ module ActiveRecord
         private
           def define_method_attribute(canonical_name, owner:, as: canonical_name)
             ActiveModel::AttributeMethods::AttrNames.define_attribute_accessor_method(
-              owner, canonical_name
+              canonical_name
             ) do |temp_method_name, attr_name_expr|
               owner.define_cached_method(temp_method_name, as: as, namespace: :active_record) do |batch|
                 batch <<

--- a/activerecord/lib/active_record/attribute_methods/write.rb
+++ b/activerecord/lib/active_record/attribute_methods/write.rb
@@ -14,7 +14,7 @@ module ActiveRecord
         private
           def define_method_attribute=(canonical_name, owner:, as: canonical_name)
             ActiveModel::AttributeMethods::AttrNames.define_attribute_accessor_method(
-              owner, canonical_name, writer: true,
+              canonical_name, writer: true,
             ) do |temp_method_name, attr_name_expr|
               owner.define_cached_method(temp_method_name, as: "#{as}=", namespace: :active_record) do |batch|
                 batch <<


### PR DESCRIPTION
Follow-up to the recent unused-code cleanups (#58214, #58193). Each commit removes one piece of dead code, verified with repo-wide greps (including dynamic dispatch, `send`, and symbol references):

<details>

* **`owner` parameter of `AttrNames.define_attribute_accessor_method`** — unused since ca5542fed3 removed the `owner.rename_method` call from the body. All three callers (Active Model `Attributes`, Active Record `Read` and `Write`) define their methods on `owner` inside the yielded block instead, so the argument never participates.
* **`name` parameter of `define_call`** — unused since 514d474836 switched `define_cached_method` to key on `mangled_name`.
* **Private `validation_context=` writer** — unused since afecc8fd6c made `valid?` set `context_for_validation.context` directly. It was private before that change as well.
* **`record` and `attribute` parameters of `ConfirmationValidator#confirmation_value_equal?`** — unused since the method was introduced in 2438a1cf4e.

</details>