### PR TITLE
Remove unused Active Job parameters

### DIFF
--- a/activejob/lib/active_job/continuation.rb
+++ b/activejob/lib/active_job/continuation.rb
@@ -313,7 +313,7 @@ module ActiveJob
         end
       end
 
-      def run_step_inline(name, start:, **options, &block)
+      def run_step_inline(name, start:, &block)
         @running_step = true
         @current ||= new_step(name, start, resumed: false)
 

--- a/activejob/lib/active_job/queue_adapters/async_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/async_adapter.rb
@@ -37,11 +37,11 @@ module ActiveJob
       end
 
       def enqueue(job) # :nodoc:
-        @scheduler.enqueue JobWrapper.new(job), queue_name: job.queue_name
+        @scheduler.enqueue JobWrapper.new(job)
       end
 
       def enqueue_at(job, timestamp) # :nodoc:
-        @scheduler.enqueue_at JobWrapper.new(job), timestamp, queue_name: job.queue_name
+        @scheduler.enqueue_at JobWrapper.new(job), timestamp
       end
 
       # Gracefully stop processing jobs. Finishes in-progress work and handles
@@ -93,16 +93,16 @@ module ActiveJob
           )
         end
 
-        def enqueue(job, queue_name:)
+        def enqueue(job)
           executor.post(job, &:perform)
         end
 
-        def enqueue_at(job, timestamp, queue_name:)
+        def enqueue_at(job, timestamp)
           delay = timestamp - Time.current.to_f
           if !immediate && delay > 0
             Concurrent::ScheduledTask.execute(delay, args: [job], executor: executor, &:perform)
           else
-            enqueue(job, queue_name: queue_name)
+            enqueue(job)
           end
         end
 


### PR DESCRIPTION
Follow-up to the recent unused-code cleanups (#58214). Each commit removes one unused parameter, verified with repo-wide greps:

<details>

* **`**options` parameter of `Continuation#run_step_inline`** — never read or populated since the method was introduced in 1b4484c43f; the sole caller passes only `name` and `start:`.
* **`queue_name:` parameter of the async adapter's `Scheduler#enqueue`/`#enqueue_at`** — the scheduler has used a single global executor since a66780bfff replaced the per-queue `AsyncJob` implementation, so the queue name has never influenced scheduling. The adapter-facing API (`AsyncAdapter#enqueue(job)`) is unchanged.

</details>