### PR TITLE
Remove unused Action View internals

### DIFF
--- a/actionview/lib/action_view/cache_expiry.rb
+++ b/actionview/lib/action_view/cache_expiry.rb
@@ -3,13 +3,13 @@
 module ActionView
   module CacheExpiry # :nodoc: all
     class ViewReloader
-      def self.create(watcher:, &block)
-        reloader = new(watcher: watcher, &block)
+      def self.create(watcher:)
+        reloader = new(watcher: watcher)
         ActionView::PathRegistry.file_system_resolver_hooks << reloader.hook
         reloader
       end
 
-      def initialize(watcher:, &block)
+      def initialize(watcher:)
         @mutex = Mutex.new
         @watcher_class = watcher
         @watched_dirs = nil

--- a/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
@@ -70,13 +70,13 @@ module ActionView
         collection.preload! if callable_cache_key?
 
         collection.each_with_object([{}, []]) do |item, (hash, ordered_keys)|
-          key = expanded_cache_key(seed.call(item), view, template, digest_path)
+          key = expanded_cache_key(seed.call(item), view, digest_path)
           ordered_keys << key
           hash[key] = item
         end
       end
 
-      def expanded_cache_key(key, view, template, digest_path)
+      def expanded_cache_key(key, view, digest_path)
         key = view.combined_fragment_cache_key(view.cache_fragment_name(key, digest_path: digest_path))
         key.frozen? ? key.dup : key # #read_multi & #write may require mutability, Dalli 2.6.0.
       end

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -307,7 +307,7 @@ module ActionView
         end
       end
     rescue => e
-      handle_render_error(view, e)
+      handle_render_error(e)
     end
 
     def type
@@ -573,7 +573,7 @@ module ActionView
         end
       end
 
-      def handle_render_error(view, e)
+      def handle_render_error(e)
         if e.is_a?(Template::Error)
           e.sub_template_of(self)
           raise e


### PR DESCRIPTION
Follow-up to the recent unused-code cleanups (#58214, #58198). Each commit removes one piece of dead code, verified with repo-wide greps (including dynamic dispatch, `send`, and symbol references):

<details>

* **`view` parameter of `Template#handle_render_error`** — unused since b8e6594181 removed the `refresh(view)` fallback from the error path. The sole caller is the `render` rescue in the same file.
* **`template` parameter of `expanded_cache_key`** — unused since 4671fe2040 stopped passing `virtual_path` to `cache_fragment_name`. The sole caller still uses `template` for `digest_path_from_template`, so only the argument is dropped.
* **Block parameter of `CacheExpiry::ViewReloader.create` and `#initialize`** — the block has never been stored or yielded since the class was introduced in 72abd6357d, and no caller passes one.

</details>