### PR TITLE
Remove unused code from Railties and Action Cable

### DIFF
--- a/actioncable/lib/action_cable/server/socket/stream.rb
+++ b/actioncable/lib/action_cable/server/socket/stream.rb
@@ -108,7 +108,7 @@ module ActionCable
         private
           def clean_rack_hijack
             return unless @rack_hijack_io
-            @event_loop.detach(@rack_hijack_io, self)
+            @event_loop.detach(@rack_hijack_io)
             @rack_hijack_io = nil
           end
       end

--- a/actioncable/lib/action_cable/server/stream_event_loop.rb
+++ b/actioncable/lib/action_cable/server/stream_event_loop.rb
@@ -24,7 +24,7 @@ module ActionCable
         wakeup
       end
 
-      def detach(io, stream)
+      def detach(io)
         @todo << lambda do
           @nio.deregister io
           @map.delete io

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -814,15 +814,6 @@ module Rails
         self.class.edge_branch
       end
 
-      def dockerfile_chown_directories
-        directories = %w(log tmp)
-
-        directories << "storage" unless skip_storage?
-        directories << "db" unless skip_active_record?
-
-        directories.sort
-      end
-
       def database
         @database ||= Database.build(options[:database])
       end


### PR DESCRIPTION
Follow-up to the recent unused-code cleanups (#58214, #58193). Each commit removes one piece of dead code, verified with repo-wide greps (including generator templates and JavaScript):

<details>

* **`AppBase#dockerfile_chown_directories`** — unused since 658c989d8b switched the generated Dockerfile to `COPY --chown` and dropped the `chown -R` line that consumed it. No `.tt` template references it.
* **`stream` parameter of `StreamEventLoop#detach`** — unused since the event loop was introduced in 322dca293b; only `attach` stores the stream, and deregistration is keyed by `io` alone. The single caller is updated.

</details>