### PR TITLE
Add config to raise on invalid TimeZone#parse strings

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Add `ActiveSupport::TimeZone.raise_on_invalid_parse_string`.
+
+    Raise `ArgumentError` on `ActiveSupport::TimeZone#parse` for any invalid
+    string. Historically, strings without recognizable date information
+    (e.g. `"foobar"`) returned `nil`, while strings with out-of-range date
+    components (e.g. `"9000"`) raised `ArgumentError`. When enabled, both
+    cases raise `ArgumentError`, matching the Ruby standard library's `Time.parse`.
+
+    *Said Kaldybaev*
+
 *   Preserve sub-second precision when subtracting a `DateTime` from a `Time`.
 
     `Time - DateTime` converted both sides via `to_f`, so microsecond-level

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,4 +1,4 @@
-*   Add `ActiveSupport::TimeZone.raise_on_invalid_time_zone_parse`.
+*   Add `ActiveSupport.raise_on_invalid_time_zone_parse`.
 
     Raise `ArgumentError` on `ActiveSupport::TimeZone#parse` for any invalid
     string. Historically, strings without recognizable date information

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,4 +1,4 @@
-*   Add `ActiveSupport::TimeZone.raise_on_invalid_parse_string`.
+*   Add `ActiveSupport::TimeZone.raise_on_invalid_time_zone_parse`.
 
     Raise `ArgumentError` on `ActiveSupport::TimeZone#parse` for any invalid
     string. Historically, strings without recognizable date information

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -162,6 +162,15 @@ module ActiveSupport
   #   zone.utc_to_local(Time.utc(2000, 1)) # => 1999-12-31 19:00:00 -0500
   singleton_class.attr_accessor :utc_to_local_returns_utc_offset_times
   @utc_to_local_returns_utc_offset_times = false
+
+  # When +true+, <tt>ActiveSupport::TimeZone#parse</tt> raises +ArgumentError+
+  # for strings with no recognizable date information (e.g. +"foobar"+),
+  # instead of returning +nil+. Out-of-range components always raise.
+  #
+  # Defaults to +false+. Set via +config.active_support.raise_on_invalid_time_zone_parse+
+  # (enabled by default with <tt>config.load_defaults "8.2"</tt>).
+  singleton_class.attr_accessor :raise_on_invalid_time_zone_parse
+  @raise_on_invalid_time_zone_parse = false
 end
 
 autoload :I18n, "active_support/i18n"

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -31,10 +31,10 @@ module ActiveSupport
       end
     end
 
-    initializer "active_support.raise_on_invalid_parse_string" do |app|
+    initializer "active_support.raise_on_invalid_time_zone_parse" do |app|
       config.after_initialize do
-        if app.config.active_support.raise_on_invalid_parse_string
-          ActiveSupport::TimeZone.raise_on_invalid_parse_string = true
+        if app.config.active_support.raise_on_invalid_time_zone_parse
+          ActiveSupport::TimeZone.raise_on_invalid_time_zone_parse = true
         end
       end
     end

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -31,6 +31,14 @@ module ActiveSupport
       end
     end
 
+    initializer "active_support.raise_on_invalid_parse_string" do |app|
+      config.after_initialize do
+        if app.config.active_support.raise_on_invalid_parse_string
+          ActiveSupport::TimeZone.raise_on_invalid_parse_string = true
+        end
+      end
+    end
+
     initializer "active_support.set_authenticated_message_encryption" do |app|
       config.after_initialize do
         unless app.config.active_support.use_authenticated_message_encryption.nil?

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -31,14 +31,6 @@ module ActiveSupport
       end
     end
 
-    initializer "active_support.raise_on_invalid_time_zone_parse" do |app|
-      config.after_initialize do
-        if app.config.active_support.raise_on_invalid_time_zone_parse
-          ActiveSupport::TimeZone.raise_on_invalid_time_zone_parse = true
-        end
-      end
-    end
-
     initializer "active_support.set_authenticated_message_encryption" do |app|
       config.after_initialize do
         unless app.config.active_support.use_authenticated_message_encryption.nil?

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -2,6 +2,7 @@
 
 require "tzinfo"
 require "concurrent/map"
+require "active_support/core_ext/class/attribute"
 
 module ActiveSupport
   # = Active Support \Time Zone
@@ -188,6 +189,8 @@ module ActiveSupport
     UTC_OFFSET_WITH_COLON = "%s%02d:%02d" # :nodoc:
     UTC_OFFSET_WITHOUT_COLON = UTC_OFFSET_WITH_COLON.tr(":", "") # :nodoc:
     private_constant :UTC_OFFSET_WITH_COLON, :UTC_OFFSET_WITHOUT_COLON
+
+    class_attribute :raise_on_invalid_parse_string, instance_accessor: false, default: false
 
     @lazy_zones_map = Concurrent::Map.new
     @country_zones  = Concurrent::Map.new
@@ -456,7 +459,14 @@ module ActiveSupport
     #
     #   Time.zone.parse('Mar 2000') # => Wed, 01 Mar 2000 00:00:00 HST -10:00
     #
-    # If the string is invalid then an +ArgumentError+ could be raised.
+    # Strings with no recognizable date information return +nil+, while strings
+    # with out-of-range components raise +ArgumentError+:
+    #
+    #   Time.zone.parse('foobar') # => nil
+    #   Time.zone.parse('9000')   # => ArgumentError: argument out of range
+    #
+    # Set ActiveSupport::TimeZone.raise_on_invalid_parse_string to +true+ to
+    # raise +ArgumentError+ in both cases.
     def parse(str, now = now())
       parts_to_time(Date._parse(str, false), now)
     end
@@ -591,7 +601,10 @@ module ActiveSupport
     private
       def parts_to_time(parts, now)
         raise ArgumentError, "invalid date" if parts.nil?
-        return if parts.empty?
+        if parts.empty?
+          raise ArgumentError, "invalid date" if TimeZone.raise_on_invalid_parse_string
+          return
+        end
 
         if parts[:seconds]
           time = Time.at(parts[:seconds] + parts.fetch(:sec_fraction, 0))

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -2,7 +2,6 @@
 
 require "tzinfo"
 require "concurrent/map"
-require "active_support/core_ext/class/attribute"
 
 module ActiveSupport
   # = Active Support \Time Zone
@@ -189,8 +188,6 @@ module ActiveSupport
     UTC_OFFSET_WITH_COLON = "%s%02d:%02d" # :nodoc:
     UTC_OFFSET_WITHOUT_COLON = UTC_OFFSET_WITH_COLON.tr(":", "") # :nodoc:
     private_constant :UTC_OFFSET_WITH_COLON, :UTC_OFFSET_WITHOUT_COLON
-
-    class_attribute :raise_on_invalid_time_zone_parse, instance_accessor: false, default: false
 
     @lazy_zones_map = Concurrent::Map.new
     @country_zones  = Concurrent::Map.new
@@ -465,7 +462,7 @@ module ActiveSupport
     #   Time.zone.parse('foobar') # => nil
     #   Time.zone.parse('9000')   # => ArgumentError: argument out of range
     #
-    # Set ActiveSupport::TimeZone.raise_on_invalid_time_zone_parse to +true+ to
+    # Set ActiveSupport.raise_on_invalid_time_zone_parse to +true+ to
     # raise +ArgumentError+ in both cases.
     def parse(str, now = now())
       parts_to_time(Date._parse(str, false), now)
@@ -602,7 +599,7 @@ module ActiveSupport
       def parts_to_time(parts, now)
         raise ArgumentError, "invalid date" if parts.nil?
         if parts.empty?
-          raise ArgumentError, "invalid date" if TimeZone.raise_on_invalid_time_zone_parse
+          raise ArgumentError, "invalid date" if ActiveSupport.raise_on_invalid_time_zone_parse
           return
         end
 

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -190,7 +190,7 @@ module ActiveSupport
     UTC_OFFSET_WITHOUT_COLON = UTC_OFFSET_WITH_COLON.tr(":", "") # :nodoc:
     private_constant :UTC_OFFSET_WITH_COLON, :UTC_OFFSET_WITHOUT_COLON
 
-    class_attribute :raise_on_invalid_parse_string, instance_accessor: false, default: false
+    class_attribute :raise_on_invalid_time_zone_parse, instance_accessor: false, default: false
 
     @lazy_zones_map = Concurrent::Map.new
     @country_zones  = Concurrent::Map.new
@@ -465,7 +465,7 @@ module ActiveSupport
     #   Time.zone.parse('foobar') # => nil
     #   Time.zone.parse('9000')   # => ArgumentError: argument out of range
     #
-    # Set ActiveSupport::TimeZone.raise_on_invalid_parse_string to +true+ to
+    # Set ActiveSupport::TimeZone.raise_on_invalid_time_zone_parse to +true+ to
     # raise +ArgumentError+ in both cases.
     def parse(str, now = now())
       parts_to_time(Date._parse(str, false), now)
@@ -602,7 +602,7 @@ module ActiveSupport
       def parts_to_time(parts, now)
         raise ArgumentError, "invalid date" if parts.nil?
         if parts.empty?
-          raise ArgumentError, "invalid date" if TimeZone.raise_on_invalid_parse_string
+          raise ArgumentError, "invalid date" if TimeZone.raise_on_invalid_time_zone_parse
           return
         end
 

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -506,7 +506,7 @@ class TimeZoneTest < ActiveSupport::TestCase
   def test_parse_raises_on_unparseable_string_when_strict
     zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]
 
-    ActiveSupport::TimeZone.with(raise_on_invalid_time_zone_parse: true) do
+    ActiveSupport.with(raise_on_invalid_time_zone_parse: true) do
       exception = assert_raises(ArgumentError) { zone.parse("foobar") }
       assert_equal "invalid date", exception.message
 
@@ -518,7 +518,7 @@ class TimeZoneTest < ActiveSupport::TestCase
   def test_parse_raises_on_out_of_range_date_when_strict
     zone = ActiveSupport::TimeZone["UTC"]
 
-    ActiveSupport::TimeZone.with(raise_on_invalid_time_zone_parse: true) do
+    ActiveSupport.with(raise_on_invalid_time_zone_parse: true) do
       exception = assert_raises(ArgumentError) { zone.parse("9000") }
       assert_equal "argument out of range", exception.message
     end
@@ -527,7 +527,7 @@ class TimeZoneTest < ActiveSupport::TestCase
   def test_parse_still_accepts_valid_strings_when_strict
     zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]
 
-    ActiveSupport::TimeZone.with(raise_on_invalid_time_zone_parse: true) do
+    ActiveSupport.with(raise_on_invalid_time_zone_parse: true) do
       twz = zone.parse("1999-12-31 19:00:00")
       assert_equal Time.utc(2000, 1, 1), twz.utc
       assert_equal zone, twz.time_zone

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -2,6 +2,7 @@
 
 require_relative "abstract_unit"
 require "active_support/time"
+require "active_support/core_ext/object/with"
 require_relative "time_zone_test_helpers"
 require "yaml"
 
@@ -500,6 +501,37 @@ class TimeZoneTest < ActiveSupport::TestCase
     end
 
     assert_equal "argument out of range", exception.message
+  end
+
+  def test_parse_raises_on_unparseable_string_when_strict
+    zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]
+
+    ActiveSupport::TimeZone.with(raise_on_invalid_parse_string: true) do
+      exception = assert_raises(ArgumentError) { zone.parse("foobar") }
+      assert_equal "invalid date", exception.message
+
+      exception = assert_raises(ArgumentError) { zone.parse("   ") }
+      assert_equal "invalid date", exception.message
+    end
+  end
+
+  def test_parse_raises_on_out_of_range_date_when_strict
+    zone = ActiveSupport::TimeZone["UTC"]
+
+    ActiveSupport::TimeZone.with(raise_on_invalid_parse_string: true) do
+      exception = assert_raises(ArgumentError) { zone.parse("9000") }
+      assert_equal "argument out of range", exception.message
+    end
+  end
+
+  def test_parse_still_accepts_valid_strings_when_strict
+    zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]
+
+    ActiveSupport::TimeZone.with(raise_on_invalid_parse_string: true) do
+      twz = zone.parse("1999-12-31 19:00:00")
+      assert_equal Time.utc(2000, 1, 1), twz.utc
+      assert_equal zone, twz.time_zone
+    end
   end
 
   def test_parse_with_ambiguous_time

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -506,7 +506,7 @@ class TimeZoneTest < ActiveSupport::TestCase
   def test_parse_raises_on_unparseable_string_when_strict
     zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]
 
-    ActiveSupport::TimeZone.with(raise_on_invalid_parse_string: true) do
+    ActiveSupport::TimeZone.with(raise_on_invalid_time_zone_parse: true) do
       exception = assert_raises(ArgumentError) { zone.parse("foobar") }
       assert_equal "invalid date", exception.message
 
@@ -518,7 +518,7 @@ class TimeZoneTest < ActiveSupport::TestCase
   def test_parse_raises_on_out_of_range_date_when_strict
     zone = ActiveSupport::TimeZone["UTC"]
 
-    ActiveSupport::TimeZone.with(raise_on_invalid_parse_string: true) do
+    ActiveSupport::TimeZone.with(raise_on_invalid_time_zone_parse: true) do
       exception = assert_raises(ArgumentError) { zone.parse("9000") }
       assert_equal "argument out of range", exception.message
     end
@@ -527,7 +527,7 @@ class TimeZoneTest < ActiveSupport::TestCase
   def test_parse_still_accepts_valid_strings_when_strict
     zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]
 
-    ActiveSupport::TimeZone.with(raise_on_invalid_parse_string: true) do
+    ActiveSupport::TimeZone.with(raise_on_invalid_time_zone_parse: true) do
       twz = zone.parse("1999-12-31 19:00:00")
       assert_equal Time.utc(2000, 1, 1), twz.utc
       assert_equal zone, twz.time_zone

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -69,6 +69,7 @@ Below are the default values associated with each target version. In cases of co
 - [`config.active_record.postgresql_adapter_decode_bytea`](#config-active-record-postgresql-adapter-decode-bytea): `true`
 - [`config.active_record.postgresql_adapter_decode_money`](#config-active-record-postgresql-adapter-decode-money): `true`
 - [`config.active_storage.analyze`](#config-active-storage-analyze): `:immediately`
+- [`config.active_support.raise_on_invalid_parse_string`](#config-active-support-raise-on-invalid-parse-string): `true`
 
 #### Default Values for Target Version 8.1
 
@@ -3281,6 +3282,30 @@ The default value depends on the `config.load_defaults` target version:
 
 [ActiveSupport::Cache::Store#fetch]: https://api.rubyonrails.org/classes/ActiveSupport/Cache/Store.html#method-i-fetch
 [ActiveSupport::Cache::Store#write]: https://api.rubyonrails.org/classes/ActiveSupport/Cache/Store.html#method-i-write
+
+#### `config.active_support.raise_on_invalid_parse_string`
+
+Specifies whether [`ActiveSupport::TimeZone#parse`][] raises `ArgumentError`
+for strings that contain no recognizable date information (e.g. `"foobar"`).
+
+Historically, `TimeZone#parse` had two different behaviors for invalid
+strings: it returned `nil` when the string contained no recognizable date
+information, but raised `ArgumentError` when the string looked like a date
+but contained out-of-range values (e.g. `"9000"`, which is interpreted as
+month 90).
+
+When set to `true`, both cases raise `ArgumentError`, which matches the
+Ruby standard library's `Time.parse` and makes failures less likely to
+go unnoticed.
+
+The default value depends on the `config.load_defaults` target version:
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `false`              |
+| 8.2                   | `true`               |
+
+[`ActiveSupport::TimeZone#parse`]: https://api.rubyonrails.org/classes/ActiveSupport/TimeZone.html#method-i-parse
 
 #### `config.active_support.event_reporter_context_store`
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -69,7 +69,7 @@ Below are the default values associated with each target version. In cases of co
 - [`config.active_record.postgresql_adapter_decode_bytea`](#config-active-record-postgresql-adapter-decode-bytea): `true`
 - [`config.active_record.postgresql_adapter_decode_money`](#config-active-record-postgresql-adapter-decode-money): `true`
 - [`config.active_storage.analyze`](#config-active-storage-analyze): `:immediately`
-- [`config.active_support.raise_on_invalid_parse_string`](#config-active-support-raise-on-invalid-parse-string): `true`
+- [`config.active_support.raise_on_invalid_time_zone_parse`](#config-active-support-raise-on-invalid-time-zone-parse): `true`
 
 #### Default Values for Target Version 8.1
 
@@ -3283,7 +3283,7 @@ The default value depends on the `config.load_defaults` target version:
 [ActiveSupport::Cache::Store#fetch]: https://api.rubyonrails.org/classes/ActiveSupport/Cache/Store.html#method-i-fetch
 [ActiveSupport::Cache::Store#write]: https://api.rubyonrails.org/classes/ActiveSupport/Cache/Store.html#method-i-write
 
-#### `config.active_support.raise_on_invalid_parse_string`
+#### `config.active_support.raise_on_invalid_time_zone_parse`
 
 Specifies whether [`ActiveSupport::TimeZone#parse`][] raises `ArgumentError`
 for strings that contain no recognizable date information (e.g. `"foobar"`).

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -397,6 +397,10 @@ module Rails
           if respond_to?(:active_job)
             active_job.enqueue_after_transaction_commit = true
           end
+
+          if respond_to?(:active_support)
+            active_support.raise_on_invalid_parse_string = true
+          end
         else
           raise "Unknown version #{target_version.to_s.inspect}"
         end

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -399,7 +399,7 @@ module Rails
           end
 
           if respond_to?(:active_support)
-            active_support.raise_on_invalid_parse_string = true
+            active_support.raise_on_invalid_time_zone_parse = true
           end
         else
           raise "Unknown version #{target_version.to_s.inspect}"

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
@@ -117,4 +117,4 @@
 # `"9000"`) raised `ArgumentError`. When enabled, both cases raise
 # `ArgumentError`, matching the Ruby standard library's `Time.parse`.
 #++
-# Rails.application.config.active_support.raise_on_invalid_parse_string = true
+# Rails.application.config.active_support.raise_on_invalid_time_zone_parse = true

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
@@ -108,3 +108,13 @@
 # `Accept: application/json, */*` now returns JSON.
 #++
 # Rails.application.config.action_dispatch.strict_accept_header = true
+
+# Raise `ArgumentError` on `ActiveSupport::TimeZone#parse` for any invalid
+# string.
+#
+# Historically, strings without recognizable date information (e.g. `"foobar"`)
+# returned `nil`, while strings with out-of-range date components (e.g.
+# `"9000"`) raised `ArgumentError`. When enabled, both cases raise
+# `ArgumentError`, matching the Ruby standard library's `Time.parse`.
+#++
+# Rails.application.config.active_support.raise_on_invalid_parse_string = true

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -4890,31 +4890,31 @@ module ApplicationTests
       assert_equal true, ActiveSupport::Cache::Store.raise_on_invalid_cache_expiration_time
     end
 
-    test "raise_on_invalid_parse_string is false with 8.1 defaults" do
+    test "raise_on_invalid_time_zone_parse is false with 8.1 defaults" do
       remove_from_config '.*config\.load_defaults.*\n'
       add_to_config 'config.load_defaults "8.1"'
       app "development"
 
-      assert_equal false, ActiveSupport::TimeZone.raise_on_invalid_parse_string
+      assert_equal false, ActiveSupport::TimeZone.raise_on_invalid_time_zone_parse
     end
 
-    test "raise_on_invalid_parse_string is true with 8.2 defaults" do
+    test "raise_on_invalid_time_zone_parse is true with 8.2 defaults" do
       remove_from_config '.*config\.load_defaults.*\n'
       add_to_config 'config.load_defaults "8.2"'
       app "development"
 
-      assert_equal true, ActiveSupport::TimeZone.raise_on_invalid_parse_string
+      assert_equal true, ActiveSupport::TimeZone.raise_on_invalid_time_zone_parse
     end
 
-    test "raise_on_invalid_parse_string can be set via new framework defaults" do
+    test "raise_on_invalid_time_zone_parse can be set via new framework defaults" do
       remove_from_config '.*config\.load_defaults.*\n'
       add_to_config 'config.load_defaults "8.1"'
       app_file "config/initializers/new_framework_defaults_8_2.rb", <<-RUBY
-        Rails.application.config.active_support.raise_on_invalid_parse_string = true
+        Rails.application.config.active_support.raise_on_invalid_time_zone_parse = true
       RUBY
       app "development"
 
-      assert_equal true, ActiveSupport::TimeZone.raise_on_invalid_parse_string
+      assert_equal true, ActiveSupport::TimeZone.raise_on_invalid_time_zone_parse
     end
 
     test "adds a time zone aware type if using PostgreSQL" do

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -4895,7 +4895,7 @@ module ApplicationTests
       add_to_config 'config.load_defaults "8.1"'
       app "development"
 
-      assert_equal false, ActiveSupport::TimeZone.raise_on_invalid_time_zone_parse
+      assert_equal false, ActiveSupport.raise_on_invalid_time_zone_parse
     end
 
     test "raise_on_invalid_time_zone_parse is true with 8.2 defaults" do
@@ -4903,7 +4903,7 @@ module ApplicationTests
       add_to_config 'config.load_defaults "8.2"'
       app "development"
 
-      assert_equal true, ActiveSupport::TimeZone.raise_on_invalid_time_zone_parse
+      assert_equal true, ActiveSupport.raise_on_invalid_time_zone_parse
     end
 
     test "raise_on_invalid_time_zone_parse can be set via new framework defaults" do
@@ -4914,7 +4914,7 @@ module ApplicationTests
       RUBY
       app "development"
 
-      assert_equal true, ActiveSupport::TimeZone.raise_on_invalid_time_zone_parse
+      assert_equal true, ActiveSupport.raise_on_invalid_time_zone_parse
     end
 
     test "adds a time zone aware type if using PostgreSQL" do

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -4890,6 +4890,33 @@ module ApplicationTests
       assert_equal true, ActiveSupport::Cache::Store.raise_on_invalid_cache_expiration_time
     end
 
+    test "raise_on_invalid_parse_string is false with 8.1 defaults" do
+      remove_from_config '.*config\.load_defaults.*\n'
+      add_to_config 'config.load_defaults "8.1"'
+      app "development"
+
+      assert_equal false, ActiveSupport::TimeZone.raise_on_invalid_parse_string
+    end
+
+    test "raise_on_invalid_parse_string is true with 8.2 defaults" do
+      remove_from_config '.*config\.load_defaults.*\n'
+      add_to_config 'config.load_defaults "8.2"'
+      app "development"
+
+      assert_equal true, ActiveSupport::TimeZone.raise_on_invalid_parse_string
+    end
+
+    test "raise_on_invalid_parse_string can be set via new framework defaults" do
+      remove_from_config '.*config\.load_defaults.*\n'
+      add_to_config 'config.load_defaults "8.1"'
+      app_file "config/initializers/new_framework_defaults_8_2.rb", <<-RUBY
+        Rails.application.config.active_support.raise_on_invalid_parse_string = true
+      RUBY
+      app "development"
+
+      assert_equal true, ActiveSupport::TimeZone.raise_on_invalid_parse_string
+    end
+
     test "adds a time zone aware type if using PostgreSQL" do
       original_configurations = ActiveRecord::Base.configurations
       ActiveRecord::Base.configurations = { production: { db1: { adapter: "postgresql" } } }


### PR DESCRIPTION
### Motivation / Background

Follow-up to #57194

This PR unifies the behavior so `TimeZone#parse` always raises `ArgumentError` for any invalid string, matching the Ruby standard library's `Time.parse`. The change is gated behind a config flag (defaulting to `false`) to preserve backwards compatibility, and is enabled by default in `config.load_defaults "8.2"`.

### Detail

* `config.active_support.raise_on_invalid_time_zone_parse` → `ActiveSupport.raise_on_invalid_time_zone_parse`
* Applied via the existing `active_support.set_configs` railtie (no dedicated initializer)
* Default: `false`; `true` under `load_defaults "8.2"`
* Documented in `configuring.md` and the method docs for `#parse`

### Review feedback addressed

* Use a plain `singleton_class.attr_accessor` on `ActiveSupport` instead of `class_attribute` on `TimeZone`
* Drop the custom railtie initializer so config is applied through `set_configs`

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.