### PR TITLE
Make lazy route loading thread-safe

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -162,11 +162,7 @@ module Rails
 
     # Reload application routes regardless if they changed or not.
     def reload_routes!
-      if routes_reloader.execute_unless_loaded
-        routes_reloader.loaded = false
-      else
-        routes_reloader.reload!
-      end
+      routes_reloader.reload!
     end
 
     def reload_routes_unless_loaded # :nodoc:

--- a/railties/lib/rails/application/routes_reloader.rb
+++ b/railties/lib/rails/application/routes_reloader.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
+require "monitor"
 
 module Rails
   class Application
     class RoutesReloader
       include ActiveSupport::Callbacks
 
-      attr_reader :route_sets, :paths, :external_routes, :loaded
+      attr_reader :route_sets, :paths, :external_routes
       attr_accessor :eager_load
-      attr_writer :run_once_after_load_paths, :loaded # :nodoc:
+      attr_writer :run_once_after_load_paths # :nodoc:
       delegate :execute_if_updated, :updated?, to: :updater
 
       def initialize(file_watcher: ActiveSupport::FileUpdateChecker)
@@ -16,28 +17,47 @@ module Rails
         @route_sets = []
         @external_routes = []
         @eager_load = false
-        @loaded = false
+        @load_state = nil # nil (not loaded yet) | :loading | :loaded
+        @load_lock = Monitor.new
         @file_watcher = file_watcher
       end
 
       def reload!
-        clear!
-        load_paths
-        finalize!
-        route_sets.each(&:eager_load!) if eager_load
-      ensure
-        revert
+        @load_lock.synchronize do
+          previous_state, @load_state = @load_state, :loading
+          clear!
+          load_paths
+          finalize!
+          route_sets.each(&:eager_load!) if eager_load
+        ensure
+          @load_state = previous_state
+          revert
+        end
       end
 
       def execute
-        @loaded = true
         updater.execute
       end
 
       def execute_unless_loaded
-        unless @loaded
+        return false if @load_state == :loaded
+
+        @load_lock.synchronize do
+          # Another thread finished the load while this one was blocked on
+          # @load_lock. Return true so callers like
+          # LazyRouteSet#method_missing retry the url helper that was
+          # missing when they were called.
+          return true if @load_state == :loaded
+
+          # Drawing the routes re-enters this method on the same thread —
+          # config/routes.rb itself calls routes.draw — through the
+          # reentrant Monitor; without this check the nested call would
+          # recurse into another draw.
+          return false if @load_state == :loading
+
           execute
           ActiveSupport.run_load_hooks(:after_routes_loaded, Rails.application)
+          @load_state = :loaded
           true
         end
       end

--- a/railties/test/application/routes_reloader_test.rb
+++ b/railties/test/application/routes_reloader_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+class RoutesReloaderTest < ActiveSupport::TestCase
+  test "a failed initial load is surfaced to waiting threads and retried" do
+    reloader = Rails::Application::RoutesReloader.new
+    draw_started = Queue.new
+    draw_resume = Queue.new
+    draws = 0
+
+    updater = Object.new
+    updater.define_singleton_method(:execute) do
+      draws += 1
+      draw_started << true
+      draw_resume.pop
+      raise "invalid routes" if draws == 1
+    end
+    reloader.instance_variable_set(:@updater, updater)
+
+    failing = Thread.new do
+      reloader.execute_unless_loaded
+    rescue RuntimeError => error
+      error
+    end
+    draw_started.pop
+
+    waiting = Thread.new { reloader.execute_unless_loaded }
+    Thread.pass until waiting.stop?
+    draw_resume << true
+
+    assert_instance_of(RuntimeError, failing.value)
+
+    # The waiting thread retries the draw rather than proceeding as if the
+    # routes were loaded.
+    draw_resume << true if draw_started.pop(timeout: 5)
+
+    assert_equal(true, waiting.value)
+    assert_equal(false, reloader.execute_unless_loaded)
+  end
+end

--- a/railties/test/engine/lazy_route_set_test.rb
+++ b/railties/test/engine/lazy_route_set_test.rb
@@ -82,6 +82,69 @@ module Rails
         assert_equal(200, response.first)
       end
 
+      test "concurrent requests during the first route load wait for routes to be fully drawn" do
+        pause_route_draw
+
+        require "#{app_path}/config/environment"
+
+        @app = Rails.application
+
+        first_request = Thread.new { get("/") }
+        $route_draw_started.pop
+
+        concurrent_request = Thread.new { get("/") }
+
+        # Wait for the concurrent request to either finish (it was routed
+        # against a half-drawn route set) or block until the draw completes.
+        deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 10
+        until !concurrent_request.alive? ||
+              (concurrent_request.stop? && concurrent_request.backtrace&.any? { |frame| frame.include?("execute_unless_loaded") })
+          flunk("Timed out waiting for the concurrent request") if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+          Thread.pass
+        end
+
+        $route_draw_resume << true
+
+        assert_equal(200, first_request.value.first)
+        assert_equal(200, concurrent_request.value.first)
+      end
+
+      test "url helpers called while another thread draws the routes wait for the draw" do
+        pause_route_draw
+
+        require "#{app_path}/config/environment"
+
+        helpers = app_url_helpers
+
+        drawing = Thread.new { helpers.root_path }
+        $route_draw_started.pop
+
+        waiting = Thread.new { helpers.root_path }
+        Thread.pass until waiting.stop?
+        $route_draw_resume << true
+
+        assert_equal("/", drawing.value)
+        assert_equal("/", waiting.value)
+      end
+
+      test "respond_to? on url helpers called while another thread draws the routes waits for the draw" do
+        pause_route_draw
+
+        require "#{app_path}/config/environment"
+
+        helpers = app_url_helpers
+
+        drawing = Thread.new { helpers.root_path }
+        $route_draw_started.pop
+
+        waiting = Thread.new { helpers.respond_to?(:root_path) }
+        Thread.pass until waiting.stop?
+        $route_draw_resume << true
+
+        assert_equal("/", drawing.value)
+        assert(waiting.value)
+      end
+
       test "app lazily loads routes when url_for is used" do
         require "#{app_path}/config/environment"
 
@@ -143,6 +206,23 @@ module Rails
       end
 
       private
+        # Parks the initial route draw until $route_draw_resume is signaled,
+        # so a test can deterministically overlap it with other threads.
+        def pause_route_draw
+          app_file "config/initializers/pause_route_draw.rb", <<~RUBY
+            $route_draw_started = Queue.new
+            $route_draw_resume = Queue.new
+
+            Rails.application.routes_reloader.singleton_class.prepend(Module.new do
+              def load_paths
+                $route_draw_started << true
+                $route_draw_resume.pop
+                super
+              end
+            end)
+          RUBY
+        end
+
         def build_app
           super
 


### PR DESCRIPTION
### Motivation / Background

Since Rails 8.0 (#52353, originally #51614), route drawing is deferred until the first request when `config.eager_load` is `false` (the default for development and test). Production isn't affected, since it eager-loads routes at boot.

That deferred draw isn't thread-safe. `RoutesReloader` marks itself as loaded *before* it actually finishes drawing routes, so if two threads hit the app at the same time — a threaded dev server, or a test suite firing off concurrent requests — the second thread can see the flag and start dispatching against a route set that's only half-drawn. That shows up as a 404 for a route that clearly exists, or a `NoMethodError` from a url helper that hasn't been defined yet. It's also possible for both threads to start drawing at once.

I ran into this in a real app's test suite: two concurrent first requests, one of them deterministically 404s. The workaround was calling `Rails.application.routes.eager_load!` before the test, but that's just papering over the race.

### Detail

The reentrancy wrinkle first, because it shaped everything: drawing routes re-enters the lazy-load path on the same thread — `config/routes.rb` itself calls `routes.draw`, and url helpers used while drawing do the same — so whatever guards the draw has to turn those nested calls into no-ops instead of recursing into another draw. That guard used to be `@loaded`, set before the draw started, which doubled as the "routes were loaded" flag — and that double duty is exactly what made the race possible.

The state now lives in a single `@load_state` — `nil` (not loaded yet), `:loading` or `:loaded`:

* route drawing happens under a reentrant `Monitor` owned by the reloader
* `reload!` marks `:loading` for the duration of the draw and restores the previous state after, so nested calls from the drawing thread short-circuit — and since the guard sits where the drawing happens, every entry point into a draw is covered
* other threads block on the Monitor until the draw is done, then dispatch against the fully drawn set
* `:loaded` is only set once the initial draw (and its `after_routes_loaded` hooks) finish — it's what gives every request after the first its lock-free fast path
* threads that had to wait get told to retry, so `LazyRouteSet` can re-check a url helper that didn't exist yet when it was first called
* a failed draw restores the previous state in the `ensure` and never reaches `:loaded`, so waiters retry the draw and see the real error instead of dispatching against a half-drawn set — no rescue needed

With the guard inside `reload!`, the workaround in `reload_routes!` from #54306 isn't needed anymore: plain `reload!` is safe to call even before the initial lazy load, so it's back to a one-liner. Its behavior is preserved — a forced reload before the initial load still leaves the next lazy trigger to draw the routes again. One small delta: `after_routes_loaded` hooks no longer fire for that early forced reload. They used to fire twice (once as a side effect of the workaround, once at the real initial load); now it's just once, at the initial load. The `loaded` reader and writer had no remaining callers and are removed.

### Tests

The new tests pause the reloader mid-draw (by prepending a module on `load_paths`) and hit it from a second thread — making a request, calling a url helper, or checking `respond_to?`. There's also a unit test for the failed-draw case. All of them fail on `main` and pass with this change. The existing `reload_routes!` coverage, including #54306's rake test, still passes.

### Checklist

- [x] This PR includes tests
- [x] CHANGELOG entry added (railties)