### PR TITLE
Deprecate `TransactionState` predicates and fix stale ivar in `Persistence::ClassMethods#inherited`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Deprecate `ActiveRecord::ConnectionAdapters::TransactionState#fully_committed?`,
+    `#fully_rolledback?`, `#fully_completed?`, and `#nullify!`.
+
+    These methods are no longer used by the framework. Use `#committed?`,
+    `#rolledback?`, and `#completed?` to inspect the transaction state instead.
+
+    *Kenta Ishizaki*
+
 *   Bump the minimum supported SQLite version to 3.35.0.
 
     SQLite 3.35.0 introduced the `RETURNING` clause, which the SQLite3 adapter

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -74,6 +74,9 @@ module ActiveRecord
       def nullify!
         @state = nil
       end
+
+      deprecate :fully_committed?, :fully_rolledback?, :nullify!,
+        fully_completed?: :completed?, deprecator: ActiveRecord.deprecator
     end
 
     class TransactionInstrumenter

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -291,7 +291,7 @@ module ActiveRecord
         def inherited(subclass)
           super
           subclass.class_eval do
-            @_query_constraints_list = nil
+            @query_constraints_list = nil
             @has_query_constraints = false
           end
         end

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -1411,7 +1411,26 @@ class TransactionTest < ActiveRecord::TestCase
 
     transaction.commit
 
-    assert_nil transaction.state.nullify!
+    assert_deprecated(/nullify!/, ActiveRecord.deprecator) do
+      assert_nil transaction.state.nullify!
+    end
+  end
+
+  def test_deprecated_transaction_state_predicates
+    state = ActiveRecord::ConnectionAdapters::TransactionState.new
+
+    state.full_commit!
+    assert_deprecated(/fully_committed\?/, ActiveRecord.deprecator) do
+      assert_predicate state, :fully_committed?
+    end
+    assert_deprecated(/completed\?/, ActiveRecord.deprecator) do
+      assert_predicate state, :fully_completed?
+    end
+
+    state.full_rollback!
+    assert_deprecated(/fully_rolledback\?/, ActiveRecord.deprecator) do
+      assert_predicate state, :fully_rolledback?
+    end
   end
 
   def test_transaction_rollback_with_primarykeyless_tables


### PR DESCRIPTION
### Motivation / Background

Follow-up to #58217, where two commits were dropped based on review feedback:

- `ActiveRecord::ConnectionAdapters::TransactionState` is documented API, so its unused methods should go through a deprecation cycle rather than being removed outright.
- The `@_query_constraints_list` reset in `Persistence::ClassMethods#inherited` exists to pre-define instance variables for consistent object shapes, so it should be fixed rather than removed.

### Detail

The first commit deprecates `TransactionState#fully_committed?`, `#fully_rolledback?`, `#fully_completed?`, and `#nullify!`. They lost their last callers in 77f7b2df3a, 8180c39610, and 6c745b0c51 respectively, and the state they expose remains observable through `#committed?`, `#rolledback?`, and `#completed?` (which `fully_completed?` is an alias of). Includes a CHANGELOG entry and deprecation tests.

The second commit updates the reset in `inherited` to `@query_constraints_list`. 767cd52e76 renamed the memoized variable but left the reset on the old `@_query_constraints_list` name, so the pre-defined ivar no longer matched the one `query_constraints_list` memoizes into. No behavior change, so no CHANGELOG entry.