### PR TITLE
Remove dead branch in MySQL column introspection

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -212,8 +212,6 @@ module ActiveRecord
             elsif type_metadata.type == :text && default&.start_with?("'")
               # strip and unescape quotes
               default = default[1...-1].gsub("\\'", "'")
-            elsif default&.match?(/\A\d/)
-              # Its a number so we can skip the query to check if it is a function
             end
 
             MySQL::Column.new(


### PR DESCRIPTION
It was introduced in 4ccd79cdd6 to prevent `default_type` running `SHOW CREATE TABLE` once per column to classify a default as `:string`, `:integer`, or `:function`. The `/\A\d/` branch short-circuited numeric defaults so that expensive query was skipped for the common case.

c2c158c760 moved MariaDB function-default detection into `column_definitions`, so there is no longer a need to skip `default_type`.