### PR TITLE
Allow Relation#preload! to work on an already loaded relation

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Allow `ActiveRecord::Relation#preload!` to work on an already loaded relation.
+
+    Previously, calling `preload!` on a relation that had already been loaded
+    raised `ActiveRecord::UnmodifiableRelation`. Now it immediately preloads
+    the requested associations onto the already-loaded records instead.
+
+    ```ruby
+    posts = Post.all.load
+    posts.preload!(:comments) # => preloads comments onto the loaded posts
+    posts.first.comments # no additional query
+    ```
+
+    *Bogdan Gusiev*
+
 *   Remove unused `rest` parameter from merge and merge!
 
     *Aaron Patterson*

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -325,7 +325,12 @@ module ActiveRecord
     end
 
     def preload!(*args) # :nodoc:
-      self.preload_values |= args
+      # Preloading doesn't affect the query itself, so it's safe to mutate
+      # +preload_values+ even after the relation has been loaded or its
+      # Arel has been built, unlike the other query methods guarded by
+      # +assert_modifiable!+.
+      @values[:preload] = preload_values | args
+      preload_associations(records) if loaded?
       self
     end
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -694,6 +694,20 @@ class RelationTest < ActiveRecord::TestCase
     end
   end
 
+  def test_preload_bang_on_loaded_relation_preloads_immediately
+    posts = Post.all.load
+    assert_predicate posts, :loaded?
+    post = posts.first
+    assert_not_predicate post.association(:comments), :loaded?
+
+    assert_queries_count(1) do
+      posts.preload!(:comments)
+    end
+
+    assert_predicate post.association(:comments), :loaded?
+    assert_no_queries { post.comments.to_a }
+  end
+
   def test_preload_applies_to_all_chained_preloaded_scopes
     assert_queries_count(3) do
       post = Post.with_comments.with_tags.first


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `ActiveRecord::Relation#preload!` raised `ActiveRecord::UnmodifiableRelation` when called on a relation that had already been loaded. It went through the generic `preload_values=` setter, which is guarded by `assert_modifiable!` like every other query-value setter (`where!`, `limit!`, etc.). That guard makes sense for methods that affect the SQL/Arel already built for the relation, but preloading doesn't affect the query at all — it's a post-load step — so there was no reason to block it once a relation was loaded.

### Detail

This Pull Request changes `preload!` to write directly to `@values[:preload]` instead of going through the guarded setter, and to immediately preload the requested associations onto the relation's records if it's already loaded, instead of raising:

```ruby
posts = Post.all.load
posts.preload!(:comments) # => preloads comments onto the already-loaded posts
posts.first.comments      # no additional query
```

### Additional information

No other query-value method (`where!`, `includes!`, etc.) is affected — only `preload!`, since it's the one case where mutating after load is safe and useful.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.