### PR TITLE
Collapse whitespace for inline code blocks

### DIFF
--- a/guides/assets/stylesrc/_main.scss
+++ b/guides/assets/stylesrc/_main.scss
@@ -356,6 +356,7 @@ body.guide {
     background: $gray-200;
     border-radius: calc($base-border-radius / 2);
     padding: 1px 3px;
+    white-space: normal;
   }
 
   p img {

--- a/guides/assets/stylesrc/_main.scss
+++ b/guides/assets/stylesrc/_main.scss
@@ -356,6 +356,7 @@ body.guide {
     background: $gray-200;
     border-radius: calc($base-border-radius / 2);
     padding: 1px 3px;
+    white-space: nowrap;
   }
 
   p img {


### PR DESCRIPTION
We limit the guides markdown to a width of 80 columns. This causes code in code fences to sometimes span over multiple lines. These linebreaks should not be visible in the resulting HTML.

By using `white-space: normal` whitespace is collapsed but lines are still wrapped if it extends the container width.

# Before

<img width="656" height="100" alt="image" src="https://github.com/user-attachments/assets/1662bde0-f1bb-431d-a7de-ffa1a93aa479" />

# After

<img width="666" height="103" alt="image" src="https://github.com/user-attachments/assets/63d29d12-5474-45ab-a312-bba02ab70afc" />

It still wraps if the context extends the container width:
<img width="661" height="105" alt="image" src="https://github.com/user-attachments/assets/c0e2aea3-801c-4a73-982d-9b4090561ccc" />

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
