### PR TITLE
Fix reason phrase casing in the 404 error page title

### DIFF
--- a/actionmailbox/test/dummy/public/404.html
+++ b/actionmailbox/test/dummy/public/404.html
@@ -4,7 +4,7 @@
 
   <head>
 
-    <title>The page you were looking for doesn't exist (404 Not found)</title>
+    <title>The page you were looking for doesn't exist (404 Not Found)</title>
 
     <meta charset="utf-8">
     <meta name="viewport" content="initial-scale=1, width=device-width">

--- a/actiontext/test/dummy/public/404.html
+++ b/actiontext/test/dummy/public/404.html
@@ -4,7 +4,7 @@
 
   <head>
 
-    <title>The page you were looking for doesn't exist (404 Not found)</title>
+    <title>The page you were looking for doesn't exist (404 Not Found)</title>
 
     <meta charset="utf-8">
     <meta name="viewport" content="initial-scale=1, width=device-width">

--- a/activestorage/test/dummy/public/404.html
+++ b/activestorage/test/dummy/public/404.html
@@ -4,7 +4,7 @@
 
   <head>
 
-    <title>The page you were looking for doesn't exist (404 Not found)</title>
+    <title>The page you were looking for doesn't exist (404 Not Found)</title>
 
     <meta charset="utf-8">
     <meta name="viewport" content="initial-scale=1, width=device-width">

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2562,7 +2562,7 @@ defaults to `true`.
 
 The `config.action_dispatch.show_exceptions` configuration controls how Action Pack (specifically the [`ActionDispatch::ShowExceptions`](/configuring.html#actiondispatch-showexceptions) middleware) handles exceptions raised while responding to requests.
 
-Setting the value to `:all` configures Action Pack to rescue from exceptions and render corresponding error pages. For example, Action Pack would rescue from an `ActiveRecord::RecordNotFound` exception and render the contents of `public/404.html` with a `404 Not found` status code.
+Setting the value to `:all` configures Action Pack to rescue from exceptions and render corresponding error pages. For example, Action Pack would rescue from an `ActiveRecord::RecordNotFound` exception and render the contents of `public/404.html` with a `404 Not Found` status code.
 
 Setting the value to `:rescuable` configures Action Pack to rescue from exceptions defined in [`config.action_dispatch.rescue_responses`](/configuring.html#config-action-dispatch-rescue-responses), and raise all others. For example, Action Pack would rescue from `ActiveRecord::RecordNotFound`, but would raise a `NoMethodError`.
 

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -498,7 +498,7 @@ config.active_record.encryption.support_sha1_for_non_deterministic_encryption = 
 
 The `config.action_dispatch.show_exceptions` configuration controls how Action Pack handles exceptions raised while responding to requests.
 
-Prior to Rails 7.1, setting `config.action_dispatch.show_exceptions = true` configured Action Pack to rescue exceptions and render appropriate HTML error pages, like rendering `public/404.html` with a `404 Not found` status code instead of raising an `ActiveRecord::RecordNotFound` exception. Setting `config.action_dispatch.show_exceptions = false` configured Action Pack to not rescue the exception. Prior to Rails 7.1, new applications were generated with a line in `config/environments/test.rb` that set `config.action_dispatch.show_exceptions = false`.
+Prior to Rails 7.1, setting `config.action_dispatch.show_exceptions = true` configured Action Pack to rescue exceptions and render appropriate HTML error pages, like rendering `public/404.html` with a `404 Not Found` status code instead of raising an `ActiveRecord::RecordNotFound` exception. Setting `config.action_dispatch.show_exceptions = false` configured Action Pack to not rescue the exception. Prior to Rails 7.1, new applications were generated with a line in `config/environments/test.rb` that set `config.action_dispatch.show_exceptions = false`.
 
 Rails 7.1 changes the acceptable values from `true` and `false` to `:all`, `:rescuable`, and `:none`.
 

--- a/railties/lib/rails/generators/rails/app/templates/public/404.html
+++ b/railties/lib/rails/generators/rails/app/templates/public/404.html
@@ -4,7 +4,7 @@
 
   <head>
 
-    <title>The page you were looking for doesn't exist (404 Not found)</title>
+    <title>The page you were looking for doesn't exist (404 Not Found)</title>
 
     <meta charset="utf-8">
     <meta name="viewport" content="initial-scale=1, width=device-width">


### PR DESCRIPTION
### Motivation / Background

The redesigned static error pages (#53045) added HTTP reason phrases to the page titles, but the 404 page is the odd one out:

| Page | Title suffix |
|------|--------------|
| 400  | `(400 Bad Request)` |
| 404  | `(404 Not found)` ← |
| 406  | `(406 Not Acceptable)` |
| 422  | `(422 Unprocessable Entity)` |
| 500  | `(500 Internal Server Error)` |

The HTTP reason phrase is `Not Found` ([RFC 9110 §15.5.5](https://www.rfc-editor.org/rfc/rfc9110#name-404-not-found)), as the other four pages already have it. Even the 404 page's own SVG artwork renders the phrase as "Not Found" — with this change the `<title>` matches the artwork it sits above.

<img width="2940" height="1484" alt="The page you were looking for doesn&#39;t exist (404 Not found)" src="https://github.com/user-attachments/assets/474fbe67-dabf-4551-8677-2b90d21a5276" />

### Detail

Updates every remaining `404 Not found` in the repo to `404 Not Found`:

- the generated `public/404.html` template, plus its `test/dummy` copies in Active Storage, Action Mailbox, and Action Text
- two mentions in the guides (`configuring.md`, `upgrading_ruby_on_rails.md`)

Text-only change; no assertions reference these strings.
