### PR TITLE
Fix skip_forgery_protection lost when protect_from_forgery is reapplied

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -17,6 +17,13 @@
 
     *Chad Cole*
 
+*   Fix `protect_from_forgery` re-registering callbacks when called again on the
+    same controller, which could wipe action-specific `skip_forgery_protection`
+    conditions on descendants.
+
+    *arimu1*
+
+
 *   Fix route recognition still matching routes that were removed by redrawing
     a route set as empty.
 

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -299,14 +299,7 @@ module ActionController # :nodoc:
         self.forgery_protection_verification_strategy = verification_strategy(options[:using] || forgery_protection_verification_strategy)
         self.forgery_protection_trusted_origins = Array(options[:trusted_origins]) if options.key?(:trusted_origins)
 
-        if options[:prepend]
-          prepend_before_action :verify_request_for_forgery_protection, options
-          prepend_before_action :verify_authenticity_token, options
-        else
-          before_action :verify_authenticity_token, :verify_request_for_forgery_protection, options
-        end
-        append_after_action :verify_same_origin_request
-        append_after_action :append_sec_fetch_site_to_vary_header, options
+        install_forgery_protection_callbacks(options) unless forgery_protection_callbacks_installed?
       end
 
       # Turn off request forgery protection. This is a wrapper for:
@@ -322,6 +315,21 @@ module ActionController # :nodoc:
       end
 
       private
+        def forgery_protection_callbacks_installed?
+          _process_action_callbacks.any? { |callback| callback.filter == :verify_request_for_forgery_protection }
+        end
+
+        def install_forgery_protection_callbacks(options)
+          if options[:prepend]
+            prepend_before_action :verify_request_for_forgery_protection, options
+            prepend_before_action :verify_authenticity_token, options
+          else
+            before_action :verify_authenticity_token, :verify_request_for_forgery_protection, options
+          end
+          append_after_action :verify_same_origin_request
+          append_after_action :append_sec_fetch_site_to_vary_header, options
+        end
+
         def protection_method_class(name)
           case name
           when :null_session

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -299,7 +299,10 @@ module ActionController # :nodoc:
         self.forgery_protection_verification_strategy = verification_strategy(options[:using] || forgery_protection_verification_strategy)
         self.forgery_protection_trusted_origins = Array(options[:trusted_origins]) if options.key?(:trusted_origins)
 
-        install_forgery_protection_callbacks(options) unless forgery_protection_callbacks_installed?
+        unless @forgery_protection_callbacks_installed
+          install_forgery_protection_callbacks(options)
+          @forgery_protection_callbacks_installed = true
+        end
       end
 
       # Turn off request forgery protection. This is a wrapper for:
@@ -315,10 +318,6 @@ module ActionController # :nodoc:
       end
 
       private
-        def forgery_protection_callbacks_installed?
-          _process_action_callbacks.any? { |callback| callback.filter == :verify_request_for_forgery_protection }
-        end
-
         def install_forgery_protection_callbacks(options)
           if options[:prepend]
             prepend_before_action :verify_request_for_forgery_protection, options

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -139,6 +139,8 @@ module ActionController # :nodoc:
       helper_method :protect_against_forgery?
     end
 
+    FORGERY_PROTECTION_CALLBACK_OPTIONS = [:only, :except, :if, :unless, :prepend].freeze
+
     module ClassMethods
       # Turn on request forgery protection. Bear in mind that GET and HEAD requests
       # are not checked.
@@ -299,9 +301,10 @@ module ActionController # :nodoc:
         self.forgery_protection_verification_strategy = verification_strategy(options[:using] || forgery_protection_verification_strategy)
         self.forgery_protection_trusted_origins = Array(options[:trusted_origins]) if options.key?(:trusted_origins)
 
-        unless @forgery_protection_callbacks_installed
+        callback_options = options.slice(*FORGERY_PROTECTION_CALLBACK_OPTIONS)
+        unless forgery_protection_callbacks_installed?(callback_options)
           install_forgery_protection_callbacks(options)
-          @forgery_protection_callbacks_installed = true
+          @forgery_protection_callback_options = callback_options
         end
       end
 
@@ -318,6 +321,10 @@ module ActionController # :nodoc:
       end
 
       private
+        def forgery_protection_callbacks_installed?(callback_options)
+          @forgery_protection_callback_options == callback_options
+        end
+
         def install_forgery_protection_callbacks(options)
           if options[:prepend]
             prepend_before_action :verify_request_for_forgery_protection, options

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -230,6 +230,15 @@ class ProtectsOnlyIndexController < ProtectedOnlyIndexParentController
   protect_from_forgery only: :index, with: :exception
 end
 
+class ProtectedExceptIndexParentController < ActionController::Base
+  protect_from_forgery with: :exception
+end
+
+class ProtectsExceptIndexController < ProtectedExceptIndexParentController
+  include RequestForgeryProtectionActions
+  protect_from_forgery except: :index, with: :exception
+end
+
 # Controller using the deprecated skip_before_action :verify_authenticity_token
 class DeprecatedSkipVerifyAuthenticityTokenController < ActionController::Base
   include RequestForgeryProtectionActions
@@ -1374,6 +1383,25 @@ class ProtectsOnlyIndexControllerTest < ActionController::TestCase
 
   test "does not protect other actions when child re-applies protect_from_forgery with only" do
     post :unsafe
+    assert_response :success
+  end
+end
+
+class ProtectsExceptIndexControllerTest < ActionController::TestCase
+  test "allows excepted action when child re-applies protect_from_forgery with except" do
+    assert_not_blocked { post :index }
+  end
+
+  test "still protects non-excepted actions when child re-applies protect_from_forgery with except" do
+    assert_blocked { post :unsafe }
+  end
+
+  def assert_blocked(&block)
+    assert_raises(ActionController::InvalidCrossOriginRequest, &block)
+  end
+
+  def assert_not_blocked(&block)
+    assert_nothing_raised(&block)
     assert_response :success
   end
 end

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -208,6 +208,19 @@ class SkipsInheritedProtectionController < ProtectedParentController
   skip_forgery_protection
 end
 
+class ReprotectedParentController < ActionController::Base
+  protect_from_forgery with: :exception
+end
+
+class SkipsProtectionForOneActionController < ReprotectedParentController
+  include RequestForgeryProtectionActions
+  skip_forgery_protection only: :index
+end
+
+# Re-applying protect_from_forgery on the parent must not remove the
+# action-specific skip already registered on the child.
+ReprotectedParentController.protect_from_forgery with: :exception
+
 # Controller using the deprecated skip_before_action :verify_authenticity_token
 class DeprecatedSkipVerifyAuthenticityTokenController < ActionController::Base
   include RequestForgeryProtectionActions
@@ -1331,6 +1344,17 @@ class SkipsInheritedProtectionControllerTest < ActionController::TestCase
     @request.set_header "HTTP_SEC_FETCH_SITE", "cross-site"
     post :index
     assert_response :success
+  end
+end
+
+class SkipsProtectionForOneActionControllerTest < ActionController::TestCase
+  test "keeps action-specific skip after protect_from_forgery is reapplied on an ancestor" do
+    assert_nothing_raised { post :index }
+    assert_response :success
+  end
+
+  test "still protects other actions after protect_from_forgery is reapplied on an ancestor" do
+    assert_raises(ActionController::InvalidCrossOriginRequest) { post :unsafe }
   end
 end
 

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -221,6 +221,15 @@ end
 # action-specific skip already registered on the child.
 ReprotectedParentController.protect_from_forgery with: :exception
 
+class ProtectedOnlyIndexParentController < ActionController::Base
+  protect_from_forgery with: :exception
+end
+
+class ProtectsOnlyIndexController < ProtectedOnlyIndexParentController
+  include RequestForgeryProtectionActions
+  protect_from_forgery only: :index, with: :exception
+end
+
 # Controller using the deprecated skip_before_action :verify_authenticity_token
 class DeprecatedSkipVerifyAuthenticityTokenController < ActionController::Base
   include RequestForgeryProtectionActions
@@ -1349,12 +1358,23 @@ end
 
 class SkipsProtectionForOneActionControllerTest < ActionController::TestCase
   test "keeps action-specific skip after protect_from_forgery is reapplied on an ancestor" do
-    assert_nothing_raised { post :index }
+    post :index
     assert_response :success
   end
 
   test "still protects other actions after protect_from_forgery is reapplied on an ancestor" do
     assert_raises(ActionController::InvalidCrossOriginRequest) { post :unsafe }
+  end
+end
+
+class ProtectsOnlyIndexControllerTest < ActionController::TestCase
+  test "protects only the specified action when child re-applies protect_from_forgery" do
+    assert_raises(ActionController::InvalidCrossOriginRequest) { post :index }
+  end
+
+  test "does not protect other actions when child re-applies protect_from_forgery with only" do
+    post :unsafe
+    assert_response :success
   end
 end
 


### PR DESCRIPTION
## Summary

- Prevents `protect_from_forgery` from re-registering forgery callbacks when the same callback options are already installed on that controller class.
- Re-applying protection on an ancestor with identical callback options no longer duplicates `verify_request_for_forgery_protection` callbacks, which previously replaced action-specific `skip_forgery_protection` conditions on descendants (Active Support `remove_duplicates`).
- Tracks per-class `@forgery_protection_callback_options` (the sliced `only` / `except` / `prepend` options) so a subclass can still install its own scoped callbacks — for example `protect_from_forgery only:` — even when inherited callbacks are present. A later call with different callback options still installs; an identical re-call is skipped.
- Strategy / storage / verification / trusted-origins config still updates on every call. Prefer `skip_forgery_protection` for action exclusions rather than reshaping the chain via a second `protect_from_forgery`.
- Adds regression coverage for ancestor re-apply + child `skip_forgery_protection only:`, and for subclass `protect_from_forgery only:` / `except:`.

Fixes #58232.

## Test plan

- [x] Focused: `SkipsProtectionForOneActionControllerTest` + `ProtectsOnlyIndexControllerTest` (and except coverage) — 0 failures
- [x] `bundle exec ruby -Itest test/controller/request_forgery_protection_test.rb` — **346 runs, 0 failures**