### PR TITLE
Remove stale requires

### DIFF
--- a/actionmailer/lib/action_mailer/log_subscriber.rb
+++ b/actionmailer/lib/action_mailer/log_subscriber.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/log_subscriber"
-
 module ActionMailer
   class LogSubscriber < ActiveSupport::EventReporter::LogSubscriber # :nodoc:
     self.namespace = "action_mailer"

--- a/actiontext/lib/generators/action_text/install/install_generator.rb
+++ b/actiontext/lib/generators/action_text/install/install_generator.rb
@@ -3,7 +3,6 @@
 # :markup: markdown
 
 require "pathname"
-require "json"
 require "rails/generators/js_package_manager"
 
 module ActionText

--- a/actionview/lib/action_view/log_subscriber.rb
+++ b/actionview/lib/action_view/log_subscriber.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/log_subscriber"
-
 module ActionView
   class LogSubscriber < ActiveSupport::EventReporter::LogSubscriber # :nodoc:
     VIEWS_PATTERN = /^app\/views\//

--- a/activejob/lib/active_job/log_subscriber.rb
+++ b/activejob/lib/active_job/log_subscriber.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/log_subscriber"
-
 module ActiveJob
   class LogSubscriber < ActiveSupport::EventReporter::LogSubscriber # :nodoc:
     class_attribute :backtrace_cleaner, default: ActiveSupport::BacktraceCleaner.new

--- a/activestorage/lib/active_storage/log_subscriber.rb
+++ b/activestorage/lib/active_storage/log_subscriber.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/log_subscriber"
-
 module ActiveStorage
   class LogSubscriber < ActiveSupport::EventReporter::LogSubscriber # :nodoc:
     self.namespace = "active_storage"

--- a/activestorage/lib/active_storage/service/disk_service.rb
+++ b/activestorage/lib/active_storage/service/disk_service.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "fileutils"
-require "pathname"
-require "openssl"
 require "active_support/core_ext/numeric/bytes"
 
 module ActiveStorage


### PR DESCRIPTION
Three groups of `require`s that no longer match the code around them.

### `active_support/log_subscriber` in four log subscribers

Action Mailer, Action View, Active Job and Active Storage each require `active_support/log_subscriber`, but their log subscribers inherit from `ActiveSupport::EventReporter::LogSubscriber`, which is autoloaded from `active_support/event_reporter.rb`. None of the four reference `ActiveSupport::LogSubscriber`, so the require loads a class they do not use.

The log subscribers converted alongside them already omit it:

| log subscriber | requires `active_support/log_subscriber` |
| --- | --- |
| `active_record/log_subscriber.rb` | no |
| `action_controller/log_subscriber.rb` | no |
| `action_dispatch/log_subscriber.rb` | no |
| `action_mailer/log_subscriber.rb` | yes → removed |
| `action_view/log_subscriber.rb` | yes → removed |
| `active_job/log_subscriber.rb` | yes → removed |
| `active_storage/log_subscriber.rb` | yes → removed |

### `pathname` and `openssl` in the Active Storage disk service

`Pathname` has not been referenced since c39e176eb5, and `OpenSSL` since checksum handling moved out of the service in d1e31dd4f9. `fileutils` and `active_support/core_ext/numeric/bytes` are still used and are kept.

### `json` in the Action Text install generator

`JSON` has not been referenced since 82e4432058. `pathname` is still used and is kept.