### PR TITLE
Fix dangling Action Text autoloads for `Configurator` and `Registry`

### DIFF
--- a/actiontext/lib/action_text.rb
+++ b/actiontext/lib/action_text.rb
@@ -18,7 +18,6 @@ module ActionText
   autoload :Attachment
   autoload :Attribute
   autoload :BottomUpReducer
-  autoload :Configurator
   autoload :Content
   autoload :Editor
   autoload :Encryption
@@ -27,7 +26,6 @@ module ActionText
   autoload :HtmlConversion
   autoload :MarkdownConversion
   autoload :PlainTextConversion
-  autoload :Registry
   autoload :Rendering
   autoload :Serialization
   autoload :TrixAttachment


### PR DESCRIPTION
`ActionText` autoloads `Configurator` from `action_text/configurator` and `Registry` from `action_text/registry`. Neither file exists, so referencing either constant raises `LoadError` instead of `NameError`:

```ruby
ActionText::Configurator
# => LoadError: cannot load such file -- action_text/configurator
ActionText::Registry
# => LoadError: cannot load such file -- action_text/registry
```

After this change both raise `NameError`, like any other undefined constant.

Both classes live under `ActionText::Editor` and are autoloaded from `action_text/editor.rb`:

```ruby
ActionText::Editor::Configurator # => ActionText::Editor::Configurator
ActionText::Editor::Registry     # => ActionText::Editor::Registry
```

Nothing in the framework or its tests refers to the top-level names, and both classes are `:nodoc:`. The autoloads were added in cb0fd2254a and are unreleased.

---

> [!NOTE]
> 
> - No CHANGELOG entry: the constants are internal (`:nodoc:`) and the autoloads are unreleased.
> - No test added: the removed autoloads point at files that do not exist, so there is no behavior to pin beyond constant lookup raising `NameError`.