### PR TITLE
Fix Encoding::CompatibilityError in template digests.

### DIFF
--- a/actionview/lib/action_view/dependency_tracker/ruby_tracker.rb
+++ b/actionview/lib/action_view/dependency_tracker/ruby_tracker.rb
@@ -27,7 +27,7 @@ module ActionView
         def render_dependencies
           return [] unless template.source.include?("render")
 
-          compiled_source = template.handler.call(template, template.source)
+          compiled_source = template.handler.call(template, template.encode!)
 
           RenderParser.new(@name, compiled_source).render_calls.filter_map do |render_call|
             render_call.gsub(%r|/_|, "/")

--- a/actionview/test/template/dependency_tracker_test.rb
+++ b/actionview/test/template/dependency_tracker_test.rb
@@ -22,6 +22,10 @@ class FakeTemplate
   def type
     ["text/html"]
   end
+
+  def encode!
+    source
+  end
 end
 
 Neckbeard = lambda { |template, source| source }
@@ -336,5 +340,29 @@ class RubyTrackerTest < Minitest::Test
     tracker = make_tracker("messages/show", template)
 
     assert_equal [], tracker.dependencies
+  end
+
+  def test_dependencies_encode_binary_non_ascii_source_before_handler
+    handler = lambda do |_template, source|
+      # Mimic Temple::Filters::StaticMerger concatenating a UTF-8 literal with
+      # template content. This raises Encoding::CompatibilityError when +source+
+      # is still tagged ASCII-8BIT and contains bytes > 0x7F.
+      _ = source + "介護"
+      'render "posts/child"'
+    end
+
+    binary_source = (+"= render \"posts/child\"\n介護").force_encoding(Encoding::BINARY)
+    template = ActionView::Template.new(
+      binary_source,
+      "posts/show",
+      handler,
+      virtual_path: "posts/show",
+      format: :html,
+      locals: []
+    )
+
+    tracker = make_tracker("posts/show", template)
+
+    assert_equal ["posts/child"], tracker.dependencies
   end
 end


### PR DESCRIPTION
### Motivation / Background

Fixes #58203.

Computing a template digest for a file-backed Haml template with non-ASCII text and a `render` call raises `Encoding::CompatibilityError` during dependency tracking. That can surface as a 500 when fragment caching digests such a template.

### Detail

File-backed templates are loaded via `File.binread` (ASCII-8BIT). Normal compilation runs `template.encode!` before calling the handler, but `DependencyTracker::RubyTracker` passed the raw `template.source` instead.

This PR makes `RubyTracker` pass `template.encode!` to the handler, matching `Template#compiled_source`, so handlers like Haml/Temple can concatenate UTF-8 static strings without raising.

Adds a regression test that mimics Temple's static merger without requiring Haml as a dependency.

### Additional information

Related to #56904 / #56906 (same ASCII-8BIT / `File.binread` encoding class of bug).

### Checklist

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
