### PR TITLE
Remove `ruby2_keywords` usage

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -656,11 +656,11 @@ module ActionMailer
       @_message = Mail.new
     end
 
-    def process(method_name, *args) # :nodoc:
+    def process(method_name, *args, **kwargs) # :nodoc:
       payload = {
         mailer: self.class.name,
         action: method_name,
-        args: args
+        args: kwargs.empty? ? args : args + [kwargs]
       }
 
       ActiveSupport::Notifications.instrument("process.action_mailer", payload) do
@@ -668,7 +668,6 @@ module ActionMailer
         @_message = NullMail.new unless @_mail_was_called
       end
     end
-    ruby2_keywords(:process)
 
     class NullMail # :nodoc:
       def body; "" end

--- a/actionmailer/lib/action_mailer/message_delivery.rb
+++ b/actionmailer/lib/action_mailer/message_delivery.rb
@@ -19,7 +19,8 @@ module ActionMailer
   class MessageDelivery < Delegator
     attr_reader :mailer_class, :action, :params, :args # :nodoc:
 
-    def initialize(mailer_class, action, *args) # :nodoc:
+    def initialize(mailer_class, action, *args, **kwargs) # :nodoc:
+      args << Hash.ruby2_keywords_hash(kwargs) unless kwargs.empty?
       @mailer_class, @action, @args = mailer_class, action, args
 
       # The mail is only processed if we try to call any methods on it.
@@ -27,7 +28,6 @@ module ActionMailer
       @processed_mailer = nil
       @mail_message = nil
     end
-    ruby2_keywords(:initialize)
 
     # Method calls are delegated to the Mail::Message that's ready to deliver.
     def __getobj__ # :nodoc:

--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -2,7 +2,6 @@
 
 # :markup: markdown
 
-require "active_support/core_ext/array/extract_options"
 require "action_dispatch/middleware/stack"
 
 module ActionController
@@ -41,11 +40,10 @@ module ActionController
       EXCLUDE = ActiveSupport::Ractors.shareable_lambda { |list, action| !list.include? action }
       NULL    = ActiveSupport::Ractors.shareable_lambda { |list, action| true }
 
-      def build_middleware(klass, args, block)
-        options = args.extract_options!
-        only   = Array(options.delete(:only)).map(&:to_s)
-        except = Array(options.delete(:except)).map(&:to_s)
-        args << options unless options.empty?
+      def build_middleware(klass, args, kwargs, block)
+        only   = Array(kwargs.delete(:only)).map(&:to_s)
+        except = Array(kwargs.delete(:except)).map(&:to_s)
+        args << Hash.ruby2_keywords_hash(kwargs) unless kwargs.empty?
 
         strategy = NULL
         list     = nil

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -601,14 +601,13 @@ module ActionController
       end
 
       private
-        def method_missing(selector, *args, &block)
+        def method_missing(selector, ...)
           if defined?(@controller) && @controller && defined?(@routes) && @routes && @routes.named_routes.route_defined?(selector)
-            @controller.public_send(selector, *args, &block)
+            @controller.public_send(selector, ...)
           else
             super
           end
         end
-        ruby2_keywords(:method_missing)
 
         def setup_request(controller_class_name, action, parameters, session, flash, xhr)
           generated_extras = @routes.generate_extras(parameters.merge(controller: controller_class_name, action: action))

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -210,8 +210,8 @@ module ActionDispatch
     #
     # For debugging purposes, when called with arguments this method will fall back
     # to Object#method
-    def method(*args)
-      if args.empty?
+    def method(*args, **kwargs)
+      if args.empty? && kwargs.empty?
         @method ||= check_method(
           get_header("rack.methodoverride.original_method") ||
           get_header("REQUEST_METHOD")
@@ -220,7 +220,6 @@ module ActionDispatch
         super
       end
     end
-    ruby2_keywords(:method)
 
     # Returns a symbol form of the #method.
     def method_symbol

--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -94,35 +94,31 @@ module ActionDispatch
       middlewares[i]
     end
 
-    def unshift(klass, *args, &block)
-      middlewares.unshift(build_middleware(klass, args, block))
+    def unshift(klass, *args, **kwargs, &block)
+      middlewares.unshift(build_middleware(klass, args, kwargs, block))
     end
-    ruby2_keywords(:unshift)
 
     def initialize_copy(other)
       self.middlewares = other.middlewares.dup
     end
 
-    def insert(index, klass, *args, &block)
+    def insert(index, klass, *args, **kwargs, &block)
       index = assert_index(index, :before)
-      middlewares.insert(index, build_middleware(klass, args, block))
+      middlewares.insert(index, build_middleware(klass, args, kwargs, block))
     end
-    ruby2_keywords(:insert)
 
     alias_method :insert_before, :insert
 
-    def insert_after(index, *args, &block)
+    def insert_after(index, ...)
       index = assert_index(index, :after)
-      insert(index + 1, *args, &block)
+      insert(index + 1, ...)
     end
-    ruby2_keywords(:insert_after)
 
-    def swap(target, *args, &block)
+    def swap(target, ...)
       index = assert_index(target, :before)
-      insert(index, *args, &block)
+      insert(index, ...)
       middlewares.delete_at(index + 1)
     end
-    ruby2_keywords(:swap)
 
     # Deletes a middleware from the middleware stack.
     #
@@ -158,10 +154,9 @@ module ActionDispatch
       middlewares.insert(target_index + 1, source_middleware)
     end
 
-    def use(klass, *args, &block)
-      middlewares.push(build_middleware(klass, args, block))
+    def use(klass, *args, **kwargs, &block)
+      middlewares.push(build_middleware(klass, args, kwargs, block))
     end
-    ruby2_keywords(:use)
 
     def build(app = nil, &block)
       instrumenting = ActiveSupport::Notifications.notifier.listening?(InstrumentationProxy::EVENT_NAME)
@@ -181,7 +176,8 @@ module ActionDispatch
         i
       end
 
-      def build_middleware(klass, args, block)
+      def build_middleware(klass, args, kwargs, block)
+        args << Hash.ruby2_keywords_hash(kwargs) unless kwargs.empty?
         Middleware.new(klass, args, block)
       end
 

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -2211,12 +2211,11 @@ class FormWithActsLikeFormForTest < FormWithTest
   class LabelledFormBuilder < ActionView::Helpers::FormBuilder
     (field_helpers - %w(hidden_field)).each do |selector|
       class_eval <<-RUBY_EVAL, __FILE__, __LINE__ + 1
-        def #{selector}(field, *args, &proc)
+        def #{selector}(field, ...)
           ("<label for='\#{field}'>\#{field.to_s.humanize}:</label> " + super + "<br/>").html_safe
         end
       RUBY_EVAL
     end
-    ruby2_keywords(:fields)
   end
 
   def test_form_with_with_labelled_builder

--- a/activejob/lib/active_job/core.rb
+++ b/activejob/lib/active_job/core.rb
@@ -100,7 +100,8 @@ module ActiveJob
 
     # Creates a new job instance. Takes the arguments that will be
     # passed to the perform method.
-    def initialize(*arguments)
+    def initialize(*arguments, **kwargs)
+      arguments << Hash.ruby2_keywords_hash(kwargs) unless kwargs.empty?
       @arguments  = arguments
       @job_id     = SecureRandom.uuid
       @queue_name = self.class.queue_name
@@ -110,7 +111,6 @@ module ActiveJob
       @exception_executions = {}
       @timezone   = Time.zone&.name
     end
-    ruby2_keywords(:initialize)
 
     # Returns a hash with the job data that can safely be passed to the
     # queuing adapter.

--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -58,10 +58,9 @@ module ActiveJob
       end
 
       private
-        def job_or_instantiate(*args, &) # :doc:
-          args.first.is_a?(self) ? args.first : new(*args)
+        def job_or_instantiate(*args, **kwargs, &) # :doc:
+          args.first.is_a?(self) ? args.first : new(*args, **kwargs)
         end
-        ruby2_keywords(:job_or_instantiate)
     end
 
     # Enqueues the job to be performed by the queue adapter.

--- a/activemodel/lib/active_model/type/registry.rb
+++ b/activemodel/lib/active_model/type/registry.rb
@@ -13,10 +13,7 @@ module ActiveModel
       end
 
       def register(type_name, klass = nil, &block)
-        unless block_given?
-          block = proc { |_, *args| klass.new(*args) }
-          block.ruby2_keywords if block.respond_to?(:ruby2_keywords)
-        end
+        block ||= proc { |_, *args, **kwargs| klass.new(*args, **kwargs) }
         registrations[type_name] = block
       end
 

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1064,22 +1064,21 @@ module ActiveRecord
       @pool || ActiveRecord::Tasks::DatabaseTasks.migration_connection_pool
     end
 
-    def method_missing(method, *arguments, &block)
-      say_with_time "#{method}(#{format_arguments(arguments)})" do
+    def method_missing(method, *arguments, **kwargs, &block)
+      say_with_time "#{method}(#{format_arguments(arguments, kwargs)})" do
         unless connection.respond_to? :revert
           unless arguments.empty? || [:execute, :enable_extension, :disable_extension].include?(method)
             arguments[0] = proper_table_name(arguments.first, table_name_options)
             if method == :rename_table ||
-              (method == :remove_foreign_key && !arguments.second.is_a?(Hash))
+              (method == :remove_foreign_key && arguments.second)
               arguments[1] = proper_table_name(arguments.second, table_name_options)
             end
           end
         end
         return super unless execution_strategy.respond_to?(method)
-        execution_strategy.send(method, *arguments, &block)
+        execution_strategy.send(method, *arguments, **kwargs, &block)
       end
     end
-    ruby2_keywords(:method_missing)
 
     def copy(destination, sources, options = {})
       copied = []
@@ -1174,15 +1173,10 @@ module ActiveRecord
         end
       end
 
-      def format_arguments(arguments)
-        arg_list = arguments[0...-1].map(&:inspect)
-        last_arg = arguments.last
-        if last_arg.is_a?(Hash)
-          last_arg = last_arg.reject { |k, _v| internal_option?(k) }
-          arg_list << last_arg.inspect unless last_arg.empty?
-        else
-          arg_list << last_arg.inspect
-        end
+      def format_arguments(arguments, kwargs)
+        arg_list = arguments.map(&:inspect)
+        kwargs = kwargs.reject { |k, _v| internal_option?(k) }
+        arg_list << kwargs.inspect unless kwargs.empty?
         arg_list.join(", ")
       end
 

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -127,11 +127,11 @@ module ActiveRecord
 
       ReversibleAndIrreversibleMethods.each do |method|
         class_eval <<-EOV, __FILE__, __LINE__ + 1
-          def #{method}(*args, &block)          # def create_table(*args, &block)
-            record(:"#{method}", args, &block)  #   record(:create_table, args, &block)
-          end                                   # end
+          def #{method}(*args, **kwargs, &block)                          # def create_table(*args, **kwargs, &block)
+            args << Hash.ruby2_keywords_hash(kwargs) unless kwargs.empty? #   args << Hash.ruby2_keywords_hash(kwargs) unless kwargs.empty?
+            record(:"#{method}", args, &block)                            #   record(:create_table, args, &block)
+          end                                                             # end
         EOV
-        ruby2_keywords(method)
       end
       alias :add_belongs_to :add_reference
       alias :remove_belongs_to :remove_reference

--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -172,15 +172,15 @@ module ActiveRecord
           scope_method =
             if body.respond_to?(:to_proc)
               scope_body = ActiveSupport::Ractors.try_shareable_proc(&body)
-              proc do |*args|
-                scope = all._exec_scope(*args, &scope_body)
+              proc do |*args, **kwargs|
+                scope = all._exec_scope(*args, **kwargs, &scope_body)
                 scope = scope.extending(extension) if extension
                 scope
               end
             else
               callable = body
-              proc do |*args|
-                scope = callable.call(*args) || all
+              proc do |*args, **kwargs|
+                scope = callable.call(*args, **kwargs) || all
                 scope = scope.extending(extension) if extension
                 scope
               end
@@ -188,7 +188,6 @@ module ActiveRecord
           scope_method = ActiveSupport::Ractors.try_shareable_proc(&scope_method)
 
           singleton_class.define_method(name, &scope_method)
-          singleton_class.send(:ruby2_keywords, name)
 
           generate_relation_method(name)
         end

--- a/activerecord/lib/active_record/type/adapter_specific_registry.rb
+++ b/activerecord/lib/active_record/type/adapter_specific_registry.rb
@@ -17,10 +17,7 @@ module ActiveRecord
       end
 
       def register(type_name, klass = nil, **options, &block)
-        unless block_given?
-          block = proc { |_, *args| klass.new(*args) }
-          block.ruby2_keywords if block.respond_to?(:ruby2_keywords)
-        end
+        block ||= proc { |_, *args, **kwargs| klass.new(*args, **kwargs) }
         registrations << Registration.new(type_name, block, **options)
       end
 

--- a/activesupport/lib/active_support/core_ext/object/try.rb
+++ b/activesupport/lib/active_support/core_ext/object/try.rb
@@ -5,31 +5,29 @@ require "delegate"
 
 module ActiveSupport
   module Tryable # :nodoc:
-    def try(*args, &block)
-      if args.empty? && block_given?
+    def try(*args, **kwargs, &block)
+      if args.empty? && kwargs.empty? && block_given?
         if block.arity == 0
           instance_eval(&block)
         else
           yield self
         end
       elsif respond_to?(args.first)
-        public_send(*args, &block)
+        public_send(*args, **kwargs, &block)
       end
     end
-    ruby2_keywords(:try)
 
-    def try!(*args, &block)
-      if args.empty? && block_given?
+    def try!(*args, **kwargs, &block)
+      if args.empty? && kwargs.empty? && block_given?
         if block.arity == 0
           instance_eval(&block)
         else
           yield self
         end
       else
-        public_send(*args, &block)
+        public_send(*args, **kwargs, &block)
       end
     end
-    ruby2_keywords(:try!)
   end
 end
 

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -42,20 +42,18 @@ class Time
 
     # Layers additional behavior on Time.at so that ActiveSupport::TimeWithZone and DateTime
     # instances can be used when called with a single argument
-    def at_with_coercion(time_or_number, *args)
-      if args.empty?
-        if time_or_number.is_a?(ActiveSupport::TimeWithZone)
-          at_without_coercion(time_or_number.to_r).getlocal
-        elsif time_or_number.is_a?(DateTime)
-          at_without_coercion(time_or_number.to_i + time_or_number.sec_fraction).getlocal
-        else
-          at_without_coercion(time_or_number)
-        end
+    def at_with_coercion(time_or_number, *args, **kwargs)
+      return at_without_coercion(time_or_number, *args, **kwargs) unless args.empty? && kwargs.empty?
+
+      case time_or_number
+      when ActiveSupport::TimeWithZone
+        at_without_coercion(time_or_number.to_r).getlocal
+      when DateTime
+        at_without_coercion(time_or_number.to_i + time_or_number.sec_fraction).getlocal
       else
-        at_without_coercion(time_or_number, *args)
+        at_without_coercion(time_or_number)
       end
     end
-    ruby2_keywords :at_with_coercion
     alias_method :at_without_coercion, :at
     alias_method :at, :at_with_coercion
 

--- a/activesupport/lib/active_support/deprecation/method_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/method_wrappers.rb
@@ -43,20 +43,18 @@ module ActiveSupport
           if target_module.method_defined?(method_name) || target_module.private_method_defined?(method_name)
             method = target_module.instance_method(method_name)
             target_module.module_eval do
-              redefine_method(method_name) do |*args, &block|
+              redefine_method(method_name) do |*args, **kwargs, &block|
                 deprecator.deprecation_warning(method_name, message)
-                method.bind_call(self, *args, &block)
+                method.bind_call(self, *args, **kwargs, &block)
               end
-              ruby2_keywords(method_name)
             end
           else
             mod ||= Module.new
             mod.module_eval do
-              define_method(method_name) do |*args, &block|
+              define_method(method_name) do |*args, **kwargs, &block|
                 deprecator.deprecation_warning(method_name, message)
-                super(*args, &block)
+                super(*args, **kwargs, &block)
               end
-              ruby2_keywords(method_name)
             end
           end
         end

--- a/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
@@ -19,11 +19,10 @@ module ActiveSupport
       end
 
       private
-        def method_missing(called, *args, &block)
-          warn caller_locations, called, args
-          target.__send__(called, *args, &block)
+        def method_missing(called, ...)
+          warn(caller_locations, called, ...)
+          target.__send__(called, ...)
         end
-        ruby2_keywords :method_missing
     end
 
     # DeprecatedObjectProxy transforms an object into a deprecated one. It takes an object, a deprecation message, and
@@ -52,7 +51,7 @@ module ActiveSupport
           @object
         end
 
-        def warn(callstack, called, args)
+        def warn(callstack, called, *, **)
           @deprecator.warn(@message, callstack)
         end
     end
@@ -102,7 +101,8 @@ module ActiveSupport
           @instance.__send__(@method)
         end
 
-        def warn(callstack, called, args)
+        def warn(callstack, called, *args, **kwargs)
+          args << kwargs unless kwargs.empty?
           @deprecator.warn("#{@var} is deprecated! Call #{@method}.#{called} instead of #{@var}.#{called}. Args: #{args.inspect}", callstack)
         end
     end


### PR DESCRIPTION
`ruby2_keywords` was necessary for libraries that supported both Ruby 2.7 and Ruby 3.0+ during the keyword arguments separation transition. Since Rails now requires Ruby 3.3.1+ (where kwargs are properly separated), these shims are no longer necessary.

Replace all `ruby2_keywords` method usages with explicit `*args`, `**kwargs`, `&block` or argument forwarding (`...`) where possible. Some places continue to use `Hash.ruby2_keywords_hash` to combine kwargs into args as a trailing flagged hash, preserving the existing wire/storage format (e.g. ActiveJob argument serialization).

This direction is aligned with a Ruby proposal to deprecate `ruby2_keywords` in the future (https://bugs.ruby-lang.org/issues/22205), since libraries that only support Ruby 3.0+ no longer need it.
