### PR TITLE
Refactor `CommandRecorder` to store args and kwargs separately

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Change the shape of `ActiveRecord::Migration::CommandRecorder#commands`.
+
+    Each recorded migration command is now stored as
+    `[cmd, args, kwargs, block]` (4-element) instead of
+    `[cmd, args, block]` (3-element) with kwargs bundled into a trailing
+    hash inside `args`. Code that inspects `recorder.commands` directly
+    needs to adapt to the new tuple shape.
+
+    *Ryuta Kamizono*
+
 *   Add query predicate hooks for Active Model types.
 
     Types can override `transforms_query_predicates?`, `query_attribute`, and

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1669,15 +1669,15 @@ module ActiveRecord
       def bulk_change_table(table_name, operations) # :nodoc:
         alter_table = create_alter_table(table_name)
 
-        operations.each do |command, args|
+        operations.each do |command, args, kwargs|
           args.shift # remove table_name
 
           if alter_table.class::COMBINABLE_COMMANDS.include?(command)
-            alter_table.public_send(command, *args)
+            alter_table.public_send(command, *args, **kwargs)
           else
             execute_alter_table(alter_table)
             alter_table = create_alter_table(table_name)
-            send(command, table_name, *args)
+            send(command, table_name, *args, **kwargs)
           end
         end
 

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -91,10 +91,9 @@ module ActiveRecord
 
       ReversibleAndIrreversibleMethods.each do |method|
         class_eval <<-EOV, __FILE__, __LINE__ + 1
-          def #{method}(*args, **kwargs, &block)                          # def create_table(*args, **kwargs, &block)
-            args << Hash.ruby2_keywords_hash(kwargs) unless kwargs.empty? #   args << Hash.ruby2_keywords_hash(kwargs) unless kwargs.empty?
-            record(:"#{method}", args, &block)                            #   record(:create_table, args, &block)
-          end                                                             # end
+          def #{method}(*args, **kwargs, &block)        # def create_table(*args, **kwargs, &block)
+            record(:"#{method}", args, kwargs, &block)  #   record(:create_table, args, kwargs, &block)
+          end                                           # end
         EOV
       end
       alias :add_belongs_to :add_reference
@@ -106,28 +105,28 @@ module ActiveRecord
           recorder.reverting = @reverting
           yield recorder.delegate.update_table_definition(table_name, recorder)
           commands = recorder.commands
-          @commands << [:change_table, [table_name], -> t { bulk_change_table(t.name, commands.reverse) }]
+          @commands << [:change_table, [table_name], {}, -> t { bulk_change_table(t.name, commands.reverse) }]
         else
           yield delegate.update_table_definition(table_name, self)
         end
       end
 
       def replay(migration)
-        commands.each do |cmd, args, block|
-          migration.send(cmd, *args, &block)
+        commands.each do |cmd, args, kwargs, block|
+          migration.send(cmd, *args, **kwargs, &block)
         end
       end
 
       private
-        def record(*command, &block)
+        def record(command, args, kwargs, &block)
           if @reverting
-            @commands << inverse_of(*command, &block)
+            @commands << inverse_of(command, args, kwargs, &block)
           else
-            @commands << (command << block)
+            @commands << [command, args, kwargs, block]
           end
         end
 
-        def inverse_of(command, args, &block)
+        def inverse_of(command, args, kwargs, &block)
           method = :"invert_#{command}"
           raise IrreversibleMigration, <<~MSG unless respond_to?(method, true)
             This migration uses #{command}, which is not automatically reversible.
@@ -135,7 +134,7 @@ module ActiveRecord
             1. Define #up and #down methods in place of the #change method.
             2. Use the #reversible method to define reversible behavior.
           MSG
-          send(method, args, &block)
+          send(method, args, kwargs, &block)
         end
 
         module StraightReversions # :nodoc:
@@ -159,9 +158,9 @@ module ActiveRecord
             }.each do |cmd, inv|
               [[inv, cmd], [cmd, inv]].uniq.each do |method, inverse|
                 class_eval <<-EOV, __FILE__, __LINE__ + 1
-                  def invert_#{method}(args, &block)    # def invert_create_table(args, &block)
-                    [:#{inverse}, args, block]          #   [:drop_table, args, block]
-                  end                                   # end
+                  def invert_#{method}(args, kwargs, &block)  # def invert_create_table(args, kwargs, &block)
+                    [:#{inverse}, args, kwargs, block]        #   [:drop_table, args, kwargs, block]
+                  end                                         # end
                 EOV
               end
             end
@@ -169,17 +168,17 @@ module ActiveRecord
 
         include StraightReversions
 
-        def invert_enable_index(args)
+        def invert_enable_index(args, kwargs)
           table_name, index_name = args
-          [:disable_index, [table_name, index_name]]
+          [:disable_index, [table_name, index_name], kwargs]
         end
 
-        def invert_disable_index(args)
+        def invert_disable_index(args, kwargs)
           table_name, index_name = args
-          [:enable_index, [table_name, index_name]]
+          [:enable_index, [table_name, index_name], kwargs]
         end
 
-        def invert_transaction(args, &block)
+        def invert_transaction(args, kwargs, &block)
           sub_recorder = CommandRecorder.new(delegate)
           sub_recorder.revert(&block)
 
@@ -187,242 +186,193 @@ module ActiveRecord
             sub_recorder.replay(self)
           }
 
-          [:transaction, args, invertions_proc]
+          [:transaction, args, kwargs, invertions_proc]
         end
 
-        def invert_create_table(args, &block)
-          if args.last.is_a?(Hash)
-            args.last.delete(:if_not_exists)
-          end
+        def invert_create_table(args, kwargs, &block)
+          kwargs.delete(:if_not_exists)
           super
         end
 
-        def invert_drop_table(args, &block)
-          options = args.extract_options!
-          options.delete(:if_exists)
+        def invert_drop_table(args, kwargs, &block)
+          kwargs.delete(:if_exists)
 
           if args.size > 1
             raise ActiveRecord::IrreversibleMigration, "To avoid mistakes, drop_table is only reversible if given a single table name."
           end
 
-          if args.size == 1 && options == {} && block == nil
+          if args.size == 1 && kwargs.empty? && block == nil
             raise ActiveRecord::IrreversibleMigration, "To avoid mistakes, drop_table is only reversible if given options or a block (can be empty)."
           end
 
-          args << options unless options.empty?
-
-          super(args, &block)
-        end
-
-        def invert_rename_table(args)
-          old_name, new_name, options = args
-          args = [new_name, old_name]
-          args << options if options
-          [:rename_table, args]
-        end
-
-        def invert_remove_column(args)
-          if args.size <= 2 || args[2].is_a?(Hash)
-            raise ActiveRecord::IrreversibleMigration, "remove_column is only reversible if given a type."
-          end
-          if (options = args.last).is_a?(Hash)
-            options[:if_not_exists] = options.delete(:if_exists) if options.key?(:if_exists)
-          end
           super
         end
 
-        def invert_remove_columns(args)
-          unless args[-1].is_a?(Hash) && args[-1].has_key?(:type)
+        def invert_rename_table(args, kwargs)
+          old_name, new_name = args
+          [:rename_table, [new_name, old_name], kwargs]
+        end
+
+        def invert_remove_column(args, kwargs)
+          if args.size < 3
+            raise ActiveRecord::IrreversibleMigration, "remove_column is only reversible if given a type."
+          end
+          kwargs[:if_not_exists] = kwargs.delete(:if_exists) if kwargs.key?(:if_exists)
+          super
+        end
+
+        def invert_remove_columns(args, kwargs)
+          unless kwargs.key?(:type)
             raise ActiveRecord::IrreversibleMigration, "remove_columns is only reversible if given a type."
           end
 
-          [:add_columns, args]
+          [:add_columns, args, kwargs]
         end
 
-        def invert_rename_index(args)
+        def invert_rename_index(args, kwargs)
           table_name, old_name, new_name = args
-          [:rename_index, [table_name, new_name, old_name]]
+          [:rename_index, [table_name, new_name, old_name], kwargs]
         end
 
-        def invert_rename_column(args)
-          table_name, old_name, new_name, options = args
-          args = [table_name, new_name, old_name]
-          args << options if options
-          [:rename_column, args]
+        def invert_rename_column(args, kwargs)
+          table_name, old_name, new_name = args
+          [:rename_column, [table_name, new_name, old_name], kwargs]
         end
 
-        def invert_remove_index(args)
-          options = args.extract_options!
+        def invert_remove_index(args, kwargs)
           table, columns = args
 
-          columns ||= options.delete(:column)
+          columns ||= kwargs.delete(:column)
 
           unless columns
             raise ActiveRecord::IrreversibleMigration, "remove_index is only reversible if given a :column option."
           end
 
-          options[:if_not_exists] = options.delete(:if_exists) if options.key?(:if_exists)
+          kwargs[:if_not_exists] = kwargs.delete(:if_exists) if kwargs.key?(:if_exists)
 
-          args = [table, columns]
-          args << options unless options.empty?
-
-          [:add_index, args]
+          [:add_index, [table, columns], kwargs]
         end
 
-        def invert_add_reference(args)
-          if (options = args.last).is_a?(Hash)
-            options[:if_exists] = options.delete(:if_not_exists) if options.key?(:if_not_exists)
-          end
+        def invert_add_reference(args, kwargs)
+          kwargs[:if_exists] = kwargs.delete(:if_not_exists) if kwargs.key?(:if_not_exists)
           super
         end
 
-        def invert_remove_reference(args)
-          if (options = args.last).is_a?(Hash)
-            options[:if_not_exists] = options.delete(:if_exists) if options.key?(:if_exists)
-          end
+        def invert_remove_reference(args, kwargs)
+          kwargs[:if_not_exists] = kwargs.delete(:if_exists) if kwargs.key?(:if_exists)
           super
         end
 
         alias :invert_add_belongs_to :invert_add_reference
         alias :invert_remove_belongs_to :invert_remove_reference
 
-        def invert_change_column_default(args)
-          table, column, options = args
-
-          unless options.is_a?(Hash) && options.has_key?(:from) && options.has_key?(:to)
+        def invert_change_column_default(args, kwargs)
+          unless kwargs.has_key?(:from) && kwargs.has_key?(:to)
             raise ActiveRecord::IrreversibleMigration, "change_column_default is only reversible if given a :from and :to option."
           end
 
-          [:change_column_default, [table, column, from: options[:to], to: options[:from]]]
+          [:change_column_default, args, { from: kwargs[:to], to: kwargs[:from] }]
         end
 
-        def invert_change_column_null(args)
-          args[2] = !args[2]
-          [:change_column_null, args]
+        def invert_change_column_null(args, kwargs)
+          table_name, column_name, null, default = args
+          [:change_column_null, [table_name, column_name, !null, default], kwargs]
         end
 
-        def invert_add_column(args)
-          if (options = args.last).is_a?(Hash)
-            options[:if_exists] = options.delete(:if_not_exists) if options.key?(:if_not_exists)
-          end
+        def invert_add_column(args, kwargs)
+          kwargs[:if_exists] = kwargs.delete(:if_not_exists) if kwargs.key?(:if_not_exists)
           super
         end
 
-        def invert_add_index(args)
-          if (options = args.last).is_a?(Hash)
-            options[:if_exists] = options.delete(:if_not_exists) if options.key?(:if_not_exists)
-          end
+        def invert_add_index(args, kwargs)
+          kwargs[:if_exists] = kwargs.delete(:if_not_exists) if kwargs.key?(:if_not_exists)
           super
         end
 
-        def invert_add_foreign_key(args)
-          if (options = args.last).is_a?(Hash)
-            options.delete(:validate)
-            options[:if_exists] = options.delete(:if_not_exists) if options.key?(:if_not_exists)
-          end
+        def invert_add_foreign_key(args, kwargs)
+          kwargs.delete(:validate)
+          kwargs[:if_exists] = kwargs.delete(:if_not_exists) if kwargs.key?(:if_not_exists)
           super
         end
 
-        def invert_remove_foreign_key(args)
-          options = args.extract_options!
+        def invert_remove_foreign_key(args, kwargs)
           from_table, to_table = args
 
-          to_table ||= options.delete(:to_table)
-          options[:if_not_exists] = options.delete(:if_exists) if options.key?(:if_exists)
+          to_table ||= kwargs.delete(:to_table)
+          kwargs[:if_not_exists] = kwargs.delete(:if_exists) if kwargs.key?(:if_exists)
 
           raise ActiveRecord::IrreversibleMigration, "remove_foreign_key is only reversible if given a second table" if to_table.nil?
 
-          reversed_args = [from_table, to_table]
-          reversed_args << options unless options.empty?
-
-          [:add_foreign_key, reversed_args]
+          [:add_foreign_key, [from_table, to_table], kwargs]
         end
 
-        def invert_change_column_comment(args)
-          table, column, options = args
-
-          unless options.is_a?(Hash) && options.has_key?(:from) && options.has_key?(:to)
+        def invert_change_column_comment(args, kwargs)
+          unless kwargs.has_key?(:from) && kwargs.has_key?(:to)
             raise ActiveRecord::IrreversibleMigration, "change_column_comment is only reversible if given a :from and :to option."
           end
 
-          [:change_column_comment, [table, column, from: options[:to], to: options[:from]]]
+          [:change_column_comment, args, { from: kwargs[:to], to: kwargs[:from] }]
         end
 
-        def invert_change_table_comment(args)
-          table, options = args
-
-          unless options.is_a?(Hash) && options.has_key?(:from) && options.has_key?(:to)
+        def invert_change_table_comment(args, kwargs)
+          unless kwargs.has_key?(:from) && kwargs.has_key?(:to)
             raise ActiveRecord::IrreversibleMigration, "change_table_comment is only reversible if given a :from and :to option."
           end
 
-          [:change_table_comment, [table, from: options[:to], to: options[:from]]]
+          [:change_table_comment, args, { from: kwargs[:to], to: kwargs[:from] }]
         end
 
-        def invert_add_check_constraint(args)
-          if (options = args.last).is_a?(Hash)
-            options.delete(:validate)
-            options[:if_exists] = options.delete(:if_not_exists) if options.key?(:if_not_exists)
-          end
+        def invert_add_check_constraint(args, kwargs)
+          kwargs.delete(:validate)
+          kwargs[:if_exists] = kwargs.delete(:if_not_exists) if kwargs.key?(:if_not_exists)
           super
         end
 
-        def invert_remove_check_constraint(args)
+        def invert_remove_check_constraint(args, kwargs)
           raise ActiveRecord::IrreversibleMigration, "remove_check_constraint is only reversible if given an expression." if args.size < 2
 
-          if (options = args.last).is_a?(Hash)
-            options[:if_not_exists] = options.delete(:if_exists) if options.key?(:if_exists)
-          end
+          kwargs[:if_not_exists] = kwargs.delete(:if_exists) if kwargs.key?(:if_exists)
           super
         end
 
-        def invert_remove_exclusion_constraint(args)
+        def invert_remove_exclusion_constraint(args, kwargs)
           raise ActiveRecord::IrreversibleMigration, "remove_exclusion_constraint is only reversible if given an expression." if args.size < 2
           super
         end
 
-        def invert_add_unique_constraint(args)
-          options = args.dup.extract_options!
-
-          raise ActiveRecord::IrreversibleMigration, "add_unique_constraint is not reversible if given a using_index." if options[:using_index]
+        def invert_add_unique_constraint(args, kwargs)
+          raise ActiveRecord::IrreversibleMigration, "add_unique_constraint is not reversible if given a using_index." if kwargs[:using_index]
           super
         end
 
-        def invert_remove_unique_constraint(args)
-          _table, columns = args.dup.tap(&:extract_options!)
-
+        def invert_remove_unique_constraint(args, kwargs)
+          _table, columns = args
           raise ActiveRecord::IrreversibleMigration, "remove_unique_constraint is only reversible if given a column_name." if columns.blank?
           super
         end
 
-        def invert_drop_enum(args)
-          _enum, values = args.dup.tap(&:extract_options!)
+        def invert_drop_enum(args, kwargs)
+          _enum, values = args
           raise ActiveRecord::IrreversibleMigration, "drop_enum is only reversible if given a list of enum values." unless values
           super
         end
 
-        def invert_rename_enum(args)
-          name, new_name, = args
-
-          if new_name.is_a?(Hash) && new_name.key?(:to)
-            new_name = new_name[:to]
-          end
-
-          [:rename_enum, [new_name, name]]
+        def invert_rename_enum(args, kwargs)
+          old_name, new_name = args
+          new_name ||= kwargs.delete(:to)
+          [:rename_enum, [new_name, old_name], kwargs]
         end
 
-        def invert_rename_enum_value(args)
-          type_name, options = args
-
-          unless options.is_a?(Hash) && options.has_key?(:from) && options.has_key?(:to)
+        def invert_rename_enum_value(args, kwargs)
+          unless kwargs.has_key?(:from) && kwargs.has_key?(:to)
             raise ActiveRecord::IrreversibleMigration, "rename_enum_value is only reversible if given a :from and :to option."
           end
 
-          options[:to], options[:from] = options[:from], options[:to]
-          [:rename_enum_value, [type_name, options]]
+          [:rename_enum_value, args, { from: kwargs[:to], to: kwargs[:from] }]
         end
 
-        def invert_drop_virtual_table(args)
-          _table_name, _module_name, values = args.dup.tap(&:extract_options!)
+        def invert_drop_virtual_table(args, kwargs)
+          _table_name, _module_name, values = args
           raise ActiveRecord::IrreversibleMigration, "drop_virtual_table is only reversible if given options." unless values
           super
         end

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -303,16 +303,16 @@ module ActiveRecord
         end
 
         module CommandRecorder
-          def invert_transaction(args, &block)
-            [:transaction, args, block]
+          def invert_transaction(args, kwargs, &block)
+            [:transaction, args, kwargs, block]
           end
 
-          def invert_change_column_comment(args)
-            [:change_column_comment, args]
+          def invert_change_column_comment(args, kwargs)
+            [:change_column_comment, args, kwargs]
           end
 
-          def invert_change_table_comment(args)
-            [:change_table_comment, args]
+          def invert_change_table_comment(args, kwargs)
+            [:change_table_comment, args, kwargs]
           end
         end
 

--- a/activerecord/test/cases/invertible_migration_test.rb
+++ b/activerecord/test/cases/invertible_migration_test.rb
@@ -473,10 +473,10 @@ module ActiveRecord
           create_table("grapes")
         end
       end
-      assert_equal [[:create_table, ["apples"], block], [:drop_table, ["elderberries"], nil],
-                    [:create_table, ["clementines"], nil], [:create_table, ["dates"], nil],
-                    [:drop_table, ["bananas"], block], [:drop_table, ["grapes"], nil],
-                    [:drop_table, ["figs"], nil]], recorder.commands
+      assert_equal [[:create_table, ["apples"], {}, block], [:drop_table, ["elderberries"], {}, nil],
+                    [:create_table, ["clementines"], {}, nil], [:create_table, ["dates"], {}, nil],
+                    [:drop_table, ["bananas"], {}, block], [:drop_table, ["grapes"], {}, nil],
+                    [:drop_table, ["figs"], {}, nil]], recorder.commands
     end
 
     def test_legacy_up

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -29,7 +29,7 @@ module ActiveRecord
         }.new)
         assert_respond_to recorder, :create_table
         recorder.send(:create_table, :horses)
-        assert_equal [[:create_table, [:horses], nil]], recorder.commands
+        assert_equal [[:create_table, [:horses], {}, nil]], recorder.commands
       end
 
       def test_unknown_commands_delegate
@@ -58,7 +58,7 @@ module ActiveRecord
           @recorder.create_table :hello
           @recorder.create_table :world
         end
-        tables = @recorder.commands.map { |_cmd, args, _block| args }
+        tables = @recorder.commands.map { |_cmd, args, _kwargs, _block| args }
         assert_equal [[:world], [:hello]], tables
       end
 
@@ -79,10 +79,10 @@ module ActiveRecord
             create_table("grapes")
           end
         end
-        assert_equal [[:create_table, ["apples"], block], [:drop_table, ["elderberries"], nil],
-                      [:create_table, ["clementines"], block], [:create_table, ["dates"], nil],
-                      [:drop_table, ["bananas"], block], [:drop_table, ["grapes"], nil],
-                      [:drop_table, ["figs"], block]], @recorder.commands
+        assert_equal [[:create_table, ["apples"], {}, block], [:drop_table, ["elderberries"], {}, nil],
+                      [:create_table, ["clementines"], {}, block], [:create_table, ["dates"], {}, nil],
+                      [:drop_table, ["bananas"], {}, block], [:drop_table, ["grapes"], {}, nil],
+                      [:drop_table, ["figs"], {}, block]], @recorder.commands
       end
 
       def test_invert_change_table
@@ -94,8 +94,8 @@ module ActiveRecord
         end
 
         assert_equal [
-          [:rename_column, [:fruits, :cultivar, :kind]],
-          [:remove_column, [:fruits, :name, :string], nil],
+          [:rename_column, [:fruits, :cultivar, :kind], {}],
+          [:remove_column, [:fruits, :name, :string], {}, nil],
         ], @recorder.commands
 
         assert_raises(ActiveRecord::IrreversibleMigration) do
@@ -125,8 +125,8 @@ module ActiveRecord
           end
 
           assert_equal [
-            [:change_table, [:fruits]],
-            [:change_table, [:fruits]]
+            [:change_table, [:fruits], {}],
+            [:change_table, [:fruits], {}]
           ], @recorder.commands.map { |command| command[0...-1] }
         end
       end
@@ -136,7 +136,7 @@ module ActiveRecord
           @recorder.create_table :system_settings
         end
         drop_table = @recorder.commands.first
-        assert_equal [:drop_table, [:system_settings], nil], drop_table
+        assert_equal [:drop_table, [:system_settings], {}, nil], drop_table
       end
 
       def test_invert_create_table_with_if_not_exists
@@ -144,7 +144,7 @@ module ActiveRecord
           @recorder.create_table :system_settings, if_not_exists: true
         end
         drop_table = @recorder.commands.first
-        assert_equal [:drop_table, [:system_settings, {}], nil], drop_table
+        assert_equal [:drop_table, [:system_settings], {}, nil], drop_table
       end
 
       def test_invert_create_table_with_options_and_block
@@ -152,7 +152,7 @@ module ActiveRecord
         @recorder.revert do
           @recorder.create_table(:people_reminders, id: false, &block)
         end
-        assert_equal [:drop_table, [:people_reminders, id: false], block], @recorder.commands.first
+        assert_equal [:drop_table, [:people_reminders], { id: false }, block], @recorder.commands.first
       end
 
       def test_invert_drop_table
@@ -160,7 +160,7 @@ module ActiveRecord
         @recorder.revert do
           @recorder.drop_table(:people_reminders, id: false, &block)
         end
-        assert_equal [:create_table, [:people_reminders, id: false], block], @recorder.commands.first
+        assert_equal [:create_table, [:people_reminders], { id: false }, block], @recorder.commands.first
       end
 
       def test_invert_drop_table_with_if_exists
@@ -168,7 +168,7 @@ module ActiveRecord
         @recorder.revert do
           @recorder.drop_table(:people_reminders, id: false, if_exists: true, &block)
         end
-        assert_equal [:create_table, [:people_reminders, id: false], block], @recorder.commands.first
+        assert_equal [:create_table, [:people_reminders], { id: false }, block], @recorder.commands.first
       end
 
       def test_invert_drop_table_without_a_block_nor_option
@@ -209,14 +209,14 @@ module ActiveRecord
         @recorder.revert do
           @recorder.create_join_table(:musics, :artists)
         end
-        assert_equal [:drop_join_table, [:musics, :artists], nil], @recorder.commands.first
+        assert_equal [:drop_join_table, [:musics, :artists], {}, nil], @recorder.commands.first
       end
 
       def test_invert_create_join_table_with_table_name
         @recorder.revert do
           @recorder.create_join_table(:musics, :artists, table_name: :catalog)
         end
-        assert_equal [:drop_join_table, [:musics, :artists, table_name: :catalog], nil], @recorder.commands.first
+        assert_equal [:drop_join_table, [:musics, :artists], { table_name: :catalog }, nil], @recorder.commands.first
       end
 
       def test_invert_drop_join_table
@@ -224,28 +224,28 @@ module ActiveRecord
         @recorder.revert do
           @recorder.drop_join_table(:musics, :artists, table_name: :catalog, &block)
         end
-        assert_equal [:create_join_table, [:musics, :artists, table_name: :catalog], block], @recorder.commands.first
+        assert_equal [:create_join_table, [:musics, :artists], { table_name: :catalog }, block], @recorder.commands.first
       end
 
       def test_invert_rename_table
         @recorder.revert do
           @recorder.rename_table(:old, :new)
         end
-        assert_equal [:rename_table, [:new, :old]], @recorder.commands.first
+        assert_equal [:rename_table, [:new, :old], {}], @recorder.commands.first
       end
 
       def test_invert_add_column
         @recorder.revert do
           @recorder.add_column(:table, :column, :type)
         end
-        assert_equal [:remove_column, [:table, :column, :type], nil], @recorder.commands.first
+        assert_equal [:remove_column, [:table, :column, :type], {}, nil], @recorder.commands.first
       end
 
       def test_invert_add_column_if_not_exists
         @recorder.revert do
           @recorder.add_column(:table, :column, :type, if_not_exists: true)
         end
-        assert_equal [:remove_column, [:table, :column, :type, if_exists: true], nil], @recorder.commands.first
+        assert_equal [:remove_column, [:table, :column, :type], { if_exists: true }, nil], @recorder.commands.first
       end
 
       def test_invert_change_column
@@ -268,14 +268,14 @@ module ActiveRecord
         @recorder.revert do
           @recorder.change_column_default(:table, :column, from: "old_value", to: "new_value")
         end
-        assert_equal [:change_column_default, [:table, :column, from: "new_value", to: "old_value"]], @recorder.commands.first
+        assert_equal [:change_column_default, [:table, :column], { from: "new_value", to: "old_value" }], @recorder.commands.first
       end
 
       def test_invert_change_column_default_with_from_and_to_with_boolean
         @recorder.revert do
           @recorder.change_column_default(:table, :column, from: true, to: false)
         end
-        assert_equal [:change_column_default, [:table, :column, from: false, to: true]], @recorder.commands.first
+        assert_equal [:change_column_default, [:table, :column], { from: false, to: true }], @recorder.commands.first
       end
 
       if ActiveRecord::Base.lease_connection.supports_comments?
@@ -291,14 +291,14 @@ module ActiveRecord
           @recorder.revert do
             @recorder.change_column_comment(:table, :column, from: "old_value", to: "new_value")
           end
-          assert_equal [:change_column_comment, [:table, :column, from: "new_value", to: "old_value"]], @recorder.commands.first
+          assert_equal [:change_column_comment, [:table, :column], { from: "new_value", to: "old_value" }], @recorder.commands.first
         end
 
         def test_invert_change_column_comment_with_from_and_to_with_nil
           @recorder.revert do
             @recorder.change_column_comment(:table, :column, from: nil, to: "new_value")
           end
-          assert_equal [:change_column_comment, [:table, :column, from: "new_value", to: nil]], @recorder.commands.first
+          assert_equal [:change_column_comment, [:table, :column], { from: "new_value", to: nil }], @recorder.commands.first
         end
 
         def test_invert_change_table_comment
@@ -313,14 +313,14 @@ module ActiveRecord
           @recorder.revert do
             @recorder.change_table_comment(:table, from: "old_value", to: "new_value")
           end
-          assert_equal [:change_table_comment, [:table, from: "new_value", to: "old_value"]], @recorder.commands.first
+          assert_equal [:change_table_comment, [:table], { from: "new_value", to: "old_value" }], @recorder.commands.first
         end
 
         def test_invert_change_table_comment_with_from_and_to_with_nil
           @recorder.revert do
             @recorder.change_table_comment(:table, from: nil, to: "new_value")
           end
-          assert_equal [:change_table_comment, [:table, from: "new_value", to: nil]], @recorder.commands.first
+          assert_equal [:change_table_comment, [:table], { from: "new_value", to: nil }], @recorder.commands.first
         end
       end
 
@@ -328,21 +328,21 @@ module ActiveRecord
         @recorder.revert do
           @recorder.change_column_null(:table, :column, true)
         end
-        assert_equal [:change_column_null, [:table, :column, false]], @recorder.commands.first
+        assert_equal [:change_column_null, [:table, :column, false, nil], {}], @recorder.commands.first
       end
 
       def test_invert_remove_column
         @recorder.revert do
           @recorder.remove_column(:table, :column, :type)
         end
-        assert_equal [:add_column, [:table, :column, :type], nil], @recorder.commands.first
+        assert_equal [:add_column, [:table, :column, :type], {}, nil], @recorder.commands.first
       end
 
       def test_invert_remove_column_if_exists
         @recorder.revert do
           @recorder.remove_column(:table, :column, :string, if_exists: true)
         end
-        assert_equal [:add_column, [:table, :column, :string, if_not_exists: true], nil], @recorder.commands.first
+        assert_equal [:add_column, [:table, :column, :string], { if_not_exists: true }, nil], @recorder.commands.first
       end
 
       def test_invert_remove_column_without_type
@@ -365,42 +365,42 @@ module ActiveRecord
         @recorder.revert do
           @recorder.rename_column(:table, :old, :new)
         end
-        assert_equal [:rename_column, [:table, :new, :old]], @recorder.commands.first
+        assert_equal [:rename_column, [:table, :new, :old], {}], @recorder.commands.first
       end
 
       def test_invert_rename_column_with_options
         @recorder.revert do
           @recorder.rename_column(:table, :old, :new, algorithm: :inplace, lock: :none)
         end
-        assert_equal [:rename_column, [:table, :new, :old, { algorithm: :inplace, lock: :none }]], @recorder.commands.first
+        assert_equal [:rename_column, [:table, :new, :old], { algorithm: :inplace, lock: :none }], @recorder.commands.first
       end
 
       def test_invert_add_index
         @recorder.revert do
           @recorder.add_index(:table, [:one, :two])
         end
-        assert_equal [:remove_index, [:table, [:one, :two]], nil], @recorder.commands.first
+        assert_equal [:remove_index, [:table, [:one, :two]], {}, nil], @recorder.commands.first
       end
 
       def test_invert_add_index_with_name
         @recorder.revert do
           @recorder.add_index(:table, [:one, :two], name: "new_index")
         end
-        assert_equal [:remove_index, [:table, [:one, :two], name: "new_index"], nil], @recorder.commands.first
+        assert_equal [:remove_index, [:table, [:one, :two]], { name: "new_index" }, nil], @recorder.commands.first
       end
 
       def test_invert_add_index_with_algorithm_option
         @recorder.revert do
           @recorder.add_index(:table, :one, algorithm: :concurrently)
         end
-        assert_equal [:remove_index, [:table, :one, algorithm: :concurrently], nil], @recorder.commands.first
+        assert_equal [:remove_index, [:table, :one], { algorithm: :concurrently }, nil], @recorder.commands.first
       end
 
       def test_invert_add_index_if_not_exists
         @recorder.revert do
           @recorder.add_index(:table, :one, if_not_exists: true)
         end
-        assert_equal [:remove_index, [:table, :one, if_exists: true], nil], @recorder.commands.first
+        assert_equal [:remove_index, [:table, :one], { if_exists: true }, nil], @recorder.commands.first
       end
 
       if ActiveRecord::Base.lease_connection.supports_disabling_indexes?
@@ -408,28 +408,28 @@ module ActiveRecord
           @recorder.revert do
             @recorder.add_index(:table, :one, enabled: false)
           end
-          assert_equal [:remove_index, [:table, :one, enabled: false], nil], @recorder.commands.first
+          assert_equal [:remove_index, [:table, :one], { enabled: false }, nil], @recorder.commands.first
         end
 
         def test_invert_remove_index_with_disabled_option
           @recorder.revert do
             @recorder.remove_index(:table, :one, enabled: false)
           end
-          assert_equal [:add_index, [:table, :one, enabled: false]], @recorder.commands.first
+          assert_equal [:add_index, [:table, :one], { enabled: false }], @recorder.commands.first
         end
 
         def test_invert_disable_index
           @recorder.revert do
             @recorder.disable_index(:table, :disabled_index)
           end
-          assert_equal [:enable_index, [:table, :disabled_index]], @recorder.commands.first
+          assert_equal [:enable_index, [:table, :disabled_index], {}], @recorder.commands.first
         end
 
         def test_invert_enable_index
           @recorder.revert do
             @recorder.enable_index(:table, :enabled_index)
           end
-          assert_equal [:disable_index, [:table, :enabled_index]], @recorder.commands.first
+          assert_equal [:disable_index, [:table, :enabled_index], {}], @recorder.commands.first
         end
       end
 
@@ -437,42 +437,42 @@ module ActiveRecord
         @recorder.revert do
           @recorder.remove_index(:table, :one)
         end
-        assert_equal [:add_index, [:table, :one]], @recorder.commands.first
+        assert_equal [:add_index, [:table, :one], {}], @recorder.commands.first
       end
 
       def test_invert_remove_index_with_positional_column
         @recorder.revert do
           @recorder.remove_index(:table, [:one, :two], options: true)
         end
-        assert_equal [:add_index, [:table, [:one, :two], options: true]], @recorder.commands.first
+        assert_equal [:add_index, [:table, [:one, :two]], { options: true }], @recorder.commands.first
       end
 
       def test_invert_remove_index_with_column
         @recorder.revert do
           @recorder.remove_index(:table, column: [:one, :two], options: true)
         end
-        assert_equal [:add_index, [:table, [:one, :two], options: true]], @recorder.commands.first
+        assert_equal [:add_index, [:table, [:one, :two]], { options: true }], @recorder.commands.first
       end
 
       def test_invert_remove_index_with_name
         @recorder.revert do
           @recorder.remove_index(:table, column: [:one, :two], name: "new_index")
         end
-        assert_equal [:add_index, [:table, [:one, :two], name: "new_index"]], @recorder.commands.first
+        assert_equal [:add_index, [:table, [:one, :two]], { name: "new_index" }], @recorder.commands.first
       end
 
       def test_invert_remove_index_with_no_special_options
         @recorder.revert do
           @recorder.remove_index(:table, column: [:one, :two])
         end
-        assert_equal [:add_index, [:table, [:one, :two]]], @recorder.commands.first
+        assert_equal [:add_index, [:table, [:one, :two]], {}], @recorder.commands.first
       end
 
       def test_invert_remove_index_if_exists
         @recorder.revert do
           @recorder.remove_index(:table, column: [:one, :two], if_exists: true)
         end
-        assert_equal [:add_index, [:table, [:one, :two], if_not_exists: true]], @recorder.commands.first
+        assert_equal [:add_index, [:table, [:one, :two]], { if_not_exists: true }], @recorder.commands.first
       end
 
       def test_invert_remove_index_with_no_column
@@ -487,187 +487,187 @@ module ActiveRecord
         @recorder.revert do
           @recorder.rename_index(:table, :old, :new)
         end
-        assert_equal [:rename_index, [:table, :new, :old]], @recorder.commands.first
+        assert_equal [:rename_index, [:table, :new, :old], {}], @recorder.commands.first
       end
 
       def test_invert_add_timestamps
         @recorder.revert do
           @recorder.add_timestamps(:table)
         end
-        assert_equal [:remove_timestamps, [:table], nil], @recorder.commands.first
+        assert_equal [:remove_timestamps, [:table], {}, nil], @recorder.commands.first
       end
 
       def test_invert_remove_timestamps
         @recorder.revert do
           @recorder.remove_timestamps(:table, null: true)
         end
-        assert_equal [:add_timestamps, [:table, { null: true }], nil], @recorder.commands.first
+        assert_equal [:add_timestamps, [:table], { null: true }, nil], @recorder.commands.first
       end
 
       def test_invert_add_reference
         @recorder.revert do
           @recorder.add_reference(:table, :taggable, polymorphic: true)
         end
-        assert_equal [:remove_reference, [:table, :taggable, { polymorphic: true }], nil], @recorder.commands.first
+        assert_equal [:remove_reference, [:table, :taggable], { polymorphic: true }, nil], @recorder.commands.first
       end
 
       def test_invert_add_belongs_to_alias
         @recorder.revert do
           @recorder.add_belongs_to(:table, :user)
         end
-        assert_equal [:remove_reference, [:table, :user], nil], @recorder.commands.first
+        assert_equal [:remove_reference, [:table, :user], {}, nil], @recorder.commands.first
       end
 
       def test_invert_remove_reference
         @recorder.revert do
           @recorder.remove_reference(:table, :taggable, polymorphic: true)
         end
-        assert_equal [:add_reference, [:table, :taggable, { polymorphic: true }], nil], @recorder.commands.first
+        assert_equal [:add_reference, [:table, :taggable], { polymorphic: true }, nil], @recorder.commands.first
       end
 
       def test_invert_remove_reference_with_index_and_foreign_key
         @recorder.revert do
           @recorder.remove_reference(:table, :taggable, index: true, foreign_key: true)
         end
-        assert_equal [:add_reference, [:table, :taggable, { index: true, foreign_key: true }], nil], @recorder.commands.first
+        assert_equal [:add_reference, [:table, :taggable], { index: true, foreign_key: true }, nil], @recorder.commands.first
       end
 
       def test_invert_remove_belongs_to_alias
         @recorder.revert do
           @recorder.remove_belongs_to(:table, :user)
         end
-        assert_equal [:add_reference, [:table, :user], nil], @recorder.commands.first
+        assert_equal [:add_reference, [:table, :user], {}, nil], @recorder.commands.first
       end
 
       def test_invert_add_reference_if_not_exists
         @recorder.revert do
           @recorder.add_reference(:table, :taggable, polymorphic: true, if_not_exists: true)
         end
-        assert_equal [:remove_reference, [:table, :taggable, { polymorphic: true, if_exists: true }], nil], @recorder.commands.first
+        assert_equal [:remove_reference, [:table, :taggable], { polymorphic: true, if_exists: true }, nil], @recorder.commands.first
       end
 
       def test_invert_remove_reference_if_exists
         @recorder.revert do
           @recorder.remove_reference(:table, :taggable, polymorphic: true, if_exists: true)
         end
-        assert_equal [:add_reference, [:table, :taggable, { polymorphic: true, if_not_exists: true }], nil], @recorder.commands.first
+        assert_equal [:add_reference, [:table, :taggable], { polymorphic: true, if_not_exists: true }, nil], @recorder.commands.first
       end
 
       def test_invert_enable_extension
         @recorder.revert do
           @recorder.enable_extension("uuid-ossp")
         end
-        assert_equal [:disable_extension, ["uuid-ossp"], nil], @recorder.commands.first
+        assert_equal [:disable_extension, ["uuid-ossp"], {}, nil], @recorder.commands.first
       end
 
       def test_invert_disable_extension
         @recorder.revert do
           @recorder.disable_extension("uuid-ossp")
         end
-        assert_equal [:enable_extension, ["uuid-ossp"], nil], @recorder.commands.first
+        assert_equal [:enable_extension, ["uuid-ossp"], {}, nil], @recorder.commands.first
       end
 
       def test_invert_create_schema
         @recorder.revert do
           @recorder.create_schema("myschema")
         end
-        assert_equal [:drop_schema, ["myschema"], nil], @recorder.commands.first
+        assert_equal [:drop_schema, ["myschema"], {}, nil], @recorder.commands.first
       end
 
       def test_invert_drop_schema
         @recorder.revert do
           @recorder.drop_schema("myschema")
         end
-        assert_equal [:create_schema, ["myschema"], nil], @recorder.commands.first
+        assert_equal [:create_schema, ["myschema"], {}, nil], @recorder.commands.first
       end
 
       def test_invert_add_foreign_key
         @recorder.revert do
           @recorder.add_foreign_key(:dogs, :people)
         end
-        assert_equal [:remove_foreign_key, [:dogs, :people], nil], @recorder.commands.first
+        assert_equal [:remove_foreign_key, [:dogs, :people], {}, nil], @recorder.commands.first
       end
 
       def test_invert_remove_foreign_key
         @recorder.revert do
           @recorder.remove_foreign_key(:dogs, :people)
         end
-        assert_equal [:add_foreign_key, [:dogs, :people]], @recorder.commands.first
+        assert_equal [:add_foreign_key, [:dogs, :people], {}], @recorder.commands.first
       end
 
       def test_invert_add_foreign_key_with_column
         @recorder.revert do
           @recorder.add_foreign_key(:dogs, :people, column: "owner_id")
         end
-        assert_equal [:remove_foreign_key, [:dogs, :people, column: "owner_id"], nil], @recorder.commands.first
+        assert_equal [:remove_foreign_key, [:dogs, :people], { column: "owner_id" }, nil], @recorder.commands.first
       end
 
       def test_invert_add_foreign_key_if_not_exists
         @recorder.revert do
           @recorder.add_foreign_key(:dogs, :people, if_not_exists: true)
         end
-        assert_equal [:remove_foreign_key, [:dogs, :people, if_exists: true], nil], @recorder.commands.first
+        assert_equal [:remove_foreign_key, [:dogs, :people], { if_exists: true }, nil], @recorder.commands.first
       end
 
       def test_invert_remove_foreign_key_with_column
         @recorder.revert do
           @recorder.remove_foreign_key(:dogs, :people, column: "owner_id")
         end
-        assert_equal [:add_foreign_key, [:dogs, :people, column: "owner_id"]], @recorder.commands.first
+        assert_equal [:add_foreign_key, [:dogs, :people], { column: "owner_id" }], @recorder.commands.first
       end
 
       def test_invert_remove_foreign_key_if_exists
         @recorder.revert do
           @recorder.remove_foreign_key(:dogs, :people, if_exists: true)
         end
-        assert_equal [:add_foreign_key, [:dogs, :people, if_not_exists: true]], @recorder.commands.first
+        assert_equal [:add_foreign_key, [:dogs, :people], { if_not_exists: true }], @recorder.commands.first
       end
 
       def test_invert_add_foreign_key_with_column_and_name
         @recorder.revert do
           @recorder.add_foreign_key(:dogs, :people, column: "owner_id", name: "fk")
         end
-        assert_equal [:remove_foreign_key, [:dogs, :people, column: "owner_id", name: "fk"], nil], @recorder.commands.first
+        assert_equal [:remove_foreign_key, [:dogs, :people], { column: "owner_id", name: "fk" }, nil], @recorder.commands.first
       end
 
       def test_invert_remove_foreign_key_with_column_and_name
         @recorder.revert do
           @recorder.remove_foreign_key(:dogs, :people, column: "owner_id", name: "fk")
         end
-        assert_equal [:add_foreign_key, [:dogs, :people, column: "owner_id", name: "fk"]], @recorder.commands.first
+        assert_equal [:add_foreign_key, [:dogs, :people], { column: "owner_id", name: "fk" }], @recorder.commands.first
       end
 
       def test_invert_remove_foreign_key_with_primary_key
         @recorder.revert do
           @recorder.remove_foreign_key(:dogs, :people, primary_key: "person_id")
         end
-        assert_equal [:add_foreign_key, [:dogs, :people, primary_key: "person_id"]], @recorder.commands.first
+        assert_equal [:add_foreign_key, [:dogs, :people], { primary_key: "person_id" }], @recorder.commands.first
       end
 
       def test_invert_remove_foreign_key_with_primary_key_and_to_table_in_options
         @recorder.revert do
           @recorder.remove_foreign_key(:dogs, to_table: :people, primary_key: "uuid")
         end
-        assert_equal [:add_foreign_key, [:dogs, :people, primary_key: "uuid"]], @recorder.commands.first
+        assert_equal [:add_foreign_key, [:dogs, :people], { primary_key: "uuid" }], @recorder.commands.first
       end
 
       def test_invert_remove_foreign_key_with_on_delete_on_update
         @recorder.revert do
           @recorder.remove_foreign_key(:dogs, :people, on_delete: :nullify, on_update: :cascade)
         end
-        assert_equal [:add_foreign_key, [:dogs, :people, on_delete: :nullify, on_update: :cascade]], @recorder.commands.first
+        assert_equal [:add_foreign_key, [:dogs, :people], { on_delete: :nullify, on_update: :cascade }], @recorder.commands.first
       end
 
       def test_invert_remove_foreign_key_with_to_table_in_options
         @recorder.revert do
           @recorder.remove_foreign_key(:dogs, to_table: :people)
         end
-        assert_equal [:add_foreign_key, [:dogs, :people]], @recorder.commands.first
+        assert_equal [:add_foreign_key, [:dogs, :people], {}], @recorder.commands.first
 
         @recorder.revert do
           @recorder.remove_foreign_key(:dogs, to_table: :people, column: :owner_id)
         end
-        assert_equal [:add_foreign_key, [:dogs, :people, column: :owner_id]], @recorder.commands.last
+        assert_equal [:add_foreign_key, [:dogs, :people], { column: :owner_id }], @recorder.commands.last
       end
 
       def test_invert_remove_foreign_key_is_irreversible_without_to_table
@@ -704,21 +704,21 @@ module ActiveRecord
         @recorder.revert do
           @recorder.add_check_constraint(:dogs, "speed > 0", name: "speed_check")
         end
-        assert_equal [:remove_check_constraint, [:dogs, "speed > 0", name: "speed_check"], nil], @recorder.commands.first
+        assert_equal [:remove_check_constraint, [:dogs, "speed > 0"], { name: "speed_check" }, nil], @recorder.commands.first
       end
 
       def test_invert_add_check_constraint_if_not_exists
         @recorder.revert do
           @recorder.add_check_constraint(:dogs, "speed > 0", name: "speed_check", if_not_exists: true)
         end
-        assert_equal [:remove_check_constraint, [:dogs, "speed > 0", name: "speed_check", if_exists: true], nil], @recorder.commands.first
+        assert_equal [:remove_check_constraint, [:dogs, "speed > 0"], { name: "speed_check", if_exists: true }, nil], @recorder.commands.first
       end
 
       def test_invert_remove_check_constraint
         @recorder.revert do
           @recorder.remove_check_constraint(:dogs, "speed > 0", name: "speed_check")
         end
-        assert_equal [:add_check_constraint, [:dogs, "speed > 0", name: "speed_check"], nil], @recorder.commands.first
+        assert_equal [:add_check_constraint, [:dogs, "speed > 0"], { name: "speed_check" }, nil], @recorder.commands.first
       end
 
       def test_invert_remove_check_constraint_without_expression
@@ -733,7 +733,7 @@ module ActiveRecord
         @recorder.revert do
           @recorder.remove_check_constraint(:dogs, "speed > 0", name: "speed_check", if_exists: true)
         end
-        assert_equal [:add_check_constraint, [:dogs, "speed > 0", name: "speed_check", if_not_exists: true], nil], @recorder.commands.first
+        assert_equal [:add_check_constraint, [:dogs, "speed > 0"], { name: "speed_check", if_not_exists: true }, nil], @recorder.commands.first
       end
 
       def test_invert_add_unique_constraint_constraint_with_using_index
@@ -748,14 +748,14 @@ module ActiveRecord
         @recorder.revert do
           @recorder.remove_unique_constraint(:dogs, ["speed"], deferrable: :deferred, name: "uniq_speed")
         end
-        assert_equal [:add_unique_constraint, [:dogs, ["speed"], deferrable: :deferred, name: "uniq_speed"], nil], @recorder.commands.first
+        assert_equal [:add_unique_constraint, [:dogs, ["speed"]], { deferrable: :deferred, name: "uniq_speed" }, nil], @recorder.commands.first
       end
 
       def test_invert_remove_unique_constraint_constraint_without_options
         @recorder.revert do
           @recorder.remove_unique_constraint(:dogs, ["speed"])
         end
-        assert_equal [:add_unique_constraint, [:dogs, ["speed"]], nil], @recorder.commands.first
+        assert_equal [:add_unique_constraint, [:dogs, ["speed"]], {}, nil], @recorder.commands.first
       end
 
       def test_invert_remove_unique_constraint_constraint_without_columns
@@ -770,14 +770,14 @@ module ActiveRecord
         @recorder.revert do
           @recorder.create_enum(:color, ["blue", "green"])
         end
-        assert_equal [:drop_enum, [:color, ["blue", "green"]], nil], @recorder.commands.first
+        assert_equal [:drop_enum, [:color, ["blue", "green"]], {}, nil], @recorder.commands.first
       end
 
       def test_invert_drop_enum
         @recorder.revert do
           @recorder.drop_enum(:color, ["blue", "green"])
         end
-        assert_equal [:create_enum, [:color, ["blue", "green"]], nil], @recorder.commands.first
+        assert_equal [:create_enum, [:color, ["blue", "green"]], {}, nil], @recorder.commands.first
       end
 
       def test_invert_drop_enum_without_values
@@ -798,14 +798,14 @@ module ActiveRecord
         @recorder.revert do
           @recorder.rename_enum(:dog_breed, :breed)
         end
-        assert_equal [:rename_enum, [:breed, :dog_breed]], @recorder.commands.first
+        assert_equal [:rename_enum, [:breed, :dog_breed], {}], @recorder.commands.first
       end
 
       def test_invert_rename_enum_with_to_option
         @recorder.revert do
           @recorder.rename_enum(:dog_breed, to: :breed)
         end
-        assert_equal [:rename_enum, [:breed, :dog_breed]], @recorder.commands.first
+        assert_equal [:rename_enum, [:breed, :dog_breed], {}], @recorder.commands.first
       end
 
       def test_invert_add_enum_value
@@ -820,7 +820,7 @@ module ActiveRecord
         @recorder.revert do
           @recorder.rename_enum_value(:dog_breed, from: :retriever, to: :beagle)
         end
-        assert_equal [:rename_enum_value, [:dog_breed, from: :beagle, to: :retriever]], @recorder.commands.first
+        assert_equal [:rename_enum_value, [:dog_breed], { from: :beagle, to: :retriever }], @recorder.commands.first
       end
 
       def test_invert_rename_enum_value_without_from
@@ -843,14 +843,14 @@ module ActiveRecord
         @recorder.revert do
           @recorder.create_virtual_table(:searchables, :fts5, ["content", "meta UNINDEXED", "tokenize='porter ascii'"])
         end
-        assert_equal [:drop_virtual_table, [:searchables, :fts5, ["content", "meta UNINDEXED", "tokenize='porter ascii'"]], nil], @recorder.commands.first
+        assert_equal [:drop_virtual_table, [:searchables, :fts5, ["content", "meta UNINDEXED", "tokenize='porter ascii'"]], {}, nil], @recorder.commands.first
       end
 
       def test_invert_drop_virtual_table
         @recorder.revert do
           @recorder.drop_virtual_table(:searchables, :fts5, ["title", "content"])
         end
-        assert_equal [:create_virtual_table, [:searchables, :fts5, ["title", "content"]], nil], @recorder.commands.first
+        assert_equal [:create_virtual_table, [:searchables, :fts5, ["title", "content"]], {}, nil], @recorder.commands.first
       end
 
       def test_invert_drop_virtual_table_without_options


### PR DESCRIPTION
`recorder.commands` now stores each recorded migration command as `[cmd, args, kwargs, block]` (4-element) instead of `[cmd, args, block]` (3-element) with kwargs bundled into a trailing hash inside `args`. Code that inspects `recorder.commands` directly needs to adapt to the new tuple shape.

The old encoding was inherited from the `ruby2_keywords` transition period, where kwargs and positional args had to travel through a single flat array with the trailing hash marked as kwargs. Since Rails now requires Ruby 3.3.1+ (where kwargs are properly separated), the shim is no longer needed. All `invert_*` helpers now receive args and kwargs separately — removing the `.extract_options!`, `.last.is_a?(Hash)`, and `args << options` patterns that the `ruby2_keywords` idiom required.

This direction is aligned with a Ruby proposal to deprecate `ruby2_keywords` in the future (https://bugs.ruby-lang.org/issues/22205), since libraries that only support Ruby 3.0+ no longer need it.