### PR TITLE
Document that `connected_to_all_shards` raises with no shards

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -190,8 +190,9 @@ module ActiveRecord
     end
 
     # Passes the block to +connected_to+ for every +shard+ the
-    # model is configured to connect to (if any), and returns the
-    # results in an array.
+    # model is configured to connect to, and returns the results
+    # in an array. Raises an ArgumentError if the model is not
+    # connected to any shards.
     #
     # Optionally, +role+ and/or +prevent_writes+ can be passed which
     # will be forwarded to each +connected_to+ call. +prevent_writes+


### PR DESCRIPTION
Follow-up to #58117.

Since 697fc4c0b9, `connected_to_all_shards` raises an `ArgumentError` when called on a model that is not connected to any shards. The CHANGELOG and tests were updated with that change, but the RDoc still described the empty case as supported:

> Passes the block to `connected_to` for every `shard` the model is configured
> to connect to **(if any)**, and returns the results in an array.

This updates the doc to drop "(if any)" and document the error instead, so the API docs match the behavior before it ships in 8.2.