### PR TITLE
Normalize mixed-case percent escapes in paths

### DIFF
--- a/actionpack/lib/action_dispatch/journey/router/utils.rb
+++ b/actionpack/lib/action_dispatch/journey/router/utils.rb
@@ -31,7 +31,7 @@ module ActionDispatch
 
           unless path == "/"
             path.delete_suffix!("/")
-            path.gsub!(/(%[a-f0-9]{2})/) { $1.upcase }
+            path.gsub!(/(%[a-f0-9]{2})/i) { $1.upcase }
           end
 
           path.force_encoding(encoding)

--- a/actionpack/test/journey/router/utils_test.rb
+++ b/actionpack/test/journey/router/utils_test.rb
@@ -34,6 +34,10 @@ module ActionDispatch
           assert_equal "/foo%AAbar%AAbaz", Utils.normalize_path("/foo%aabar%aabaz")
         end
 
+        def test_normalize_path_uppercases_mixed_case_percent_escapes
+          assert_equal "/foo%AAbar%AAbaz", Utils.normalize_path("/foo%aAbar%Aabaz")
+        end
+
         def test_normalize_path_maintains_string_encoding
           path = "/foo%AAbar%AAbaz".b
           assert_equal Encoding::BINARY, Utils.normalize_path(path).encoding


### PR DESCRIPTION
Normalize percent-encoded path bytes when either hexadecimal digit is lowercase. Mixed-case escapes such as  previously remained noncanonical while lowercase escapes were uppercased. Add a regression test covering mixed-case input.