### PR TITLE
Shift local times in a DST gap forward by the gap's length

### DIFF
--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -569,10 +569,21 @@ module ActiveSupport
         begin
           period || @time_zone.period_for_local(@time)
         rescue ::TZInfo::PeriodNotFound
-          # time is in the "spring forward" hour gap, so we're moving the time forward one hour and trying again
-          @time += 1.hour
+          # time is in the "spring forward" gap, so we're moving the time forward by the gap's length and trying again
+          @time += spring_forward_gap
           retry
         end
+      end
+
+      # Not every DST gap is one hour long, e.g. Australia/Lord_Howe's DST
+      # transition is 30 minutes.
+      def spring_forward_gap
+        transition = @time_zone.tzinfo.transitions_up_to(@time + 1.day, @time - 1.day).find do |t|
+          (t.at.to_i + t.previous_offset.observed_utc_offset) <= @time.to_i &&
+            @time.to_i < (t.at.to_i + t.offset.observed_utc_offset)
+        end
+
+        transition ? transition.offset.observed_utc_offset - transition.previous_offset.observed_utc_offset : 3600
       end
 
       def transfer_time_values_to_utc_constructor(time)

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -210,6 +210,14 @@ class TimeZoneTest < ActiveSupport::TestCase
     assert_equal ActiveSupport::TimeZone["Hawaii"], time.time_zone
   end
 
+  def test_local_enforces_spring_dst_rules_with_a_sub_hour_gap
+    zone = ActiveSupport::TimeZone["Australia/Lord_Howe"] # 30-minute DST
+    twz = zone.local(2025, 10, 5, 2, 15) # 2:15AM does not exist because at 2AM, time springs forward to 2:30AM
+    assert_equal Time.utc(2025, 10, 5, 2, 45), twz.time
+    assert_equal Time.utc(2025, 10, 4, 15, 45), twz.utc
+    assert_equal true, twz.dst?
+  end
+
   def test_local_enforces_spring_dst_rules
     zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]
     twz = zone.local(2006, 4, 2, 1, 59, 59) # 1 second before DST start


### PR DESCRIPTION
`TimeZone#local`/`#parse` and `Time#change` resolve a local time that falls in a DST spring-forward gap by moving it past the gap. The shift was hardcoded to one hour, which overshoots in the only time zone with a sub-hour DST transition:

```ruby
ActiveSupport::TimeZone["Australia/Lord_Howe"].local(2025, 10, 5, 2, 15)
# Before: 2025-10-05 03:15:00 +1100
# After:  2025-10-05 02:45:00 +1100
```

Lord Howe Island observes a 30-minute DST transition, so 2:15AM sits 15 minutes into a 30-minute gap. The "before" result corresponds to neither the pre-gap nor the post-gap reading of the input, and diverges from both the behavior this suite already asserts for one-hour zones (Eastern 2:30AM → 3:30AM) and what `Time.local` produces for the same input (2:45AM +11:00).

The gap's length is now taken from the actual transition.