### PR TITLE
Set the default deprecation_horizon to 9.0

### DIFF
--- a/activesupport/lib/active_support/deprecation.rb
+++ b/activesupport/lib/active_support/deprecation.rb
@@ -68,7 +68,7 @@ module ActiveSupport
     # and the second is a library name.
     #
     #   ActiveSupport::Deprecation.new('2.0', 'MyLibrary')
-    def initialize(deprecation_horizon = "8.3", gem_name = "Rails")
+    def initialize(deprecation_horizon = "9.0", gem_name = "Rails")
       self.gem_name = gem_name
       self.deprecation_horizon = deprecation_horizon
       # By default, warnings are not silenced and debugging is off.


### PR DESCRIPTION
## Summary

Updates the default `deprecation_horizon` from `8.3` to `9.0`.

Rails follows a major/minor versioning scheme (e.g. `4.0`, `4.1`, `4.2`, `5.0`, `5.1`, `5.2`, etc.), so `8.3` is not a valid planned release version. Using `9.0` better reflects the expected next deprecation horizon.