### PR TITLE
Fix inaccurate docstring in `CommandRecorder#inverse_of` [ci-skip]

### DIFF
--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -107,11 +107,6 @@ module ActiveRecord
       #   recorder.inverse_of(:rename_table, [:old, :new])
       #   # => [:rename_table, [:new, :old]]
       #
-      # If the inverse of a command requires several commands, returns array of commands.
-      #
-      #   recorder.inverse_of(:remove_columns, [:some_table, :foo, :bar, type: :string])
-      #   # => [[:add_column, :some_table, :foo, :string], [:add_column, :some_table, :bar, :string]]
-      #
       # This method will raise an +IrreversibleMigration+ exception if it cannot
       # invert the +command+.
       def inverse_of(command, args, &block)


### PR DESCRIPTION
The docstring claimed that if the inverse of a command requires several commands, it returns an array of commands. This was true for `invert_remove_columns` until it was refactored in 3582de977d (2020) to return a single flat `[:add_columns, ...]` command instead of expanding into individual `[:add_column, ...]` entries.

Remove the outdated claim and its example.
