### PR TITLE
Fix `number_to_human_size` crashing above a terabyte

### DIFF
--- a/activesupport/lib/active_support/number_helper/number_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_converter.rb
@@ -84,7 +84,10 @@ module ActiveSupport
               kb: "KB",
               mb: "MB",
               gb: "GB",
-              tb: "TB"
+              tb: "TB",
+              pb: "PB",
+              eb: "EB",
+              zb: "ZB"
             }.freeze
           }.freeze,
           # Used in number_to_human

--- a/activesupport/test/number_helper_i18n_test.rb
+++ b/activesupport/test/number_helper_i18n_test.rb
@@ -127,6 +127,9 @@ module ActiveSupport
     def test_number_to_i18n_human_size_with_empty_i18n_store
       assert_equal("2 KB", number_to_human_size(2048, locale: "empty"))
       assert_equal("42 Bytes", number_to_human_size(42, locale: "empty"))
+      assert_equal("2 PB", number_to_human_size(2 * 1024**5, locale: "empty"))
+      assert_equal("2 EB", number_to_human_size(2 * 1024**6, locale: "empty"))
+      assert_equal("2 ZB", number_to_human_size(2 * 1024**7, locale: "empty"))
     end
 
     def test_number_to_human_with_default_translation_scope


### PR DESCRIPTION
`number_to_human_size` quantifies up to zettabyte and falls back to a built-in unit name when the current locale does not translate one, but that fallback only covered up to terabyte:

```ruby
number_to_human_size(1024 ** 4, locale: :cs)
# Before: "1 TB"
# After:  "1 TB"

number_to_human_size(1024 ** 5, locale: :cs)
# Before: TypeError: no implicit conversion of nil into String
# After:  "1 PB"
```

The fallback table `DEFAULTS` was last updated when terabyte was the largest unit. Petabyte, exabyte, and zettabyte were added to the helper and to the English locale in #22732 (2015) and #47771 (2023), but neither updated `DEFAULTS`, so the first size above a locale's largest translated unit raises instead of falling back.

Of the 122 locales that ship storage unit translations in `rails-i18n`, 58 lack petabyte, 59 lack exabyte, and 116 lack zettabyte — every locale defines up to terabyte, so the gap is invisible until an application formats a larger value.

Locales that do translate the larger units are unaffected, since a translation still takes precedence over the fallback.

`number_to_human`'s `decimal_units` are unaffected — those fallbacks already match the English locale exactly.

### Doesn't this leak English into a translated page?

No more than the existing entries do — `byte`/`kb`/`mb`/`gb`/`tb` are already English in this fallback, and it exists precisely for untranslated keys. In practice it is also the right string for most locales: of the 58 locales that lack petabyte, 45 spell terabyte as `"TB"` already. The remaining 13 use a localized form (`ТБ`, `To`, `ترابایت`, …) and would get `"PB"` — a language mismatch, but strictly better than a `TypeError`.