### PR TITLE
Intermittent FrozenError on ActiveSupport::Dependencies.autoload_path…

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Ensure the main autoloader is configured after all engine autoload paths.
+
+    Fixes #58069.
+
+    *Nicolas Vandenbogaerde*
+
 *   Validate subcommand in `rails plugin` command.
 
     `rails plugin foo bar` silently ignored the invalid subcommand "foo"

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -10,11 +10,11 @@ module Rails
     module Finisher
       include Initializable
 
-      initializer :add_generator_templates do
+      initializer :add_generator_templates, before: :setup_main_autoloader do
         ensure_generator_templates_added
       end
 
-      initializer :setup_main_autoloader do
+      initializer :setup_main_autoloader, after: :bootstrap_hook do
         autoloader = Rails.autoloaders.main
 
         # Normally empty, but if the user already defined some, we won't

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -315,6 +315,17 @@ module RailtiesTest
       assert_includes $test_autoload_paths, "#{app_path}/app/controllers"
     end
 
+    test "the main autoloader setup runs after the bootstrap hook" do
+      require "#{app_path}/config/application"
+
+      application = Rails.app_class.instance
+      initializers = Rails::Initializable::Collection.new(application.initializers.to_a.reverse)
+      initializer_names = initializers.tsort.map(&:name)
+
+      assert_operator initializer_names.index(:bootstrap_hook), :<, initializer_names.index(:setup_main_autoloader)
+      assert_operator initializer_names.index(:add_generator_templates), :<, initializer_names.index(:setup_main_autoloader)
+    end
+
     test "puts its models directory on autoload path" do
       @plugin.write "app/models/my_bukkit.rb", "class MyBukkit ; end"
       boot_rails


### PR DESCRIPTION
issue : https://github.com/rails/rails/issues/58232

| Fichier modifié | Changement | Objectif |
|---|---|---|
| `railties/lib/rails/application/finisher.rb` | Ordonne `setup_main_autoloader` après `bootstrap_hook`, et `add_generator_templates` avant celui-ci. | Éviter le `FrozenError` intermittent lorsque les engines ajoutent leurs chemins d’autoload au démarrage. |
| `railties/test/railties/engine_test.rb` | Ajoute un test vérifiant l’ordre des trois initializers. | Garantir que la régression ne revienne pas. |
| `railties/CHANGELOG.md` | Ajoute une entrée de changelog pour le correctif. | Documenter la modification dans Railties. |