### PR TITLE
Fix: infinite route reload when after_routes_loaded accesses routes

### DIFF
--- a/railties/lib/rails/application/routes_reloader.rb
+++ b/railties/lib/rails/application/routes_reloader.rb
@@ -55,10 +55,18 @@ module Rails
           # recurse into another draw.
           return false if @load_state == :loading
 
-          execute
-          ActiveSupport.run_load_hooks(:after_routes_loaded, Rails.application)
-          @load_state = :loaded
-          true
+          # Hold :loading across after_routes_loaded as well. reload! restores
+          # the previous state when it finishes, so if we left that as nil a
+          # hook that touched routes would re-enter and draw again.
+          @load_state = :loading
+          begin
+            execute
+            ActiveSupport.run_load_hooks(:after_routes_loaded, Rails.application)
+            @load_state = :loaded
+            true
+          ensure
+            @load_state = nil if @load_state == :loading
+          end
         end
       end
 

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -394,6 +394,39 @@ class LoadingTest < ActiveSupport::TestCase
     assert_equal "3", last_response.body
   end
 
+  test "after_routes_loaded hooks that access routes do not reload infinitely" do
+    add_to_config <<-RUBY
+      config.enable_reloading = true
+    RUBY
+
+    app_file "config/routes.rb", <<-RUBY
+      $draws ||= 0
+      $draws += 1
+      raise "routes drew more than once" if $draws > 1
+      Rails.application.routes.draw do
+        get "/c", to: lambda { |env| [200, {"Content-Type" => "text/plain"}, [$draws.to_s]] }
+      end
+    RUBY
+
+    app_file "config/initializers/after_routes_loaded.rb", <<-RUBY
+      Rails.configuration.after_routes_loaded do
+        # Touch the route set while after_routes_loaded hooks are still running.
+        Rails.application.routes.routes.size
+      end
+    RUBY
+
+    boot_app "development"
+
+    require "rack/test"
+    extend Rack::Test::Methods
+
+    require "#{rails_root}/config/environment"
+
+    get "/c"
+    assert_equal "1", last_response.body
+    assert_equal 1, $draws
+  end
+
   test "columns migrations also trigger reloading" do
     add_to_config <<-RUBY
       config.enable_reloading = true


### PR DESCRIPTION
### Detail
After #58225, reload! restored @load_state to nil before after_routes_loaded hooks ran. A hook that touched the route set could re-enter execute_unless_loaded and draw routes again. Hold :loading for the whole execute_unless_loaded critical section, including hooks, and only mark :loaded when they finish. Reset to nil on failure so a retry can still draw.

cc @grk @byroot 



Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
