### PR TITLE
fix mailgun

### DIFF
--- a/actionmailbox/CHANGELOG.md
+++ b/actionmailbox/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow Mailgun inbound email payloads larger than Rack's query parser limit.
+
+    *Nicolas Vaillancourt*
+
 *   Return `422 Unprocessable Content` for malformed Mailgun, Postmark, and SendGrid raw email parameters.
 
     *Andrii Furmanets*

--- a/actionmailbox/CHANGELOG.md
+++ b/actionmailbox/CHANGELOG.md
@@ -1,6 +1,6 @@
 *   Allow Mailgun inbound email payloads larger than Rack's query parser limit.
 
-    *Nicolas Vaillancourt*
+    *Nicolas Vandenbogaerde*
 
 *   Return `422 Unprocessable Content` for malformed Mailgun, Postmark, and SendGrid raw email parameters.
 

--- a/actionmailbox/lib/action_mailbox/engine.rb
+++ b/actionmailbox/lib/action_mailbox/engine.rb
@@ -7,6 +7,7 @@ require "active_record/railtie"
 require "active_storage/engine"
 
 require "action_mailbox"
+require "action_mailbox/ingresses/mailgun/request_parser"
 
 module ActionMailbox
   class Engine < Rails::Engine
@@ -16,6 +17,7 @@ module ActionMailbox
     config.action_mailbox = ActiveSupport::OrderedOptions.new
     config.action_mailbox.incinerate = true
     config.action_mailbox.incinerate_after = 30.days
+    config.action_mailbox.mailgun_payload_size_limit = 25.megabytes
 
     config.action_mailbox.queues = ActiveSupport::InheritableOptions.new \
       incineration: :action_mailbox_incineration, routing: :action_mailbox_routing
@@ -37,6 +39,12 @@ module ActionMailbox
         ActionMailbox.ingress = app.config.action_mailbox.ingress
         ActionMailbox.storage_service = app.config.action_mailbox.storage_service
       end
+    end
+
+    initializer "action_mailbox.mailgun_request_parser", before: :build_middleware_stack do |app|
+      app.middleware.insert_before Rack::MethodOverride,
+        ActionMailbox::Ingresses::Mailgun::RequestParser,
+        bytesize_limit: app.config.action_mailbox.mailgun_payload_size_limit
     end
   end
 end

--- a/actionmailbox/lib/action_mailbox/engine.rb
+++ b/actionmailbox/lib/action_mailbox/engine.rb
@@ -42,7 +42,7 @@ module ActionMailbox
     end
 
     initializer "action_mailbox.mailgun_request_parser", before: :build_middleware_stack do |app|
-      app.middleware.insert_before Rack::MethodOverride,
+      app.middleware.unshift \
         ActionMailbox::Ingresses::Mailgun::RequestParser,
         bytesize_limit: app.config.action_mailbox.mailgun_payload_size_limit
     end

--- a/actionmailbox/lib/action_mailbox/ingresses/mailgun/request_parser.rb
+++ b/actionmailbox/lib/action_mailbox/ingresses/mailgun/request_parser.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rack"
+require "stringio"
+
+module ActionMailbox
+  module Ingresses
+    module Mailgun
+      class RequestParser
+        PATH = "/rails/action_mailbox/mailgun/inbound_emails/mime"
+        CONTENT_TYPE = "application/x-www-form-urlencoded"
+
+        def initialize(app, bytesize_limit:)
+          @app = app
+          @query_parser = Rack::QueryParser.make_default(
+            Rack::Utils.default_query_parser.param_depth_limit,
+            bytesize_limit: bytesize_limit
+          )
+        end
+
+        def call(env)
+          if mailgun_request?(env)
+            form_vars = env.fetch("rack.input").read
+            env["rack.input"] = StringIO.new(form_vars)
+            env["rack.request.form_vars"] = form_vars
+            env["rack.request.form_pairs"] = @query_parser.parse_query_pairs(form_vars)
+          end
+
+          @app.call(env)
+        end
+
+        private
+          def mailgun_request?(env)
+            env["REQUEST_METHOD"] == "POST" &&
+              env["PATH_INFO"] == PATH &&
+              Rack::MediaType.type(env["CONTENT_TYPE"]) == CONTENT_TYPE
+          end
+      end
+    end
+  end
+end

--- a/actionmailbox/lib/action_mailbox/ingresses/mailgun/request_parser.rb
+++ b/actionmailbox/lib/action_mailbox/ingresses/mailgun/request_parser.rb
@@ -12,6 +12,7 @@ module ActionMailbox
 
         def initialize(app, bytesize_limit:)
           @app = app
+          @bytesize_limit = bytesize_limit
           @query_parser = Rack::QueryParser.make_default(
             Rack::Utils.default_query_parser.param_depth_limit,
             bytesize_limit: bytesize_limit
@@ -20,10 +21,13 @@ module ActionMailbox
 
         def call(env)
           if mailgun_request?(env)
-            form_vars = env.fetch("rack.input").read
+            read_limit = @bytesize_limit ? @bytesize_limit + 2 : nil
+            form_vars = env.fetch("rack.input").read(read_limit) || ""
+            form_vars.slice!(-1) if form_vars.end_with?("\0")
+
             env["rack.input"] = StringIO.new(form_vars)
             env["rack.request.form_vars"] = form_vars
-            env["rack.request.form_pairs"] = @query_parser.parse_query_pairs(form_vars)
+            env["rack.request.form_pairs"] = @query_parser.parse_query_pairs(form_vars, "&")
           end
 
           @app.call(env)

--- a/actionmailbox/test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb
+++ b/actionmailbox/test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb
@@ -49,6 +49,20 @@ class ActionMailbox::Ingresses::Mailgun::InboundEmailsControllerTest < ActionDis
     assert_equal "05988AA6EC0D44318855A5E39E3B6F9E@jansterba.com", inbound_email.message_id
   end
 
+  test "receiving a Mailgun payload larger than Rack's query parser limit" do
+    body = [
+      "timestamp=1",
+      "token=test-token",
+      "signature=test-signature",
+      "body-mime=#{"a" * 5.megabytes}"
+    ].join("&")
+
+    post rails_mailgun_inbound_emails_url, params: body,
+      headers: { "CONTENT_TYPE" => "application/x-www-form-urlencoded" }
+
+    assert_response :unauthorized
+  end
+
   test "add X-Original-To to email from Mailgun" do
     assert_difference -> { ActionMailbox::InboundEmail.count }, +1 do
       travel_to "2018-10-09 15:15:00 EDT"

--- a/actionmailbox/test/unit/ingresses/mailgun/request_parser_test.rb
+++ b/actionmailbox/test/unit/ingresses/mailgun/request_parser_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require_relative "../../../test_helper"
+
+require "action_mailbox/ingresses/mailgun/request_parser"
+require "rack/mock"
+
+class ActionMailbox::Ingresses::Mailgun::RequestParserTest < ActiveSupport::TestCase
+  PATH = ActionMailbox::Ingresses::Mailgun::RequestParser::PATH
+  CONTENT_TYPE = ActionMailbox::Ingresses::Mailgun::RequestParser::CONTENT_TYPE
+
+  test "parses Mailgun form data within the configured limit" do
+    env = mailgun_env("foo=bar")
+
+    parser(bytesize_limit: 7).call(env)
+
+    assert_equal "foo=bar", env["rack.request.form_vars"]
+    assert_equal [["foo", "bar"]], env["rack.request.form_pairs"]
+    assert_equal "foo=bar", env["rack.input"].read
+  end
+
+  test "reads only enough data to reject a payload above the configured limit" do
+    env = mailgun_env("foo=12345")
+    rack_input = env["rack.input"]
+
+    assert_raises Rack::QueryParser::QueryLimitError do
+      parser(bytesize_limit: 5).call(env)
+    end
+
+    assert_equal 7, rack_input.pos
+  end
+
+  test "does not parse form data for unrelated endpoints" do
+    env = mailgun_env("foo=bar", path: "/unrelated")
+    rack_input = env["rack.input"]
+
+    parser(bytesize_limit: 7).call(env)
+
+    assert_same rack_input, env["rack.input"]
+    assert_not env.key?("rack.request.form_vars")
+    assert_not env.key?("rack.request.form_pairs")
+    assert_equal 0, rack_input.pos
+  end
+
+  test "does not change Rack's payload size limit for unrelated endpoints" do
+    env = mailgun_env("foo=#{"a" * 5.megabytes}", path: "/unrelated")
+    app = ->(env) { Rack::Request.new(env).POST }
+
+    assert_raises Rack::QueryParser::QueryLimitError do
+      parser(app: app, bytesize_limit: 6.megabytes).call(env)
+    end
+  end
+
+  private
+    def parser(app: ->(_env) { [200, {}, []] }, bytesize_limit:)
+      ActionMailbox::Ingresses::Mailgun::RequestParser.new(
+        app,
+        bytesize_limit: bytesize_limit
+      )
+    end
+
+    def mailgun_env(body, path: PATH)
+      Rack::MockRequest.env_for(path,
+        method: "POST",
+        input: body,
+        "CONTENT_TYPE" => CONTENT_TYPE)
+    end
+end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2824,6 +2824,14 @@ Accepts an `ActiveSupport::Duration` indicating how long after processing `Actio
 config.action_mailbox.incinerate_after = 14.days
 ```
 
+#### `config.action_mailbox.mailgun_payload_size_limit`
+
+Sets the maximum size, in bytes, of the URL-encoded payload accepted by the Mailgun ingress. It defaults to `25.megabytes`. This limit applies only to the Mailgun ingress and does not change Rack's query parser limit for other requests.
+
+```ruby
+config.action_mailbox.mailgun_payload_size_limit = 50.megabytes
+```
+
 #### `config.action_mailbox.queues.incineration`
 
 Accepts a symbol indicating the Active Job queue to use for incineration jobs.

--- a/railties/test/commands/middleware_test.rb
+++ b/railties/test/commands/middleware_test.rb
@@ -26,6 +26,7 @@ class Rails::Command::MiddlewareTest < ActiveSupport::TestCase
     boot!
 
     assert_equal [
+      "ActionMailbox::Ingresses::Mailgun::RequestParser",
       "ActionDispatch::HostAuthorization",
       "ActionDispatch::Static",
       "Propshaft::Server",
@@ -61,6 +62,7 @@ class Rails::Command::MiddlewareTest < ActiveSupport::TestCase
     boot!
 
     assert_equal [
+      "ActionMailbox::Ingresses::Mailgun::RequestParser",
       "ActionDispatch::HostAuthorization",
       "ActionDispatch::Static",
       "Propshaft::Server",
@@ -95,6 +97,7 @@ class Rails::Command::MiddlewareTest < ActiveSupport::TestCase
     boot!
 
     assert_equal [
+      "ActionMailbox::Ingresses::Mailgun::RequestParser",
       "ActionDispatch::HostAuthorization",
       "ActionDispatch::Static",
       "Propshaft::Server",
@@ -112,6 +115,17 @@ class Rails::Command::MiddlewareTest < ActiveSupport::TestCase
       "Rack::ConditionalGet",
       "Rack::ETag"
     ], middleware
+  end
+
+  test "configures the Mailgun request parser payload size limit" do
+    add_to_config "config.action_mailbox.mailgun_payload_size_limit = 50.megabytes"
+
+    boot!
+
+    mailgun_parser = Rails.application.middleware.find do |middleware|
+      middleware.klass == ActionMailbox::Ingresses::Mailgun::RequestParser
+    end
+    assert_equal [{ bytesize_limit: 50.megabytes }], mailgun_parser.args
   end
 
   test "middleware dependencies" do
@@ -211,7 +225,8 @@ class Rails::Command::MiddlewareTest < ActiveSupport::TestCase
     add_to_config "config.ssl_options = { redirect: { host: 'example.com' } }"
     boot!
 
-    assert_equal [{ redirect: { host: "example.com" }, ssl_default_redirect_status: 308 }], Rails.application.middleware[1].args
+    ssl_middleware = Rails.application.middleware.find { |middleware| middleware.klass == ActionDispatch::SSL }
+    assert_equal [{ redirect: { host: "example.com" }, ssl_default_redirect_status: 308 }], ssl_middleware.args
   end
 
   test "ActionDispatch::PermissionsPolicy::MiddlewareStack is included if permissions_policy set" do
@@ -308,20 +323,20 @@ class Rails::Command::MiddlewareTest < ActiveSupport::TestCase
   test "unshift middleware" do
     add_to_config "config.middleware.unshift Rack::Config"
     boot!
-    assert_equal "Rack::Config", middleware.first
+    assert_equal "Rack::Config", middleware.second
   end
 
   test "Rails.cache does not respond to middleware" do
     add_to_config "config.cache_store = :file_store, '/tmp/cache'"
     boot!
-    assert_equal "Rack::Runtime", middleware[4]
+    assert_equal "Rack::Runtime", middleware[5]
     assert_instance_of ActiveSupport::Cache::FileStore, Rails.cache
   end
 
   test "Rails.cache does respond to middleware" do
     boot!
-    assert_equal "ActiveSupport::Cache::Strategy::LocalCache", middleware[4]
-    assert_equal "Rack::Runtime", middleware[5]
+    assert_equal "ActiveSupport::Cache::Strategy::LocalCache", middleware[5]
+    assert_equal "Rack::Runtime", middleware[6]
   end
 
   test "insert middleware before" do


### PR DESCRIPTION
Issue : https://github.com/rails/rails/issues/57822

### Motivation / Background

This Pull Request has been created because Mailgun inbound email payloads can exceed Rack's default query parser size limit, causing valid inbound emails with large `body-mime` payloads to be rejected before Action Mailbox can process them.

### Detail

This Pull Request adds a Mailgun-specific request parser middleware that allows larger URL-encoded payloads for the Mailgun ingress without changing Rack's global query parser limit. It also introduces a new `config.action_mailbox.mailgun_payload_size_limit` setting, documents it, and adds a test covering payloads larger than Rack's default limit.

### Additional information

The new limit defaults to `25.megabytes` and applies only to the Mailgun MIME endpoint.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
