### PR TITLE
Deprecate `insert_returning` option and `use_insert_returning?`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Deprecate the `insert_returning` option in PostgreSQL database
+    configurations, and the `PostgreSQLAdapter#use_insert_returning?` method.
+
+    The option only affected single-row INSERT statements. Other paths such
+    as `insert_all`, `upsert_all`, and RETURNING for `update` already use
+    RETURNING when the database supports it, so the option cannot fully
+    disable RETURNING and has become vestigial.
+
+    *Ryuta Kamizono*
+
 *   Remove unused `rest` parameter from merge and merge!
 
     *Aaron Patterson*

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -30,7 +30,7 @@ module ActiveRecord
         end
 
         def _exec_insert(intent, pk = nil, sequence_name = nil, returning: nil) # :nodoc:
-          if use_insert_returning? || pk == false
+          if @use_insert_returning || pk == false
             super
           else
             intent.execute!

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -41,8 +41,6 @@ module ActiveRecord
     #   <tt>SET client_min_messages TO <min_messages></tt> call on the connection.
     # * <tt>:variables</tt> - An optional hash of additional parameters that
     #   will be used in <tt>SET SESSION key = val</tt> calls on the connection.
-    # * <tt>:insert_returning</tt> - An optional boolean to control the use of <tt>RETURNING</tt> for <tt>INSERT</tt> statements
-    #   defaults to true.
     #
     # Any further options are used as connection parameters to libpq. See
     # https://www.postgresql.org/docs/current/static/libpq-connect.html for the
@@ -403,7 +401,18 @@ module ActiveRecord
         @notice_receiver_sql_warnings = []
         @notice_receiver_fatal_error = nil
 
-        @use_insert_returning = @config.key?(:insert_returning) ? self.class.type_cast_config_to_boolean(@config[:insert_returning]) : true
+        @use_insert_returning = if @config.key?(:insert_returning)
+          ActiveRecord.deprecator.warn(<<~MSG.squish)
+            The `insert_returning` option in database configurations is deprecated
+            and will be removed in Rails 8.3. The option only affects single-row
+            INSERT statements; other paths such as `insert_all`, `upsert_all`, and
+            RETURNING for `update` already use RETURNING when the database supports
+            it, so the option cannot fully disable RETURNING.
+          MSG
+          self.class.type_cast_config_to_boolean(@config[:insert_returning])
+        else
+          true
+        end
       end
 
       def connected?
@@ -703,6 +712,7 @@ module ActiveRecord
       def use_insert_returning?
         @use_insert_returning
       end
+      deprecate :use_insert_returning?, deprecator: ActiveRecord.deprecator
 
       # Returns the version of the connected PostgreSQL server.
       def get_database_version # :nodoc:

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -1705,7 +1705,9 @@ module ActiveRecord
 
         def connection_without_insert_returning(&block)
           db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
-          with_postgresql_adapter(db_config.configuration_hash.merge(insert_returning: false), &block)
+          assert_deprecated(ActiveRecord.deprecator) do
+            with_postgresql_adapter(db_config.configuration_hash.merge(insert_returning: false), &block)
+          end
         end
 
         def oid_lookup_query?(query)


### PR DESCRIPTION
The `:insert_returning` option in PostgreSQL database configurations only affects single-row INSERT statements via `_exec_insert`. Other paths such as `insert_all`, `upsert_all`, and RETURNING for `update` already use RETURNING when the database supports it (via `supports_insert_returning?` / `supports_update_returning?`), so the option cannot fully disable RETURNING and has become vestigial.

Deprecate both the `:insert_returning` config option and the `PostgreSQLAdapter#use_insert_returning?` method that reads it.
