### PR TITLE
[ci skip] Update Mailgun setup documentation links

### DIFF
--- a/actionmailbox/app/controllers/action_mailbox/ingresses/mailgun/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/action_mailbox/ingresses/mailgun/inbound_emails_controller.rb
@@ -37,7 +37,7 @@ module ActionMailbox
   #        # config/environments/production.rb
   #        config.action_mailbox.ingress = :mailgun
   #
-  # 3. {Configure Mailgun}[https://documentation.mailgun.com/en/latest/user_manual.html#receiving-forwarding-and-storing-messages]
+  # 3. {Configure Mailgun}[https://documentation.mailgun.com/docs/mailgun/user-manual/receive-forward-store/receive-http]
   #    to forward inbound emails to +/rails/action_mailbox/mailgun/inbound_emails/mime+.
   #
   #    If your application lived at <tt>https://example.com</tt>, you would specify the fully-qualified URL

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -134,7 +134,7 @@ config.action_mailbox.ingress = :mailgun
 ```
 
 [Configure
-Mailgun](https://documentation.mailgun.com/docs/mailgun/user-manual/receive-forward-store/)
+Mailgun](https://documentation.mailgun.com/docs/mailgun/user-manual/receive-forward-store/receive-http)
 to forward inbound emails to
 `/rails/action_mailbox/mailgun/inbound_emails/mime`. If your application lived
 at `https://example.com`, you would specify the fully-qualified URL


### PR DESCRIPTION
The Mailgun links in the Action Mailbox guide and API documentation no longer lead to the HTTP forwarding instructions.

Update both references to Mailgun's canonical documentation for receiving messages through a `forward()` action. The target page documents the `mime` URL suffix and `body-mime` payload used by Action Mailbox.

Verified with:

- `bundle exec rake guides:generate ONLY=action_mailbox_basics`
- `bundle exec rake guides:lint:check_links ONLY=action_mailbox_basics`
- `bundle exec rake rdoc`