### PR TITLE
Require Markdown APIs in new files

### DIFF
--- a/.github/workflows/check-markdown-api.yml
+++ b/.github/workflows/check-markdown-api.yml
@@ -1,0 +1,26 @@
+name: Markdown API
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  markdown_api:
+    name: Check Markdown APIs in new files
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ruby
+      - name: Check Markdown APIs in new files
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: ruby .github/workflows/scripts/check-markdown-api.rb $BASE_SHA $HEAD_SHA

--- a/.github/workflows/scripts/check-markdown-api.rb
+++ b/.github/workflows/scripts/check-markdown-api.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+base_sha, head_sha = ARGV
+
+added_files = `git diff --name-only --diff-filter=A #{base_sha}...#{head_sha}`.lines(chomp: true)
+
+abort "Error shelling out to git #{$?}" unless $?.success?
+
+invalid_files = []
+
+added_files.each do |path|
+  next unless File.fnmatch?("*/{app,lib}/**/*.rb", path, File::FNM_EXTGLOB | File::FNM_PATHNAME)
+
+  markdown = false
+
+  File.foreach(path, chomp: true) do |line|
+    if line == "# :markup: markdown"
+      markdown = true
+      break
+    elsif !line.start_with?("#")
+      break
+    end
+  end
+
+  invalid_files << path unless markdown
+end
+
+if invalid_files.any?
+  warn "New Ruby files must use Markdown for their API documentation."
+  warn "Please add `# :markup: markdown` at the top of:"
+  invalid_files.each do |path|
+    warn "  #{path}"
+  end
+
+  exit 1
+end


### PR DESCRIPTION
We are gradually converting our API to Markdown.

By requiring new files to be documented in Markdown we prevent RDoc markup from being introduced while the migration is ongoing.