### PR TITLE
Remove unused `binds` argument from `update_with_result`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -261,10 +261,10 @@ module ActiveRecord
 
       # Executes the update statement and returns an ActiveRecord::Result
       # Some adapters support the `returning` keyword argument
-      def update_with_result(arel, name = nil, binds = [], returning:) # :nodoc:
+      def update_with_result(arel, name = nil, returning:) # :nodoc:
         arel.returning(returning.map { |column| Arel.sql(quote_column_name(column)) })
 
-        intent = QueryIntent.new(adapter: self, arel: arel, name: name, binds: binds)
+        intent = QueryIntent.new(adapter: self, arel: arel, name: name)
 
         intent.execute!
         intent.cast_result


### PR DESCRIPTION
Since 213796fb4936dce1da2f0c097a054e1af5c25c2c, Arel itself holds bind values, so passing `binds` alongside an Arel AST is forbidden (see `to_sql_and_binds`). And since `update_with_result` calls `arel.returning(...)`, `arel` must always be an Arel statement manager, never a raw SQL string. Therefore the `binds` argument was never usable and is unused by the sole caller `_update_record_with_result`.
