### PR TITLE
Delegate `ids` back to `pluck`

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -373,47 +373,11 @@ module ActiveRecord
     #   Person.ids # SELECT people.id FROM people
     #   Person.joins(:company).ids # SELECT people.id FROM people INNER JOIN companies ON companies.id = people.company_id
     def ids
-      if @none
-        if @async
-          return Promise::Complete.new([])
-        else
-          return []
-        end
+      if !loaded? && has_include?(primary_key)
+        return apply_join_dependency.group(*primary_key).pluck(*primary_key)
       end
 
-      primary_key_array = Array(primary_key)
-
-      if loaded?
-        result = records.map do |record|
-          if primary_key_array.one?
-            record._read_attribute(primary_key_array.first)
-          else
-            primary_key_array.map { |column| record._read_attribute(column) }
-          end
-        end
-        return @async ? Promise::Complete.new(result) : result
-      end
-
-      if has_include?(primary_key)
-        relation = apply_join_dependency.group(*primary_key_array)
-        return relation.ids
-      end
-
-      columns = arel_columns(primary_key_array)
-      relation = spawn
-      relation.select_values = columns
-
-      result = if relation.where_clause.contradiction?
-        ActiveRecord::Result.empty(async: @async)
-      else
-        skip_query_cache_if_necessary do
-          model.with_connection do |c|
-            c.select_all(relation, "#{model.name} Ids", async: @async)
-          end
-        end
-      end
-
-      result.then { |result| type_cast_pluck_values(result, columns) }
+      pluck(*primary_key)
     end
 
     # Same as #ids, but performs the query asynchronously and returns an


### PR DESCRIPTION
Before #46503, `ids` was implemented simply as `pluck(primary_key)`. That PR split them so `ids` could deduplicate rows when eager loading associations (`Post.includes(:comments).where(id: 1).ids` was returning `[1, 1, 1, 1, 1]` instead of `[1]`).

Since then the two implementations have drifted, and each drift has produced an asymmetry bug fixed only on the `ids` side after the fact:

  - #47762: `ids` didn't support a composite primary key
  - #51167: `ids_reader` returned duplicate rows for a CPK association
  - #58004: `none.ids` fired a real `SELECT ... WHERE (1=0)` query, while `none.pluck(:id)` short-circuited to `[]`

Restore the delegation so future fixes to `pluck` automatically apply to `ids`. The only piece that genuinely needs custom handling is the deduplication when `has_include?(primary_key)` is true (the original #46503 fix).

The log tag changes from `"Model Ids"` back to `"Model Pluck"`, which matches the pre-#46503 behavior and is consistent with `pick`.
