### PR TITLE
Add named lock strengths to lock, lock! and with_lock

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,23 @@
+*   Allow requesting a named row-lock strength with `lock`, `lock!`, and
+    `with_lock` by passing a symbol, resolved by the database adapter:
+
+    ```ruby
+    Account.lock(:no_key_update).find(1)  # SELECT ... FOR NO KEY UPDATE
+    account.with_lock(:share) { ... }     # FOR SHARE / LOCK IN SHARE MODE
+    ```
+
+    Supported strengths are `:update` (all adapters), `:share` (PostgreSQL
+    and MySQL), and `:no_key_update` / `:key_share` (PostgreSQL). An
+    `ArgumentError` is raised when the adapter does not support the requested
+    strength. Previously, passing a symbol silently disabled locking.
+
+    On PostgreSQL, `:no_key_update` provides the same mutual exclusion
+    between writers as `FOR UPDATE` without blocking the `FOR KEY SHARE`
+    locks taken by foreign-key checks — so inserts into tables referencing
+    the locked row no longer queue behind it.
+
+    *Mikael Henriksson*
+
 *   Deprecate the `insert_returning` option in PostgreSQL database
     configurations, and the `PostgreSQLAdapter#use_insert_returning?` method.
 

--- a/activerecord/lib/active_record/locking/pessimistic.rb
+++ b/activerecord/lib/active_record/locking/pessimistic.rb
@@ -56,6 +56,55 @@ module ActiveRecord
     #     account.save!
     #   end
     #
+    # == Lock strengths
+    #
+    # Instead of a raw SQL clause, you can request a named lock strength as a
+    # Symbol. The clause is resolved by the database adapter, and an
+    # ArgumentError is raised when the adapter does not support the requested
+    # strength:
+    #
+    #   account.with_lock(:no_key_update) do
+    #     # SELECT ... FOR NO KEY UPDATE
+    #     account.update!(balance: account.balance - 100)
+    #   end
+    #
+    # [+:update+]
+    #   <tt>FOR UPDATE</tt>. The strongest row lock — what +true+ requests.
+    #   All adapters.
+    # [+:no_key_update+]
+    #   <tt>FOR NO KEY UPDATE</tt>. Behaves like <tt>FOR UPDATE</tt> towards
+    #   other writers, but does not conflict with <tt>FOR KEY SHARE</tt>.
+    #   \PostgreSQL only.
+    # [+:share+]
+    #   <tt>FOR SHARE</tt> (\PostgreSQL) / <tt>LOCK IN SHARE MODE</tt>
+    #   (\MySQL). A shared lock: blocks writers, allows other shared locks.
+    # [+:key_share+]
+    #   <tt>FOR KEY SHARE</tt>. The weakest strength: only blocks
+    #   key-modifying writes and +DELETE+. \PostgreSQL only.
+    #
+    # === Row locks and foreign keys (PostgreSQL)
+    #
+    # On \PostgreSQL, <tt>FOR UPDATE</tt> interacts with foreign keys in a way
+    # that is easy to miss: inserting a row into a table whose foreign key
+    # references a locked row makes the referential integrity check take
+    # <tt>FOR KEY SHARE</tt> on the referenced row — and <tt>FOR KEY SHARE</tt>
+    # conflicts with <tt>FOR UPDATE</tt> (and with nothing weaker). While a
+    # transaction holds <tt>FOR UPDATE</tt> on a parent row, every +INSERT+ of
+    # a child row referencing it blocks, even though those inserts never touch
+    # the parent. Long-held <tt>FOR UPDATE</tt> locks on hot parent rows can
+    # therefore starve completely unrelated inserts until they exceed
+    # +statement_timeout+ ("canceling statement due to statement timeout ...
+    # while locking tuple").
+    #
+    # When the critical section only updates non-key columns of the locked row
+    # (balances, counters, state columns), <tt>:no_key_update</tt> provides the
+    # same mutual exclusion between writers without blocking those child
+    # inserts. Note that an +UPDATE+ of a column covered by a unique index, or
+    # a +DELETE+ of the locked row, still escalates to the stronger lock —
+    # keep <tt>:update</tt> (the default) when the critical section deletes
+    # the row, changes key columns, or relies on child inserts being blocked
+    # (for example, checking an invariant over the row's children).
+    #
     # Database-specific information on row locking:
     #
     # [MySQL]
@@ -66,8 +115,9 @@ module ActiveRecord
     module Pessimistic
       # Obtain a row lock on this record. Reloads the record to obtain the requested
       # lock. Pass an SQL locking clause to append the end of the SELECT statement
-      # or pass true for "FOR UPDATE" (the default, an exclusive row lock). Returns
-      # the locked record.
+      # or pass true for "FOR UPDATE" (the default, an exclusive row lock), or a
+      # Symbol naming a lock strength (see ActiveRecord::Locking::Pessimistic).
+      # Returns the locked record.
       def lock!(lock = true)
         if self.class.current_preventing_writes
           raise ActiveRecord::ReadOnlyError, "Lock query attempted while in readonly mode"
@@ -91,8 +141,8 @@ module ActiveRecord
 
       # Wraps the passed block in a transaction, reloading the object with a
       # lock before yielding. Yields the current transaction so you can
-      # register callbacks. You can pass the SQL locking clause
-      # as an optional argument (see #lock!).
+      # register callbacks. You can pass the SQL locking clause or a lock
+      # strength Symbol as an optional argument (see #lock!).
       #
       # You can also pass options like <tt>requires_new:</tt>, <tt>isolation:</tt>,
       # and <tt>joinable:</tt> to the wrapping transaction (see

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1301,15 +1301,40 @@ module ActiveRecord
       self
     end
 
-    # Specifies locking settings (default to +true+). For more information
-    # on locking, please see ActiveRecord::Locking.
+    # Specifies locking settings (default to +true+).
+    #
+    #   Account.lock.find(1)                    # SELECT ... FOR UPDATE
+    #   Account.lock("FOR UPDATE NOWAIT")       # database-specific SQL clause
+    #   Account.lock(:no_key_update).find(1)    # SELECT ... FOR NO KEY UPDATE
+    #
+    # Passing a Symbol requests a named lock strength, resolved by the
+    # database adapter when the SQL is generated:
+    #
+    # [+:update+]
+    #   <tt>FOR UPDATE</tt> — an exclusive row lock (all adapters; the
+    #   default).
+    # [+:no_key_update+]
+    #   <tt>FOR NO KEY UPDATE</tt> — exclusive against other writers, but
+    #   does not block <tt>FOR KEY SHARE</tt>, so +INSERT+s into tables with
+    #   a foreign key referencing the locked row are not blocked
+    #   (\PostgreSQL only).
+    # [+:share+]
+    #   <tt>FOR SHARE</tt> / <tt>LOCK IN SHARE MODE</tt> — shared lock,
+    #   blocks writers (\PostgreSQL, \MySQL).
+    # [+:key_share+]
+    #   <tt>FOR KEY SHARE</tt> — the weakest lock, blocks only key-modifying
+    #   writes and +DELETE+ (\PostgreSQL only).
+    #
+    # An ArgumentError is raised when the adapter does not support the
+    # requested strength. For more information on locking, please see
+    # ActiveRecord::Locking.
     def lock(locks = true)
       spawn.lock!(locks)
     end
 
     def lock!(locks = true) # :nodoc:
       case locks
-      when String, TrueClass, NilClass
+      when String, Symbol, TrueClass, NilClass
         self.lock_value = locks || true
       else
         self.lock_value = false

--- a/activerecord/lib/arel/select_manager.rb
+++ b/activerecord/lib/arel/select_manager.rb
@@ -55,7 +55,9 @@ module Arel # :nodoc: all
       case locking
       when true
         locking = Arel.sql("FOR UPDATE")
-      when Arel::Nodes::SqlLiteral
+      when Arel::Nodes::SqlLiteral, Symbol
+        # Symbols are lock strengths (:update, :share, ...) resolved by the
+        # database-specific visitor when the SQL is generated.
       when String
         locking = Arel.sql locking
       end

--- a/activerecord/lib/arel/visitors/mysql.rb
+++ b/activerecord/lib/arel/visitors/mysql.rb
@@ -3,6 +3,13 @@
 module Arel # :nodoc: all
   module Visitors
     class MySQL < Arel::Visitors::ToSql
+      # LOCK IN SHARE MODE rather than FOR SHARE: identical semantics on
+      # MySQL 8.0+, and it also works on MySQL 5.7 and MariaDB.
+      LOCK_CLAUSES = {
+        update: "FOR UPDATE",
+        share: "LOCK IN SHARE MODE",
+      }.freeze
+
       private
         def visit_Arel_Nodes_Bin(o, collector)
           collector << "CAST("

--- a/activerecord/lib/arel/visitors/postgresql.rb
+++ b/activerecord/lib/arel/visitors/postgresql.rb
@@ -3,6 +3,13 @@
 module Arel # :nodoc: all
   module Visitors
     class PostgreSQL < Arel::Visitors::ToSql
+      LOCK_CLAUSES = {
+        update: "FOR UPDATE",
+        no_key_update: "FOR NO KEY UPDATE",
+        share: "FOR SHARE",
+        key_share: "FOR KEY SHARE",
+      }.freeze
+
       private
         def visit_Arel_Nodes_UpdateStatement(o, collector)
           collector.retryable = false

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -335,8 +335,27 @@ module Arel # :nodoc: all
           visit o.expr, collector
         end
 
+        # Row-lock strengths that may be requested as symbols through
+        # ActiveRecord::QueryMethods#lock (and Base#lock! / #with_lock).
+        # Adapter visitors override this constant with the clauses their
+        # database supports.
+        LOCK_CLAUSES = { update: "FOR UPDATE" }.freeze
+
         def visit_Arel_Nodes_Lock(o, collector)
-          visit o.expr, collector
+          if o.expr.is_a?(Symbol)
+            collector << lock_clause_for(o.expr)
+          else
+            visit o.expr, collector
+          end
+        end
+
+        def lock_clause_for(strength)
+          self.class::LOCK_CLAUSES.fetch(strength) do
+            supported = self.class::LOCK_CLAUSES.keys.map(&:inspect).join(", ")
+            raise ArgumentError,
+              "Unknown lock strength #{strength.inspect} for this database adapter. " \
+              "Supported lock strengths: #{supported}."
+          end
         end
 
         def visit_Arel_Nodes_Grouping(o, collector)

--- a/activerecord/test/cases/arel/visitors/mysql_test.rb
+++ b/activerecord/test/cases/arel/visitors/mysql_test.rb
@@ -44,6 +44,17 @@ module Arel
         assert_like "LOCK IN SHARE MODE", compile(node)
       end
 
+      test "locking resolves lock strength symbols" do
+        assert_like "FOR UPDATE", compile(Nodes::Lock.new(:update))
+        assert_like "LOCK IN SHARE MODE", compile(Nodes::Lock.new(:share))
+      end
+
+      test "locking raises for a lock strength the database does not support" do
+        error = assert_raises(ArgumentError) { compile(Nodes::Lock.new(:no_key_update)) }
+        assert_match(/Unknown lock strength :no_key_update/, error.message)
+        assert_match(/:share/, error.message)
+      end
+
       test "concat concats columns" do
         table = Table.new(name: :users)
         query = table[:name].concat(table[:name])

--- a/activerecord/test/cases/arel/visitors/postgres_test.rb
+++ b/activerecord/test/cases/arel/visitors/postgres_test.rb
@@ -24,6 +24,19 @@ module Arel
         }, compile(node)
       end
 
+      test "locking resolves lock strength symbols" do
+        assert_like "FOR UPDATE", compile(Nodes::Lock.new(:update))
+        assert_like "FOR NO KEY UPDATE", compile(Nodes::Lock.new(:no_key_update))
+        assert_like "FOR SHARE", compile(Nodes::Lock.new(:share))
+        assert_like "FOR KEY SHARE", compile(Nodes::Lock.new(:key_share))
+      end
+
+      test "locking raises for an unknown lock strength" do
+        error = assert_raises(ArgumentError) { compile(Nodes::Lock.new(:nonsense)) }
+        assert_match(/Unknown lock strength :nonsense/, error.message)
+        assert_match(/:no_key_update/, error.message)
+      end
+
       test "should escape LIMIT" do
         sc = Arel::Nodes::SelectStatement.new
         sc.limit = Nodes::Limit.new(Nodes.build_quoted("omg"))

--- a/activerecord/test/cases/arel/visitors/sqlite_test.rb
+++ b/activerecord/test/cases/arel/visitors/sqlite_test.rb
@@ -21,6 +21,11 @@ module Arel
         assert_equal "", @visitor.accept(node, Collectors::SQLString.new).value
       end
 
+      test "ignores lock strength symbols like every other lock" do
+        node = Nodes::Lock.new(:no_key_update)
+        assert_equal "", @visitor.accept(node, Collectors::SQLString.new).value
+      end
+
       test "Nodes::IsNotDistinctFrom should construct a valid generic SQL statement" do
         test = Table.new(name: :users)[:name].is_not_distinct_from "Aaron Patterson"
         assert_like %{

--- a/activerecord/test/cases/arel/visitors/to_sql_test.rb
+++ b/activerecord/test/cases/arel/visitors/to_sql_test.rb
@@ -19,6 +19,16 @@ module Arel
         assert_like "?", sql
       end
 
+      test "locking resolves the :update lock strength" do
+        assert_like "FOR UPDATE", compile(Nodes::Lock.new(:update))
+      end
+
+      test "locking raises for an unknown lock strength" do
+        error = assert_raises(ArgumentError) { compile(Nodes::Lock.new(:nonsense)) }
+        assert_match(/Unknown lock strength :nonsense/, error.message)
+        assert_match(/:update/, error.message)
+      end
+
       test "the to_sql visitor does not quote BindParams used as part of a ValuesList" do
         bp = Nodes::BindParam.new(1)
         values = Nodes::ValuesList.new([[bp]])

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -771,6 +771,40 @@ class PessimisticLockingTest < ActiveRecord::TestCase
       end
     end
 
+    def test_find_with_lock_strength_symbol
+      assert_nothing_raised do
+        Person.transaction do
+          Person.lock(:update).find(1)
+        end
+      end
+    end
+
+    if current_adapter?(:PostgreSQLAdapter)
+      def test_find_with_no_key_update_lock_strength
+        assert_match(/FOR NO KEY UPDATE\z/, Person.lock(:no_key_update).to_sql)
+
+        assert_nothing_raised do
+          Person.transaction do
+            Person.lock(:no_key_update).find(1)
+          end
+        end
+      end
+
+      def test_lock_bang_with_lock_strength_symbol
+        person = Person.find 1
+        assert_queries_match(/FOR NO KEY UPDATE/) do
+          Person.transaction { person.lock!(:no_key_update) }
+        end
+      end
+
+      def test_with_lock_with_lock_strength_symbol
+        person = Person.find 1
+        assert_queries_match(/FOR NO KEY UPDATE/) do
+          person.with_lock(:no_key_update) { }
+        end
+      end
+    end
+
     # PostgreSQL protests SELECT ... FOR UPDATE on an outer join.
     unless current_adapter?(:PostgreSQLAdapter)
       # Test locked eager find.

--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -204,6 +204,8 @@ The primary operation of `ActiveRecord::Relation` can be summarized as:
     https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-where
 [`with_lock`]:
     https://api.rubyonrails.org/classes/ActiveRecord/Locking/Pessimistic.html#method-i-with_lock
+[`ActiveRecord::Locking::Pessimistic`]:
+    https://api.rubyonrails.org/classes/ActiveRecord/Locking/Pessimistic.html
 [`sqlcourse`]: https://www.khanacademy.org/computing/computer-programming/sql
 [`rdbmsinfo`]: https://www.devart.com/what-is-rdbms/
 
@@ -2383,6 +2385,34 @@ end
 WARNING: Your database needs to support the raw SQL that you pass in to the
 `lock` method, otherwise an `ActiveRecord::StatementInvalid` exception will be
 raised.
+
+Instead of raw SQL, you can request a named lock strength as a symbol, which
+the database adapter resolves to the correct clause — raising `ArgumentError`
+when the database doesn't support that strength:
+
+```ruby
+Book.transaction do
+  book = Book.lock(:no_key_update).find(1)  # SELECT ... FOR NO KEY UPDATE
+  book.increment!(:views)
+end
+```
+
+The available strengths are `:update` (`FOR UPDATE` — the default, all
+adapters), `:share` (`FOR SHARE` on PostgreSQL, `LOCK IN SHARE MODE` on
+MySQL), and, on PostgreSQL only, `:no_key_update` (`FOR NO KEY UPDATE`) and
+`:key_share` (`FOR KEY SHARE`).
+
+NOTE: On PostgreSQL, `FOR UPDATE` blocks more than other writers. Inserting a
+row whose foreign key references a locked row takes `FOR KEY SHARE` on the
+referenced row for the integrity check, and `FOR KEY SHARE` conflicts with
+`FOR UPDATE` — so while a transaction holds `FOR UPDATE` on a parent row,
+every insert of a child row referencing it waits, even though those inserts
+never modify the parent. If the critical section only updates non-key columns
+(balances, counters, state), `:no_key_update` gives the same mutual exclusion
+between writers without blocking child inserts. Keep the default `:update`
+strength when the section deletes the row, changes unique-indexed columns, or
+relies on child inserts being blocked. See
+[`ActiveRecord::Locking::Pessimistic`][] for details.
 
 If you already have an instance of your model, you can start a transaction and
 acquire the lock in one go using the [`with_lock`][] method. The block receives


### PR DESCRIPTION
### Summary

Passing a Symbol to `lock` / `lock!` / `with_lock` now requests a named row-lock strength, resolved to the correct clause by the database adapter's Arel visitor:

```ruby
Account.lock(:no_key_update).find(1)  # SELECT ... FOR NO KEY UPDATE
account.with_lock(:share) { ... }     # FOR SHARE / LOCK IN SHARE MODE
```

Supported strengths: `:update` (all adapters), `:share` (PostgreSQL; MySQL/MariaDB as `LOCK IN SHARE MODE`), `:no_key_update` and `:key_share` (PostgreSQL). Requesting a strength the adapter can't express raises `ArgumentError` naming the supported ones. SQLite continues to ignore lock clauses of every kind, symbols included.

This also fixes a silent footgun: today a Symbol falls through `QueryMethods#lock!`'s type filter into the `else` branch, which sets `lock_value = false` — `Account.lock(:no_key_update)` currently **silently disables locking entirely** rather than erroring.

### Motivation

On PostgreSQL, `FOR UPDATE` conflicts with the `FOR KEY SHARE` locks taken by foreign-key integrity checks. While a transaction holds `FOR UPDATE` on a parent row, every `INSERT` of a child row referencing it blocks — even though those inserts never modify the parent.

We hit this in production in a payments system: settlement code held `FOR UPDATE` on `accounts` rows (via plain `with_lock`) while customer-facing checkout INSERTs into a table with an `accounts` FK queued behind them until `statement_timeout` killed them with the famously cryptic:

```
PG::QueryCanceled: ERROR: canceling statement due to statement timeout
CONTEXT: while locking tuple (2,69) in relation "accounts"
SQL statement "SELECT 1 FROM ONLY "public"."accounts" x WHERE "id" = $1 FOR KEY SHARE OF x"
```

The fix — `FOR NO KEY UPDATE`, which gives identical writer-vs-writer exclusion when the critical section only writes non-key columns (balances, counters, state machines) — was a one-line change per call site, but discovering it required reading the PostgreSQL lock-conflict matrix, and expressing it in Active Record requires a raw SQL string that is undiscoverable and ungreppable. The API and documentation gap seemed worth closing upstream: nothing in Rails' docs currently mentions this interaction.

### Why not change the default?

Deliberately out of scope, because `FOR UPDATE` is the only universally safe default:

- `with_lock { destroy! }` and updates to unique-indexed columns escalate the tuple lock mid-transaction under `:no_key_update`, opening lock-upgrade deadlock windows `FOR UPDATE` structurally prevents.
- Code that locks a parent to guard invariants over its children ("check `children.count`, then act") relies exactly on `FOR UPDATE` blocking the FK checks.
- The weaker strengths don't exist on MySQL.

The new docs (module docs + querying guide) spell out both when `:no_key_update` helps and when to keep the default. If maintainers see value in an opt-in application-level default (e.g. a `config.active_record` setting for apps that have audited their lock sites), happy to explore that in a follow-up.

### Tests

- Visitor tests (DB-free) for the clause mapping on ToSql/PostgreSQL/MySQL/SQLite, including the unsupported-strength and unknown-strength errors.
- Integration tests in `locking_test.rb`: `lock(:update)` on all adapters; `lock(:no_key_update)` / `lock!` / `with_lock` under the PostgreSQL adapter.
- Ran locally against SQLite3 and PostgreSQL (276 runs, 0 failures); MySQL clause mapping is covered by the DB-free visitor tests.