### PR TITLE
Restore silenced? on the Action View render Start subscriber

### DIFF
--- a/actionview/lib/action_view/structured_event_subscriber.rb
+++ b/actionview/lib/action_view/structured_event_subscriber.rb
@@ -73,6 +73,10 @@ module ActionView
     class Start # :nodoc:
       include Utils
 
+      def silenced?(_name)
+        !ActiveSupport.event_reporter.debug_mode?
+      end
+
       def start(name, id, payload)
         ActiveSupport.event_reporter.debug("action_view.render_start",
           filter_payload: false,

--- a/actionview/test/template/structured_event_subscriber_test.rb
+++ b/actionview/test/template/structured_event_subscriber_test.rb
@@ -33,6 +33,30 @@ module ActionView
       Rails.instance_eval { undef :root } if defined?(@defined_root)
     end
 
+    def test_render_notifications_are_silenced_outside_debug_mode
+      original = ActiveSupport.event_reporter.debug_mode?
+      ActiveSupport.event_reporter.debug_mode = false
+
+      Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
+        assert_not ActiveSupport::Notifications.notifier.listening?("render_template.action_view")
+        assert_not ActiveSupport::Notifications.notifier.listening?("render_layout.action_view")
+
+        assert_no_event_reported("action_view.render_start") do
+          assert_equal "Hello world!", @view.render(template: "test/hello_world")
+        end
+
+        with_debug_event_reporting do
+          assert ActiveSupport::Notifications.notifier.listening?("render_template.action_view")
+
+          assert_event_reported("action_view.render_start", payload: { identifier: "test/hello_world.erb" }) do
+            @view.render(template: "test/hello_world")
+          end
+        end
+      end
+    ensure
+      ActiveSupport.event_reporter.debug_mode = original
+    end
+
     def test_render_template
       Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
         with_debug_event_reporting do


### PR DESCRIPTION
### Motivation / Background

#50751 added `silenced?` to Action View's render `Start` subscriber so that
`render_template.action_view` / `render_layout.action_view` instrumentation could be
skipped entirely when the log level is above debug ("so that it can also benefit from the
`subscribe_log_level` optimization").

The structured-events rewrite (#55690) introduced a new `Start` class subscribed to the
same two events, without a `silenced?` method. `ActiveSupport::Notifications::Fanout`
treats a subscriber that doesn't respond to `silenced?` as permanently active, so these
two events currently run the full notification machinery — `listening?` is unconditionally
true, a real `Handle` is built, and `Start#start` builds its debug-event kwargs (including
two `from_rails_root` string operations) on every template and layout render in every
environment — only for `ActiveSupport.event_reporter.debug` to discard the event one layer
down whenever debug mode is off (the default outside development).

### Detail

This restores `silenced?` on the new `Start`: the subscriber is silenced whenever the
event reporter is not in debug mode, as the #50751 fix did for the log level.

When debug mode is on, behavior is unchanged — the events fire exactly as before. The
existing `structured_event_subscriber_test.rb` assertions (which force debug mode via
`with_debug_event_reporting`) pass unchanged, and a new test pins the gate from both
sides: with debug mode off the notifications layer stops listening to both render
events (an assertion that fails without this change) and a real render reports
nothing; with debug reporting on, `listening?` flips back. Full Action View suite
passes.

### Benchmark

Rendering with an event-reporter subscriber attached and `debug_mode` off (a
production-shaped configuration — bootstrap sets debug mode from `config.log_level`,
which is `:info` in production). In development (debug mode on) behavior and cost are
unchanged.

Objects allocated per render (`GC.stat(:total_allocated_objects)` delta over 1000
renders — deterministic, identical in every round):

| | main | patch |
|---|---|---|
| render minimal template | 60 | **37** |
| render template + 25-item partial collection | 324 | **301** |

`benchmark-ips`, best of 3 alternating 5s runs (Ruby 3.3.11, arm64-darwin):

| | main | patch | |
|---|---|---|---|
| render minimal template | 107.3k i/s | 158.2k i/s | **1.47x** |
| render minimal template (YJIT) | 162.4k i/s | 256.2k i/s | **1.58x** |
| render template + 25 partials | 18.6k i/s | 20.0k i/s | 1.08x |
| render template + 25 partials (YJIT) | 31.1k i/s | 33.3k i/s | 1.07x |

<details>
  <summary>Benchmark source</summary>

```ruby
# frozen_string_literal: true

# Benchmark for "Restore silenced? on the Action View render Start subscriber".
# Run from a Rails checkout root (or set RAILS_ROOT), once per branch:
#
#   git switch main && ruby bench_render_start.rb
#   git switch <patch-branch> && ruby bench_render_start.rb   # prints comparison
#
require "bundler/inline"

RAILS_ROOT = ENV.fetch("RAILS_ROOT", Dir.pwd)
LABEL = ENV["BRANCH"] || `git -C #{RAILS_ROOT} rev-parse --abbrev-ref HEAD`.strip

gemfile(true) do
  source "https://rubygems.org"
  gem "activesupport", path: RAILS_ROOT
  gem "actionview", path: RAILS_ROOT
  gem "benchmark-ips"
end

require "active_support"
require "active_support/notifications"
require "action_view"
require "action_view/structured_event_subscriber"

# Mirror a production app's wiring: the framework's own log subscribers are
# event-reporter subscribers, and bootstrap sets debug_mode from config.log_level
# (:info in production => false). Outside a booted app the reporter defaults to
# debug_mode = true, which would mask the difference this patch makes.
ActionView::StructuredEventSubscriber.attach_to :action_view
ActiveSupport.event_reporter.subscribe(Class.new { def emit(event); event; end }.new)
ActiveSupport.event_reporter.debug_mode = false

require "tmpdir"
templates = Dir.mktmpdir
File.write(File.join(templates, "bench.html.erb"), <<~ERB)
  <h1>Bench</h1>
  <ul><%= render partial: "item", collection: @items %></ul>
ERB
File.write(File.join(templates, "_item.html.erb"), "<li><%= item[:name] %> x <%= item[:qty] %></li>\n")
File.write(File.join(templates, "tiny.html.erb"), "<h1>Hi <%= 1 + 1 %></h1>\n")

paths = ActionView::PathSet.new([ActionView::FileSystemResolver.new(templates)])
lookup = ActionView::LookupContext.new(paths)
view_klass = ActionView::Base.with_empty_template_cache
renderer = ActionView::Renderer.new(lookup)
items = (1..25).map { |i| { name: "item #{i}", qty: i } }

# Deterministic allocation counts (objects per render)
render_tiny = -> { renderer.render(view_klass.new(lookup, {}, nil), template: "tiny", layout: false) }
render_bench = -> { renderer.render(view_klass.new(lookup, { items: items }, nil), template: "bench", layout: false) }
allocs = lambda do |callable, n = 1000|
  callable.call
  before = GC.stat(:total_allocated_objects)
  n.times { callable.call }
  (GC.stat(:total_allocated_objects) - before) / n
end
puts format("OBJECTS per render (%s): minimal=%d, 25-partials=%d", LABEL, allocs.(render_tiny), allocs.(render_bench))

require "benchmark/ips"
hold = File.join(Dir.tmpdir, "render_start_bench#{"_yjit" if defined?(RubyVM::YJIT) && RubyVM::YJIT.enabled?}.json")

Benchmark.ips do |x|
  x.config(time: Float(ENV.fetch("BENCH_TIME", "10")), warmup: Float(ENV.fetch("BENCH_WARMUP", "2")))
  x.report("render minimal template (#{LABEL})") do
    renderer.render(view_klass.new(lookup, {}, nil), template: "tiny", layout: false)
  end
  x.report("render template + 25 partials (#{LABEL})") do
    renderer.render(view_klass.new(lookup, { items: items }, nil), template: "bench", layout: false)
  end
  unless ENV["NO_HOLD"]
    x.save!(hold)
    x.compare!
  end
end
```
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
