### PR TITLE
[RF-DOCS] Rewrite the debugging guide

### DIFF
--- a/guides/source/debugging_rails_applications.md
+++ b/guides/source/debugging_rails_applications.md
@@ -3,374 +3,480 @@
 Debugging Rails Applications
 ============================
 
-This guide introduces techniques for debugging Ruby on Rails applications.
+This guide covers the tools and techniques for debugging Rails applications.
 
 After reading this guide, you will know:
 
-* The purpose of debugging.
-* How to track down problems and issues in your application that your tests aren't identifying.
-* The different ways of debugging.
-* How to analyze the stack trace.
+- How Rails' logging machinery works.
+- How to use Ruby's `debug` gem.
+- The Rails helper methods which aid with debugging.
+- How to inject a Ruby console in your view.
 
 --------------------------------------------------------------------------------
 
-View Helpers for Debugging
---------------------------
+Introduction
+------------
 
-One common task is to inspect the contents of a variable. Rails provides three different ways to do this:
+[Debugging](https://en.wikipedia.org/wiki/Debugging) is the process of finding
+the cause, and potential solutions or workarounds to software defects.
 
-* `debug`
-* `to_yaml`
-* `inspect`
+There are several strategies that can be used depending on the nature of the
+bug. Using a debugger, you can step through the code line-by-line to ensure
+statements execute correctly and verify the application's state. Inspecting logs
+can show which database queries are made, which views are rendered, and how long
+different statements take to execute. If your application is using too much
+memory, you can use instrumentation tools to check how your application
+allocates memory.
 
-### `debug`
+In this guide, we'll discuss some common tools, techniques, and approaches to
+debugging.
 
-The `debug` helper will return a \<pre> tag that renders the object using the YAML format. This will generate human-readable data from any object. For example, if you have this code in a view:
+Debugging Using the Rails Logger
+--------------------------------
 
-```html+erb
-<%= debug @article %>
-<p>
-  <b>Title:</b>
-  <%= @article.title %>
-</p>
-```
-
-You'll see something like this:
-
-```yaml
---- !ruby/object Article
-attributes:
-  updated_at: 2008-09-05 22:55:47
-  body: It's a very helpful guide for debugging your Rails app.
-  title: Rails debugging guide
-  published: t
-  id: "1"
-  created_at: 2008-09-05 22:55:47
-attributes_cache: {}
-
-
-Title: Rails debugging guide
-```
-
-### `to_yaml`
-
-Alternatively, calling `to_yaml` on any object converts it to YAML. You can pass this converted object into the `simple_format` helper method to format the output. This is how `debug` does its magic.
-
-```html+erb
-<%= simple_format @article.to_yaml %>
-<p>
-  <b>Title:</b>
-  <%= @article.title %>
-</p>
-```
-
-The above code will render something like this:
-
-```yaml
---- !ruby/object Article
-attributes:
-updated_at: 2008-09-05 22:55:47
-body: It's a very helpful guide for debugging your Rails app.
-title: Rails debugging guide
-published: t
-id: "1"
-created_at: 2008-09-05 22:55:47
-attributes_cache: {}
-
-Title: Rails debugging guide
-```
-
-### `inspect`
-
-Another useful method for displaying object values is `inspect`, especially when working with arrays or hashes. This will print the object value as a string. For example:
-
-```html+erb
-<%= [1, 2, 3, 4, 5].inspect %>
-<p>
-  <b>Title:</b>
-  <%= @article.title %>
-</p>
-```
-
-Will render:
-
-```
-[1, 2, 3, 4, 5]
-
-Title: Rails debugging guide
-```
-
-The Logger
-----------
-
-It can also be useful to save information to log files at runtime. Rails maintains a separate log file for each runtime environment.
-
-### What is the Logger?
-
-Rails makes use of the `ActiveSupport::Logger` class to write log information. Other loggers, such as `Log4r`, may be substituted:
+Writing to the logs is a useful technique to trace the application while it is
+running. The most basic way to use logs as a debugging tool is to add `puts`
+statements in your code:
 
 ```ruby
-# config/environments/production.rb
-config.logger = Logger.new(STDOUT)
-config.logger = Log4r::Logger.new("Application Log")
+class Search
+  def initialize(params)
+    @id = SecureRandom.hex(10)
+    @params = params
+  end
+
+  def run
+    puts "Starting search (#{@id}) at #{Time.zone.now}"
+    # ...
+    puts "Finshed search (#{@id}) at #{Time.zone.now}"
+  end
+end
 ```
 
-TIP: By default, each log is created under `Rails.root/log/` and the log file is named after the environment in which the application is running.
+`puts` writes statements to [`STDOUT`][] only. It offers no configuration
+options to enable or disable certain log statements, or write to multiple
+destinations. In a production setting, more control over logging is required. As
+such, Rails provides its own logger
+([`ActiveSupport::Logger`](https://api.rubyonrails.org/classes/ActiveSupport/Logger.html))
+which offers several features to control logging behavior.
+
+Access the Rails logger using `Rails.logger`. In development and test
+environments, it writes logs to the file `log/<environment>.log`. In
+development, it also writes to `STDOUT`, and in production it writes **ONLY** to
+[`STDOUT`][] by default. Log destinations for each environment
+[can be configured](#log-destinations).
+
+Here's an example of writing messages using the Rails logger:
+
+```ruby
+class Search
+  def initialize(params)
+    @id = SecureRandom.hex(10)
+    @params = params
+  end
+
+  def run
+    Rails.logger.debug { "Starting search (#{@id}) at #{Time.zone.now}" }
+    # ...
+    Rails.logger.debug { "Finshed search (#{@id}) at #{Time.zone.now}" }
+  end
+end
+```
+
+In the next sections, we'll dig deeper into the features of the Rails logger.
 
 ### Log Levels
 
-When something is logged, it's printed into the corresponding log if the log
-level of the message is equal to or higher than the configured log level. If you
-want to know the current log level, you can call the `Rails.logger.level`
-method.
+Every message logged by the Rails logger must be assigned a _level_. The
+available log levels and their corresponding integer values are:
 
-The available log levels are: `:debug`, `:info`, `:warn`, `:error`, `:fatal`,
-and `:unknown`, corresponding to the log level numbers from 0 up to 5,
-respectively. To change the default log level:
+|            |     |
+| ---------- | --- |
+| `:debug`   | 0   |
+| `:info`    | 1   |
+| `:warn`    | 2   |
+| `:error`   | 3   |
+| `:fatal`   | 4   |
+| `:unknown` | 5   |
+
+A message is only written to the output if its level is equal to or higher than
+the configured log level. `Rails.logger.level` returns the current log level.
+
+The default Rails log level is `:debug` in development and `:info` in
+production. You can set the log level for an environment in the application
+config:
 
 ```ruby
-# config/environments/production.rb
+# config/environments/<environment>.rb
+
 config.log_level = :warn
 ```
 
-This is useful when you want to log under development or staging without flooding your production log with unnecessary information.
+Logging has a [small performance overhead](#impact-of-logs-on-performance). Use
+log levels to control the verbosity of your logs.
 
-TIP: The default Rails log level is `:debug`. However, it is set to `:info` for the `production` environment in the default generated `config/environments/production.rb`.
+### Logging Messages
 
-### Sending Messages
-
-To write in the current log use the `logger.(debug|info|warn|error|fatal|unknown)` method from within a controller, model, or mailer:
+To write a log message, call `logger.(debug|info|warn|error|fatal)` method from
+anywhere in your app:
 
 ```ruby
-logger.debug "Person attributes hash: #{@person.attributes.inspect}"
-logger.info "Processing the request..."
-logger.fatal "Terminating application, raised unrecoverable error!!!"
+logger.debug  { "Person attributes: #{@person.attributes.inspect}" }
+logger.info   { "Processing the request..." }
+logger.fatal  { "Terminating application, raised unrecoverable error!!!" }
 ```
+
+Where `logger` isn't directly available, such as in a plain Ruby class that
+doesn't inherit from any Rails classes (sometimes called a PORO, for **P**lain
+**O**ld **R**uby **O**bject), use `Rails.logger`:
+
+```ruby
+class Search
+  def initialize(params)
+    @params = params
+  end
+
+  def run
+    Rails.logger.info { "Running search with params: #{@params}" }
+    # ...
+  end
+end
+```
+
+TIP: Always pass a block to `logger#<level>` instead of a string. This way, the
+message will only be evaluated if its log level is active. See the
+[Impact of Logs on Performance](#impact-of-logs-on-performance) section for more
+information.
 
 Here's an example of a method instrumented with extra logging:
 
 ```ruby
-class ArticlesController < ApplicationController
+class PostsController < ApplicationController
   # ...
 
   def create
-    @article = Article.new(article_params)
-    logger.debug "New article: #{@article.attributes.inspect}"
-    logger.debug "Article should be valid: #{@article.valid?}"
+    @post = Post.new(post_params)
+    logger.debug { "New post instantiated: #{@post.attributes.inspect}" }
 
-    if @article.save
-      logger.debug "The article was saved and now the user is going to be redirected..."
-      redirect_to @article, notice: 'Article was successfully created.'
+    if @post.save
+      logger.debug { "The post was saved, redirecting ..." }
+      redirect_to @post, notice: 'Your post was created.'
     else
-      render :new, status: :unprocessable_entity
+      logger.debug { "Post invalid: #{@post.errors.full_messages.inspect}" }
+      render :new, status: :unprocessable_content
     end
   end
 
   # ...
-
-  private
-    def article_params
-      params.expect(article: [:title, :body, :published])
-    end
 end
 ```
 
-Here's an example of the log generated when this controller action is executed:
-
-```
-Started POST "/articles" for 127.0.0.1 at 2018-10-18 20:09:23 -0400
-Processing by ArticlesController#create as HTML
-  Parameters: {"utf8"=>"✓", "authenticity_token"=>"XLveDrKzF1SwaiNRPTaMtkrsTzedtebPPkmxEFIU0ordLjICSnXsSNfrdMa4ccyBjuGwnnEiQhEoMN6H1Gtz3A==", "article"=>{"title"=>"Debugging Rails", "body"=>"I'm learning how to print in logs.", "published"=>"0"}, "commit"=>"Create Article"}
-New article: {"id"=>nil, "title"=>"Debugging Rails", "body"=>"I'm learning how to print in logs.", "published"=>false, "created_at"=>nil, "updated_at"=>nil}
-Article should be valid: true
-   (0.0ms)  begin transaction
-  ↳ app/controllers/articles_controller.rb:31
-  Article Create (0.5ms)  INSERT INTO "articles" ("title", "body", "published", "created_at", "updated_at") VALUES (?, ?, ?, ?, ?)  [["title", "Debugging Rails"], ["body", "I'm learning how to print in logs."], ["published", 0], ["created_at", "2018-10-19 00:09:23.216549"], ["updated_at", "2018-10-19 00:09:23.216549"]]
-  ↳ app/controllers/articles_controller.rb:31
-   (2.3ms)  commit transaction
-  ↳ app/controllers/articles_controller.rb:31
-The article was saved and now the user is going to be redirected...
-Redirected to http://localhost:3000/articles/1
-Completed 302 Found in 4ms (ActiveRecord: 0.8ms)
+```#4,11
+Started POST "/posts" for 127.0.0.1 at 2026-03-30 18:19:42 +0100
+Processing by PostsController#create as HTML
+  Parameters: {"post" => {"title" => "Debugging Rails", "body" => "Debugging using application logs..."}}
+New post instantiated: {"id" => nil, "title" => "Debugging Rails", "body" => "Debugging using application logs...", "created_at" => nil, "updated_at" => nil}
+  TRANSACTION (0.2ms)  BEGIN immediate TRANSACTION /*action='create',application='RailsGuidesDemo',controller='posts'*/
+  ↳ app/controllers/posts_controller.rb:12:in 'PostsController#create'
+  Post Create (2.0ms)  INSERT INTO "posts" ("title", "body", "created_at", "updated_at") VALUES ('Debugging Rails', 'Debugging using application logs...', '2026-03-30 17:19:42.522214', '2026-03-30 17:19:42.522214') RETURNING "id" /*action='create',application='RailsGuidesDemo',controller='posts'*/
+  ↳ app/controllers/posts_controller.rb:12:in 'PostsController#create'
+  TRANSACTION (0.2ms)  COMMIT TRANSACTION /*action='create',application='RailsGuidesDemo',controller='posts'*/
+  ↳ app/controllers/posts_controller.rb:12:in 'PostsController#create'
+The post was saved, redirecting ...
+Redirected to http://localhost:3000/posts/1
+↳ app/controllers/posts_controller.rb:14:in 'PostsController#create'
+Completed 302 Found in 10ms (ActiveRecord: 2.4ms (1 query, 0 cached) | GC: 0.0ms)
 ```
 
-Adding extra logging like this makes it easy to search for unexpected or unusual behavior in your logs. If you add extra logging, be sure to make sensible use of log levels to avoid filling your production logs with useless trivia.
+Adding granular logging like this makes it easier to track down unexpected
+behavior in your application.
+
+### Log Destinations
+
+Rails can write logs to multiple destinations. This is facilitated using
+[`ActiveSupport::BroadcastLogger`][] which wraps one or more loggers (known as
+`broadcasts`). When a message is logged, it is propogated to each logger.
+`Rails.logger` will return an instance of [`ActiveSupport::BroadcastLogger`][].
+
+```irb
+(dev):001> Rails.logger.class
+=> ActiveSupport::BroadcastLogger
+```
+
+The default logger is an instance of [`ActiveSupport::Logger`][] which
+`include`s [`ActiveSupport::TaggedLogging`][] to enable
+[stamping log messages with tags](#tagged-logging). This object can be accessed
+using `Rails.logger.broadcasts.first`:
+
+```irb
+(dev):001> Rails.logger.broadcasts.first.class
+=> ActiveSupport::Logger
+```
+
+When running the Rails server in development (using `bin/rails server`), an
+additional logger which writes to `STDOUT` is also added. This way, logs are
+visible in the console, as well as written to the `log/development.log` file.
+
+Invoking the Rails console (using `bin/rails console`) also adds a second logger
+which writes to [`STDERR`][]. This ensures log output doesn't interfere with the
+REPL (Read-Eval-Print-Loop) which requires control of [`STDIN`][] and
+[`STDOUT`][].
+
+NOTE: These secondary loggers are also instances of [`ActiveSupport::Logger`],
+but do not `include` [`ActiveSupport::TaggedLogging`][].
+
+[`ActiveSupport::Logger`]:
+  https://api.rubyonrails.org/classes/ActiveSupport/Logger.html
+[`ActiveSupport::TaggedLogging`]:
+  https://api.rubyonrails.org/classes/ActiveSupport/TaggedLogging.html
+[`ActiveSupport::BroadcastLogger`]:
+  https://api.rubyonrails.org/classes/ActiveSupport/BroadcastLogger.html
+[`STDOUT`]:
+  https://en.wikipedia.org/wiki/Standard_streams#Standard_output_(stdout)
+[`STDIN`]: https://en.wikipedia.org/wiki/Standard_streams#Standard_input_(stdin)
+[`STDERR`]:
+  https://en.wikipedia.org/wiki/Standard_streams#Standard_error_(stderr)
+
+### Impact of Logs on Performance
+
+Logging has small impact on the performance of your Rails app, particularly when
+logging to disk.
+
+The greater the number of strings written to the log, the greater the
+performance penalty. Use an appropriate log level in production to ensure a
+balance between performance overhead and quantity of logged information.
+
+Always pass a block to the logger, rather than a string.
+
+```ruby
+# DO
+logger.debug { "Post: #{@post.inspect}" }
+
+# DON'T
+logger.debug "Post: #{@post.inspect}"
+```
+
+When you pass a string to the logger, Ruby evaluates it regardless of log level.
+This means the (somewhat heavy) `String` object has to be instantiated and the
+variables interpolated even if the message won't be logged based on the current
+level. Blocks, on the other hand, are lazily evaluated only when the current log
+level includes the message.
+
+These are micro-optimizations. Performance savings are only noticeable with
+large amounts of logging, however, it is recommended as a best-practice.
+
+### Tagged Logging
+
+In complex applications, the ability to filter logs based on certain rules is a
+useful tool. The `tagged` method can be used to add _stamps_ to your log
+messages, which can then be used for filtering.
+
+```ruby
+logger.tagged("BCX").info { "Stuff" }
+# "[BCX] Stuff"
+
+logger.tagged("BCX", "Jason").info { "Stuff" }
+# "[BCX] [Jason] Stuff"
+
+logger.tagged("BCX") { logger.tagged("Jason").info { "Stuff" } }
+# "[BCX] [Jason] Stuff"
+```
+
+NOTE: Tags are only added to log messages written to the log file, or to
+[`STDOUT`][] in production. They are not visible in the console.
+
+Advanced Logging
+----------------
+
+There are a few advanced configuration options and techniques you can use to
+maximize the utility of logs when debugging.
 
 ### Verbose Query Logs
 
-When looking at database query output in logs, it may not be immediately clear why multiple database queries are triggered when a single method is called:
+The `verbose_query_logs` option enables logging of the source location from
+where each SQL query is triggered. This is useful to inspect how many SQL
+queries a request is triggering, and fix any code triggering excessive queries.
 
-```irb
-irb(main):001:0> Article.pamplemousse
-  Article Load (0.4ms)  SELECT "articles".* FROM "articles"
-  Comment Load (0.2ms)  SELECT "comments".* FROM "comments" WHERE "comments"."article_id" = ?  [["article_id", 1]]
-  Comment Load (0.1ms)  SELECT "comments".* FROM "comments" WHERE "comments"."article_id" = ?  [["article_id", 2]]
-  Comment Load (0.1ms)  SELECT "comments".* FROM "comments" WHERE "comments"."article_id" = ?  [["article_id", 3]]
-=> #<Comment id: 2, author: "1", body: "Well, actually...", article_id: 1, created_at: "2018-10-19 00:56:10", updated_at: "2018-10-19 00:56:10">
+It's enabled by default in development.
+
+```ruby
+# config/environments/development.rb
+
+config.active_record.verbose_query_logs = true
 ```
 
-After enabling `verbose_query_logs` we can see additional information for each query:
+Consider an example where a `Post` model `belongs_to` an `Author` model. The
+below controller and view would generate the following logs when it is rendered:
 
-```irb
-irb(main):003:0> Article.pamplemousse
-  Article Load (0.2ms)  SELECT "articles".* FROM "articles"
-  ↳ app/models/article.rb:5
-  Comment Load (0.1ms)  SELECT "comments".* FROM "comments" WHERE "comments"."article_id" = ?  [["article_id", 1]]
-  ↳ app/models/article.rb:6
-  Comment Load (0.1ms)  SELECT "comments".* FROM "comments" WHERE "comments"."article_id" = ?  [["article_id", 2]]
-  ↳ app/models/article.rb:6
-  Comment Load (0.1ms)  SELECT "comments".* FROM "comments" WHERE "comments"."article_id" = ?  [["article_id", 3]]
-  ↳ app/models/article.rb:6
-=> #<Comment id: 2, author: "1", body: "Well, actually...", article_id: 1, created_at: "2018-10-19 00:56:10", updated_at: "2018-10-19 00:56:10">
+```ruby
+class PostsController < ApplicationController
+  def index
+    @posts = Post.all
+  end
+end
 ```
 
-Below each database statement you can see arrows pointing to the specific source filename (and line number) of the method that resulted in a database call e.g. `↳ app/models/article.rb:5`.
+```html+erb
+<h1>Posts</h1>
+<ul>
+  <%= @posts.each do |post| %>
+    <li>
+      <hgroup>
+        <h2><%= post.title %></h2>
+        <p><%= post.author.name %></p>
+      </hgroup>
+    </li>
+  <% end %>
+</ul>
+```
 
-This can help you identify and address performance problems caused by N+1 queries: i.e. single database queries that generate multiple additional queries.
+```#7,9,11,13
+Started GET "/posts" for 127.0.0.1 at 2026-03-31 17:01:02 +0100
+  ActiveRecord::SchemaMigration Load (0.1ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC /*application='RailsGuidesDemo'*/
+Processing by PostsController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering posts/index.html.erb within layouts/application
+  Post Load (0.5ms)  SELECT "posts".* FROM "posts" /*action='index',application='RailsGuidesDemo',controller='posts'*/
+  ↳ app/views/posts/index.html.erb:4
+  Author Load (0.0ms)  SELECT "authors".* FROM "authors" WHERE "authors"."id" = 1 LIMIT 1 /*action='index',application='RailsGuidesDemo',controller='posts'*/
+  ↳ app/views/posts/index.html.erb:8
+  CACHE Author Load (0.0ms)  SELECT "authors".* FROM "authors" WHERE "authors"."id" = 1 LIMIT 1
+  ↳ app/views/posts/index.html.erb:8
+  CACHE Author Load (0.0ms)  SELECT "authors".* FROM "authors" WHERE "authors"."id" = 1 LIMIT 1
+  ↳ app/views/posts/index.html.erb:8
+  Rendered posts/index.html.erb within layouts/application (Duration: 8.5ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 12.9ms | GC: 0.0ms)
+Completed 200 OK in 24ms (Views: 13.0ms | ActiveRecord: 1.2ms (4 queries, 2 cached) | GC: 0.1ms)
+```
 
-Verbose query logs are [enabled by default](configuring.html#config-active-record-verbose-query-logs) in the development environment logs.
+The highlighted lines above are controlled by the `verbose_query_logs` option.
+In this case, it demonstrates an N+1 query and its source file and line. We can
+fix it by eager loading the `Author` records: `Post.includes(:author).all`
 
-WARNING: We recommend against using this setting in production environments. It relies on Ruby's `Kernel#caller` method which tends to allocate a lot of memory in order to generate stacktraces of method calls. Use query log tags (see below) instead.
+WARNING: Avoid using this setting in production. It invokes Ruby's
+`Kernel#caller` method which tends to allocate a lot of memory in order to
+generate stacktraces of method calls. Use [SQL Query Logs](#sql-query-logs)
+instead.
+
+### SQL Query Logs
+
+SQL statements can be decorated with a comment containing tags with runtime
+information, such as the name of the controller or job that triggered the query.
+This can aid with tracing troublesome queries back to their source.
+
+This option is enabled by default in development.
+
+```ruby
+# config/environments/development.rb
+
+config.active_record.query_log_tags_enabled = true
+```
+
+WARNING: Enabling Query tags automatically disables
+[prepared statements](https://en.wikipedia.org/wiki/Prepared_statement) by
+default, because each query has a high chance of being unique, making prepared
+statements a useless overhead.
+
+Rails logs the name of the application, along with the name and action of the
+controller or the name of the job. It is formatted for
+[SQLCommenter](https://open-telemetry.github.io/opentelemetry-sqlcommenter/).
+
+```
+Post Load (0.5ms)  SELECT "posts".* FROM "posts" /*action='index',application='RailsGuidesDemo',controller='posts'*/
+```
+
+The log can be customized using `config.active_record.query_log_tags`. Consult
+the
+[API documentation](https://api.rubyonrails.org/classes/ActiveRecord/QueryLogs.html)
+for details.
 
 ### Verbose Enqueue Logs
 
-Similar to the "Verbose Query Logs" above, allows printing source locations of methods that enqueue background jobs.
-
-Verbose enqueue logs are [enabled by default](/7_1_release_notes.html#active-job-notable-changes) in the development environment logs.
+`verbose_enqueue_logs` is a configuration option for
+[Active Job](active_job_basics.html) which logs the source location of the line
+which enqueues a job. This option is enabled by default in development.
 
 ```ruby
 # config/environments/development.rb
 config.active_job.verbose_enqueue_logs = true
 ```
 
-```irb
-# bin/rails console
-ActiveJob.verbose_enqueue_logs = true
+Consider a `Post` model which has a `notify` method that enqueues a
+`SendNotificationJob`. The highlighed line below will only be logged with
+`verbose_enqueue_logs` enabled:
+
+```#4
+(dev):001> Post.first.notify
+  Post Load (0.1ms)  SELECT "posts".* FROM "posts" ORDER BY "posts"."id" ASC LIMIT 1 /*application='RailsGuidesDemo'*/
+Enqueued SendNotificationJob (Job ID: 586340a5-5186-40ee-b5a3-21d173dced70) to Async(default) with arguments: {source: #<GlobalID:0x000000012ee5e960 @uri=#<URI::GID gid://rails-guides-demo/Post/1>>}
+↳ app/models/post.rb:6:in 'Post#notify'
 ```
 
-WARNING: We recommend against using this setting in production environments.
+WARNING: Avoid using this setting in production. It invokes Ruby's
+`Kernel#caller` method which tends to allocate a lot of memory in order to
+generate stacktraces of method calls.
 
-### Verbose redirect logs
+### Verbose Redirect Logs
 
-Similar to other verbose log settings above, this logs the source location of a redirect.
+Using the `verbose_redirect_logs` configuration option, you can control whether
+the source location of the
+[`redirect_to`](https://api.rubyonrails.org/classes/ActionController/Redirecting.html#method-i-redirect_to)
+invocation is logged when a request is redirected. It's enabled by default in
+development.
 
+```ruby
+# config/environments/development.rb
+config.action_dispatch.verbose_redirect_logs = true
 ```
+
+The highlighted line below is only logged when this option is enabled.
+
+```#2
 Redirected to http://localhost:3000/posts/1
 ↳ app/controllers/posts_controller.rb:32:in `block (2 levels) in create'
 ```
 
-It is enabled by default in development. To enable in other environments, use this configuration:
+WARNING: Avoid using this setting in production. It invokes Ruby's
+`Kernel#caller` method which tends to allocate a lot of memory in order to
+generate stacktraces of method calls.
 
-```rb
-config.action_dispatch.verbose_redirect_logs = true
-```
+### Custom Loggers
 
-As with other verbose loggers, it is not recommended to be used in production environments.
-
-SQL Query Comments
-------------------
-
-SQL statements can be commented with tags containing runtime information, such as the name of the controller or job, to
-trace troublesome queries back to the area of the application that generated these statements. This is useful when you are
-logging slow queries (e.g. [MySQL](https://dev.mysql.com/doc/refman/en/slow-query-log.html), [PostgreSQL](https://www.postgresql.org/docs/current/runtime-config-logging.html#GUC-LOG-MIN-DURATION-STATEMENT)),
-viewing currently running queries, or for end-to-end tracing tools.
+The logger
+[can be customized](https://guides.rubyonrails.org/configuring.html#config-logger)
+to use another utility such as `Log4r`:
 
 ```ruby
-config.active_record.query_log_tags_enabled = true
+# config/environments/production.rb
+
+config.logger = Log4r::Logger.new("Application Log")
 ```
 
-NOTE: Enabling Query tags automatically disables prepared statements, because it makes most queries unique.
+Using the `debug` Gem
+---------------------
 
-By default the name of the application, the name and action of the controller, or the name of the job are logged. The
-default format is [SQLCommenter](https://open-telemetry.github.io/opentelemetry-sqlcommenter/). For example:
+A debugger is used to pause program execution, and then manually control further
+execution while running commands to inspect the application's state. Ruby's
+native debugger is provided by the [`debug`](https://github.com/ruby/debug) gem,
+and is installed in Rails apps by default. The gem is not available in the
+production environment.
 
-```
-Article Load (0.2ms)  SELECT "articles".* FROM "articles" /*application='Blog',controller='articles',action='index'*/
+NOTE: `debug` is excluded when using
+[alternate Ruby implementations](https://www.ruby-lang.org/en/about/#other-implementations-of-ruby)
+such as JRuby or TruffleRuby. It's only included when running CRuby (sometimes
+known as MRI).
 
-Article Update (0.3ms)  UPDATE "articles" SET "title" = ?, "updated_at" = ? WHERE "posts"."id" = ? /*application='Blog',job='ImproveTitleJob'*/  [["title", "Improved Rails debugging guide"], ["updated_at", "2022-10-16 20:25:40.091371"], ["id", 1]]
-```
+This section contains a brief overview of key debugger features. Consult
+[the documentation](https://github.com/ruby/debug?tab=readme-ov-file) for
+detailed usage information.
 
-The behavior of [`ActiveRecord::QueryLogs`](https://api.rubyonrails.org/classes/ActiveRecord/QueryLogs.html) can be
-modified to include anything that helps connect the dots from the SQL query, such as request and job ids for
-application logs, account and tenant identifiers, etc.
+### Entering the Debugger
 
-### Tagged Logging
+Add a breakpoint in your code using `debugger` or one of its aliases:
+`binding.break` and `binding.b`.
 
-When running multi-user, multi-account applications, it's often useful
-to be able to filter the logs using some custom rules. `TaggedLogging`
-in Active Support helps you do exactly that by stamping log lines with subdomains, request ids, and anything else to aid debugging such applications.
-
-```ruby
-logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
-logger.tagged("BCX") { logger.info "Stuff" }                            # Logs "[BCX] Stuff"
-logger.tagged("BCX", "Jason") { logger.info "Stuff" }                   # Logs "[BCX] [Jason] Stuff"
-logger.tagged("BCX") { logger.tagged("Jason") { logger.info "Stuff" } } # Logs "[BCX] [Jason] Stuff"
-```
-
-### Impact of Logs on Performance
-
-Logging will always have a small impact on the performance of your Rails app,
-particularly when logging to disk. Additionally, there are a few subtleties:
-
-Using the `:debug` level will have a greater performance penalty than `:fatal`,
-as a far greater number of strings are being evaluated and written to the
-log output (e.g. disk).
-
-Another potential pitfall is too many calls to `Logger` in your code:
-
-```ruby
-logger.debug "Person attributes hash: #{@person.attributes.inspect}"
-```
-
-In the above example, there will be a performance impact even if the allowed
-output level doesn't include debug. The reason is that Ruby has to evaluate
-these strings, which includes instantiating the somewhat heavy `String` object
-and interpolating the variables.
-
-Therefore, it's recommended to pass blocks to the logger methods, as these are
-only evaluated if the output level is the same as — or included in — the allowed level
-(i.e. lazy loading). The same code rewritten would be:
-
-```ruby
-logger.debug { "Person attributes hash: #{@person.attributes.inspect}" }
-```
-
-The contents of the block, and therefore the string interpolation, are only
-evaluated if debug is enabled. This performance savings are only really
-noticeable with large amounts of logging, but it's a good practice to employ.
-
-INFO: This section was written by [Jon Cairns at a Stack Overflow answer](https://stackoverflow.com/questions/16546730/logging-in-rails-is-there-any-performance-hit/16546935#16546935)
-and it is licensed under [cc by-sa 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
-
-Debugging with the `debug` Gem
-------------------------------
-
-When your code is behaving in unexpected ways, you can try printing to logs or
-the console to diagnose the problem. Unfortunately, there are times when this
-sort of error tracking is not effective in finding the root cause of a problem.
-When you actually need to journey into your running source code, the debugger
-is your best companion.
-
-The debugger can also help you if you want to learn about the Rails source code
-but don't know where to start. Just debug any request to your application and
-use this guide to learn how to move from the code you have written into the
-underlying Rails code.
-
-Rails 7 includes the `debug` gem in the `Gemfile` of new applications generated
-by CRuby. By default, it is ready in the `development` and `test` environments.
-Please check its [documentation](https://github.com/ruby/debug) for usage.
-
-### Entering a Debugging Session
-
-By default, a debugging session will start after the `debug` library is required, which happens when your app boots. But don't worry, the session won't interfere with your application.
-
-To enter the debugging session, you can use `binding.break` and its aliases: `binding.b` and `debugger`. The following examples will use `debugger`:
-
-```ruby
+```ruby#4
 class PostsController < ApplicationController
-  before_action :set_post, only: %i[ show edit update destroy ]
-
-  # GET /posts or /posts.json
   def index
     @posts = Post.all
     debugger
@@ -379,541 +485,382 @@ class PostsController < ApplicationController
 end
 ```
 
-Once your app evaluates the debugging statement, it'll enter the debugging session:
+When the app evaluates the `debugger` statement, execution will pause, and you
+can access the debugger in your console:
 
-```ruby
+```
 Processing by PostsController#index as HTML
-[2, 11] in ~/projects/rails-guide-example/app/controllers/posts_controller.rb
-     2|   before_action :set_post, only: %i[ show edit update destroy ]
-     3|
-     4|   # GET /posts or /posts.json
-     5|   def index
-     6|     @posts = Post.all
-=>   7|     debugger
-     8|   end
-     9|
-    10|   # GET /posts/1 or /posts/1.json
-    11|   def show
-=>#0    PostsController#index at ~/projects/rails-guide-example/app/controllers/posts_controller.rb:7
-  #1    ActionController::BasicImplicitRender#send_action(method="index", args=[]) at ~/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/actionpack-8.2.0.alpha/lib/action_controller/metal/basic_implicit_render.rb:6
-  # and 72 frames (use `bt' command for all frames)
+[1, 6] in ~/projects/rails-guides-demo/app/controllers/posts_controller.rb
+     1| class PostsController < ApplicationController
+     2|   def index
+     3|     @posts = Post.all
+=>   4|     debugger
+     5|   end
+     6| end
+=>#0  PostsController#index at ~/projects/rails-guides-demo/app/controllers/posts_controller.rb:4
+  #1  ActionController::BasicImplicitRender#send_action(method="index", args=[]) at ~/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.1.2/lib/action_controller/metal/basic_implicit_render.rb:8
+  # and 78 frames (use `bt' command for all frames)
 (rdbg)
 ```
 
-You can exit the debugging session at any time and continue your application execution with the `continue` (or `c`) command. Or, to exit both the debugging session and your application, use the `quit` (or `q`) command.
+Within this prompt, you can run debugger commands to inspect the state of your
+application. Continue program execution using `continue` (or `c`), or quit the
+debugger and terminate your program using `quit` (or `q`).
 
-### The Context
+When inside the debugger, you can run Ruby code just like IRB or the Rails
+console.
 
-After entering the debugging session, you can type in Ruby code as if you are in a Rails console or IRB.
-
-```ruby
-(rdbg) @posts    # ruby
-[]
+```
+(ruby) @posts
+  Post Load (1.7ms)  SELECT "posts".* FROM "posts" /* loading for pp */ LIMIT 11 /*action='index',application='RailsGuidesDemo',controller='posts'*/
+  ↳ app/controllers/posts_controller.rb:4:in 'PostsController#index'
+[#<Post:0x00000001225d2be0 id: 1 ...>,
+ #<Post:0x00000001225d2aa0 id: 2 ...>]
 (rdbg) self
-#<PostsController:0x0000000000aeb0>
+#<PostsController:0x00000000006330>
 (rdbg)
 ```
 
-You can also use the `p` or `pp` command to evaluate Ruby expressions, which is useful when a variable name conflicts with a debugger command.
+### Debugger Commands
 
-```ruby
-(rdbg) p headers    # command
-=> {"X-Frame-Options"=>"SAMEORIGIN", "X-XSS-Protection"=>"1; mode=block", "X-Content-Type-Options"=>"nosniff", "X-Download-Options"=>"noopen", "X-Permitted-Cross-Domain-Policies"=>"none", "Referrer-Policy"=>"strict-origin-when-cross-origin"}
-(rdbg) pp headers    # command
-{"X-Frame-Options"=>"SAMEORIGIN",
- "X-XSS-Protection"=>"1; mode=block",
- "X-Content-Type-Options"=>"nosniff",
- "X-Download-Options"=>"noopen",
- "X-Permitted-Cross-Domain-Policies"=>"none",
- "Referrer-Policy"=>"strict-origin-when-cross-origin"}
-(rdbg)
+Besides direct evaluation, the debugger supports a plethora of commands to
+collect information and control program flow. Some examples are:
+
+- `help` (or `h`) - Show help for all commands.
+- `step` (or `s`) - Step into the current line.
+- `next` (or `n`) - Resume program until the next line.
+- `backtrace` (or `bt`) - Show the backtrace with additional related
+  information.
+- `break` (or `b`) - List or modify breakpoints.
+
+TIP: When a Ruby expression clashes with a debugger command, evaluate it using
+`p` or `eval`. For example, if you had a variable called `step`, you'd evaluate
+it by running: `p step`. You can also use `pp` which will _pretty print_ the
+output.
+
+#### Control Flow
+
+When inside the debugger, you can control program execution. For example, you
+can continue execution for a set number of lines before the program pauses once
+again with the interactive debugger prompt.
+
+Some useful commands are:
+
+```shell
+# Step into the current line
+(rdbg) step
+
+# Continue to the next line
+(rdbg) next
+
+# Continue for 5 lines
+(rdbg) next 5
 ```
 
-Besides direct evaluation, the debugger also helps you collect a rich amount of information through different commands, such as:
+[The `debug` gem documentation](https://github.com/ruby/debug?tab=readme-ov-file#control-flow)
+lists all available control flow commands.
 
-- `info` (or `i`) - Information about current frame.
-- `backtrace` (or `bt`) - Backtrace (with additional information).
-- `outline` (or `o`, `ls`) - Available methods, constants, local variables, and instance variables in the current scope.
+#### `backtrace`
 
-#### The `info` Command
+The `backtrace` command lists all the frames on the stack:
 
-`info` provides an overview of the values of local and instance variables that are visible from the current frame.
-
-```ruby
-(rdbg) info    # command
-%self = #<PostsController:0x0000000000af78>
-@_action_has_layout = true
-@_action_name = "index"
-@_config = {}
-@_lookup_context = #<ActionView::LookupContext:0x00007fd91a037e38 @details_key=nil, @digest_cache=...
-@_request = #<ActionDispatch::Request GET "http://localhost:3000/posts" for 127.0.0.1>
-@_response = #<ActionDispatch::Response:0x00007fd91a03ea08 @mon_data=#<Monitor:0x00007fd91a03e8c8>...
-@_response_body = nil
-@_routes = nil
-@marked_for_same_origin_verification = true
-@posts = []
-@rendered_format = nil
 ```
-
-#### The `backtrace` Command
-
-When used without any options, `backtrace` lists all the frames on the stack:
-
-```ruby
-=>#0    PostsController#index at ~/projects/rails-guide-example/app/controllers/posts_controller.rb:7
-  #1    ActionController::BasicImplicitRender#send_action(method="index", args=[]) at ~/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/actionpack-2.0.alpha/lib/action_controller/metal/basic_implicit_render.rb:6
-  #2    AbstractController::Base#process_action(method_name="index", args=[]) at ~/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/actionpack-8.2.0.alpha/lib/abstract_controller/base.rb:214
-  #3    ActionController::Rendering#process_action(#arg_rest=nil) at ~/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/actionpack-8.2.0.alpha/lib/action_controller/metal/rendering.rb:53
-  #4    block in process_action at ~/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/actionpack-8.2.0.alpha/lib/abstract_controller/callbacks.rb:221
-  #5    block in run_callbacks at ~/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/activesupport-8.2.0.alpha/lib/active_support/callbacks.rb:118
-  #6    ActionText::Rendering::ClassMethods#with_renderer(renderer=#<PostsController:0x0000000000af78>) at ~/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/actiontext-8.2.0.alpha/lib/action_text/rendering.rb:20
-  #7    block {|controller=#<PostsController:0x0000000000af78>, action=#<Proc:0x00007fd91985f1c0 /Users/st0012/...|} in <class:Engine> (4 levels) at ~/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/actiontext-8.2.0.alpha/lib/action_text/engine.rb:69
-  #8    [C] BasicObject#instance_exec at ~/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/activesupport-8.2.0.alpha/lib/active_support/callbacks.rb:127
+=>#0  PostsController#index at ~/projects/rails-guides-demo/app/controllers/posts_controller.rb:4
+  #1  ActionController::BasicImplicitRender#send_action(method="index", args=[]) at ~/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.1.2/lib/action_controller/metal/basic_implicit_render.rb:8
+  #2  AbstractController::Base#process_action at ~/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.1.2/lib/abstract_controller/base.rb:221
+  #3  ActionController::Rendering#process_action at ~/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.1.2/lib/action_controller/metal/rendering.rb:199
+  #4  block in AbstractController::Callbacks#process_action at ~/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.1.2/lib/abstract_controller/callbacks.rb:267
+  #5  block in ActiveSupport::Callbacks#run_callbacks at ~/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.1.2/lib/active_support/callbacks.rb:121
+  #6  Turbo.with_request_id(request_id=nil) at ~/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/turbo-rails-2.0.23/lib/turbo-rails.rb:24
   ..... and more
 ```
 
-Every frame comes with:
+Every frame includes:
 
-- Frame identifier
+- The frame identifier
 - Call location
-- Additional information (e.g. block or method arguments)
+- Additional information (such as block or method arguments)
 
-This will give you a great sense about what is happening in your app. However, you probably will notice that:
+While this is useful, there are far too many frames and they're mostly from
+within Rails and other libraries. You can specify how many frames are printed
+out by supplying a number to `backtrace`:
 
-- There are too many frames (usually 50+ in a Rails app).
-- Most of the frames are from Rails or other libraries you use.
-
-The `backtrace` command provides 2 options to help you filter frames:
-
-- `backtrace [num]` - only show `num` numbers of frames, e.g. `backtrace 10` .
-- `backtrace /pattern/` - only show frames with identifier or location that matches the pattern, e.g. `backtrace /MyModel/`.
-
-It is also possible to use these options together: `backtrace [num] /pattern/`.
-
-#### The `outline` Command
-
-`outline` is similar to `pry` and `irb`'s `ls` command. It will show you what is accessible from the current scope, including:
-
-- Local variables
-- Instance variables
-- Class variables
-- Methods & their sources
-
-```ruby
-ActiveSupport::Configurable#methods: config
-AbstractController::Base#methods:
-  action_methods  action_name  action_name=  available_action?  controller_path  inspect
-  response_body
-ActionController::Metal#methods:
-  content_type       content_type=  controller_name  dispatch          headers
-  location           location=      media_type       middleware_stack  middleware_stack=
-  middleware_stack?  performed?     request          request=          reset_session
-  response           response=      response_body=   response_code     session
-  set_request!       set_response!  status           status=           to_a
-ActionView::ViewPaths#methods:
-  _prefixes  any_templates?  append_view_path   details_for_lookup  formats     formats=  locale
-  locale=    lookup_context  prepend_view_path  template_exists?    view_paths
-AbstractController::Rendering#methods: view_assigns
-
-# .....
-
-PostsController#methods: create  destroy  edit  index  new  show  update
-instance variables:
-  @_action_has_layout  @_action_name    @_config  @_lookup_context                      @_request
-  @_response           @_response_body  @_routes  @marked_for_same_origin_verification  @posts
-  @rendered_format
-class variables: @@raise_on_open_redirects
+```shell
+(rdbg) backtrace 11
 ```
 
-### Breakpoints
+A regex can be used to filter frames by its identifier or location:
 
-There are many ways to insert and trigger a breakpoint in the debugger. In addition to adding debugging statements (e.g. `debugger`) directly in your code, you can also insert breakpoints with commands:
-
-- `break` (or `b`)
-  - `break` - list all breakpoints
-  - `break <num>` - set a breakpoint on the `num` line of the current file
-  - `break <file:num>` - set a breakpoint on the `num` line of `file`
-  - `break <Class#method>` or `break <Class.method>` - set a breakpoint on `Class#method` or `Class.method`
-  - `break <expr>.<method>` - sets a breakpoint on `<expr>` result's `<method>` method.
-- `catch <Exception>` - set a breakpoint that'll stop when `Exception` is raised
-- `watch <@ivar>` - set a breakpoint that'll stop when the result of current object's `@ivar` is changed (this is slow)
-
-And to remove them, you can use:
-
-- `delete` (or `del`)
-  - `delete` - delete all breakpoints
-  - `delete <num>` - delete the breakpoint with id `num`
-
-#### The `break` Command
-
-**Set a breakpoint on a specified line number - e.g. `b 28`**
-
-```ruby
-[20, 29] in ~/projects/rails-guide-example/app/controllers/posts_controller.rb
-    20|   end
-    21|
-    22|   # POST /posts or /posts.json
-    23|   def create
-    24|     @post = Post.new(post_params)
-=>  25|     debugger
-    26|
-    27|     respond_to do |format|
-    28|       if @post.save
-    29|         format.html { redirect_to @post, notice: "Post was successfully created." }
-=>#0    PostsController#create at ~/projects/rails-guide-example/app/controllers/posts_controller.rb:25
-  #1    ActionController::BasicImplicitRender#send_action(method="create", args=[]) at ~/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/actionpack-7.0.0.alpha2/lib/action_controller/metal/basic_implicit_render.rb:6
-  # and 72 frames (use `bt' command for all frames)
-(rdbg) b 28    # break command
-#0  BP - Line  /Users/st0012/projects/rails-guide-example/app/controllers/posts_controller.rb:28 (line)
+```shell
+(rdbg) backtrace /Posts/
 ```
 
-```ruby
-(rdbg) c    # continue command
-[23, 32] in ~/projects/rails-guide-example/app/controllers/posts_controller.rb
-    23|   def create
-    24|     @post = Post.new(post_params)
-    25|     debugger
-    26|
-    27|     respond_to do |format|
-=>  28|       if @post.save
-    29|         format.html { redirect_to @post, notice: "Post was successfully created." }
-    30|         format.json { render :show, status: :created, location: @post }
-    31|       else
-    32|         format.html { render :new, status: :unprocessable_entity }
-=>#0    block {|format=#<ActionController::MimeResponds::Collec...|} in create at ~/projects/rails-guide-example/app/controllers/posts_controller.rb:28
-  #1    ActionController::MimeResponds#respond_to(mimes=[]) at ~/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/actionpack-7.0.0.alpha2/lib/action_controller/metal/mime_responds.rb:205
-  # and 74 frames (use `bt' command for all frames)
-
-Stop by #0  BP - Line  /Users/st0012/projects/rails-guide-example/app/controllers/posts_controller.rb:28 (line)
+```shell
+(rdbg) backtrace /actionpack/
 ```
 
-Set a breakpoint on a given method call - e.g. `b @post.save`.
+These options can also be used together:
 
-```ruby
-[20, 29] in ~/projects/rails-guide-example/app/controllers/posts_controller.rb
-    20|   end
-    21|
-    22|   # POST /posts or /posts.json
-    23|   def create
-    24|     @post = Post.new(post_params)
-=>  25|     debugger
-    26|
-    27|     respond_to do |format|
-    28|       if @post.save
-    29|         format.html { redirect_to @post, notice: "Post was successfully created." }
-=>#0    PostsController#create at ~/projects/rails-guide-example/app/controllers/posts_controller.rb:25
-  #1    ActionController::BasicImplicitRender#send_action(method="create", args=[]) at ~/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/actionpack-7.0.0.alpha2/lib/action_controller/metal/basic_implicit_render.rb:6
-  # and 72 frames (use `bt' command for all frames)
-(rdbg) b @post.save    # break command
-#0  BP - Method  @post.save at /Users/st0012/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/activerecord-7.0.0.alpha2/lib/active_record/suppressor.rb:43
-
+```shell
+(rdbg) backtrace 11 /actionpack/
 ```
 
-```ruby
-(rdbg) c    # continue command
-[39, 48] in ~/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/activerecord-7.0.0.alpha2/lib/active_record/suppressor.rb
-    39|         SuppressorRegistry.suppressed[name] = previous_state
-    40|       end
-    41|     end
-    42|
-    43|     def save(**) # :nodoc:
-=>  44|       SuppressorRegistry.suppressed[self.class.name] ? true : super
-    45|     end
-    46|
-    47|     def save!(**) # :nodoc:
-    48|       SuppressorRegistry.suppressed[self.class.name] ? true : super
-=>#0    ActiveRecord::Suppressor#save(#arg_rest=nil) at ~/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/activerecord-7.0.0.alpha2/lib/active_record/suppressor.rb:44
-  #1    block {|format=#<ActionController::MimeResponds::Collec...|} in create at ~/projects/rails-guide-example/app/controllers/posts_controller.rb:28
-  # and 75 frames (use `bt' command for all frames)
+#### `break`
 
-Stop by #0  BP - Method  @post.save at /Users/st0012/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/activerecord-7.0.0.alpha2/lib/active_record/suppressor.rb:43
+Dynamically add and remove breakpoints while inside the debugger using `break`
+(or `b`).
+
+```shell
+# List all breakpoints
+(rdbg) break
+
+# Set a breakpoint on a specific line of the current file
+(rdbg) break 7
+
+# Set a breakpoint on a line in another file
+(rdbg) break app/controllers/books_controller.rb:12
+
+# Set a breakpoint on a method in specific class
+(rdbg) break BooksController#index
 ```
 
-#### The `catch` Command
+NOTE: When setting a breakpoint in another file, you need to specify its
+relative path from your project's root. In the development environment,
+constants are [lazily auto-loaded](autoloading_and_reloading_constants.html)
+when referenced. Hence, a breakpoint in another file that hasn't been loaded yet
+will show as `(pending)` until that file is referenced and automatically loaded,
+at which point the breakpoint will become active.
 
-Stop when an exception is raised - e.g. `catch ActiveRecord::RecordInvalid`.
+Remove breakpoints using `delete` (or `del`):
 
-```ruby
-[20, 29] in ~/projects/rails-guide-example/app/controllers/posts_controller.rb
-    20|   end
-    21|
-    22|   # POST /posts or /posts.json
-    23|   def create
-    24|     @post = Post.new(post_params)
-=>  25|     debugger
-    26|
-    27|     respond_to do |format|
-    28|       if @post.save!
-    29|         format.html { redirect_to @post, notice: "Post was successfully created." }
-=>#0    PostsController#create at ~/projects/rails-guide-example/app/controllers/posts_controller.rb:25
-  #1    ActionController::BasicImplicitRender#send_action(method="create", args=[]) at ~/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/actionpack-7.0.0.alpha2/lib/action_controller/metal/basic_implicit_render.rb:6
-  # and 72 frames (use `bt' command for all frames)
-(rdbg) catch ActiveRecord::RecordInvalid    # command
-#1  BP - Catch  "ActiveRecord::RecordInvalid"
+```shell
+# Delete all breakpoints
+(rdbg) del
+
+# Delete the breakpoint using its ID
+(rdbg) del 21
 ```
 
-```ruby
-(rdbg) c    # continue command
-[75, 84] in ~/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/activerecord-7.0.0.alpha2/lib/active_record/validations.rb
-    75|     def default_validation_context
-    76|       new_record? ? :create : :update
-    77|     end
-    78|
-    79|     def raise_validation_error
-=>  80|       raise(RecordInvalid.new(self))
-    81|     end
-    82|
-    83|     def perform_validations(options = {})
-    84|       options[:validate] == false || valid?(options[:context])
-=>#0    ActiveRecord::Validations#raise_validation_error at ~/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/activerecord-7.0.0.alpha2/lib/active_record/validations.rb:80
-  #1    ActiveRecord::Validations#save!(options={}) at ~/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/activerecord-7.0.0.alpha2/lib/active_record/validations.rb:53
-  # and 88 frames (use `bt' command for all frames)
+#### `catch`
 
-Stop by #1  BP - Catch  "ActiveRecord::RecordInvalid"
+Add a breakpoint where an exception is raised.
+
+```shell
+(rdbg) catch ActiveRecord::RecordInvalid
 ```
 
-#### The `watch` Command
+#### `watch`
 
-Stop when the instance variable is changed - e.g. `watch @_response_body`.
+Add a breakpoint where an instance variable is mutated.
 
-```ruby
-[20, 29] in ~/projects/rails-guide-example/app/controllers/posts_controller.rb
-    20|   end
-    21|
-    22|   # POST /posts or /posts.json
-    23|   def create
-    24|     @post = Post.new(post_params)
-=>  25|     debugger
-    26|
-    27|     respond_to do |format|
-    28|       if @post.save!
-    29|         format.html { redirect_to @post, notice: "Post was successfully created." }
-=>#0    PostsController#create at ~/projects/rails-guide-example/app/controllers/posts_controller.rb:25
-  #1    ActionController::BasicImplicitRender#send_action(method="create", args=[]) at ~/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/actionpack-7.0.0.alpha2/lib/action_controller/metal/basic_implicit_render.rb:6
-  # and 72 frames (use `bt' command for all frames)
-(rdbg) watch @_response_body    # command
-#0  BP - Watch  #<PostsController:0x00007fce69ca5320> @_response_body =
+```shell
+(rdbg) watch @posts
 ```
 
-```ruby
-(rdbg) c    # continue command
-[173, 182] in ~/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/actionpack-7.0.0.alpha2/lib/action_controller/metal.rb
-   173|       body = [body] unless body.nil? || body.respond_to?(:each)
-   174|       response.reset_body!
-   175|       return unless body
-   176|       response.body = body
-   177|       super
-=> 178|     end
-   179|
-   180|     # Tests if render or redirect has already happened.
-   181|     def performed?
-   182|       response_body || response.committed?
-=>#0    ActionController::Metal#response_body=(body=["<html><body>You are being <a href=\"ht...) at ~/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/actionpack-7.0.0.alpha2/lib/action_controller/metal.rb:178 #=> ["<html><body>You are being <a href=\"ht...
-  #1    ActionController::Redirecting#redirect_to(options=#<Post id: 13, title: "qweqwe", content:..., response_options={:allow_other_host=>false}) at ~/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/actionpack-7.0.0.alpha2/lib/action_controller/metal/redirecting.rb:74
-  # and 82 frames (use `bt' command for all frames)
+TIP: The debugger supports several more commands, and more options even within
+the commands demonstrated. Consult
+[the documentation](https://github.com/ruby/debug?tab=readme-ov-file#debug-command-on-the-debug-console)
+for a complete manual.
 
-Stop by #0  BP - Watch  #<PostsController:0x00007fce69ca5320> @_response_body =  -> ["<html><body>You are being <a href=\"http://localhost:3000/posts/13\">redirected</a>.</body></html>"]
-(rdbg)
-```
+### Program Your Debugging Workflow
 
-#### Breakpoint Options
+The `debugger` statement supports `do:` and `pre:` keywords to add automation to
+your debugging workflow.
 
-In addition to different types of breakpoints, you can also specify options to achieve more advanced debugging workflows. Currently, the debugger supports 4 options:
+`do:` pauses the program, runs the supplied value as a debugging command, and
+then continues the program. Use this when you want to run a specific debugger
+command without stopping the program.
 
-- `do: <cmd or expr>` - when the breakpoint is triggered, execute the given command/expression and continue the program:
-  - `break Foo#bar do: bt` - when `Foo#bar` is called, print the stack frames.
-- `pre: <cmd or expr>` - when the breakpoint is triggered, execute the given command/expression before stopping:
-  - `break Foo#bar pre: info` - when `Foo#bar` is called, print its surrounding variables before stopping.
-- `if: <expr>` - the breakpoint only stops if the result of `<expr`> is true:
-  - `break Post#save if: params[:debug]` - stops at `Post#save` if `params[:debug]` is also true.
-- `path: <path_regexp>` - the breakpoint only stops if the event that triggers it (e.g. a method call) happens from the given path:
-  - `break Post#save path: app/services/a_service` - stops at `Post#save` if the method call happens at a path that includes `app/services/a_service`.
-
-Please also note that the first 3 options: `do:`, `pre:` and `if:` are also available for the debug statements we mentioned earlier. For example:
-
-```ruby
-[2, 11] in ~/projects/rails-guide-example/app/controllers/posts_controller.rb
-     2|   before_action :set_post, only: %i[ show edit update destroy ]
-     3|
-     4|   # GET /posts or /posts.json
-     5|   def index
-     6|     @posts = Post.all
-=>   7|     debugger(do: "info")
-     8|   end
-     9|
-    10|   # GET /posts/1 or /posts/1.json
-    11|   def show
-=>#0    PostsController#index at ~/projects/rails-guide-example/app/controllers/posts_controller.rb:7
-  #1    ActionController::BasicImplicitRender#send_action(method="index", args=[]) at ~/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/actionpack-7.0.0.alpha2/lib/action_controller/metal/basic_implicit_render.rb:6
-  # and 72 frames (use `bt' command for all frames)
-(rdbg:binding.break) info
-%self = #<PostsController:0x00000000017480>
-@_action_has_layout = true
-@_action_name = "index"
-@_config = {}
-@_lookup_context = #<ActionView::LookupContext:0x00007fce3ad336b8 @details_key=nil, @digest_cache=...
-@_request = #<ActionDispatch::Request GET "http://localhost:3000/posts" for 127.0.0.1>
-@_response = #<ActionDispatch::Response:0x00007fce3ad397e8 @mon_data=#<Monitor:0x00007fce3ad396a8>...
-@_response_body = nil
-@_routes = nil
-@marked_for_same_origin_verification = true
-@posts = #<ActiveRecord::Relation [#<Post id: 2, title: "qweqwe", content: "qweqwe", created_at: "...
-@rendered_format = nil
-```
-
-#### Program Your Debugging Workflow
-
-With those options, you can script your debugging workflow in one line like:
-
-```ruby
-def create
-  debugger(do: "catch ActiveRecord::RecordInvalid do: bt 10")
-  # ...
-end
-```
-
-And then the debugger will run the scripted command and insert the catch breakpoint
-
-```ruby
-(rdbg:binding.break) catch ActiveRecord::RecordInvalid do: bt 10
-#0  BP - Catch  "ActiveRecord::RecordInvalid"
-[75, 84] in ~/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/activerecord-7.0.0.alpha2/lib/active_record/validations.rb
-    75|     def default_validation_context
-    76|       new_record? ? :create : :update
-    77|     end
-    78|
-    79|     def raise_validation_error
-=>  80|       raise(RecordInvalid.new(self))
-    81|     end
-    82|
-    83|     def perform_validations(options = {})
-    84|       options[:validate] == false || valid?(options[:context])
-=>#0    ActiveRecord::Validations#raise_validation_error at ~/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/activerecord-7.0.0.alpha2/lib/active_record/validations.rb:80
-  #1    ActiveRecord::Validations#save!(options={}) at ~/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/activerecord-7.0.0.alpha2/lib/active_record/validations.rb:53
-  # and 88 frames (use `bt' command for all frames)
-```
-
-Once the catch breakpoint is triggered, it'll print the stack frames
-
-```ruby
-Stop by #0  BP - Catch  "ActiveRecord::RecordInvalid"
-
-(rdbg:catch) bt 10
-=>#0    ActiveRecord::Validations#raise_validation_error at ~/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/activerecord-7.0.0.alpha2/lib/active_record/validations.rb:80
-  #1    ActiveRecord::Validations#save!(options={}) at ~/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/activerecord-7.0.0.alpha2/lib/active_record/validations.rb:53
-  #2    block in save! at ~/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/activerecord-7.0.0.alpha2/lib/active_record/transactions.rb:302
-```
-
-This technique can save you from repeated manual input and make the debugging experience smoother.
-
-You can find more commands and configuration options from its [documentation](https://github.com/ruby/debug).
-
-Debugging with the `web-console` Gem
-------------------------------------
-
-Web Console is a bit like `debug`, but it runs in the browser. You can request a console in the context of a view or a controller on any page. The console would be rendered next to your HTML content.
-
-### Console
-
-Inside any controller action or view, you can invoke the console by
-calling the `console` method.
-
-For example, in a controller:
+The below example runs `info` and adds a breakpoint when `@posts` is modified,
+then continues the program.
 
 ```ruby
 class PostsController < ApplicationController
-  def new
-    console
-    @post = Post.new
+  def index
+    @posts = Post.all
+    debugger(do: "info \n watch @posts")
   end
 end
 ```
 
-Or in a view:
+`pre:` runs the supplied debugging command and keeps the program suspended so
+you can use the interactive console. This is useful for automatically printing
+relevant information such as the backtrace when the breakpoint is hit.
+
+```ruby
+class PostsController < ApplicationController
+  def index
+    @posts = Post.all
+    debugger(pre: "backtrace 10")
+  end
+end
+```
+
+### Remote Debugging
+
+A Rails server in development might be run alongside other programs such as a
+jobs executor, or a CSS/JavaScript watcher (provided by `cssbundling-rails` or
+`jsbundling-rails`). This is usually done using
+[foreman](https://github.com/ddollar/foreman) via a `Procfile` invoked by
+running `bin/dev`.
+
+Debugging a program requires it to be running within a
+[terminal](<https://en.wikipedia.org/wiki/Tty_(Unix)>). When foreman is used to
+run multiple programs, it forks them as child processes and _pipes_ their input
+and output into the parent process. As such the Rails server process isn't
+running within a terminal and cannot be used for interactive debugging.
+
+To remedy this, the auto-generated `Procfile.dev` sets the environment variable
+`RUBY_DEBUG_OPEN=true` when starting the Rails server to enable _remote
+debugging_.
+
+```
+$ bin/dev
+
+14:11:34 web.1  | DEBUGGER: Debugger can attach via UNIX domain socket (/var/folders/z2/z6q9dxmd4mb9v_8khdtgsll00000gn/T/rdbg-501/rdbg-24515)
+14:11:34 web.1  | DEBUGGER: wait for debugger connection...
+```
+
+The debugger now needs to be externally attached to the server process, rather
+than run within it. Run `rdbg -a` in a new terminal window to attach the
+debugger to your Rails process and start a session.
+
+```
+$ rdbg -a
+DEBUGGER (client): Connected. PID:24515, $0:bin/rails
+
+[1, 10] in ~/projects/rails-guides-demo/app/controllers/posts_controller.rb
+     1| class PostsController < ApplicationController
+     2|   def index
+     3|     @posts = Post.all
+=>   4|     debugger
+     5|   end
+     6| end
+=>#0  PostsController#index at ~/projects/rails-guides-demo/app/controllers/posts_controller.rb:4
+  #1  ActionController::BasicImplicitRender#send_action(method="index", args=[]) at ~/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.1.2/lib/action_controller/metal/basic_implicit_render.rb:8
+  # and 78 frames (use `bt' command for all frames)
+(rdbg:remote)
+```
+
+Debugging in the View
+---------------------
+
+Sometimes it's useful to dump debug output right into the view, so it can be
+inspected in the browser.
+
+### The `debug` helper
+
+The `debug` helper method renders a `<pre>` tag containing a YAML dump of the
+supplied object.
+
+For example, the below view code:
+
+```html+erb
+<%= debug @post %>
+
+<h1><%= @post.title %></h1>
+```
+
+will render the following HTML:
+
+```html
+<pre class="debug_dump">
+  --- !ruby/object:Post
+  concise_attributes:
+  - !ruby/object:ActiveModel::Attribute::FromDatabase
+    name: id
+    value_before_type_cast: 1
+  - !ruby/object:ActiveModel::Attribute::FromDatabase
+    name: title
+    value_before_type_cast: Debugging Rails with View Helpers
+  - !ruby/object:ActiveModel::Attribute::FromDatabase
+    name: body
+    value_before_type_cast: "...";
+  - !ruby/object:ActiveModel::Attribute::FromDatabase
+    name: created_at
+    value_before_type_cast: "2026-03-30 15:04:27.776801";
+  - !ruby/object:ActiveModel::Attribute::FromDatabase
+    name: updated_at
+    value_before_type_cast: "2026-03-30 15:04:27.776801";
+  new_record: false
+  active_record_yaml_version: 2
+</pre>
+
+<h1>Debugging Rails with View Helpers</h1>
+```
+
+### `inspect`ing Objects
+
+The
+[`inspect`](https://docs.ruby-lang.org/en/master/Object.html#method-i-inspect)
+method is available on all Ruby objects except
+[`BasicObject`](https://docs.ruby-lang.org/en/master/BasicObject.html). It
+provides a human-readable representation of the object, and hence can be useful
+to render in a view for debugging.
+
+```html+erb
+<%= @post.inspect %>
+
+<h1><%= @post.title></h1>
+```
+
+renders:
+
+```
+#<Post id: 1, title: "Debugging Rails with View Helpers", body: "...";, created_at: "2026-03-30 15:04:27.776801000 +0000", updated_at: "2026-03-30 15:04:27.776801000 +0000">
+
+<h1>Debugging Rails with View Helpers</h1>
+```
+
+NOTE: The `inspect` method can be overridden just like any other method. As
+such, its output may differ significantly depending on the object.
+
+### Web-based Ruby Console
+
+The [`web-console`](https://github.com/rails/web-console) gem allows you to
+inject an interactive Ruby console within your view. It's installed in Rails
+apps for the development environment.
+
+Add a `console` directive in your controller or view.
+
+```ruby
+class PostsController < ApplicationController
+  def index
+    @posts = Post.all
+    console
+  end
+end
+```
+
+or
 
 ```html+erb
 <% console %>
 
-<h2>New Post</h2>
+<h1>Posts</h1>
 ```
 
-This will render a console inside your view. You don't need to care about the
-location of the `console` call; it won't be rendered on the spot of its
-invocation but next to your HTML content.
+Navigate to `/posts` in your browser and you'll see a console at the bottom of
+the screen. This is an interative prompt where you can evaluate Ruby expressions
+to inspect the current state of your application.
 
-The console executes pure Ruby code: You can define and instantiate
-custom classes, create new models, and inspect variables.
+NOTE: Only one console can be rendered per request. `web-console` will raise an
+error on a second `console` invocation.
 
-NOTE: Only one console can be rendered per request. Otherwise `web-console`
-will raise an error on the second `console` invocation.
+See the gem's
+[Readme](https://github.com/rails/web-console?tab=readme-ov-file#web-console-)
+for advanced usage and configuration options.
 
-### Inspecting Variables
-
-You can invoke `instance_variables` to list all the instance variables
-available in your context. If you want to list all the local variables, you can
-do that with `local_variables`.
-
-### Settings
-
-* `config.web_console.allowed_ips`: Authorized list of IPv4 or IPv6
-  addresses and networks (defaults: `127.0.0.1/8, ::1`).
-* `config.web_console.whiny_requests`: Log a message when a console rendering
-  is prevented (defaults: `true`).
-
-Since `web-console` evaluates plain Ruby code remotely on the server, don't try
-to use it in production.
+WARNING: Since `web-console` evaluates plain Ruby code remotely on the server,
+never use it in production.
 
 Debugging Memory Leaks
 ----------------------
 
-A Ruby application (on Rails or not), can leak memory — either in the Ruby code
-or at the C code level.
+All Ruby applications can leak memory — either within the Ruby itself or lower
+down in C code. This is a broad topic so this guide will not go into detail on
+this subject.
 
-In this section, you will learn how to find and fix such leaks by using tools
-such as Valgrind.
-
-### Valgrind
-
-[Valgrind](http://valgrind.org/) is an application for detecting C-based memory
-leaks and race conditions.
-
-There are Valgrind tools that can automatically detect many memory management
-and threading bugs, and profile your programs in detail. For example, if a C
-extension in the interpreter calls `malloc()` but doesn't properly call
-`free()`, this memory won't be available until the app terminates.
-
-For further information on how to install Valgrind and use with Ruby, refer to
-[Valgrind and Ruby](https://web.archive.org/web/20230518081626/https://blog.evanweaver.com/2008/02/05/valgrind-and-ruby/)
-by Evan Weaver.
-
-### Find a Memory Leak
-
-There is an excellent article about detecting and fixing memory leaks at Derailed, [which you can read here](https://github.com/schneems/derailed_benchmarks#is-my-app-leaking-memory).
-
-
-Plugins for Debugging
----------------------
-
-There are some Rails plugins to help you to find errors and debug your
-application. Here is a list of useful plugins for debugging:
-
-* [Query Trace](https://github.com/ruckus/active-record-query-trace/tree/master) Adds query
-  origin tracing to your logs.
-* [Exception Notifier](https://github.com/kmcphillips/exception_notification/tree/main)
-  Provides a mailer object and a default set of templates for sending email
-  notifications when errors occur in a Rails application.
-* [Better Errors](https://github.com/charliesome/better_errors) Replaces the
-  standard Rails error page with a new one containing more contextual information,
-  like source code and variable inspection.
-* [RailsPanel](https://github.com/dejan/rails_panel) Chrome extension for Rails
-  development that will end your tailing of development.log. Have all information
-  about your Rails app requests in the browser — in the Developer Tools panel.
-  Provides insight to db/rendering/total times, parameter list, rendered views and
-  more.
-* [Pry](https://github.com/pry/pry) An IRB alternative and runtime developer console.
-
-References
-----------
-
-* [web-console Homepage](https://github.com/rails/web-console)
-* [debug homepage](https://github.com/ruby/debug)
+A general approach for finding Ruby memory leaks is to use
+[rbtrace](https://github.com/tmm1/rbtrace), to extract a heap dump and analyze
+it with a heap analyzer.


### PR DESCRIPTION
### Motivation / Background

Rewrite and simplify the debugging guide.

### Detail

* Added a brief "Introduction" section.
* Moved the section on the `debug` gem to the top.
* Simplified the content in the `debug` gem, covering only the most commonly used debugging tasks. I've linked to the docs for further information. I don't want to recreate the `debug` docs within this guide.
* Added a section on remote debugging
* Reorganised and unified the sections about debugging in the view. It now contains sub-sections on debugging helpers and the `web-console` gem.
* Removed the `to_yaml` view helper section as it duplicated the functionality of the `debug` helper.
* Improved the section about the logger after researching how the source code works.
* Reorganised verbose logging config options and SQL query logs into an "advanced logging" section, along with custom loggers.
* Simplified the memory leaks section to signpost external guides.

### Additional information

Specific sections I would like extra attention while reviewing:

1. Remote debugging - I've heavily researched this topic to ensure my wording is technically correct. Please verify this and let me know if I've got any terminology wrong.
2. What is the logger? - An expanded section based on my investigation of the source code. 
3. Debugging memory leaks - I chose to remove links to web archive and specific tools. Instead I've linked 3 articles that might be useful for anyone encountering a memory leak.

### Internal Audit

- Section 2: consider replacing 'at runtime' with 'while it is running' to achieve more beginner-friendly language.
- Similarly to my comments on the ActionCable guide, this guide also dives in at quite a high level, which is possibly to be expected as it's the sort of content that you may not worry about too much until you have a fair bit of confidence with Rails applications. So as not to deter beginners, I think it would be nice to include a general, entry-level paragraph at the beginning of this guide about the different ways of/places for/approaches to debugging, with instructions to read on to learn about them in depth.
- Think it's worth putting the 'Debugging with the Debug Gem' a bit earlier in this guide as it's a bit simpler to digest and understand and might make a good route into some of the harder stuff.

I think the "View Helpers for Debugging", "Debugging with the Debug Gem" and "Debugging with the web-console Gem", should be consecutive (not sure in what order though).
- The "Tagged Logging" and "Impact of Logs on Performance" sections should probably not be part of the "SQL Query Comments" section.
- Maybe we should have a separate top section for debugging SQL queries?
We could also mention [explain](https://edgeapi.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-explain) there.
- I'm not sure the "Debugging Memory Leaks" section is still relevant. The "Valgrind and Ruby" article are from 2008 and probably a bit outdated? The derails_benchmarks article is probably still current, but I'm not sure debugging memory leaks should be part of this guide?
- The "Plugins for Debugging" section can probably be removed? We try not to link to gems that aren't required in a Rails app or aren't part of the Rails organization. 
- The "References" section can probably removed. Links can be inlined.
The Logger
- "By default, each log is created under Rails.root/log/ and the log file is named after the environment in which the application is running." This is no longer true for production, where we log to STDOUT for a new Rails application.
- We could mention logging with a block in the "Sending messages" section.
Using a block can help avoid doing expensive work that isn't logged (ah this is already mentioned in the "Impact of Logs on Performance" section.

- "As with other verbose loggers, it is not recommended to be used in production environments." should probably be a WARNING as well.

SQL Query Comments
- I think this shouldn't be a top section (tagged logging and performance aren't really related). We can probably reorganize with the previous section as:
  - The Logger:
    - "What is the Logger?" 
    - Log Levels
    - Sending Messages (or rename to "Logging Messages"?)
    - Impact of Logs on Performance
  - Advanced Logging
    - Verbose Query Logs
    - Verbose Enqueue Logs
    - Verbose Redirect Logs
    - SQL Query Comments
    - Tagged Logging (not sure if this would be better under The Logge
    

Debugging with debug gem
- Use the simpler`debugger` statement first, before the `binding.break` and `binding.b` statements.
- The first example could use line highlighting to highlight the debug statement.
- The example calling `@post` could show some posts instead of an empty array.
- Mention that `pp` calls pretty print which formats the output.
- Unlike the `p` and `pp` commands, the `info`, `backtrace` and `outline` commands have seperate sections.

Debugging with webconsole gem
- "Since web-console evaluates plain Ruby code remotely on the server, don't try to use it in production." Should probably be a WARNING. Maybe add something like: "If an unauthorized user could access the web-console they could change anything in your database".

Sections like "Breakpoints" are formatted a bit unconventional. 
Maybe use an code example block instead?