### PR TITLE
Consolidate `ALTER TABLE` building into `AlterTable`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -22,13 +22,19 @@ module ActiveRecord
 
       private
         def visit_AlterTable(o)
-          sql = +"ALTER TABLE #{quote_table_name(o.name)} "
-          sql << o.adds.map { |col| accept col }.join(" ")
-          sql << o.foreign_key_adds.map { |fk| visit_AddForeignKey fk }.join(" ")
-          sql << o.foreign_key_drops.map { |fk| visit_DropForeignKey fk }.join(" ")
-          sql << o.check_constraint_adds.map { |con| visit_AddCheckConstraint con }.join(" ")
-          sql << o.check_constraint_drops.map { |con| visit_DropCheckConstraint con }.join(" ")
-          sql << o.constraint_drops.map { |con| visit_DropConstraint con }.join(" ")
+          "ALTER TABLE #{quote_table_name(o.name)} #{o.operations.map { |op| accept(op) }.join(', ')}"
+        end
+
+        def visit_DropColumn(o)
+          "DROP COLUMN #{quote_column_name(o.name)}"
+        end
+
+        def visit_RenameColumn(o)
+          "RENAME COLUMN #{quote_column_name(o.from_name)} TO #{quote_column_name(o.to_name)}"
+        end
+
+        def visit_ChangeColumnNull(o)
+          "ALTER COLUMN #{quote_column_name(o.name)} #{o.null ? 'DROP' : 'SET'} NOT NULL"
         end
 
         def visit_ColumnDefinition(o)
@@ -94,11 +100,11 @@ module ActiveRecord
         end
 
         def visit_AddForeignKey(o)
-          "ADD #{accept(o)}"
+          "ADD #{accept(o.foreign_key)}"
         end
 
-        def visit_DropConstraint(name)
-          "DROP CONSTRAINT #{quote_column_name(name)}"
+        def visit_DropConstraint(o)
+          "DROP CONSTRAINT #{quote_column_name(o.name)}"
         end
         alias :visit_DropForeignKey :visit_DropConstraint
         alias :visit_DropCheckConstraint :visit_DropConstraint
@@ -127,7 +133,7 @@ module ActiveRecord
         end
 
         def visit_AddCheckConstraint(o)
-          "ADD #{accept(o)}"
+          "ADD #{accept(o.check_constraint)}"
         end
 
         def quoted_columns(o)

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -116,6 +116,15 @@ module ActiveRecord
 
     ChangeColumnDefaultDefinition = Struct.new(:column, :default) # :nodoc:
 
+    AddForeignKey = Data.define(:foreign_key) # :nodoc:
+    DropForeignKey = Data.define(:name) # :nodoc:
+    AddCheckConstraint = Data.define(:check_constraint) # :nodoc:
+    DropCheckConstraint = Data.define(:name) # :nodoc:
+    DropConstraint = Data.define(:name) # :nodoc:
+    DropColumn = Data.define(:name) # :nodoc:
+    RenameColumn = Data.define(:from_name, :to_name) # :nodoc:
+    ChangeColumnNull = Data.define(:name, :null) # :nodoc:
+
     CreateIndexDefinition = Struct.new(:index, :algorithm, :if_not_exists, :lock) # :nodoc:
 
     PrimaryKeyDefinition = Struct.new(:name) # :nodoc:
@@ -358,7 +367,7 @@ module ActiveRecord
     class TableDefinition
       include ColumnMethods
 
-      attr_reader :name, :temporary, :if_not_exists, :options, :as, :comment, :indexes, :foreign_keys, :check_constraints
+      attr_reader :name, :temporary, :if_not_exists, :options, :as, :comment, :indexes, :foreign_keys, :check_constraints, :conn
 
       def initialize(
         conn,
@@ -621,47 +630,90 @@ module ActiveRecord
     end
 
     class AlterTable # :nodoc:
-      attr_reader :adds
-      attr_reader :foreign_key_adds, :foreign_key_drops
-      attr_reader :check_constraint_adds, :check_constraint_drops
-      attr_reader :constraint_drops
+      # Commands from CommandRecorder that can be dispatched directly to AlterTable
+      # methods (combinable into a single ALTER TABLE statement). Subclasses may extend.
+      COMBINABLE_COMMANDS = %i[
+        add_column
+        remove_column
+        remove_columns
+        change_column_default
+        add_timestamps
+        remove_timestamps
+      ].freeze
+
+      attr_reader :operations, :deferred_operations
 
       def initialize(td)
-        @td   = td
-        @adds = []
-        @foreign_key_adds = []
-        @foreign_key_drops = []
-        @check_constraint_adds = []
-        @check_constraint_drops = []
-        @constraint_drops = []
+        @td = td
+        @operations = []
+        @deferred_operations = []
       end
 
       def name; @td.name; end
 
+      def add_column(column_name, type, **options)
+        column_name = column_name.to_s
+        type = type.to_sym
+        @operations << AddColumnDefinition.new(@td.new_column_definition(column_name, type, **options))
+      end
+
+      def remove_column(column_name, _type = nil, **)
+        @operations << DropColumn.new(column_name)
+      end
+
+      def remove_columns(*column_names, **)
+        column_names.each { |column_name| remove_column(column_name) }
+      end
+
+      def change_column_default(column_name, default_or_changes)
+        conn = @td.conn
+        column = conn.send(:column_for, name, column_name)
+        return unless column
+        default = conn.send(:extract_new_default_value, default_or_changes)
+        @operations << ChangeColumnDefaultDefinition.new(column, default)
+      end
+
+      def rename_column(from_name, to_name)
+        @operations << RenameColumn.new(from_name, to_name)
+      end
+
+      def change_column_null(name, null)
+        @operations << ChangeColumnNull.new(name, null)
+      end
+
+      def add_timestamps(**options)
+        options[:null] = false if options[:null].nil?
+        add_column(:created_at, :datetime, **options)
+        add_column(:updated_at, :datetime, **options)
+      end
+
+      def remove_timestamps(**)
+        remove_column(:updated_at)
+        remove_column(:created_at)
+      end
+
       def add_foreign_key(to_table, options)
-        @foreign_key_adds << @td.new_foreign_key_definition(to_table, options)
+        @operations << AddForeignKey.new(@td.new_foreign_key_definition(to_table, options))
       end
 
       def drop_foreign_key(name)
-        @foreign_key_drops << name
+        @operations << DropForeignKey.new(name)
       end
 
       def add_check_constraint(expression, options)
-        @check_constraint_adds << @td.new_check_constraint_definition(expression, options)
+        @operations << AddCheckConstraint.new(@td.new_check_constraint_definition(expression, options))
       end
 
       def drop_check_constraint(constraint_name)
-        @check_constraint_drops << constraint_name
+        @operations << DropCheckConstraint.new(constraint_name)
       end
 
       def drop_constraint(constraint_name)
-        @constraint_drops << constraint_name
+        @operations << DropConstraint.new(constraint_name)
       end
 
-      def add_column(name, type, **options)
-        name = name.to_s
-        type = type.to_sym
-        @adds << AddColumnDefinition.new(@td.new_column_definition(name, type, **options))
+      def empty?
+        @operations.empty?
       end
     end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -687,35 +687,17 @@ module ActiveRecord
       #
       # Note: only supported by MySQL.
       def add_column(table_name, column_name, type, **options)
-        add_column_def = build_add_column_definition(table_name, column_name, type, **options)
-        return unless add_column_def
+        return if options[:if_not_exists] == true && column_exists?(table_name, column_name)
 
-        execute schema_creation.accept(add_column_def)
+        at = create_alter_table(table_name)
+        at.add_column(column_name, type, **options)
+        execute_alter_table(at)
       end
 
       def add_columns(table_name, *column_names, type:, **options) # :nodoc:
         column_names.each do |column_name|
           add_column(table_name, column_name, type, **options)
         end
-      end
-
-      # Builds an AlterTable object for adding a column to a table.
-      #
-      # This definition object contains information about the column that would be created
-      # if the same arguments were passed to #add_column. See #add_column for information about
-      # passing a +table_name+, +column_name+, +type+ and other options that can be passed.
-      def build_add_column_definition(table_name, column_name, type, **options) # :nodoc:
-        return if options[:if_not_exists] == true && column_exists?(table_name, column_name)
-
-        if supports_datetime_with_precision?
-          if type == :datetime && !options.key?(:precision)
-            options[:precision] = 6
-          end
-        end
-
-        alter_table = create_alter_table(table_name)
-        alter_table.add_column(column_name, type, **options)
-        alter_table
       end
 
       # Removes the given columns from the table definition.
@@ -730,8 +712,9 @@ module ActiveRecord
           raise ArgumentError.new("You must specify at least one column name. Example: remove_columns(:people, :first_name)")
         end
 
-        remove_column_fragments = remove_columns_for_alter(table_name, *column_names, type: type, **options)
-        execute "ALTER TABLE #{quote_table_name(table_name)} #{remove_column_fragments.join(', ')}"
+        at = create_alter_table(table_name)
+        column_names.each { |column_name| at.remove_column(column_name) }
+        execute_alter_table(at)
       end
 
       # Removes the column from the table definition.
@@ -758,7 +741,9 @@ module ActiveRecord
       def remove_column(table_name, column_name, type = nil, **options)
         return if options[:if_exists] == true && !column_exists?(table_name, column_name)
 
-        execute "ALTER TABLE #{quote_table_name(table_name)} #{remove_column_for_alter(table_name, column_name, type, **options)}"
+        at = create_alter_table(table_name)
+        at.remove_column(column_name)
+        execute_alter_table(at)
       end
 
       # Changes the column's definition according to the new options.
@@ -792,15 +777,6 @@ module ActiveRecord
       #
       def change_column_default(table_name, column_name, default_or_changes)
         raise NotImplementedError, "change_column_default is not implemented"
-      end
-
-      # Builds a ChangeColumnDefaultDefinition object.
-      #
-      # This definition object contains information about the column change that would occur
-      # if the same arguments were passed to #change_column_default. See #change_column_default for
-      # information about passing a +table_name+, +column_name+, +type+ and other options that can be passed.
-      def build_change_column_default_definition(table_name, column_name, default_or_changes) # :nodoc:
-        raise NotImplementedError, "build_change_column_default_definition is not implemented"
       end
 
       # Sets or removes a <tt>NOT NULL</tt> constraint on a column. The +null+ flag
@@ -1290,7 +1266,7 @@ module ActiveRecord
         at = create_alter_table from_table
         at.add_foreign_key to_table, options
 
-        execute schema_creation.accept(at)
+        execute_alter_table(at)
       end
 
       # Removes the given foreign key from the table. Any option parameters provided
@@ -1333,7 +1309,7 @@ module ActiveRecord
         at = create_alter_table from_table
         at.drop_foreign_key fk_name_to_delete
 
-        execute schema_creation.accept(at)
+        execute_alter_table(at)
       end
 
       # Changes an existing foreign key on a table. Currently only the PostgreSQL
@@ -1419,7 +1395,7 @@ module ActiveRecord
         at = create_alter_table(table_name)
         at.add_check_constraint(expression, options)
 
-        execute schema_creation.accept(at)
+        execute_alter_table(at)
       end
 
       def check_constraint_options(table_name, expression, options) # :nodoc:
@@ -1451,7 +1427,7 @@ module ActiveRecord
         at = create_alter_table(table_name)
         at.drop_check_constraint(chk_name_to_delete)
 
-        execute schema_creation.accept(at)
+        execute_alter_table(at)
       end
 
       # Checks to see if a check constraint exists on a table for a given check constraint definition.
@@ -1469,7 +1445,7 @@ module ActiveRecord
         at = create_alter_table(table_name)
         at.drop_constraint(constraint_name)
 
-        execute schema_creation.accept(at)
+        execute_alter_table(at)
       end
 
       def dump_schema_versions # :nodoc:
@@ -1580,8 +1556,9 @@ module ActiveRecord
       #   add_timestamps(:suppliers, null: true)
       #
       def add_timestamps(table_name, **options)
-        fragments = add_timestamps_for_alter(table_name, **options)
-        execute "ALTER TABLE #{quote_table_name(table_name)} #{fragments.join(', ')}"
+        at = create_alter_table(table_name)
+        at.add_timestamps(**options)
+        execute_alter_table(at)
       end
 
       # Removes the timestamp columns (+created_at+ and +updated_at+) from the table definition.
@@ -1690,28 +1667,21 @@ module ActiveRecord
       end
 
       def bulk_change_table(table_name, operations) # :nodoc:
-        sql_fragments = []
-        non_combinable_operations = []
+        alter_table = create_alter_table(table_name)
 
         operations.each do |command, args|
           args.shift # remove table_name
-          method = :"#{command}_for_alter"
 
-          if respond_to?(method, true)
-            sqls, procs = Array(send(method, table_name, *args)).partition { |v| v.is_a?(String) }
-            sql_fragments.concat(sqls)
-            non_combinable_operations.concat(procs)
+          if alter_table.class::COMBINABLE_COMMANDS.include?(command)
+            alter_table.public_send(command, *args)
           else
-            execute "ALTER TABLE #{quote_table_name(table_name)} #{sql_fragments.join(", ")}" unless sql_fragments.empty?
-            non_combinable_operations.each(&:call)
-            sql_fragments = []
-            non_combinable_operations = []
+            execute_alter_table(alter_table)
+            alter_table = create_alter_table(table_name)
             send(command, table_name, *args)
           end
         end
 
-        execute "ALTER TABLE #{quote_table_name(table_name)} #{sql_fragments.join(", ")}" unless sql_fragments.empty?
-        non_combinable_operations.each(&:call)
+        execute_alter_table(alter_table)
       end
 
       def valid_table_definition_options # :nodoc:
@@ -1849,6 +1819,12 @@ module ActiveRecord
 
         def create_alter_table(name)
           AlterTable.new create_table_definition(name)
+        end
+
+        def execute_alter_table(alter_table)
+          result = execute(schema_creation.accept(alter_table)) unless alter_table.empty?
+          alter_table.deferred_operations.each(&:call)
+          result
         end
 
         def validate_create_table_options!(options)
@@ -1999,46 +1975,6 @@ module ActiveRecord
 
         def reference_name_for_table(table_name)
           table_name.to_s.singularize
-        end
-
-        def add_column_for_alter(table_name, column_name, type, **options)
-          td = create_table_definition(table_name)
-          cd = td.new_column_definition(column_name, type, **options)
-          schema_creation.accept(AddColumnDefinition.new(cd))
-        end
-
-        def change_column_default_for_alter(table_name, column_name, default_or_changes)
-          cd = build_change_column_default_definition(table_name, column_name, default_or_changes)
-          schema_creation.accept(cd)
-        end
-
-        def rename_column_sql(table_name, column_name, new_column_name)
-          "RENAME COLUMN #{quote_column_name(column_name)} TO #{quote_column_name(new_column_name)}"
-        end
-
-        def remove_column_for_alter(table_name, column_name, type = nil, **options)
-          "DROP COLUMN #{quote_column_name(column_name)}"
-        end
-
-        def remove_columns_for_alter(table_name, *column_names, **options)
-          column_names.map { |column_name| remove_column_for_alter(table_name, column_name) }
-        end
-
-        def add_timestamps_for_alter(table_name, **options)
-          options[:null] = false if options[:null].nil?
-
-          if !options.key?(:precision) && supports_datetime_with_precision?
-            options[:precision] = 6
-          end
-
-          [
-            add_column_for_alter(table_name, :created_at, :datetime, **options),
-            add_column_for_alter(table_name, :updated_at, :datetime, **options)
-          ]
-        end
-
-        def remove_timestamps_for_alter(table_name, **options)
-          remove_columns_for_alter(table_name, :updated_at, :created_at)
         end
 
         def insert_versions_sql(versions)

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -410,15 +410,9 @@ module ActiveRecord
       end
 
       def change_column_default(table_name, column_name, default_or_changes) # :nodoc:
-        execute "ALTER TABLE #{quote_table_name(table_name)} #{change_column_default_for_alter(table_name, column_name, default_or_changes)}"
-      end
-
-      def build_change_column_default_definition(table_name, column_name, default_or_changes) # :nodoc:
-        column = column_for(table_name, column_name)
-        return unless column
-
-        default = extract_new_default_value(default_or_changes)
-        ChangeColumnDefaultDefinition.new(column, default)
+        at = create_alter_table(table_name)
+        at.change_column_default(column_name, default_or_changes)
+        execute_alter_table(at)
       end
 
       def change_column_null(table_name, column_name, null, default = nil) # :nodoc:
@@ -437,11 +431,13 @@ module ActiveRecord
       end
 
       def add_column(table_name, column_name, type, **options) # :nodoc:
+        return if options[:if_not_exists] == true && column_exists?(table_name, column_name)
+
         algorithm = index_algorithm(options.delete(:algorithm))
         lock = lock_clause(options.delete(:lock))
-        add_column_def = build_add_column_definition(table_name, column_name, type, **options)
-        return unless add_column_def
-        sql = schema_creation.accept(add_column_def)
+        at = create_alter_table(table_name)
+        at.add_column(column_name, type, **options)
+        sql = +schema_creation.accept(at)
         sql << ", #{algorithm}" if algorithm
         sql << ", #{lock}" if lock
         execute(sql)
@@ -450,56 +446,20 @@ module ActiveRecord
       def change_column(table_name, column_name, type, **options) # :nodoc:
         algorithm = index_algorithm(options.delete(:algorithm))
         lock = lock_clause(options.delete(:lock))
-        sql = +"ALTER TABLE #{quote_table_name(table_name)} #{change_column_for_alter(table_name, column_name, type, **options)}"
+        at = create_alter_table(table_name)
+        at.change_column(column_name, type, **options)
+        sql = +schema_creation.accept(at)
         sql << ", #{algorithm}" if algorithm
         sql << ", #{lock}" if lock
         execute(sql)
       end
 
-      # Builds a ChangeColumnDefinition object.
-      #
-      # This definition object contains information about the column change that would occur
-      # if the same arguments were passed to #change_column. See #change_column for information about
-      # passing a +table_name+, +column_name+, +type+ and other options that can be passed.
-      def build_change_column_definition(table_name, column_name, type, **options) # :nodoc:
-        column = column_for(table_name, column_name)
-        type ||= column.sql_type
-
-        unless options.key?(:default)
-          options[:default] = if column.default_function
-            -> { column.default_function }
-          else
-            column.default
-          end
-        end
-
-        unless options.key?(:null)
-          options[:null] = column.null
-        end
-
-        unless options.key?(:comment)
-          options[:comment] = column.comment
-        end
-
-        if options[:collation] == :no_collation
-          options.delete(:collation)
-        else
-          options[:collation] ||= column.collation if text_type?(type)
-        end
-
-        unless options.key?(:auto_increment)
-          options[:auto_increment] = column.auto_increment?
-        end
-
-        td = create_table_definition(table_name)
-        cd = td.new_column_definition(column.name, type, **options)
-        ChangeColumnDefinition.new(cd, column.name)
-      end
-
       def rename_column(table_name, column_name, new_column_name, **options) # :nodoc:
         algorithm = index_algorithm(options.delete(:algorithm))
         lock = lock_clause(options.delete(:lock))
-        sql = +"ALTER TABLE #{quote_table_name(table_name)} #{rename_column_for_alter(table_name, column_name, new_column_name)}"
+        at = create_alter_table(table_name)
+        at.rename_column(column_name, new_column_name)
+        sql = +schema_creation.accept(at)
         sql << ", #{algorithm}" if algorithm
         sql << ", #{lock}" if lock
         execute(sql)
@@ -989,47 +949,6 @@ module ActiveRecord
           else
             super
           end
-        end
-
-        def change_column_for_alter(table_name, column_name, type, **options)
-          cd = build_change_column_definition(table_name, column_name, type, **options)
-          schema_creation.accept(cd)
-        end
-
-        def rename_column_for_alter(table_name, column_name, new_column_name)
-          return rename_column_sql(table_name, column_name, new_column_name) if supports_rename_column?
-
-          column  = column_for(table_name, column_name)
-          options = {
-            default: column.default,
-            null: column.null,
-            auto_increment: column.auto_increment?,
-            comment: column.comment
-          }
-
-          current_type = query_one("SHOW COLUMNS FROM #{quote_table_name(table_name)} LIKE #{quote(column_name)}")["Type"]
-          td = create_table_definition(table_name)
-          cd = td.new_column_definition(new_column_name, current_type, **options)
-          schema_creation.accept(ChangeColumnDefinition.new(cd, column.name))
-        end
-
-        def add_index_for_alter(table_name, column_name, **options)
-          lock = lock_clause(options.delete(:lock))
-          index, algorithm, _ = add_index_options(table_name, column_name, **options)
-          algorithm = ", #{algorithm}" if algorithm
-          lock = ", #{lock}" if lock
-
-          "ADD #{schema_creation.accept(index)}#{algorithm}#{lock}"
-        end
-
-        def remove_index_for_alter(table_name, column_name = nil, **options)
-          algorithm = index_algorithm(options.delete(:algorithm))
-          lock = lock_clause(options.delete(:lock))
-          index_name = index_name_for_remove(table_name, column_name, options)
-          sql = +"DROP INDEX #{quote_column_name(index_name)}"
-          sql << ", #{algorithm}" if algorithm
-          sql << ", #{lock}" if lock
-          sql
         end
 
         def supports_insert_raw_alias_syntax?

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
@@ -7,12 +7,26 @@ module ActiveRecord
         delegate :add_sql_comment!, :mariadb?, to: :@conn, private: true
 
         private
-          def visit_DropForeignKey(name)
-            "DROP FOREIGN KEY #{name}"
+          def visit_DropForeignKey(o)
+            "DROP FOREIGN KEY #{o.name}"
           end
 
-          def visit_DropCheckConstraint(name)
-            "DROP #{mariadb? ? 'CONSTRAINT' : 'CHECK'} #{name}"
+          def visit_DropCheckConstraint(o)
+            "DROP #{mariadb? ? 'CONSTRAINT' : 'CHECK'} #{o.name}"
+          end
+
+          def visit_AddIndex(o)
+            sql = +"ADD #{accept(o.index)}"
+            sql << ", #{o.algorithm}" if o.algorithm
+            sql << ", #{o.lock}" if o.lock
+            sql
+          end
+
+          def visit_DropIndex(o)
+            sql = +"DROP INDEX #{quote_column_name(o.name)}"
+            sql << ", #{o.algorithm}" if o.algorithm
+            sql << ", #{o.lock}" if o.lock
+            sql
           end
 
           def visit_AddColumnDefinition(o)

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
@@ -112,6 +112,82 @@ module ActiveRecord
           end
       end
 
+      AddIndex = Data.define(:index, :algorithm, :lock) # :nodoc:
+      DropIndex = Data.define(:name, :algorithm, :lock) # :nodoc:
+
+      # = Active Record MySQL Adapter Alter \Table
+      class AlterTable < ActiveRecord::ConnectionAdapters::AlterTable # :nodoc:
+        COMBINABLE_COMMANDS = (superclass::COMBINABLE_COMMANDS + %i[change_column rename_column add_index remove_index]).freeze
+
+        def add_index(column_name, **options)
+          conn = @td.conn
+          lock = conn.lock_clause(options.delete(:lock))
+          index, algorithm, _ = conn.add_index_options(name, column_name, **options)
+          @operations << AddIndex.new(index, algorithm, lock)
+        end
+
+        def remove_index(column_name = nil, **options)
+          conn = @td.conn
+          algorithm = conn.index_algorithm(options.delete(:algorithm))
+          lock = conn.lock_clause(options.delete(:lock))
+          index_name = conn.send(:index_name_for_remove, name, column_name, options)
+          @operations << DropIndex.new(index_name, algorithm, lock)
+        end
+
+        def change_column(column_name, type, **options)
+          conn = @td.conn
+          column = conn.send(:column_for, name, column_name)
+          type ||= column.sql_type
+
+          unless options.key?(:default)
+            options[:default] = if column.default_function
+              -> { column.default_function }
+            else
+              column.default
+            end
+          end
+
+          unless options.key?(:null)
+            options[:null] = column.null
+          end
+
+          unless options.key?(:comment)
+            options[:comment] = column.comment
+          end
+
+          if options[:collation] == :no_collation
+            options.delete(:collation)
+          else
+            options[:collation] ||= column.collation if conn.send(:text_type?, type)
+          end
+
+          unless options.key?(:auto_increment)
+            options[:auto_increment] = column.auto_increment?
+          end
+
+          cd = @td.new_column_definition(column.name, type, **options)
+          @operations << ChangeColumnDefinition.new(cd, column.name)
+        end
+
+        def rename_column(from_name, to_name)
+          conn = @td.conn
+          if conn.send(:supports_rename_column?)
+            super
+          else
+            column = conn.send(:column_for, name, from_name)
+            options = {
+              default: column.default,
+              null: column.null,
+              auto_increment: column.auto_increment?,
+              comment: column.comment
+            }
+            current_type = conn.query_one("SHOW COLUMNS FROM #{conn.quote_table_name(name)} LIKE #{conn.quote(from_name)}")["Type"]
+            cd = @td.new_column_definition(to_name, current_type, **options)
+            @operations << ChangeColumnDefinition.new(cd, column.name)
+          end
+        end
+      end
+
       # = Active Record MySQL Adapter \Table
       class Table < ActiveRecord::ConnectionAdapters::Table
         include ColumnMethods

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -96,7 +96,9 @@ module ActiveRecord
           algorithm = index_algorithm(options.delete(:algorithm))
           lock = lock_clause(options.delete(:lock))
           return if options[:if_exists] == true && !column_exists?(table_name, column_name)
-          sql = +"ALTER TABLE #{quote_table_name(table_name)} #{remove_column_for_alter(table_name, column_name, type, **options)}"
+          at = create_alter_table(table_name)
+          at.remove_column(column_name)
+          sql = +schema_creation.accept(at)
           sql << ", #{algorithm}" if algorithm
           sql << ", #{lock}" if lock
           execute(sql)
@@ -192,6 +194,10 @@ module ActiveRecord
 
           def create_table_definition(name, **options)
             MySQL::TableDefinition.new(self, name, **options)
+          end
+
+          def create_alter_table(name)
+            MySQL::AlterTable.new create_table_definition(name)
           end
 
           def new_column_from_field(table_name, field, _definitions)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
@@ -8,16 +8,9 @@ module ActiveRecord
           delegate :quoted_include_columns_for_index, to: :@conn
           delegate :database_version, to: :@conn
 
-          def visit_AlterTable(o)
-            sql = super
-            sql << o.constraint_validations.map { |fk| visit_ValidateConstraint fk }.join(" ")
-            sql << o.exclusion_constraint_adds.map { |con| visit_AddExclusionConstraint con }.join(" ")
-            sql << o.unique_constraint_adds.map { |con| visit_AddUniqueConstraint con }.join(" ")
-          end
-
           def visit_AddForeignKey(o)
             super.dup.tap do |sql|
-              sql << " NOT VALID" unless o.validate?
+              sql << " NOT VALID" unless o.foreign_key.validate?
             end
           end
 
@@ -32,8 +25,8 @@ module ActiveRecord
             super.dup.tap { |sql| sql << " NOT VALID" unless o.validate? }
           end
 
-          def visit_ValidateConstraint(name)
-            "VALIDATE CONSTRAINT #{quote_column_name(name)}"
+          def visit_ValidateConstraint(o)
+            "VALIDATE CONSTRAINT #{quote_column_name(o.name)}"
           end
 
           def visit_ExclusionConstraintDefinition(o)
@@ -70,11 +63,11 @@ module ActiveRecord
           end
 
           def visit_AddExclusionConstraint(o)
-            "ADD #{accept(o)}"
+            "ADD #{accept(o.exclusion_constraint)}"
           end
 
           def visit_AddUniqueConstraint(o)
-            "ADD #{accept(o)}"
+            "ADD #{accept(o.unique_constraint)}"
           end
 
           def visit_ChangeColumnDefinition(o)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
@@ -233,6 +233,10 @@ module ActiveRecord
         end
       end
 
+      ValidateConstraint = Data.define(:name) # :nodoc:
+      AddExclusionConstraint = Data.define(:exclusion_constraint) # :nodoc:
+      AddUniqueConstraint = Data.define(:unique_constraint) # :nodoc:
+
       # = Active Record PostgreSQL Adapter \Table Definition
       class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
         include ColumnMethods
@@ -375,27 +379,48 @@ module ActiveRecord
       end
 
       # = Active Record PostgreSQL Adapter Alter \Table
-      class AlterTable < ActiveRecord::ConnectionAdapters::AlterTable
-        attr_reader :constraint_validations, :exclusion_constraint_adds, :unique_constraint_adds
+      class AlterTable < ActiveRecord::ConnectionAdapters::AlterTable # :nodoc:
+        COMBINABLE_COMMANDS = (superclass::COMBINABLE_COMMANDS + %i[change_column change_column_null]).freeze
 
-        def initialize(td)
+        def add_column(column_name, type, **options)
           super
-          @constraint_validations = []
-          @exclusion_constraint_adds = []
-          @unique_constraint_adds = []
+          defer_comment(column_name, options[:comment]) if options.key?(:comment)
+        end
+
+        def change_column(column_name, type, **options)
+          cd = @td.new_column_definition(column_name, type, **options)
+          @operations << ChangeColumnDefinition.new(cd, column_name)
+          defer_comment(column_name, options[:comment]) if options.key?(:comment)
+        end
+
+        def change_column_null(column_name, null, default = nil)
+          if default.nil?
+            super(column_name, null)
+          else
+            conn = @td.conn
+            table_name = name
+            @deferred_operations << -> { conn.change_column_null(table_name, column_name, null, default) }
+          end
         end
 
         def validate_constraint(name)
-          @constraint_validations << name
+          @operations << ValidateConstraint.new(name)
         end
 
         def add_exclusion_constraint(expression, options)
-          @exclusion_constraint_adds << @td.new_exclusion_constraint_definition(expression, options)
+          @operations << AddExclusionConstraint.new(@td.new_exclusion_constraint_definition(expression, options))
         end
 
         def add_unique_constraint(column_name, options)
-          @unique_constraint_adds << @td.new_unique_constraint_definition(column_name, options)
+          @operations << AddUniqueConstraint.new(@td.new_unique_constraint_definition(column_name, options))
         end
+
+        private
+          def defer_comment(column_name, comment)
+            conn = @td.conn
+            table_name = name
+            @deferred_operations << -> { conn.change_column_comment(table_name, column_name, comment) }
+          end
       end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -632,38 +632,20 @@ module ActiveRecord
         def add_column(table_name, column_name, type, **options) # :nodoc:
           clear_cache!
           super
-          change_column_comment(table_name, column_name, options[:comment]) if options.key?(:comment)
         end
 
         def change_column(table_name, column_name, type, **options) # :nodoc:
           clear_cache!
-          sqls, procs = Array(change_column_for_alter(table_name, column_name, type, **options)).partition { |v| v.is_a?(String) }
-          execute "ALTER TABLE #{quote_table_name(table_name)} #{sqls.join(", ")}"
-          procs.each(&:call)
-        end
-
-        # Builds a ChangeColumnDefinition object.
-        #
-        # This definition object contains information about the column change that would occur
-        # if the same arguments were passed to #change_column. See #change_column for information about
-        # passing a +table_name+, +column_name+, +type+ and other options that can be passed.
-        def build_change_column_definition(table_name, column_name, type, **options) # :nodoc:
-          td = create_table_definition(table_name)
-          cd = td.new_column_definition(column_name, type, **options)
-          ChangeColumnDefinition.new(cd, column_name)
+          at = create_alter_table(table_name)
+          at.change_column(column_name, type, **options)
+          execute_alter_table(at)
         end
 
         # Changes the default value of a table column.
         def change_column_default(table_name, column_name, default_or_changes) # :nodoc:
-          execute "ALTER TABLE #{quote_table_name(table_name)} #{change_column_default_for_alter(table_name, column_name, default_or_changes)}"
-        end
-
-        def build_change_column_default_definition(table_name, column_name, default_or_changes) # :nodoc:
-          column = column_for(table_name, column_name)
-          return unless column
-
-          default = extract_new_default_value(default_or_changes)
-          ChangeColumnDefaultDefinition.new(column, default)
+          at = create_alter_table(table_name)
+          at.change_column_default(column_name, default_or_changes)
+          execute_alter_table(at)
         end
 
         def change_column_null(table_name, column_name, null, default = nil) # :nodoc:
@@ -692,7 +674,9 @@ module ActiveRecord
         # Renames a column in a table.
         def rename_column(table_name, column_name, new_column_name) # :nodoc:
           clear_cache!
-          execute("ALTER TABLE #{quote_table_name(table_name)} #{rename_column_sql(table_name, column_name, new_column_name)}")
+          at = create_alter_table(table_name)
+          at.rename_column(column_name, new_column_name)
+          execute_alter_table(at)
           rename_column_indexes(table_name, column_name, new_column_name)
         end
 
@@ -940,7 +924,7 @@ module ActiveRecord
           at = create_alter_table(table_name)
           at.add_exclusion_constraint(expression, options)
 
-          execute schema_creation.accept(at)
+          execute_alter_table(at)
         end
 
         def exclusion_constraint_options(table_name, expression, options) # :nodoc:
@@ -1002,7 +986,7 @@ module ActiveRecord
           at = create_alter_table(table_name)
           at.add_unique_constraint(column_name, options)
 
-          execute schema_creation.accept(at)
+          execute_alter_table(at)
         end
 
         def unique_constraint_options(table_name, column_name, options) # :nodoc:
@@ -1109,7 +1093,7 @@ module ActiveRecord
           at = create_alter_table table_name
           at.validate_constraint constraint_name
 
-          execute schema_creation.accept(at)
+          execute_alter_table(at)
         end
 
         # Validates the given foreign key.
@@ -1298,26 +1282,6 @@ module ActiveRecord
           def reference_name_for_table(table_name)
             _schema, table_name = extract_schema_qualified_name(table_name.to_s)
             table_name.singularize
-          end
-
-          def add_column_for_alter(table_name, column_name, type, **options)
-            return super unless options.key?(:comment)
-            [super, Proc.new { change_column_comment(table_name, column_name, options[:comment]) }]
-          end
-
-          def change_column_for_alter(table_name, column_name, type, **options)
-            change_col_def = build_change_column_definition(table_name, column_name, type, **options)
-            sqls = [schema_creation.accept(change_col_def)]
-            sqls << Proc.new { change_column_comment(table_name, column_name, options[:comment]) } if options.key?(:comment)
-            sqls
-          end
-
-          def change_column_null_for_alter(table_name, column_name, null, default = nil)
-            if default.nil?
-              "ALTER COLUMN #{quote_column_name(column_name)} #{null ? 'DROP' : 'SET'} NOT NULL"
-            else
-              Proc.new { change_column_null(table_name, column_name, null, default) }
-            end
           end
 
           def add_index_opclass(quoted_columns, **options)

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/connection_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/connection_test.rb
@@ -185,10 +185,11 @@ class ConnectionTest < ActiveRecord::AbstractMysqlTestCase
     assert_equal "SCHEMA", @subscriber.logged[0][1]
   end
 
-  def test_logs_name_rename_column_for_alter
+  def test_logs_name_rename_column_via_alter_table
     @connection.execute "CREATE TABLE `bar_baz` (`foo` varchar(255))"
     @subscriber.logged.clear
-    @connection.send(:rename_column_for_alter, "bar_baz", "foo", "foo2")
+    at = @connection.send(:create_alter_table, "bar_baz")
+    at.rename_column("foo", "foo2")
     if @connection.send(:supports_rename_column?)
       assert_empty @subscriber.logged
     else

--- a/activerecord/test/cases/migration/schema_definitions_test.rb
+++ b/activerecord/test/cases/migration/schema_definitions_test.rb
@@ -78,28 +78,31 @@ module ActiveRecord
       end
 
       unless current_adapter?(:SQLite3Adapter)
-        def test_build_change_column_definition
+        def test_change_column_via_alter_table
           connection.create_table(:test) do |t|
             t.column :foo, :string
           end
 
-          change_cd = connection.build_change_column_definition(:test, :foo, :integer)
-          change_col = change_cd.column
-          assert_equal "foo", change_col.name.to_s
+          at = connection.send(:create_alter_table, :test)
+          at.change_column(:foo, :integer)
+
+          op = at.operations.first
+          assert_equal "foo", op.column.name.to_s
         ensure
           connection.drop_table(:test) if connection.table_exists?(:test)
         end
 
-        def test_build_change_column_default_definition
+        def test_change_column_default_via_alter_table
           connection.create_table(:test) do |t|
             t.column :foo, :string
           end
 
-          change_default_cd = connection.build_change_column_default_definition(:test, :foo, "new")
-          assert_equal "new", change_default_cd.default
+          at = connection.send(:create_alter_table, :test)
+          at.change_column_default(:foo, "new")
 
-          change_col = change_default_cd.column
-          assert_equal "foo", change_col.name.to_s
+          op = at.operations.first
+          assert_equal "new", op.default
+          assert_equal "foo", op.column.name.to_s
         ensure
           connection.drop_table(:test) if connection.table_exists?(:test)
         end


### PR DESCRIPTION
`visit_AlterTable` used `.join(" ")` between different slot groups (`adds` / `foreign_key_adds` / etc.) and concatenated the joined strings without separators, producing invalid SQL whenever more than one operation across slots was present. In practice this was hidden because every caller only added a single operation to the `AlterTable`.

This refactor makes `AlterTable` the single source of truth for `ALTER TABLE` building, and rewires `bulk_change_table` and the single-caller paths to go through it uniformly.

  * Introduce `Data.define` operation wrappers (`AddColumnDefinition`, `AddForeignKey`, `DropColumn`, `RenameColumn`, `ChangeColumnNull`, `AddIndex`, ..., PG's `ValidateConstraint` / `AddExclusionConstraint` / `AddUniqueConstraint`) and store a single ordered list on `AlterTable#operations`.
  * Rewrite `visit_AlterTable` to iterate `o.operations` in order and dispatch each op through the standard `accept(op)` visitor, joined with `, `. Order is preserved across all operation kinds.
  * Move connection-side build logic (`build_add_column_definition`, `build_change_column_definition`, `build_change_column_default_definition`) into `AlterTable` methods. MySQL and PG each own their subclass-specific build. `column_exists?` guard for `:if_not_exists` stays on the single-caller side since it's a "should we act at all" precondition that issues a schema query (not build-essential).
  * Add `AlterTable#deferred_operations` for post-`execute` work such as PG's `change_column_comment` for `:comment` and PG's `UPDATE` + separate `ALTER TABLE` for `change_column_null` with a default.
  * Introduce `COMBINABLE_COMMANDS` per `AlterTable` subclass and rewrite `bulk_change_table` to dispatch `command` directly to the matching `AlterTable` method (via `public_send`), eliminating all the `#{command}_for_alter` methods.
  * Introduce private `execute_alter_table(at)` helper so every caller runs `execute` + `deferred_operations` uniformly.

