### PR TITLE
Consolidate MySQL `ALGORITHM` / `LOCK` into `MySQL::AlterTable` state

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -430,39 +430,16 @@ module ActiveRecord
         change_column table_name, column_name, nil, comment: comment
       end
 
-      def add_column(table_name, column_name, type, **options) # :nodoc:
-        return if options[:if_not_exists] == true && column_exists?(table_name, column_name)
-
-        algorithm = index_algorithm(options.delete(:algorithm))
-        lock = lock_clause(options.delete(:lock))
-        at = create_alter_table(table_name)
-        at.add_column(column_name, type, **options)
-        sql = +schema_creation.accept(at)
-        sql << ", #{algorithm}" if algorithm
-        sql << ", #{lock}" if lock
-        execute(sql)
-      end
-
       def change_column(table_name, column_name, type, **options) # :nodoc:
-        algorithm = index_algorithm(options.delete(:algorithm))
-        lock = lock_clause(options.delete(:lock))
         at = create_alter_table(table_name)
         at.change_column(column_name, type, **options)
-        sql = +schema_creation.accept(at)
-        sql << ", #{algorithm}" if algorithm
-        sql << ", #{lock}" if lock
-        execute(sql)
+        execute_alter_table(at)
       end
 
       def rename_column(table_name, column_name, new_column_name, **options) # :nodoc:
-        algorithm = index_algorithm(options.delete(:algorithm))
-        lock = lock_clause(options.delete(:lock))
         at = create_alter_table(table_name)
-        at.rename_column(column_name, new_column_name)
-        sql = +schema_creation.accept(at)
-        sql << ", #{algorithm}" if algorithm
-        sql << ", #{lock}" if lock
-        execute(sql)
+        at.rename_column(column_name, new_column_name, **options)
+        execute_alter_table(at)
         rename_column_indexes(table_name, column_name, new_column_name)
       end
 

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
@@ -7,6 +7,13 @@ module ActiveRecord
         delegate :add_sql_comment!, :mariadb?, to: :@conn, private: true
 
         private
+          def visit_AlterTable(o)
+            sql = +super
+            sql << ", #{o.algorithm}" if o.algorithm
+            sql << ", #{o.lock}" if o.lock
+            sql
+          end
+
           def visit_DropForeignKey(o)
             "DROP FOREIGN KEY #{o.name}"
           end
@@ -16,17 +23,11 @@ module ActiveRecord
           end
 
           def visit_AddIndex(o)
-            sql = +"ADD #{accept(o.index)}"
-            sql << ", #{o.algorithm}" if o.algorithm
-            sql << ", #{o.lock}" if o.lock
-            sql
+            "ADD #{accept(o.index)}"
           end
 
           def visit_DropIndex(o)
-            sql = +"DROP INDEX #{quote_column_name(o.name)}"
-            sql << ", #{o.algorithm}" if o.algorithm
-            sql << ", #{o.lock}" if o.lock
-            sql
+            "DROP INDEX #{quote_column_name(o.name)}"
           end
 
           def visit_AddColumnDefinition(o)

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
@@ -112,29 +112,47 @@ module ActiveRecord
           end
       end
 
-      AddIndex = Data.define(:index, :algorithm, :lock) # :nodoc:
-      DropIndex = Data.define(:name, :algorithm, :lock) # :nodoc:
+      AddIndex = Data.define(:index) # :nodoc:
+      DropIndex = Data.define(:name) # :nodoc:
 
       # = Active Record MySQL Adapter Alter \Table
       class AlterTable < ActiveRecord::ConnectionAdapters::AlterTable # :nodoc:
         COMBINABLE_COMMANDS = (superclass::COMBINABLE_COMMANDS + %i[change_column rename_column add_index remove_index]).freeze
 
+        attr_reader :algorithm, :lock
+
+        def algorithm=(value)
+          @algorithm = @td.conn.index_algorithm(value) if value
+        end
+
+        def lock=(value)
+          @lock = @td.conn.lock_clause(value) if value
+        end
+
+        def add_column(column_name, type, **options)
+          extract_algorithm_and_lock!(options)
+          super
+        end
+
+        def remove_column(column_name, _type = nil, **options)
+          extract_algorithm_and_lock!(options)
+          super
+        end
+
         def add_index(column_name, **options)
-          conn = @td.conn
-          lock = conn.lock_clause(options.delete(:lock))
-          index, algorithm, _ = conn.add_index_options(name, column_name, **options)
-          @operations << AddIndex.new(index, algorithm, lock)
+          extract_algorithm_and_lock!(options)
+          index, _ = @td.conn.add_index_options(name, column_name, **options)
+          @operations << AddIndex.new(index)
         end
 
         def remove_index(column_name = nil, **options)
-          conn = @td.conn
-          algorithm = conn.index_algorithm(options.delete(:algorithm))
-          lock = conn.lock_clause(options.delete(:lock))
-          index_name = conn.send(:index_name_for_remove, name, column_name, options)
-          @operations << DropIndex.new(index_name, algorithm, lock)
+          extract_algorithm_and_lock!(options)
+          index_name = @td.conn.send(:index_name_for_remove, name, column_name, options)
+          @operations << DropIndex.new(index_name)
         end
 
         def change_column(column_name, type, **options)
+          extract_algorithm_and_lock!(options)
           conn = @td.conn
           column = conn.send(:column_for, name, column_name)
           type ||= column.sql_type
@@ -169,23 +187,30 @@ module ActiveRecord
           @operations << ChangeColumnDefinition.new(cd, column.name)
         end
 
-        def rename_column(from_name, to_name)
+        def rename_column(from_name, to_name, **options)
+          extract_algorithm_and_lock!(options)
           conn = @td.conn
           if conn.send(:supports_rename_column?)
-            super
+            super(from_name, to_name)
           else
             column = conn.send(:column_for, name, from_name)
-            options = {
+            column_options = {
               default: column.default,
               null: column.null,
               auto_increment: column.auto_increment?,
               comment: column.comment
             }
             current_type = conn.query_one("SHOW COLUMNS FROM #{conn.quote_table_name(name)} LIKE #{conn.quote(from_name)}")["Type"]
-            cd = @td.new_column_definition(to_name, current_type, **options)
+            cd = @td.new_column_definition(to_name, current_type, **column_options)
             @operations << ChangeColumnDefinition.new(cd, column.name)
           end
         end
+
+        private
+          def extract_algorithm_and_lock!(options)
+            self.algorithm = options.delete(:algorithm)
+            self.lock = options.delete(:lock)
+          end
       end
 
       # = Active Record MySQL Adapter \Table

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
@@ -136,6 +136,11 @@ module ActiveRecord
 
         def remove_column(column_name, _type = nil, **options)
           extract_algorithm_and_lock!(options)
+          # MySQL rejects `DROP COLUMN` on a column referenced by a foreign key,
+          # so drop the FK in the same `ALTER TABLE` statement as the column.
+          if fk = @td.conn.send(:foreign_key_for, name, column: column_name)
+            @operations << DropForeignKey.new(fk.name)
+          end
           super
         end
 

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -93,15 +93,10 @@ module ActiveRecord
           if foreign_key_exists?(table_name, column: column_name)
             remove_foreign_key(table_name, column: column_name)
           end
-          algorithm = index_algorithm(options.delete(:algorithm))
-          lock = lock_clause(options.delete(:lock))
           return if options[:if_exists] == true && !column_exists?(table_name, column_name)
           at = create_alter_table(table_name)
-          at.remove_column(column_name)
-          sql = +schema_creation.accept(at)
-          sql << ", #{algorithm}" if algorithm
-          sql << ", #{lock}" if lock
-          execute(sql)
+          at.remove_column(column_name, type, **options)
+          execute_alter_table(at)
         end
 
         def create_table(table_name, options: default_row_format, **)

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -89,16 +89,6 @@ module ActiveRecord
           [index, algorithm, if_not_exists]
         end
 
-        def remove_column(table_name, column_name, type = nil, **options)
-          if foreign_key_exists?(table_name, column: column_name)
-            remove_foreign_key(table_name, column: column_name)
-          end
-          return if options[:if_exists] == true && !column_exists?(table_name, column_name)
-          at = create_alter_table(table_name)
-          at.remove_column(column_name, type, **options)
-          execute_alter_table(at)
-        end
-
         def create_table(table_name, options: default_row_format, **)
           super
         end

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/active_schema_test.rb
@@ -192,6 +192,27 @@ class ActiveSchemaTest < ActiveRecord::AbstractMysqlTestCase
     end
   end
 
+  def test_multiple_indexes_in_bulk_change_emit_algorithm_and_lock_once
+    expected = "ALTER TABLE `people` ADD INDEX `index_people_on_last_name` (`last_name`), " \
+               "ADD INDEX `index_people_on_first_name` (`first_name`), ALGORITHM = INPLACE, LOCK = NONE"
+    assert_queries_match(expected) do
+      ActiveRecord::Base.lease_connection.change_table(:people, bulk: true) do |t|
+        t.index :last_name, algorithm: :inplace, lock: :none
+        t.index :first_name, algorithm: :inplace, lock: :none
+      end
+    end
+  end
+
+  def test_algorithm_and_lock_apply_to_bulk_add_column
+    expected = "ALTER TABLE `people` ADD `last_name` varchar(255), ADD `first_name` varchar(255), ALGORITHM = INPLACE, LOCK = NONE"
+    assert_queries_match(expected) do
+      ActiveRecord::Base.lease_connection.change_table(:people, bulk: true) do |t|
+        t.column :last_name, :string, algorithm: :inplace, lock: :none
+        t.column :first_name, :string
+      end
+    end
+  end
+
   def test_drop_table
     assert_equal "DROP TABLE `people`", drop_table(:people)
   end


### PR DESCRIPTION
Prior to this change, `ALGORITHM = ...` and `LOCK = ...` were appended to the `ALTER TABLE` SQL by each caller individually. This had three issues:

  * Every MySQL single-caller (`add_column`, `change_column`, `rename_column`, `remove_column`) duplicated the same `sql << ", #{algorithm}"` / `sql << ", #{lock}"` pattern.
  * `MySQL::AddIndex` / `MySQL::DropIndex` held per-op `algorithm` / `lock` fields and `visit_AddIndex` / `visit_DropIndex` emitted them per-fragment. In bulk mode with more than one index op carrying the same hints, the suffix was duplicated N times, e.g. `... ADD INDEX ..., ALGORITHM = INPLACE, LOCK = NONE, ADD INDEX ..., ALGORITHM = INPLACE, LOCK = NONE`, which MySQL rejects.
  * Bulk mode `t.column`, `t.change`, etc. with `algorithm:` / `lock:` options were silently dropped, because `#{command}_for_alter` / the direct dispatch never extracted them from the recorder args.

`ALGORITHM` / `LOCK` are per-`ALTER TABLE`-statement hints, so their natural home is the `AlterTable` object.

  * Add `algorithm` / `lock` state to `MySQL::AlterTable` (with setters that go through `index_algorithm` / `lock_clause` formatting).
  * Override `MySQL::SchemaCreation#visit_AlterTable` to append them once at end of the statement.
  * `MySQL::AlterTable` overrides `add_column`, `remove_column`, `change_column`, `rename_column`, `add_index`, `remove_index` to extract `:algorithm` / `:lock` from options into the AlterTable state via a private `extract_algorithm_and_lock!` helper. Bulk mode and single-callers now share the same extraction path.
  * `MySQL::AddIndex` / `MySQL::DropIndex` lose their `algorithm` / `lock` fields; `visit_AddIndex` / `visit_DropIndex` simplify to plain `ADD ...` / `DROP INDEX ...`.
  * MySQL single-callers simplify to `at.<op>(...); execute_alter_table(at)` — no more `sql << ", ..."` suffix appending.
