### PR TITLE
Introduce decoupled query constraints for associations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -15,6 +15,18 @@
     building, creating, or assigning associated records, while queries match on
     the foreign key plus the extra columns.
 
+    An Array-valued `foreign_key` remains a writable composite foreign key:
+
+    ``` ruby
+    # Reads and writes both columns.
+    belongs_to :post, foreign_key: [:blog_id, :post_id]
+
+    # Reads with both columns, but writes only post_id.
+    belongs_to :post,
+      foreign_key: :post_id,
+      query_constraints: :blog_id
+    ```
+
     Additive query constraints do not participate in association stale tracking.
     Changing them does not invalidate a cached target; changing its foreign key does.
 
@@ -31,7 +43,7 @@
     end
     ```
 
-    *Nikita Vasilevsky*
+    *Nikita Vasilevsky* and *Adrianna Chang*
 
 *   Deprecate `ActiveRecord::Relation#uniq!`.
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -6,6 +6,33 @@
 
     *Kir Shatrov*, *Jean-Samuel Aubry-Guzzi*, *Matthew Draper*
 
+*   Support `query_constraints` on associations, decoupled from `foreign_key`.
+
+    `query_constraints` declares *additional* columns to match when querying an
+    association's targets (loading, preloading, eager loading, joins, and
+    association predicates), layered on top of the foreign key. The foreign key
+    is derived by convention when omitted, and is the only key written when
+    building, creating, or assigning associated records, while queries match on
+    the foreign key plus the extra columns.
+
+    Additive query constraints do not participate in association stale tracking.
+    Changing them does not invalidate a cached target; changing its foreign key does.
+
+    A column may map to a different name on the other side using a Hash. Query
+    constraint columns must be distinct from the association's foreign key columns:
+
+    ``` ruby
+    class BlogPost < ApplicationRecord
+      # match blog_id on both tables, and BlogPost#id -> Comment#blog_post_id
+      belongs_to :featured_comment,
+        class_name: "Comment",
+        foreign_key: :featured_comment_id,
+        query_constraints: [:blog_id, { id: :blog_post_id }]
+    end
+    ```
+
+    *Nikita Vasilevsky*
+
 *   Deprecate `ActiveRecord::Relation#uniq!`.
 
     The method was added in Rails 6.1 (#39358) as part of the migration path

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,25 @@
+*   Support `query_constraints` on associations, decoupled from `foreign_key`.
+
+    `query_constraints` declares *additional* columns to match when querying an
+    association's targets (loading, preloading, eager loading, joins, and
+    association predicates), layered on top of the foreign key. When both
+    `foreign_key` and `query_constraints` are given, only the foreign key is
+    written, while queries match on the foreign key plus the extra columns.
+
+    A column may map to a different name on the other side using a Hash, and
+    listing the foreign key itself is allowed (it is de-duplicated):
+
+    ``` ruby
+    class BlogPost < ApplicationRecord
+      # match blog_id on both tables, and BlogPost#id -> Comment#blog_post_id
+      belongs_to :featured_comment,
+        class_name: "Comment",
+        foreign_key: :featured_comment_id,
+        query_constraints: [:blog_id, { id: :blog_post_id }]
+    end
+    ```
+
+    *Nikita Vasilevsky*
 *   Add query predicate hooks for Active Model types.
 
     Types can override `transforms_query_predicates?`, `query_attribute`, and

--- a/activerecord/lib/active_record/association_relation.rb
+++ b/activerecord/lib/active_record/association_relation.rb
@@ -15,6 +15,18 @@ module ActiveRecord
       other == records
     end
 
+    # Additive +query_constraints+ are matched when querying the association, but
+    # they are never written: only the foreign key is, by
+    # +ForeignAssociation#set_owner_attributes+. The association scope carries them
+    # as ordinary equality conditions though, and every equality condition in a
+    # scope otherwise becomes a default attribute on records built from it, which
+    # would make +build+ write columns that +<<+ and autosave leave alone.
+    def scope_for_create
+      attributes = super
+      columns = @association.reflection.query_constraints_target_columns
+      columns.any? ? attributes.except!(*columns) : attributes
+    end
+
     %w(insert insert_all insert! insert_all! upsert upsert_all).each do |method|
       class_eval <<~RUBY, __FILE__, __LINE__ + 1
         def #{method}(...)

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1388,9 +1388,12 @@ module ActiveRecord
         #   Specifies an instance method to be called on the owner. The method must return true in order for the
         #   associated records to be deleted in a background job.
         # [+:query_constraints+]
-        #   Serves as a composite foreign key. Defines the list of columns to be used to query the associated object.
-        #   This is an optional option. By default Rails will attempt to derive the value automatically.
-        #   When the value is set the Array size must match associated model's primary key or +query_constraints+ size.
+        #   Defines additional column pairs used to query associated records. These constraints are added to
+        #   the foreign key match, while only the foreign key columns are written when building, creating, or
+        #   assigning associated records. The foreign key is derived by convention when +:foreign_key+ is
+        #   omitted. Symbols and strings match same-named columns on both tables. A Hash maps a column on this
+        #   model to one on the associated model, for example <tt>{ tenant_id: :account_tenant_id }</tt>, and
+        #   requires +:foreign_key+. Query constraint columns must be distinct from the foreign key columns.
         # [+:index_errors+]
         #   Allows differentiation of multiple validation errors from the association records, by including
         #   an index in the error attribute name, e.g. +roles[2].level+.
@@ -1421,7 +1424,7 @@ module ActiveRecord
         #   has_many :subscribers, through: :subscriptions, source: :user
         #   has_many :subscribers, through: :subscriptions, disable_joins: true
         #   has_many :comments, strict_loading: true
-        #   has_many :comments, query_constraints: [:blog_id, :post_id]
+        #   has_many :comments, query_constraints: :blog_id
         #   has_many :comments, index_errors: :nested_attributes_order
         def has_many(name, scope = nil, **options, &extension)
           reflection = Builder::HasMany.build(self, name, scope, options, &extension)
@@ -1603,9 +1606,12 @@ module ActiveRecord
         #   Specifies an instance method to be called on the owner. The method must return true in order for the
         #   associated records to be deleted in a background job.
         # [+:query_constraints+]
-        #   Serves as a composite foreign key. Defines the list of columns to be used to query the associated object.
-        #   This is an optional option. By default Rails will attempt to derive the value automatically.
-        #   When the value is set the Array size must match associated model's primary key or +query_constraints+ size.
+        #   Defines additional column pairs used to query associated records. These constraints are added to
+        #   the foreign key match, while only the foreign key columns are written when building, creating, or
+        #   assigning associated records. The foreign key is derived by convention when +:foreign_key+ is
+        #   omitted. Symbols and strings match same-named columns on both tables. A Hash maps a column on this
+        #   model to one on the associated model, for example <tt>{ tenant_id: :account_tenant_id }</tt>, and
+        #   requires +:foreign_key+. Query constraint columns must be distinct from the foreign key columns.
         # [+:deprecated+]
         #   If true, marks the association as deprecated. Usage of deprecated associations is reported.
         #   Please, check the class documentation above for details.
@@ -1623,7 +1629,7 @@ module ActiveRecord
         #   has_one :primary_address, -> { where(primary: true) }, through: :addressables, source: :addressable
         #   has_one :credit_card, required: true
         #   has_one :credit_card, strict_loading: true
-        #   has_one :employment_record_book, query_constraints: [:organization_id, :employee_id]
+        #   has_one :employment_record_book, query_constraints: :organization_id
         def has_one(name, scope = nil, **options)
           reflection = Builder::HasOne.build(self, name, scope, options)
           Reflection.add_reflection(self, name, reflection)
@@ -1798,9 +1804,12 @@ module ActiveRecord
         #   Specifies an instance method to be called on the owner. The method must return true in order for the
         #   associated records to be deleted in a background job.
         # [+:query_constraints+]
-        #   Serves as a composite foreign key. Defines the list of columns to be used to query the associated object.
-        #   This is an optional option. By default Rails will attempt to derive the value automatically.
-        #   When the value is set the Array size must match associated model's primary key or +query_constraints+ size.
+        #   Defines additional column pairs used to query associated records. These constraints are added to
+        #   the foreign key match, while only the foreign key columns are written when building, creating, or
+        #   assigning associated records. The foreign key is derived by convention when +:foreign_key+ is
+        #   omitted. Symbols and strings match same-named columns on both tables. A Hash maps a column on this
+        #   model to one on the associated model, for example <tt>{ tenant_id: :account_tenant_id }</tt>, and
+        #   requires +:foreign_key+. Query constraint columns must be distinct from the foreign key columns.
         # [+:deprecated+]
         #   If true, marks the association as deprecated. Usage of deprecated associations is reported.
         #   Please, check the class documentation above for details.
@@ -1819,7 +1828,7 @@ module ActiveRecord
         #   belongs_to :user, optional: true
         #   belongs_to :account, default: -> { company.account }
         #   belongs_to :account, strict_loading: true
-        #   belongs_to :note, query_constraints: [:organization_id, :note_id]
+        #   belongs_to :note, query_constraints: :organization_id
         def belongs_to(name, scope = nil, **options)
           reflection = Builder::BelongsTo.build(self, name, scope, options)
           Reflection.add_reflection(self, name, reflection)

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1388,9 +1388,12 @@ module ActiveRecord
         #   Specifies an instance method to be called on the owner. The method must return true in order for the
         #   associated records to be deleted in a background job.
         # [+:query_constraints+]
-        #   Serves as a composite foreign key. Defines the list of columns to be used to query the associated object.
-        #   This is an optional option. By default Rails will attempt to derive the value automatically.
-        #   When the value is set the Array size must match associated model's primary key or +query_constraints+ size.
+        #   Defines additional column pairs used to query associated records. When +:foreign_key+ is also set,
+        #   these constraints are added to the foreign key match, while only the foreign key columns are written
+        #   when assigning the association. Symbols and strings match same-named columns on both tables. A Hash
+        #   maps a column on this model to one on the associated model, for example
+        #   <tt>{ tenant_id: :account_tenant_id }</tt>. Hash mappings require +:foreign_key+.
+        #   Without +:foreign_key+, an Array retains the composite foreign key behavior.
         # [+:index_errors+]
         #   Allows differentiation of multiple validation errors from the association records, by including
         #   an index in the error attribute name, e.g. +roles[2].level+.
@@ -1421,7 +1424,7 @@ module ActiveRecord
         #   has_many :subscribers, through: :subscriptions, source: :user
         #   has_many :subscribers, through: :subscriptions, disable_joins: true
         #   has_many :comments, strict_loading: true
-        #   has_many :comments, query_constraints: [:blog_id, :post_id]
+        #   has_many :comments, foreign_key: :post_id, query_constraints: :blog_id
         #   has_many :comments, index_errors: :nested_attributes_order
         def has_many(name, scope = nil, **options, &extension)
           reflection = Builder::HasMany.build(self, name, scope, options, &extension)
@@ -1603,9 +1606,12 @@ module ActiveRecord
         #   Specifies an instance method to be called on the owner. The method must return true in order for the
         #   associated records to be deleted in a background job.
         # [+:query_constraints+]
-        #   Serves as a composite foreign key. Defines the list of columns to be used to query the associated object.
-        #   This is an optional option. By default Rails will attempt to derive the value automatically.
-        #   When the value is set the Array size must match associated model's primary key or +query_constraints+ size.
+        #   Defines additional column pairs used to query associated records. When +:foreign_key+ is also set,
+        #   these constraints are added to the foreign key match, while only the foreign key columns are written
+        #   when assigning the association. Symbols and strings match same-named columns on both tables. A Hash
+        #   maps a column on this model to one on the associated model, for example
+        #   <tt>{ tenant_id: :account_tenant_id }</tt>. Hash mappings require +:foreign_key+.
+        #   Without +:foreign_key+, an Array retains the composite foreign key behavior.
         # [+:deprecated+]
         #   If true, marks the association as deprecated. Usage of deprecated associations is reported.
         #   Please, check the class documentation above for details.
@@ -1623,7 +1629,7 @@ module ActiveRecord
         #   has_one :primary_address, -> { where(primary: true) }, through: :addressables, source: :addressable
         #   has_one :credit_card, required: true
         #   has_one :credit_card, strict_loading: true
-        #   has_one :employment_record_book, query_constraints: [:organization_id, :employee_id]
+        #   has_one :employment_record_book, foreign_key: :employee_id, query_constraints: :organization_id
         def has_one(name, scope = nil, **options)
           reflection = Builder::HasOne.build(self, name, scope, options)
           Reflection.add_reflection(self, name, reflection)
@@ -1798,9 +1804,12 @@ module ActiveRecord
         #   Specifies an instance method to be called on the owner. The method must return true in order for the
         #   associated records to be deleted in a background job.
         # [+:query_constraints+]
-        #   Serves as a composite foreign key. Defines the list of columns to be used to query the associated object.
-        #   This is an optional option. By default Rails will attempt to derive the value automatically.
-        #   When the value is set the Array size must match associated model's primary key or +query_constraints+ size.
+        #   Defines additional column pairs used to query associated records. When +:foreign_key+ is also set,
+        #   these constraints are added to the foreign key match, while only the foreign key columns are written
+        #   when assigning the association. Symbols and strings match same-named columns on both tables. A Hash
+        #   maps a column on this model to one on the associated model, for example
+        #   <tt>{ tenant_id: :account_tenant_id }</tt>. Hash mappings require +:foreign_key+.
+        #   Without +:foreign_key+, an Array retains the composite foreign key behavior.
         # [+:deprecated+]
         #   If true, marks the association as deprecated. Usage of deprecated associations is reported.
         #   Please, check the class documentation above for details.
@@ -1819,7 +1828,7 @@ module ActiveRecord
         #   belongs_to :user, optional: true
         #   belongs_to :account, default: -> { company.account }
         #   belongs_to :account, strict_loading: true
-        #   belongs_to :note, query_constraints: [:organization_id, :note_id]
+        #   belongs_to :note, foreign_key: :note_id, query_constraints: :organization_id
         def belongs_to(name, scope = nil, **options)
           reflection = Builder::BelongsTo.build(self, name, scope, options)
           Reflection.add_reflection(self, name, reflection)

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1393,7 +1393,8 @@ module ActiveRecord
         #   assigning associated records. The foreign key is derived by convention when +:foreign_key+ is
         #   omitted. Symbols and strings match same-named columns on both tables. A Hash maps a column on this
         #   model to one on the associated model, for example <tt>{ tenant_id: :account_tenant_id }</tt>, and
-        #   requires +:foreign_key+. Query constraint columns must be distinct from the foreign key columns.
+        #   requires +:foreign_key+. Query constraint columns must differ from foreign key columns on the table
+        #   that stores the foreign key. Changing a query constraint does not invalidate a loaded target.
         # [+:index_errors+]
         #   Allows differentiation of multiple validation errors from the association records, by including
         #   an index in the error attribute name, e.g. +roles[2].level+.
@@ -1611,7 +1612,8 @@ module ActiveRecord
         #   assigning associated records. The foreign key is derived by convention when +:foreign_key+ is
         #   omitted. Symbols and strings match same-named columns on both tables. A Hash maps a column on this
         #   model to one on the associated model, for example <tt>{ tenant_id: :account_tenant_id }</tt>, and
-        #   requires +:foreign_key+. Query constraint columns must be distinct from the foreign key columns.
+        #   requires +:foreign_key+. Query constraint columns must differ from foreign key columns on the table
+        #   that stores the foreign key. Changing a query constraint does not invalidate a loaded target.
         # [+:deprecated+]
         #   If true, marks the association as deprecated. Usage of deprecated associations is reported.
         #   Please, check the class documentation above for details.
@@ -1809,7 +1811,8 @@ module ActiveRecord
         #   assigning associated records. The foreign key is derived by convention when +:foreign_key+ is
         #   omitted. Symbols and strings match same-named columns on both tables. A Hash maps a column on this
         #   model to one on the associated model, for example <tt>{ tenant_id: :account_tenant_id }</tt>, and
-        #   requires +:foreign_key+. Query constraint columns must be distinct from the foreign key columns.
+        #   requires +:foreign_key+. Query constraint columns must differ from foreign key columns on the table
+        #   that stores the foreign key. Changing a query constraint does not invalidate a loaded target.
         # [+:deprecated+]
         #   If true, marks the association as deprecated. Usage of deprecated associations is reported.
         #   Please, check the class documentation above for details.

--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -36,7 +36,7 @@ module ActiveRecord
         binds = []
         last_reflection = chain.last
 
-        binds.push(*last_reflection.join_id_for(owner))
+        binds.push(*last_reflection.join_query_constraints_id_for(owner))
         if last_reflection.type
           binds << owner.class.polymorphic_name
         end
@@ -57,8 +57,8 @@ module ActiveRecord
         end
 
         def last_chain_scope(scope, reflection, owner)
-          primary_key = Array(reflection.join_primary_key)
-          foreign_key = Array(reflection.join_foreign_key)
+          primary_key = Array(reflection.join_query_constraints_primary_key)
+          foreign_key = Array(reflection.join_query_constraints_foreign_key)
 
           table = reflection.aliased_table
           primary_key_foreign_key_pairs = primary_key.zip(foreign_key)
@@ -80,8 +80,8 @@ module ActiveRecord
         end
 
         def next_chain_scope(scope, reflection, next_reflection)
-          primary_key = Array(reflection.join_primary_key)
-          foreign_key = Array(reflection.join_foreign_key)
+          primary_key = Array(reflection.join_query_constraints_primary_key)
+          foreign_key = Array(reflection.join_query_constraints_foreign_key)
 
           table = reflection.aliased_table
           foreign_table = next_reflection.aliased_table

--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -38,7 +38,7 @@ module ActiveRecord
         binds = []
         last_reflection = chain.last
 
-        binds.push(*last_reflection.join_id_for(owner))
+        binds.push(*last_reflection.query_key_values_for(owner))
         if last_reflection.type
           binds << owner.class.polymorphic_name
         end
@@ -59,14 +59,11 @@ module ActiveRecord
         end
 
         def last_chain_scope(scope, reflection, owner)
-          primary_key = ActiveRecord::Key.for(reflection.join_primary_key)
-          foreign_key = ActiveRecord::Key.for(reflection.join_foreign_key)
-
           table = reflection.aliased_table
-          primary_key_foreign_key_pairs = primary_key.zip(foreign_key)
-          primary_key_foreign_key_pairs.each do |join_key, foreign_key|
-            value = transform_value(owner.read_attribute(foreign_key))
-            scope = apply_scope(scope, reflection, table, join_key, value)
+
+          reflection.query_key_mapping.each do |active_record_column, associated_record_column|
+            value = transform_value(owner.read_attribute(active_record_column))
+            scope = apply_scope(scope, reflection, table, associated_record_column, value)
           end
 
           if reflection.type
@@ -82,19 +79,15 @@ module ActiveRecord
         end
 
         def next_chain_scope(scope, reflection, next_reflection)
-          primary_key = ActiveRecord::Key.for(reflection.join_primary_key)
-          foreign_key = ActiveRecord::Key.for(reflection.join_foreign_key)
-
           table = reflection.aliased_table
           foreign_table = next_reflection.aliased_table
 
           predicate_builder = scope.predicate_builder
-          primary_key_foreign_key_pairs = primary_key.zip(foreign_key)
-          constraints = primary_key_foreign_key_pairs.map do |join_primary_key, foreign_key|
-            join_primary_key_attribute = predicate_builder.predicate_attribute(table[join_primary_key])
-            foreign_key_attribute = predicate_builder.predicate_attribute(foreign_table[foreign_key])
+          constraints = reflection.query_key_mapping.map do |active_record_column, associated_record_column|
+            associated_record_attribute = predicate_builder.predicate_attribute(table[associated_record_column])
+            active_record_attribute = predicate_builder.predicate_attribute(foreign_table[active_record_column])
 
-            join_primary_key_attribute.eq(foreign_key_attribute)
+            associated_record_attribute.eq(active_record_attribute)
           end.inject(&:and)
 
           if reflection.type

--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -25,20 +25,21 @@ module ActiveRecord
         when :destroy
           raise ActiveRecord::Rollback unless target.destroy
         when :destroy_async
-          primary_key_column = reflection.active_record_primary_key
-          ids = foreign_key.map { |col| owner.public_send(col) }
-
           association_class = if reflection.polymorphic?
-            owner.public_send(foreign_type)
+            target.class
           else
             reflection.klass
           end
+
+          primary_key_column = reflection.query_primary_key(association_class)
+          query_foreign_key = ActiveRecord::Key.for(reflection.query_foreign_key)
+          ids = query_foreign_key.map { |column| owner.public_send(column) }
 
           enqueue_destroy_association(
             owner_model_name: owner.class.to_s,
             owner_id: owner.id,
             association_class: association_class.to_s,
-            association_ids: foreign_key.composite? ? [ids] : ids,
+            association_ids: query_foreign_key.composite? ? [ids] : ids,
             association_primary_key_column: primary_key_column,
             ensuring_owner_was_method: options.fetch(:ensuring_owner_was, nil)
           )
@@ -141,7 +142,12 @@ module ActiveRecord
         end
 
         def replace_keys(record, force: false)
-          target_key_values = record ? ActiveRecord::Key.for(primary_key(record.class)).map { |col| record.read_attribute(col) } : []
+          target_key = if record
+            reflection.query_key_mapping(record.class).foreign_key_associated_record_columns
+          end
+          target_key = ActiveRecord::Key.for(target_key)
+
+          target_key_values = target_key.map { |key| record.read_attribute(key) }
           owner_key_values = foreign_key.map { |fk| owner.read_attribute(fk) }
 
           return if !force && owner_key_values == target_key_values
@@ -172,10 +178,16 @@ module ActiveRecord
         end
 
         def stale_state
-          values = foreign_key.map do |fk|
-            owner.read_attribute(fk) { |n| owner.send(:missing_attribute, n, caller) }
+          keys = if reflection.options[:query_constraints]
+            reflection.foreign_key
+          else
+            reflection.query_foreign_key
           end
-          foreign_key.composite? ? (values if values.any?) : values.first
+          key = ActiveRecord::Key.for(keys)
+          values = key.map do |column|
+            owner.read_attribute(column) { |name| owner.send(:missing_attribute, name, caller) }
+          end
+          key.composite? ? (values if values.any?) : values.first
         end
     end
   end

--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -25,20 +25,21 @@ module ActiveRecord
         when :destroy
           raise ActiveRecord::Rollback unless target.destroy
         when :destroy_async
-          primary_key_column = reflection.active_record_primary_key
-          ids = foreign_key.map { |col| owner.public_send(col) }
-
           association_class = if reflection.polymorphic?
-            owner.public_send(foreign_type)
+            target.class
           else
             reflection.klass
           end
+
+          primary_key_column = reflection.join_query_constraints_primary_key(association_class)
+          query_constraints_foreign_key = ActiveRecord::Key.for(reflection.join_query_constraints_foreign_key)
+          ids = query_constraints_foreign_key.map { |column| owner.public_send(column) }
 
           enqueue_destroy_association(
             owner_model_name: owner.class.to_s,
             owner_id: owner.id,
             association_class: association_class.to_s,
-            association_ids: foreign_key.composite? ? [ids] : ids,
+            association_ids: query_constraints_foreign_key.composite? ? [ids] : ids,
             association_primary_key_column: primary_key_column,
             ensuring_owner_was_method: options.fetch(:ensuring_owner_was, nil)
           )
@@ -141,7 +142,12 @@ module ActiveRecord
         end
 
         def replace_keys(record, force: false)
-          target_key_values = record ? ActiveRecord::Key.for(primary_key(record.class)).map { |col| record.read_attribute(col) } : []
+          target_key = ActiveRecord::Key.for(record ? primary_key(record.class) : nil)
+          if record && target_key.length != foreign_key.length
+            target_key = ActiveRecord::Key.for(reflection.join_query_constraints_primary_key(record.class))
+          end
+
+          target_key_values = target_key.map { |key| record.read_attribute(key) }
           owner_key_values = foreign_key.map { |fk| owner.read_attribute(fk) }
 
           return if !force && owner_key_values == target_key_values
@@ -167,10 +173,11 @@ module ActiveRecord
         end
 
         def stale_state
-          values = foreign_key.map do |fk|
-            owner.read_attribute(fk) { |n| owner.send(:missing_attribute, n, caller) }
+          query_constraints_foreign_key = ActiveRecord::Key.for(reflection.join_query_constraints_foreign_key)
+          values = query_constraints_foreign_key.map do |key|
+            owner.read_attribute(key) { |name| owner.send(:missing_attribute, name, caller) }
           end
-          foreign_key.composite? ? (values if values.any?) : values.first
+          query_constraints_foreign_key.composite? ? (values if values.any?) : values.first
         end
     end
   end

--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -82,11 +82,11 @@ module ActiveRecord
           model_was = klass
         end
 
-        values = foreign_key.map { |fk| owner.attribute_before_last_save(fk) }
-        foreign_key_was = foreign_key.composite? ? (values if values.all?) : values.first
+        foreign_key_values = foreign_key.map { |fk| owner.attribute_before_last_save(fk) }
+        foreign_key_was = foreign_key.composite? ? foreign_key_values.all? : foreign_key_values.first
 
         if foreign_key_was && model_was < ActiveRecord::Base
-          update_counters_via_scope(model_was, foreign_key_was, -1)
+          update_counters_via_scope(model_was, -1, before_last_save: true)
         end
       end
 
@@ -122,14 +122,23 @@ module ActiveRecord
             if target && !stale_target?
               target.increment!(reflection.counter_cache_column, by, touch: reflection.options[:touch])
             else
-              update_counters_via_scope(klass, foreign_key.value_of(owner), by)
+              update_counters_via_scope(klass, by)
             end
           end
         end
 
-        def update_counters_via_scope(klass, values, by)
-          primary_key = ActiveRecord::Key.for(primary_key(klass))
-          scope = klass.all_queries_scope.where!(primary_key.where_hash(values))
+        def update_counters_via_scope(klass, by, before_last_save: false)
+          constraints = reflection.query_key_mapping(klass).to_h do |active_record_column, associated_record_column|
+            active_record_column = owner.class.attribute_aliases[active_record_column] || active_record_column
+            value = if before_last_save
+              owner.attribute_before_last_save(active_record_column)
+            else
+              owner.read_attribute(active_record_column)
+            end
+
+            [associated_record_column, value]
+          end
+          scope = klass.all_queries_scope.where!(constraints)
           scope.update_counters(reflection.counter_cache_column => by, touch: reflection.options[:touch])
         end
 

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -46,7 +46,8 @@ module ActiveRecord::Associations::Builder # :nodoc:
       association = o.association(name)
       foreign_key = association.foreign_key
 
-      old_foreign_id = if foreign_key.any? { |fk| o.public_send(change_method, fk) }
+      foreign_key_changed = foreign_key.any? { |fk| o.public_send(change_method, fk) }
+      old_foreign_key = if foreign_key_changed
         values = foreign_key.map do |fk|
           change = o.public_send(change_method, fk)
           change ? change.first : o.read_attribute(fk)
@@ -54,7 +55,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
         foreign_key.composite? ? values : values.first
       end
 
-      if old_foreign_id
+      if old_foreign_key
         reflection = association.reflection
         if reflection.polymorphic?
           foreign_type = association.foreign_type
@@ -64,8 +65,14 @@ module ActiveRecord::Associations::Builder # :nodoc:
         else
           klass = association.klass
         end
-        primary_key = reflection.association_primary_key(klass)
-        old_record = klass.find_by(primary_key => [old_foreign_id])
+        constraints = reflection.query_key_mapping(klass).to_h do |active_record_column, associated_record_column|
+          active_record_column = o.class.attribute_aliases[active_record_column] || active_record_column
+          change = o.public_send(change_method, active_record_column)
+          value = change ? change.first : o.read_attribute(active_record_column)
+
+          [associated_record_column, value]
+        end
+        old_record = klass.find_by(constraints)
 
         if old_record
           if touch != true

--- a/activerecord/lib/active_record/associations/disable_joins_association_scope.rb
+++ b/activerecord/lib/active_record/associations/disable_joins_association_scope.rb
@@ -11,19 +11,18 @@ module ActiveRecord
 
         last_reflection, last_ordered, last_join_ids = last_scope_chain(reverse_chain, owner)
 
-        add_constraints(last_reflection, last_reflection.join_primary_key, last_join_ids, owner, last_ordered)
+        add_constraints(last_reflection, Array(last_reflection.join_query_constraints_primary_key), last_join_ids, owner, last_ordered)
       end
 
       private
         def last_scope_chain(reverse_chain, owner)
           first_item = reverse_chain.shift
-          first_scope = [first_item, false, [owner.read_attribute(first_item.join_foreign_key)]]
+          first_scope = [first_item, false, [owner_query_constraint_values(first_item, owner)]]
 
           reverse_chain.inject(first_scope) do |(reflection, ordered, join_ids), next_reflection|
-            key = reflection.join_primary_key
+            key = Array(reflection.join_query_constraints_primary_key)
             records = add_constraints(reflection, key, join_ids, owner, ordered)
-            foreign_key = next_reflection.join_foreign_key
-            record_ids = records.pluck(foreign_key)
+            record_ids = pluck_query_constraint_values(records, next_reflection)
             records_ordered = records && records.order_values.any?
 
             [next_reflection, records_ordered, record_ids]
@@ -52,6 +51,33 @@ module ActiveRecord
             split_scope
           else
             scope
+          end
+        end
+
+        # Reads the owner's values for every column the reflection needs to query
+        # against (foreign key plus any additive +query_constraints+), returning a
+        # composite tuple. Uses +join_query_constraints_foreign_key+ (delegated on
+        # every chain reflection) rather than the scalar +join_foreign_key+ so
+        # decoupled query constraints participate in each hop.
+        def owner_query_constraint_values(reflection, owner)
+          Array(reflection.join_query_constraints_foreign_key).map do |key|
+            owner.read_attribute(key)
+          end
+        end
+
+        # Plucks the columns the next hop will query on (its
+        # +join_query_constraints_foreign_key+) from the records just loaded,
+        # returning a list of composite tuples. Single-column hops return
+        # one-element tuples so +where(key => join_ids)+ and the ordered
+        # +DisableJoinsAssociationRelation+ grouping stay shape-consistent with
+        # multi-column (decoupled query constraint) hops.
+        def pluck_query_constraint_values(records, reflection)
+          foreign_keys = Array(reflection.join_query_constraints_foreign_key)
+
+          if foreign_keys.size == 1
+            records.pluck(foreign_keys.first).map { |id| [id] }
+          else
+            records.pluck(*foreign_keys)
           end
         end
     end

--- a/activerecord/lib/active_record/associations/disable_joins_association_scope.rb
+++ b/activerecord/lib/active_record/associations/disable_joins_association_scope.rb
@@ -11,19 +11,18 @@ module ActiveRecord
 
         last_reflection, last_ordered, last_join_ids = last_scope_chain(reverse_chain, owner)
 
-        add_constraints(last_reflection, last_reflection.join_primary_key, last_join_ids, owner, last_ordered)
+        add_constraints(last_reflection, last_reflection.query_key_mapping.associated_record_columns, last_join_ids, owner, last_ordered)
       end
 
       private
         def last_scope_chain(reverse_chain, owner)
           first_item = reverse_chain.shift
-          first_scope = [first_item, false, [owner.read_attribute(first_item.join_foreign_key)]]
+          first_scope = [first_item, false, [first_item.query_key_mapping.values_for(owner)]]
 
           reverse_chain.inject(first_scope) do |(reflection, ordered, join_ids), next_reflection|
-            key = reflection.join_primary_key
+            key = reflection.query_key_mapping.associated_record_columns
             records = add_constraints(reflection, key, join_ids, owner, ordered)
-            foreign_key = next_reflection.join_foreign_key
-            record_ids = records.pluck(foreign_key)
+            record_ids = pluck_query_key_values(records, next_reflection)
             records_ordered = records && records.order_values.any?
 
             [next_reflection, records_ordered, record_ids]
@@ -52,6 +51,18 @@ module ActiveRecord
             split_scope
           else
             scope
+          end
+        end
+
+        # Plucks the columns on the active-record side of the next hop. Single-
+        # column hops retain a tuple shape for DisableJoinsAssociationRelation.
+        def pluck_query_key_values(records, reflection)
+          columns = reflection.query_key_mapping.active_record_columns
+
+          if columns.size == 1
+            records.pluck(columns.first).map { |id| [id] }
+          else
+            records.pluck(*columns)
           end
         end
     end

--- a/activerecord/lib/active_record/associations/foreign_association.rb
+++ b/activerecord/lib/active_record/associations/foreign_association.rb
@@ -24,14 +24,9 @@ module ActiveRecord::Associations
       def set_owner_attributes(record)
         return if options[:through]
 
-        primary_key_attribute_names = ActiveRecord::Key.for(reflection.join_primary_key)
-        foreign_key_attribute_names = ActiveRecord::Key.for(reflection.join_foreign_key)
-
-        primary_key_foreign_key_pairs = primary_key_attribute_names.zip(foreign_key_attribute_names)
-
-        primary_key_foreign_key_pairs.each do |primary_key, foreign_key|
-          value = owner.read_attribute(foreign_key)
-          record.write_attribute(primary_key, value)
+        reflection.query_key_mapping.foreign_key_pairs.each do |active_record_column, associated_record_column|
+          value = owner.read_attribute(active_record_column)
+          record.write_attribute(associated_record_column, value)
         end
 
         if reflection.type

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -159,7 +159,7 @@ module ActiveRecord
 
         # The name of the key on the associated records
         def association_key_name
-          reflection.join_primary_key(klass)
+          reflection.join_query_constraints_primary_key(klass)
         end
 
         def loader_query
@@ -239,7 +239,7 @@ module ActiveRecord
 
           # The name of the key on the model which declares the association
           def owner_key_name
-            reflection.join_foreign_key
+            reflection.join_query_constraints_foreign_key
           end
 
           def associate_records_to_owner(owner, records)

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -159,7 +159,7 @@ module ActiveRecord
 
         # The name of the key on the associated records
         def association_key_name
-          reflection.join_primary_key(klass)
+          reflection.query_primary_key(klass)
         end
 
         def loader_query
@@ -239,7 +239,7 @@ module ActiveRecord
 
           # The name of the key on the model which declares the association
           def owner_key_name
-            reflection.join_foreign_key
+            reflection.query_foreign_key
           end
 
           def associate_records_to_owner(owner, records)

--- a/activerecord/lib/active_record/associations/through_association.rb
+++ b/activerecord/lib/active_record/associations/through_association.rb
@@ -81,7 +81,7 @@ module ActiveRecord
         # to try to properly support stale-checking for nested associations.
         def stale_state
           if through_reflection.belongs_to?
-            Array(through_reflection.foreign_key).filter_map do |foreign_key_column|
+            Array(through_reflection.join_query_constraints_foreign_key).filter_map do |foreign_key_column|
               owner.read_attribute(foreign_key_column)
             end.presence
           end

--- a/activerecord/lib/active_record/associations/through_association.rb
+++ b/activerecord/lib/active_record/associations/through_association.rb
@@ -81,7 +81,13 @@ module ActiveRecord
         # to try to properly support stale-checking for nested associations.
         def stale_state
           if through_reflection.belongs_to?
-            Array(through_reflection.foreign_key).filter_map do |foreign_key_column|
+            foreign_key = if through_reflection.options[:query_constraints]
+              through_reflection.foreign_key
+            else
+              through_reflection.query_foreign_key
+            end
+
+            Array(foreign_key).filter_map do |foreign_key_column|
               owner.read_attribute(foreign_key_column)
             end.presence
           end

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -544,9 +544,11 @@ module ActiveRecord
       # In addition, it will destroy the association if it was marked for destruction.
       def save_belongs_to_association(reflection)
         association = association_instance_get(reflection.name)
-        return unless association && association.loaded? && !association.stale_target?
+        return unless association && association.loaded?
+        stale_target = association.stale_target?
+        return if stale_target && !association.target&.new_record?
 
-        record = association.load_target
+        record = stale_target ? association.target : association.load_target
         if record && !record.destroyed?
           autosave = reflection.options[:autosave]
 
@@ -566,8 +568,11 @@ module ActiveRecord
             end
 
             if association.updated?
-              primary_key = Array(reflection.association_primary_key(record.class)).map(&:to_s)
+              primary_key = Array(reflection.association_primary_key(record.class))
               foreign_key = Array(reflection.foreign_key)
+              if primary_key.size != foreign_key.size
+                primary_key = Array(reflection.join_query_constraints_primary_key(record.class))
+              end
 
               primary_key_foreign_key_pairs = primary_key.zip(foreign_key)
               primary_key_foreign_key_pairs.each do |primary_key, foreign_key|

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -492,12 +492,11 @@ module ActiveRecord
           return unless (autosave && record.changed_for_autosave?) || _record_changed?(reflection, record, primary_key_value)
 
           unless reflection.through_reflection
-            foreign_key = ActiveRecord::Key.for(reflection.foreign_key)
-            primary_key_foreign_key_pairs = primary_key.zip(foreign_key)
-
-            primary_key_foreign_key_pairs.each do |primary_key, foreign_key|
-              association_id = read_attribute(primary_key)
-              record.write_attribute(foreign_key, association_id) unless record.read_attribute(foreign_key) == association_id
+            reflection.query_key_mapping.foreign_key_pairs.each do |active_record_column, associated_record_column|
+              association_id = read_attribute(active_record_column)
+              if record.read_attribute(associated_record_column) != association_id
+                record.write_attribute(associated_record_column, association_id)
+              end
             end
             association.set_inverse_instance(record)
           end
@@ -544,9 +543,11 @@ module ActiveRecord
       # In addition, it will destroy the association if it was marked for destruction.
       def save_belongs_to_association(reflection)
         association = association_instance_get(reflection.name)
-        return unless association && association.loaded? && !association.stale_target?
+        return unless association && association.loaded?
+        stale_target = association.stale_target?
+        return if stale_target && !association.target&.new_record?
 
-        record = association.load_target
+        record = stale_target ? association.target : association.load_target
         if record && !record.destroyed?
           autosave = reflection.options[:autosave]
 
@@ -566,13 +567,9 @@ module ActiveRecord
             end
 
             if association.updated?
-              primary_key = ActiveRecord::Key.for(reflection.association_primary_key(record.class))
-              foreign_key = ActiveRecord::Key.for(reflection.foreign_key)
-
-              primary_key_foreign_key_pairs = primary_key.zip(foreign_key)
-              primary_key_foreign_key_pairs.each do |primary_key, foreign_key|
-                association_id = record.read_attribute(primary_key)
-                write_attribute(foreign_key, association_id) unless read_attribute(foreign_key) == association_id
+              reflection.query_key_mapping(record.class).foreign_key_pairs.each do |active_record_column, associated_record_column|
+                association_id = record.read_attribute(associated_record_column)
+                write_attribute(active_record_column, association_id) unless read_attribute(active_record_column) == association_id
               end
               association.loaded!
             end

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -543,11 +543,9 @@ module ActiveRecord
       # In addition, it will destroy the association if it was marked for destruction.
       def save_belongs_to_association(reflection)
         association = association_instance_get(reflection.name)
-        return unless association && association.loaded?
-        stale_target = association.stale_target?
-        return if stale_target && !association.target&.new_record?
+        return unless association && association.loaded? && !association.stale_target?
 
-        record = stale_target ? association.target : association.load_target
+        record = association.load_target
         if record && !record.destroyed?
           autosave = reflection.options[:autosave]
 

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -302,8 +302,8 @@ module ActiveRecord
           if !reflection
             value = value.id if value.respond_to?(:id)
           elsif reflection.belongs_to? && !reflection.polymorphic?
-            key = reflection.join_foreign_key
-            pkey = reflection.join_primary_key
+            key = reflection.query_foreign_key
+            pkey = reflection.query_primary_key
 
             if pkey.is_a?(Array)
               if pkey.all? { |attribute| value.respond_to?(attribute) }

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -298,8 +298,8 @@ module ActiveRecord
           if !reflection
             value = value.id if value.respond_to?(:id)
           elsif reflection.belongs_to? && !reflection.polymorphic?
-            key = reflection.join_foreign_key
-            pkey = reflection.join_primary_key
+            key = reflection.join_query_constraints_foreign_key
+            pkey = reflection.join_query_constraints_primary_key
 
             if pkey.is_a?(Array)
               if pkey.all? { |attribute| value.respond_to?(attribute) }

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -160,6 +160,70 @@ module ActiveRecord
     #     ThroughReflection
     #     PolymorphicReflection
     #     RuntimeReflection
+    # Preserves the relationship between columns on both sides of an association.
+    # Query constraint pairs precede writable foreign key pairs.
+    class QueryKeyMapping # :nodoc:
+      include Enumerable
+
+      attr_reader :query_constraint_pairs, :foreign_key_pairs,
+        :active_record_columns, :associated_record_columns,
+        :foreign_key_active_record_columns, :foreign_key_associated_record_columns
+
+      def self.normalize_query_constraints(query_constraints)
+        return unless query_constraints
+
+        query_constraints = [query_constraints] unless query_constraints.is_a?(Array)
+        query_constraints.flat_map do |constraint|
+          case constraint
+          when Symbol, String
+            column = -constraint.to_s
+            [[column, column].freeze]
+          when Hash
+            constraint.map do |active_record_column, associated_record_column|
+              [-active_record_column.to_s, -associated_record_column.to_s].freeze
+            end
+          end
+        end.uniq.freeze
+      end
+
+      def initialize(constraints:, foreign_key:)
+        @query_constraints_declared = !constraints.nil?
+        @query_constraint_pairs = freeze_pairs(constraints || [])
+        @foreign_key_pairs = freeze_pairs(foreign_key)
+        @pairs = [*@query_constraint_pairs, *@foreign_key_pairs].freeze
+        @active_record_columns = @pairs.map { |active_record_column,| active_record_column }.freeze
+        @associated_record_columns = @pairs.map { |_, associated_record_column| associated_record_column }.freeze
+        @foreign_key_active_record_columns = @foreign_key_pairs.map { |active_record_column,| active_record_column }.freeze
+        @foreign_key_associated_record_columns = @foreign_key_pairs.map { |_, associated_record_column| associated_record_column }.freeze
+        freeze
+      end
+
+      def each(&block)
+        @pairs.each(&block)
+      end
+
+      def active_record_key
+        key_for(active_record_columns)
+      end
+
+      def associated_record_key
+        key_for(associated_record_columns)
+      end
+
+      def values_for(active_record)
+        active_record_columns.map { |column| active_record.read_attribute(column) }
+      end
+
+      private
+        def freeze_pairs(pairs)
+          pairs.map { |pair| pair.frozen? ? pair : pair.freeze }.freeze
+        end
+
+        def key_for(columns)
+          @query_constraints_declared || columns.length > 1 ? columns : columns.first
+        end
+    end
+
     class AbstractReflection # :nodoc:
       def initialize
         @class_name = nil
@@ -208,16 +272,11 @@ module ActiveRecord
 
         scope_chain_items.inject(klass_scope, &:merge!)
 
-        primary_key_column_names = Array(join_primary_key)
-        foreign_key_column_names = Array(join_foreign_key)
+        query_key_mapping(foreign_klass).each do |active_record_column, associated_record_column|
+          associated_record_attribute = predicate_builder.predicate_attribute(table[associated_record_column])
+          active_record_attribute = predicate_builder.predicate_attribute(foreign_table[active_record_column])
 
-        primary_foreign_key_pairs = primary_key_column_names.zip(foreign_key_column_names)
-
-        primary_foreign_key_pairs.each do |primary_key_column_name, foreign_key_column_name|
-          primary_key_attribute = predicate_builder.predicate_attribute(table[primary_key_column_name])
-          foreign_key_attribute = predicate_builder.predicate_attribute(foreign_table[foreign_key_column_name])
-
-          klass_scope.where!(primary_key_attribute.eq(foreign_key_attribute))
+          klass_scope.where!(associated_record_attribute.eq(active_record_attribute))
         end
 
         if klass.finder_needs_type_condition?
@@ -537,18 +596,6 @@ module ActiveRecord
         @extensions = options[:extend] ? Array(options[:extend]) : FROZEN_EMPTY_ARRAY
         @extensions = @extensions.dup.freeze unless @extensions.frozen?
 
-        if options[:query_constraints]
-          raise ConfigurationError, <<~MSG.squish
-            Setting `query_constraints:` option on `#{active_record}.#{macro} :#{name}` is not allowed.
-            To get the same behavior, use the `foreign_key` option instead.
-          MSG
-        end
-
-        # If the foreign key is an array, set query constraints options and don't use the foreign key
-        if options[:foreign_key].is_a?(Array)
-          options[:query_constraints] = options.delete(:foreign_key)
-        end
-
         @deprecated = !!options[:deprecated]
 
         ensure_option_not_given_as_class!(:class_name)
@@ -568,15 +615,46 @@ module ActiveRecord
         @join_table ||= -(options[:join_table]&.to_s || derive_join_table)
       end
 
+      # The complete column mapping used to query association targets. Every pair
+      # is [column_on_active_record, column_on_associated_record]. Additive query
+      # constraints precede the writable foreign key relationship.
+      def query_key_mapping(klass = nil)
+        if polymorphic?
+          return build_query_key_mapping(klass) unless klass
+
+          (@query_key_mappings ||= Concurrent::Map.new).compute_if_absent(klass) do
+            build_query_key_mapping(klass)
+          end
+        else
+          @query_key_mapping ||= build_query_key_mapping(klass)
+        end
+      end
+
+      # The columns on the association target's table that additive query
+      # constraints match on. They take part in querying the association, but are
+      # never written when building or assigning a record — only the foreign key
+      # is. See +ForeignAssociation#set_owner_attributes+.
+      def query_constraints_target_columns
+        query_constraint_pairs&.map { |_, associated_record_column| associated_record_column } || []
+      end
+
       def foreign_key(infer_from_inverse_of: true)
         @foreign_key ||= if options[:foreign_key]
           ActiveRecord::Key.for(options[:foreign_key]).name
-        elsif options[:query_constraints]
-          options[:query_constraints].map { |fk| -fk.to_s.freeze }.freeze
         else
+          if options[:query_constraints]
+            query_constraints = options[:query_constraints]
+            query_constraints = [query_constraints] unless query_constraints.is_a?(Array)
+            if query_constraints.any?(Hash)
+              raise ArgumentError,
+                "`query_constraints` with column mapping (Hash) on `#{active_record}.#{macro} :#{name}` " \
+                "requires an explicit `foreign_key` option."
+            end
+          end
+
           derived_fk = derive_foreign_key(infer_from_inverse_of: infer_from_inverse_of)
 
-          if !derived_fk.is_a?(Array) && active_record.has_query_constraints?
+          if !options[:query_constraints] && !derived_fk.is_a?(Array) && active_record.has_query_constraints?
             derived_fk = derive_fk_query_constraints(derived_fk)
           end
 
@@ -596,9 +674,16 @@ module ActiveRecord
         @active_record_primary_key ||=
           if options[:primary_key]
             ActiveRecord::Key.for(options[:primary_key]).name
+          elsif options[:foreign_key].is_a?(Array) ||
+              (active_record.has_query_constraints? && !options[:foreign_key] && !options[:query_constraints])
+            active_record.query_constraints_list
           else
-            derive_primary_key(active_record) { |model| model.query_constraints_list }
+            active_record.primary_key_definition.inferred_id || primary_key(active_record).freeze
           end
+      end
+
+      def query_primary_key(klass = nil)
+        query_key_mapping(klass).associated_record_key
       end
 
       def join_primary_key(klass = nil)
@@ -609,12 +694,26 @@ module ActiveRecord
         type
       end
 
+      def query_foreign_key
+        if polymorphic?
+          if (constraints = query_constraint_pairs)
+            constraint_columns = constraints.map { |active_record_column,| active_record_column }
+            [*constraint_columns, *Array(join_foreign_key)].freeze
+          else
+            join_foreign_key
+          end
+        else
+          query_key_mapping.active_record_key
+        end
+      end
+
       def join_foreign_key
         active_record_primary_key
       end
 
       def check_validity!
         return if @validated
+        query_constraint_pairs
 
         check_validity_of_inverse!
 
@@ -639,6 +738,10 @@ module ActiveRecord
             is not supported.
           MSG
         end
+      end
+
+      def query_key_values_for(owner)
+        Array(query_foreign_key).map { |key| owner.read_attribute(key) }
       end
 
       def join_id_for(owner) # :nodoc:
@@ -745,6 +848,36 @@ module ActiveRecord
       end
 
       private
+        def query_constraint_pairs
+          return unless options[:query_constraints]
+
+          @query_constraint_pairs ||= begin
+            pairs = QueryKeyMapping.normalize_query_constraints(options[:query_constraints])
+            validate_query_constraint_pairs!(pairs)
+            pairs
+          end
+        end
+
+        def build_query_key_mapping(klass)
+          QueryKeyMapping.new(
+            constraints: query_constraint_pairs,
+            foreign_key: Array(join_foreign_key).zip(Array(join_primary_key(klass)))
+          )
+        end
+
+        def validate_query_constraint_pairs!(pairs)
+          query_constraint_foreign_keys = pairs.map do |active_record_column, associated_record_column|
+            belongs_to? ? active_record_column : associated_record_column
+          end
+          overlapping_foreign_keys = Array(foreign_key) & query_constraint_foreign_keys
+
+          if overlapping_foreign_keys.any?
+            raise ArgumentError,
+              "`query_constraints` on `#{active_record}.#{macro} :#{name}` " \
+              "must not include the foreign key columns #{overlapping_foreign_keys.inspect}."
+          end
+        end
+
         # Attempts to find the inverse association name automatically.
         # If it cannot find a suitable inverse association name, it returns
         # +nil+.
@@ -800,9 +933,11 @@ module ActiveRecord
         # Third, we must not have options such as <tt>:foreign_key</tt>
         # which prevent us from correctly guessing the inverse association.
         def can_find_inverse_of_automatically?(reflection, inverse_reflection = false)
+          foreign_key = reflection.options[:foreign_key]
+
           reflection.options[:inverse_of] != false &&
             !reflection.options[:through] &&
-            !reflection.options[:foreign_key] &&
+            (!foreign_key || (foreign_key.is_a?(Array) && !reflection.options[:query_constraints])) &&
             scope_allows_automatic_inverse_of?(reflection, inverse_reflection)
         end
 
@@ -820,11 +955,14 @@ module ActiveRecord
           end
         end
 
-        # Shared by +active_record_primary_key+ and +association_primary_key+ to
-        # resolve the key from +model+ once a custom +primary_key+ is ruled out.
+        # Resolves the key from +model+ once a custom +primary_key+ is ruled out.
         # The block is yielded +model+ to supply its query-constraints list.
+        #
+        # Note: callers handle the association-level +query_constraints+ option
+        # themselves, since its meaning differs by side (and it is decoupled from
+        # +foreign_key+). This only considers the model-level query constraints.
         def derive_primary_key(model)
-          if model.has_query_constraints? || options[:query_constraints]
+          if model.has_query_constraints?
             yield model
           else
             # inferred_id is nil unless the key is composite; otherwise fall back
@@ -953,7 +1091,15 @@ module ActiveRecord
 
         klass ||= self.klass
 
-        if klass.has_query_constraints? && options[:foreign_key] && !options[:query_constraints]
+        # An Array-valued `foreign_key` uses the target's composite query key.
+        if options[:foreign_key].is_a?(Array)
+          return klass.has_query_constraints? ? klass.composite_query_constraints_list : primary_key(klass)
+        end
+
+        # An explicit or derived scalar `foreign_key` handles writes, so the
+        # association's writable key is the target's primary key even when extra
+        # query constraints are layered on for reads.
+        if klass.has_query_constraints? && (options[:foreign_key] || options[:query_constraints])
           return klass.primary_key_definition.inferred_id || primary_key(klass).freeze
         end
 
@@ -989,8 +1135,13 @@ module ActiveRecord
     # Holds all the metadata about a :through association as it was specified
     # in the Active Record class.
     class ThroughReflection < AbstractReflection # :nodoc:
+      # The `query_*` key methods must be delegated the same way as their `join_*`
+      # counterparts (foreign key and key values to +source_reflection+ here,
+      # primary key overridden below), otherwise query-constraint joins would
+      # resolve to the wrong reflection on the chain. Keep the two sets in sync.
       delegate :foreign_key, :foreign_type, :association_foreign_key, :join_id_for, :type,
-               :active_record_primary_key, :join_foreign_key, to: :source_reflection
+               :active_record_primary_key, :join_foreign_key,
+               :query_key_values_for, :query_foreign_key, to: :source_reflection
 
       def initialize(delegate_reflection)
         super()
@@ -1109,6 +1260,14 @@ module ActiveRecord
         else
           primary_key(klass || self.klass)
         end
+      end
+
+      def query_primary_key(klass = self.klass)
+        source_reflection.query_primary_key(klass)
+      end
+
+      def query_key_mapping(klass = self.klass)
+        source_reflection.query_key_mapping(klass)
       end
 
       def join_primary_key(klass = self.klass)
@@ -1260,13 +1419,16 @@ module ActiveRecord
     end
 
     class PolymorphicReflection < AbstractReflection # :nodoc:
-      delegate :klass, :scope, :plural_name, :type, :join_primary_key, :join_foreign_key,
-               :name, :scope_for, to: :@reflection
+      delegate :klass, :scope, :plural_name, :type, :join_primary_key, :join_foreign_key, :name, :scope_for, :query_primary_key, :query_foreign_key, to: :@reflection
 
       def initialize(reflection, previous_reflection)
         super()
         @reflection = reflection
         @previous_reflection = previous_reflection
+      end
+
+      def query_key_mapping(klass = self.klass)
+        @reflection.query_key_mapping(klass)
       end
 
       def join_scopes(table, predicate_builder = nil, klass = self.klass, record = nil) # :nodoc:
@@ -1290,7 +1452,7 @@ module ActiveRecord
     end
 
     class RuntimeReflection < AbstractReflection # :nodoc:
-      delegate :scope, :type, :constraints, :join_foreign_key, to: :@reflection
+      delegate :scope, :type, :constraints, :join_foreign_key, :query_foreign_key, to: :@reflection
 
       def initialize(reflection, association)
         super()
@@ -1304,6 +1466,14 @@ module ActiveRecord
 
       def aliased_table
         klass.arel_table
+      end
+
+      def query_primary_key(klass = self.klass)
+        @reflection.query_primary_key(klass)
+      end
+
+      def query_key_mapping(klass = self.klass)
+        @reflection.query_key_mapping(klass)
       end
 
       def join_primary_key(klass = self.klass)

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -208,8 +208,8 @@ module ActiveRecord
 
         scope_chain_items.inject(klass_scope, &:merge!)
 
-        primary_key_column_names = Array(join_primary_key)
-        foreign_key_column_names = Array(join_foreign_key)
+        primary_key_column_names = Array(join_query_constraints_primary_key)
+        foreign_key_column_names = Array(join_query_constraints_foreign_key)
 
         primary_foreign_key_pairs = primary_key_column_names.zip(foreign_key_column_names)
 
@@ -528,15 +528,11 @@ module ActiveRecord
         @foreign_key = nil
         @association_foreign_key = nil
         @association_primary_key = nil
-        if options[:query_constraints]
-          raise ConfigurationError, <<~MSG.squish
-            Setting `query_constraints:` option on `#{active_record}.#{macro} :#{name}` is not allowed.
-            To get the same behavior, use the `foreign_key` option instead.
-          MSG
-        end
 
-        # If the foreign key is an array, set query constraints options and don't use the foreign key
-        if options[:foreign_key].is_a?(Array)
+        # Preserve legacy composite foreign key behavior by routing it through the
+        # existing multi-column query key machinery. Explicit association-level
+        # query constraints remain separate and skip this normalization.
+        if options[:foreign_key].is_a?(Array) && !options[:query_constraints]
           options[:query_constraints] = options.delete(:foreign_key)
         end
 
@@ -559,11 +555,74 @@ module ActiveRecord
         @join_table ||= -(options[:join_table]&.to_s || derive_join_table)
       end
 
+      # Normalizes the `query_constraints` option into [self_column, target_column] pairs.
+      # Returns nil for old-style query_constraints (plain FK column arrays without explicit foreign_key).
+      #
+      # Activated when `foreign_key` is also specified, or when any element is a Hash.
+      # Key = column on this model's table (self), Value = column on the other table (target).
+      #
+      # Examples:
+      #   query_constraints: :shop_id                        => [["shop_id", "shop_id"]]
+      #   query_constraints: [:blog_id, { id: :blog_post_id }] => [["blog_id", "blog_id"], ["id", "blog_post_id"]]
+      def normalized_query_constraints_mapping
+        return unless options[:query_constraints]
+
+        query_constraints = options[:query_constraints]
+        query_constraints = [query_constraints] unless query_constraints.is_a?(Array)
+        return unless options[:foreign_key] || query_constraints.any?(Hash)
+
+        @normalized_query_constraints_mapping ||= query_constraints.flat_map { |element|
+          case element
+          when Symbol, String
+            column = -element.to_s
+            [[column, column].freeze]
+          when Hash
+            element.map { |self_column, target_column| [-self_column.to_s, -target_column.to_s].freeze }
+          end
+        }.freeze
+      end
+
+      def join_query_constraints_mapping
+        return unless (mapping = normalized_query_constraints_mapping)
+
+        @join_query_constraints_mapping ||= begin
+          foreign_keys = Array(foreign_key)
+          mapping.uniq.reject { |_, target_column| foreign_keys.include?(target_column) }.freeze
+        end
+      end
+
+      # The set of columns used to query association targets (loading, preloading).
+      #
+      # `query_constraints` is a list of *additional* columns layered on top of the
+      # `foreign_key` — the foreign key always participates, since an association
+      # cannot be queried without it. Listing the foreign key in `query_constraints`
+      # is allowed and harmless: it is de-duplicated here rather than rejected.
+      #
+      # Defaults to `foreign_key` when no `query_constraints` are given.
+      def query_constraints_foreign_key
+        @query_constraints_foreign_key ||= if (mapping = join_query_constraints_mapping)
+          columns = belongs_to? ? mapping.map(&:first) : mapping.map(&:last)
+          [*columns, *Array(foreign_key)].uniq.freeze
+        elsif options[:query_constraints]
+          constraints = Array(options[:query_constraints]).map { |key| key.to_s.freeze }
+          [*constraints, *Array(foreign_key)].uniq.freeze
+        else
+          foreign_key
+        end
+      end
+
       def foreign_key(infer_from_inverse_of: true)
         @foreign_key ||= if options[:foreign_key]
           ActiveRecord::Key.for(options[:foreign_key]).name
         elsif options[:query_constraints]
-          options[:query_constraints].map { |fk| -fk.to_s.freeze }.freeze
+          query_constraints = options[:query_constraints]
+          query_constraints = [query_constraints] unless query_constraints.is_a?(Array)
+          if query_constraints.any?(Hash)
+            raise ArgumentError,
+              "`query_constraints` with column mapping (Hash) on `#{active_record}.#{macro} :#{name}` " \
+              "requires an explicit `foreign_key` option."
+          end
+          query_constraints.map { |fk| -fk.to_s.freeze }.freeze
         else
           derived_fk = derive_foreign_key(infer_from_inverse_of: infer_from_inverse_of)
 
@@ -583,13 +642,36 @@ module ActiveRecord
         primary_key(klass || self.klass)
       end
 
+      def active_record_query_constraints_primary_key
+        if options[:primary_key]
+          active_record_primary_key
+        elsif active_record.has_query_constraints? || options[:query_constraints]
+          @active_record_query_constraints_primary_key ||= active_record.query_constraints_list
+        else
+          active_record_primary_key
+        end
+      end
+
       def active_record_primary_key
         @active_record_primary_key ||=
           if options[:primary_key]
             ActiveRecord::Key.for(options[:primary_key]).name
+          elsif (active_record.has_query_constraints? || options[:query_constraints]) && !options[:foreign_key]
+            # query_constraints drive the key only when no foreign_key is given;
+            # an explicit foreign_key handles writes and takes precedence here.
+            active_record.query_constraints_list
           else
-            derive_primary_key(active_record) { |model| model.query_constraints_list }
+            active_record.primary_key_definition.inferred_id || primary_key(active_record).freeze
           end
+      end
+
+      def join_query_constraints_primary_key(klass = nil)
+        if (mapping = join_query_constraints_mapping)
+          # target (child) columns: mapping values + foreign_key
+          [*mapping.map(&:last), *Array(foreign_key)].freeze
+        else
+          query_constraints_foreign_key
+        end
       end
 
       def join_primary_key(klass = nil)
@@ -598,6 +680,15 @@ module ActiveRecord
 
       def join_primary_type
         type
+      end
+
+      def join_query_constraints_foreign_key
+        if (mapping = join_query_constraints_mapping)
+          # self (parent) columns: mapping keys + active_record_primary_key
+          [*mapping.map(&:first), *Array(active_record_primary_key)].freeze
+        else
+          active_record_query_constraints_primary_key
+        end
       end
 
       def join_foreign_key
@@ -630,6 +721,10 @@ module ActiveRecord
             is not supported.
           MSG
         end
+      end
+
+      def join_query_constraints_id_for(owner)
+        Array(join_query_constraints_foreign_key).map { |key| owner.read_attribute(key) }
       end
 
       def join_id_for(owner) # :nodoc:
@@ -815,11 +910,14 @@ module ActiveRecord
           end
         end
 
-        # Shared by +active_record_primary_key+ and +association_primary_key+ to
-        # resolve the key from +model+ once a custom +primary_key+ is ruled out.
+        # Resolves the key from +model+ once a custom +primary_key+ is ruled out.
         # The block is yielded +model+ to supply its query-constraints list.
+        #
+        # Note: callers handle the association-level +query_constraints+ option
+        # themselves, since its meaning differs by side (and it is decoupled from
+        # +foreign_key+). This only considers the model-level query constraints.
         def derive_primary_key(model)
-          if model.has_query_constraints? || options[:query_constraints]
+          if model.has_query_constraints?
             yield model
           else
             # inferred_id is nil unless the key is composite; otherwise fall back
@@ -933,6 +1031,20 @@ module ActiveRecord
         end
       end
 
+      def association_query_constraints_primary_key(klass = nil)
+        # An explicit `primary_key`/`foreign_key` pins a single-column join on the
+        # target's writable key, so defer to +association_primary_key+ even when the
+        # target is query-constrained (e.g. a polymorphic FK to a sharded model).
+        if !options[:primary_key] && !options[:foreign_key] &&
+            ((klass || self.klass).has_query_constraints? || options[:query_constraints])
+          # Not memoized: +klass+ varies for polymorphic associations, so each
+          # target may resolve to a different query-constraints list.
+          (klass || self.klass).query_constraints_list
+        else
+          association_primary_key(klass)
+        end
+      end
+
       # klass option is necessary to support loading polymorphic associations
       def association_primary_key(klass = nil)
         if options[:primary_key]
@@ -948,15 +1060,54 @@ module ActiveRecord
 
         klass ||= self.klass
 
-        if klass.has_query_constraints? && options[:foreign_key] && !options[:query_constraints]
+        # An explicit `foreign_key` handles writes, so the association's writable
+        # key is the target's single primary key even when extra `query_constraints`
+        # are layered on for reads (the decoupled query-constraints feature).
+        if klass.has_query_constraints? && options[:foreign_key]
           return klass.primary_key_definition.inferred_id || primary_key(klass).freeze
+        end
+
+        # `query_constraints` without an explicit `foreign_key` represents the
+        # legacy composite `foreign_key` form. Query-constrained targets must use
+        # their composite query key; other targets continue to use their declared
+        # primary key, which may itself be composite.
+        if options[:query_constraints]
+          return klass.has_query_constraints? ? klass.composite_query_constraints_list : primary_key(klass)
         end
 
         derive_primary_key(klass) { |model| model.composite_query_constraints_list }
       end
 
+      def join_query_constraints_mapping
+        return unless (mapping = normalized_query_constraints_mapping)
+
+        @join_query_constraints_mapping ||= begin
+          foreign_keys = Array(foreign_key)
+          mapping.uniq.reject { |self_column, _| foreign_keys.include?(self_column) }.freeze
+        end
+      end
+
+      def join_query_constraints_primary_key(klass = nil)
+        if (mapping = join_query_constraints_mapping)
+          # target (parent) columns: mapping values + association_primary_key
+          target_klass = polymorphic? ? klass : (klass || self.klass)
+          [*mapping.map(&:last), *Array(association_primary_key(target_klass))].freeze
+        else
+          polymorphic? ? association_query_constraints_primary_key(klass) : association_query_constraints_primary_key
+        end
+      end
+
       def join_primary_key(klass = nil)
         polymorphic? ? association_primary_key(klass) : association_primary_key
+      end
+
+      def join_query_constraints_foreign_key
+        if (mapping = join_query_constraints_mapping)
+          # self (child) columns: mapping keys + foreign_key
+          [*mapping.map(&:first), *Array(foreign_key)].freeze
+        else
+          query_constraints_foreign_key
+        end
       end
 
       def join_foreign_key
@@ -984,8 +1135,13 @@ module ActiveRecord
     # Holds all the metadata about a :through association as it was specified
     # in the Active Record class.
     class ThroughReflection < AbstractReflection # :nodoc:
+      # The `join_query_constraints_*` methods must be delegated the same way as
+      # their `join_*` counterparts (foreign key and id-for to +source_reflection+
+      # here, primary key overridden below), otherwise query-constraint joins would
+      # resolve to the wrong reflection on the chain. Keep the two sets in sync.
       delegate :foreign_key, :foreign_type, :association_foreign_key, :join_id_for, :type,
-               :active_record_primary_key, :join_foreign_key, to: :source_reflection
+               :active_record_primary_key, :join_foreign_key,
+               :join_query_constraints_id_for, :join_query_constraints_foreign_key, to: :source_reflection
 
       def initialize(delegate_reflection)
         super()
@@ -1104,6 +1260,10 @@ module ActiveRecord
         else
           primary_key(klass || self.klass)
         end
+      end
+
+      def join_query_constraints_primary_key(klass = self.klass)
+        source_reflection.join_query_constraints_primary_key(klass)
       end
 
       def join_primary_key(klass = self.klass)
@@ -1263,8 +1423,7 @@ module ActiveRecord
     end
 
     class PolymorphicReflection < AbstractReflection # :nodoc:
-      delegate :klass, :scope, :plural_name, :type, :join_primary_key, :join_foreign_key,
-               :name, :scope_for, to: :@reflection
+      delegate :klass, :scope, :plural_name, :type, :join_primary_key, :join_foreign_key, :name, :scope_for, :join_query_constraints_primary_key, :join_query_constraints_foreign_key, to: :@reflection
 
       def initialize(reflection, previous_reflection)
         super()
@@ -1293,7 +1452,7 @@ module ActiveRecord
     end
 
     class RuntimeReflection < AbstractReflection # :nodoc:
-      delegate :scope, :type, :constraints, :join_foreign_key, to: :@reflection
+      delegate :scope, :type, :constraints, :join_foreign_key, :join_query_constraints_foreign_key, to: :@reflection
 
       def initialize(reflection, association)
         super()
@@ -1307,6 +1466,10 @@ module ActiveRecord
 
       def aliased_table
         klass.arel_table
+      end
+
+      def join_query_constraints_primary_key(klass = self.klass)
+        @reflection.join_query_constraints_primary_key(klass)
       end
 
       def join_primary_key(klass = self.klass)

--- a/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
@@ -9,7 +9,7 @@ module ActiveRecord
       end
 
       def queries
-        key = ActiveRecord::Key.for(reflection.join_foreign_key)
+        key = ActiveRecord::Key.for(reflection.join_query_constraints_foreign_key)
         id_list = ids
         id_list = id_list.pluck(primary_key) if key.composite? && id_list.is_a?(Relation)
 
@@ -34,7 +34,7 @@ module ActiveRecord
         end
 
         def primary_key
-          reflection.join_primary_key
+          reflection.join_query_constraints_primary_key
         end
 
         def primary_type

--- a/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
@@ -9,7 +9,7 @@ module ActiveRecord
       end
 
       def queries
-        key = ActiveRecord::Key.for(reflection.join_foreign_key)
+        key = ActiveRecord::Key.for(reflection.query_foreign_key)
         id_list = ids
         id_list = id_list.pluck(primary_key) if key.composite? && id_list.is_a?(Relation)
 
@@ -34,7 +34,7 @@ module ActiveRecord
         end
 
         def primary_key
-          reflection.join_primary_key
+          reflection.query_primary_key
         end
 
         def primary_type

--- a/activerecord/lib/active_record/relation/predicate_builder/polymorphic_array_value.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/polymorphic_array_value.rb
@@ -9,12 +9,12 @@ module ActiveRecord
       end
 
       def queries
-        return [ reflection.join_foreign_key => values ] if values.empty?
+        return [ reflection.join_query_constraints_foreign_key => values ] if values.empty?
 
         type_to_ids_mapping.map do |type, ids|
           query = {}
           query[reflection.join_foreign_type] = type if type
-          query[reflection.join_foreign_key] = ids
+          query[reflection.join_query_constraints_foreign_key] = ids
           query
         end
       end
@@ -30,7 +30,7 @@ module ActiveRecord
         end
 
         def primary_key(value)
-          reflection.join_primary_key(klass(value))
+          reflection.join_query_constraints_primary_key(klass(value))
         end
 
         def klass(value)

--- a/activerecord/lib/active_record/relation/predicate_builder/polymorphic_array_value.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/polymorphic_array_value.rb
@@ -9,12 +9,12 @@ module ActiveRecord
       end
 
       def queries
-        return [ reflection.join_foreign_key => values ] if values.empty?
+        return [ reflection.query_foreign_key => values ] if values.empty?
 
         type_to_ids_mapping.map do |type, ids|
           query = {}
           query[reflection.join_foreign_type] = type if type
-          query[reflection.join_foreign_key] = ids
+          query[reflection.query_foreign_key] = ids
           query
         end
       end
@@ -30,7 +30,7 @@ module ActiveRecord
         end
 
         def primary_key(value)
-          reflection.join_primary_key(klass(value))
+          reflection.query_primary_key(klass(value))
         end
 
         def klass(value)

--- a/activerecord/test/activejob/destroy_association_async_test.rb
+++ b/activerecord/test/activejob/destroy_association_async_test.rb
@@ -50,16 +50,15 @@ class DestroyAssociationAsyncTest < ActiveRecord::TestCase
     BookDestroyAsync.delete_all
   end
 
-  test "destroying a record destroys has_many :through associated by composite primary key using a job" do
+  test "destroying a record destroys has_many :through associated by query constraints using a job" do
     blog = Sharded::Blog.create!
     blog_post = Sharded::BlogPostDestroyAsync.create!(blog_id: blog.id)
 
     tag1 = Sharded::Tag.create!(name: "Short Read", blog_id: blog.id)
     tag2 = Sharded::Tag.create!(name: "Science", blog_id: blog.id)
 
-    blog_post.tags << [tag1, tag2]
-
-    blog_post.save!
+    Sharded::BlogPostTag.create!(blog_id: blog.id, blog_post_id: blog_post.id, tag_id: tag1.id)
+    Sharded::BlogPostTag.create!(blog_id: blog.id, blog_post_id: blog_post.id, tag_id: tag2.id)
 
     assert_enqueued_jobs 1, only: ActiveRecord::DestroyAssociationAsyncJob do
       blog_post.destroy
@@ -168,15 +167,27 @@ class DestroyAssociationAsyncTest < ActiveRecord::TestCase
     BookDestroyAsync.delete_all
   end
 
-  test "belongs to associated by composite primary key" do
-    blog = Sharded::Blog.create!
-    blog_post = Sharded::BlogPostDestroyAsync.create!(blog_id: blog.id)
-    comment = Sharded::CommentDestroyAsync.create!(body: "Great post! :clap:")
+  test "belongs to associated by query constraints" do
+    blog = Sharded::Blog.create!(id: 100)
+    blog_post = Sharded::BlogPostDestroyAsync.create!(id: 200, blog_id: blog.id)
+    comment = Sharded::CommentDestroyAsync.create!(body: "Great post! :clap:", blog_id: blog.id)
 
     comment.blog_post = blog_post
     comment.save!
 
-    assert_enqueued_jobs 1, only: ActiveRecord::DestroyAssociationAsyncJob do
+    # The owner supplies the sharding constraint while assignment only writes
+    # blog_post_id. Distinct explicit IDs guarantee the writable key cannot be
+    # confused with blog_id when this file runs in isolation.
+    assert_equal blog_post.blog_id, comment.blog_id
+    assert_equal blog_post.id, comment.blog_post_id
+
+    job_args = lambda do |args|
+      options = args.first
+      options[:association_primary_key_column] == ["blog_id", "id"] &&
+        options[:association_ids] == [[blog.id, blog_post.id]]
+    end
+
+    assert_enqueued_with(job: ActiveRecord::DestroyAssociationAsyncJob, args: job_args) do
       comment.destroy
     end
 

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -42,6 +42,7 @@ require "models/image"
 require "models/shipment"
 require "models/adjustment"
 require "models/dats"
+require "models/sharded"
 
 class BelongsToAssociationsTest < ActiveRecord::TestCase
   fixtures :accounts, :companies, :developers, :projects, :topics,
@@ -1989,7 +1990,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     end
 
     assert_equal(<<~MESSAGE.squish, error.message)
-      Association Cpk::BrokenBookWithNonCpkOrder#order primary key ["id"]
+      Association Cpk::BrokenBookWithNonCpkOrder#order primary key id
       doesn't match with foreign key ["shop_id", "order_id"]. Please specify query_constraints, or primary_key and foreign_key values.
     MESSAGE
   end
@@ -2248,12 +2249,281 @@ class BelongsToPolymorphicShardedPrimaryKeyTest < ActiveRecord::TestCase
     assert_equal "id", reflection.association_primary_key(Sharded::BlogPost)
   end
 
-  def test_inverse_with_composite_query_constraints_resolves_single_primary_key
+  def test_inverse_with_decoupled_query_constraints_resolves_single_primary_key
     reflection = Adjustment.reflect_on_association(:adjustable)
     inverse = Shipment.reflect_on_association(:adjustments)
 
-    assert_equal [:region_id, :adjustable_id], inverse.options[:query_constraints]
-    assert_equal [:region_id, :id], inverse.options[:primary_key]
+    # Decoupled form: foreign_key handles the writable join (adjustable_id -> id),
+    # query_constraints scopes by the tenant column (region_id) without being written.
+    assert_equal :adjustable_id, inverse.options[:foreign_key]
+    assert_equal [:region_id], inverse.options[:query_constraints]
     assert_equal "id", reflection.association_primary_key(Shipment)
   end
+end
+
+class BelongsToWithDecoupledQueryConstraintsTest < ActiveRecord::TestCase
+  fixtures :sharded_comments, :sharded_blog_posts, :sharded_blogs
+
+  def test_legacy_composite_foreign_key_targets_query_constrained_primary_key
+    comment = sharded_comments(:great_comment_blog_post_one)
+    legacy_comment = Sharded::LegacyComment.find([comment.blog_id, comment.id])
+    expected_blog_post = sharded_blog_posts(:great_post_blog_one)
+
+    sql = capture_sql do
+      assert_nothing_raised do
+        assert_equal expected_blog_post, legacy_comment.blog_post
+      end
+    end.first
+
+    assert_match(/#{Regexp.escape(Sharded::BlogPost.lease_connection.quote_table_name("sharded_blog_posts.blog_id"))} =/, sql)
+    assert_match(/#{Regexp.escape(Sharded::BlogPost.lease_connection.quote_table_name("sharded_blog_posts.id"))} =/, sql)
+  end
+
+  def test_belongs_to_with_decoupled_qc_queries_record_using_all_constraints
+    comment = sharded_comments(:great_comment_blog_post_one)
+    expected_blog_post = sharded_blog_posts(:great_post_blog_one)
+
+    sql = capture_sql do
+      assert_equal expected_blog_post, comment.blog_post_with_decoupled_qc
+    end.first
+
+    assert_match(/#{Regexp.escape(Sharded::BlogPost.lease_connection.quote_table_name("sharded_blog_posts.blog_id"))} =/, sql)
+    assert_match(/#{Regexp.escape(Sharded::BlogPost.lease_connection.quote_table_name("sharded_blog_posts.id"))} =/, sql)
+  end
+
+  def test_belongs_to_association_preload_with_decoupled_qc
+    comment = sharded_comments(:great_comment_blog_post_one)
+    expected_blog_post = sharded_blog_posts(:great_post_blog_one)
+
+    sql = capture_sql do
+      comment = Sharded::Comment.where(id: comment.id).preload(:blog_post_with_decoupled_qc).to_a.first
+      loaded_blog_post = assert_no_queries { comment.blog_post_with_decoupled_qc }
+      assert_equal expected_blog_post, loaded_blog_post
+    end.last
+
+    assert_match(/#{Regexp.escape(Sharded::BlogPost.lease_connection.quote_table_name("sharded_blog_posts.blog_id"))} =/, sql)
+    assert_match(/#{Regexp.escape(Sharded::BlogPost.lease_connection.quote_table_name("sharded_blog_posts.id"))} =/, sql)
+  end
+
+  def test_belongs_to_association_join_with_decoupled_qc_uses_all_constraints
+    comment = sharded_comments(:great_comment_blog_post_one)
+
+    sql = capture_sql do
+      loaded_comment = Sharded::Comment.joins(:blog_post_with_decoupled_qc).where(id: comment.id).first
+      assert_equal comment, loaded_comment
+    end.first
+
+    assert_sql_join_constraint(sql, Sharded::BlogPost, "sharded_blog_posts.blog_id", Sharded::Comment, "sharded_comments.blog_id")
+    assert_sql_join_constraint(sql, Sharded::BlogPost, "sharded_blog_posts.id", Sharded::Comment, "sharded_comments.blog_post_id")
+  end
+
+  def test_belongs_to_association_eager_load_with_decoupled_qc_uses_all_constraints
+    comment = sharded_comments(:great_comment_blog_post_one)
+    expected_blog_post = sharded_blog_posts(:great_post_blog_one)
+
+    sql = capture_sql do
+      loaded_comment = Sharded::Comment.eager_load(:blog_post_with_decoupled_qc).where(id: comment.id).first
+      loaded_blog_post = assert_no_queries { loaded_comment.blog_post_with_decoupled_qc }
+      assert_equal expected_blog_post, loaded_blog_post
+    end.first
+
+    assert_sql_join_constraint(sql, Sharded::BlogPost, "sharded_blog_posts.blog_id", Sharded::Comment, "sharded_comments.blog_id")
+    assert_sql_join_constraint(sql, Sharded::BlogPost, "sharded_blog_posts.id", Sharded::Comment, "sharded_comments.blog_post_id")
+  end
+
+  def test_where_with_decoupled_query_constraints_uses_all_constraints
+    blog_post = sharded_blog_posts(:great_post_blog_one)
+    expected = Sharded::Comment.where(blog_id: blog_post.blog_id, blog_post_id: blog_post.id).to_a
+
+    sql = capture_sql do
+      assert_equal expected, Sharded::Comment.where(blog_post_with_decoupled_qc: blog_post).to_a
+    end.first
+
+    assert_match(/#{Regexp.escape(Sharded::Comment.lease_connection.quote_table_name("sharded_comments.blog_id"))} =/, sql)
+    assert_match(/#{Regexp.escape(Sharded::Comment.lease_connection.quote_table_name("sharded_comments.blog_post_id"))} =/, sql)
+  end
+
+  def test_find_by_with_decoupled_query_constraints_uses_all_constraints
+    comment = sharded_comments(:great_comment_blog_post_one)
+    blog_post = sharded_blog_posts(:great_post_blog_one)
+
+    sql = capture_sql do
+      assert_equal comment, Sharded::Comment.find_by(blog_post_with_decoupled_qc: blog_post)
+    end.first
+
+    assert_match(/#{Regexp.escape(Sharded::Comment.lease_connection.quote_table_name("sharded_comments.blog_id"))} =/, sql)
+    assert_match(/#{Regexp.escape(Sharded::Comment.lease_connection.quote_table_name("sharded_comments.blog_post_id"))} =/, sql)
+  end
+
+  def test_nullifiying_belongs_to_association_with_decoupled_query_constraints_doesnt_reset_tenant_key
+    comment = sharded_comments(:great_comment_blog_post_one)
+    comment.blog_post_with_decoupled_qc = nil
+    comment.save!
+
+    assert comment.blog_id
+    assert_nil comment.blog_post_id
+  end
+
+  def test_setting_belongs_to_association_with_decoupled_query_constraints_doesnt_set_tenant_key
+    blog_post = sharded_blog_posts(:great_post_blog_one)
+    comment = Sharded::Comment.new(blog_post_with_decoupled_qc: blog_post)
+
+    assert_nil comment.blog_id
+    assert_equal comment.blog_post_id, blog_post.id
+
+    comment.blog_id = 123_456
+    comment.save!
+
+    assert_equal 123_456, comment.blog_id
+    assert_equal comment.blog_post_id, blog_post.id
+  end
+
+  def test_saving_decoupled_query_constraints_belongs_to_autosaves_new_target_after_constraint_changes
+    blog_post = Sharded::BlogPost.new(id: 654_321, blog_id: 123_456)
+    comment = Sharded::Comment.new(blog_post_with_decoupled_qc: blog_post)
+    comment.blog_id = blog_post.blog_id
+
+    comment.save!
+
+    assert_predicate blog_post, :persisted?
+    assert_equal blog_post.id, comment.blog_post_id
+    assert_equal blog_post, comment.reload.blog_post_with_decoupled_qc
+  end
+
+  def test_belongs_to_with_query_constraints_column_mapping
+    blog_post = sharded_blog_posts(:great_post_blog_one)
+    expected_comment = sharded_comments(:great_comment_blog_post_one)
+
+    assert_equal expected_comment.id, blog_post.featured_comment_id
+
+    sql = capture_sql do
+      loaded_comment = blog_post.featured_comment
+      assert_equal expected_comment, loaded_comment
+    end.first
+
+    # All three constraints must appear in the query
+    assert_match(/#{Regexp.escape(Sharded::Comment.lease_connection.quote_table_name("sharded_comments.blog_id"))} =/, sql)
+    assert_match(/#{Regexp.escape(Sharded::Comment.lease_connection.quote_table_name("sharded_comments.blog_post_id"))} =/, sql)
+    assert_match(/#{Regexp.escape(Sharded::Comment.lease_connection.quote_table_name("sharded_comments.id"))} =/, sql)
+  end
+
+  def test_belongs_to_join_with_query_constraints_column_mapping_uses_all_constraints
+    blog_post = sharded_blog_posts(:great_post_blog_one)
+    expected_comment = sharded_comments(:great_comment_blog_post_one)
+
+    sql = capture_sql do
+      loaded_blog_post = Sharded::BlogPost.joins(:featured_comment).where(id: blog_post.id).first
+      assert_equal expected_comment.id, loaded_blog_post.featured_comment_id
+    end.first
+
+    assert_sql_join_constraint(sql, Sharded::Comment, "sharded_comments.blog_id", Sharded::BlogPost, "sharded_blog_posts.blog_id")
+    assert_sql_join_constraint(sql, Sharded::Comment, "sharded_comments.blog_post_id", Sharded::BlogPost, "sharded_blog_posts.id")
+    assert_sql_join_constraint(sql, Sharded::Comment, "sharded_comments.id", Sharded::BlogPost, "sharded_blog_posts.featured_comment_id")
+  end
+
+  def test_belongs_to_eager_load_with_query_constraints_column_mapping_uses_all_constraints
+    blog_post = sharded_blog_posts(:great_post_blog_one)
+    expected_comment = sharded_comments(:great_comment_blog_post_one)
+
+    sql = capture_sql do
+      loaded_blog_post = Sharded::BlogPost.eager_load(:featured_comment).where(id: blog_post.id).first
+      loaded_comment = assert_no_queries { loaded_blog_post.featured_comment }
+      assert_equal expected_comment, loaded_comment
+    end.first
+
+    assert_sql_join_constraint(sql, Sharded::Comment, "sharded_comments.blog_id", Sharded::BlogPost, "sharded_blog_posts.blog_id")
+    assert_sql_join_constraint(sql, Sharded::Comment, "sharded_comments.blog_post_id", Sharded::BlogPost, "sharded_blog_posts.id")
+    assert_sql_join_constraint(sql, Sharded::Comment, "sharded_comments.id", Sharded::BlogPost, "sharded_blog_posts.featured_comment_id")
+  end
+
+  def test_preload_belongs_to_with_query_constraints_column_mapping
+    blog_post = sharded_blog_posts(:great_post_blog_one)
+    expected_comment = sharded_comments(:great_comment_blog_post_one)
+
+    sql = capture_sql do
+      bp = Sharded::BlogPost.where(id: blog_post.id).preload(:featured_comment).to_a.first
+      loaded_comment = assert_no_queries { bp.featured_comment }
+      assert_equal expected_comment, loaded_comment
+    end.last
+
+    assert_match(/#{Regexp.escape(Sharded::Comment.lease_connection.quote_table_name("sharded_comments.blog_id"))} =/, sql)
+    assert_match(/#{Regexp.escape(Sharded::Comment.lease_connection.quote_table_name("sharded_comments.blog_post_id"))} =/, sql)
+    assert_match(/#{Regexp.escape(Sharded::Comment.lease_connection.quote_table_name("sharded_comments.id"))} =/, sql)
+  end
+
+  def test_belongs_to_with_fk_listed_in_query_constraints_queries_using_base_pk_fk_pair
+    comment = sharded_comments(:great_comment_blog_post_one)
+    expected_blog_post = sharded_blog_posts(:great_post_blog_one)
+
+    sql = capture_sql do
+      assert_equal expected_blog_post, comment.blog_post_with_fk_in_qc
+    end.first
+
+    # The query must use the base PK/FK pair on the target table:
+    # sharded_blog_posts.blog_id and sharded_blog_posts.id.
+    # It must NOT reference sharded_blog_posts.blog_post_id (which is not even
+    # a column on that table) — the FK listed in query_constraints is de-duplicated.
+    assert_match(/#{Regexp.escape(Sharded::BlogPost.lease_connection.quote_table_name("sharded_blog_posts.blog_id"))} =/, sql)
+    assert_match(/#{Regexp.escape(Sharded::BlogPost.lease_connection.quote_table_name("sharded_blog_posts.id"))} =/, sql)
+    assert_no_match(/#{Regexp.escape(Sharded::BlogPost.lease_connection.quote_table_name("sharded_blog_posts.blog_post_id"))} =/, sql)
+  end
+
+  def test_belongs_to_with_bare_hash_query_constraints_loads_correctly
+    blog_post = sharded_blog_posts(:great_post_blog_one)
+    expected_comment = sharded_comments(:great_comment_blog_post_one)
+
+    assert_equal expected_comment.id, blog_post.featured_comment_id
+
+    sql = capture_sql do
+      loaded_comment = blog_post.featured_comment_bare_hash_qc
+      assert_equal expected_comment, loaded_comment
+    end.first
+
+    # A bare Hash { blog_id: :blog_id } normalizes to a single constraint pair,
+    # combined with the foreign_key for the base PK/FK join.
+    assert_match(/#{Regexp.escape(Sharded::Comment.lease_connection.quote_table_name("sharded_comments.blog_id"))} =/, sql)
+    assert_match(/#{Regexp.escape(Sharded::Comment.lease_connection.quote_table_name("sharded_comments.id"))} =/, sql)
+  end
+
+  def test_changing_query_constraint_column_invalidates_cached_belongs_to
+    comment = sharded_comments(:great_comment_blog_post_one)
+    expected_blog_post = sharded_blog_posts(:great_post_blog_one)
+
+    # Load the association once — caches the target and records stale_state.
+    assert_equal expected_blog_post, comment.blog_post_with_decoupled_qc
+    assert_predicate comment.association(:blog_post_with_decoupled_qc), :loaded?
+
+    # Change ONLY the query-constraint column (blog_id), NOT the foreign_key
+    # (blog_post_id). The cached target must become stale.
+    comment.blog_id = comment.blog_id + 1_000_000
+
+    # The reader must reload — issuing exactly one query — rather than serving
+    # the stale cache.
+    assert_queries_count(1) do
+      comment.blog_post_with_decoupled_qc
+    end
+
+    # With a non-existent blog_id the query finds no matching BlogPost.
+    assert_nil comment.blog_post_with_decoupled_qc
+  end
+
+  def test_changing_query_constraint_column_invalidates_cached_has_one_through
+    comment = sharded_comments(:great_comment_blog_post_one)
+    expected_blog = sharded_blogs(:sharded_blog_one)
+
+    assert_equal expected_blog, comment.blog_through_post_with_decoupled_qc
+    comment.blog_id = comment.blog_id + 1_000_000
+
+    assert_queries_count(1) do
+      assert_nil comment.blog_through_post_with_decoupled_qc
+    end
+  end
+
+  private
+    def assert_sql_join_constraint(sql, left_model, left_column_name, right_model, right_column_name)
+      left_column = Regexp.escape(left_model.lease_connection.quote_table_name(left_column_name))
+      right_column = Regexp.escape(right_model.lease_connection.quote_table_name(right_column_name))
+
+      assert_match(/#{left_column} = #{right_column}/, sql)
+    end
 end

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -42,6 +42,7 @@ require "models/image"
 require "models/shipment"
 require "models/adjustment"
 require "models/dats"
+require "models/sharded"
 require "models/human"
 
 class BelongsToContainedKeyChapter < Cpk::Chapter
@@ -2062,7 +2063,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     end
 
     assert_equal(<<~MESSAGE.squish, error.message)
-      Association Cpk::BrokenBookWithNonCpkOrder#order primary key ["id"]
+      Association Cpk::BrokenBookWithNonCpkOrder#order primary key id
       doesn't match with foreign key ["shop_id", "order_id"]. Please specify query_constraints, or primary_key and foreign_key values.
     MESSAGE
   end
@@ -2321,12 +2322,273 @@ class BelongsToPolymorphicShardedPrimaryKeyTest < ActiveRecord::TestCase
     assert_equal "id", reflection.association_primary_key(Sharded::BlogPost)
   end
 
-  def test_inverse_with_composite_query_constraints_resolves_single_primary_key
+  def test_inverse_with_decoupled_query_constraints_resolves_single_primary_key
     reflection = Adjustment.reflect_on_association(:adjustable)
     inverse = Shipment.reflect_on_association(:adjustments)
 
-    assert_equal [:region_id, :adjustable_id], inverse.options[:query_constraints]
-    assert_equal [:region_id, :id], inverse.options[:primary_key]
+    # Decoupled form: foreign_key handles the writable join (adjustable_id -> id),
+    # query_constraints scopes by the tenant column (region_id) without being written.
+    assert_equal :adjustable_id, inverse.options[:foreign_key]
+    assert_equal [:region_id], inverse.options[:query_constraints]
     assert_equal "id", reflection.association_primary_key(Shipment)
   end
+end
+
+class BelongsToWithDecoupledQueryConstraintsTest < ActiveRecord::TestCase
+  fixtures :sharded_comments, :sharded_blog_posts, :sharded_blogs
+
+  def test_legacy_composite_foreign_key_targets_query_constrained_primary_key
+    comment = sharded_comments(:great_comment_blog_post_one)
+    legacy_comment = Sharded::LegacyComment.find([comment.blog_id, comment.id])
+    expected_blog_post = sharded_blog_posts(:great_post_blog_one)
+
+    sql = capture_sql do
+      assert_nothing_raised do
+        assert_equal expected_blog_post, legacy_comment.blog_post
+      end
+    end.first
+
+    assert_match(/#{Regexp.escape(Sharded::BlogPost.lease_connection.quote_table_name("sharded_blog_posts.blog_id"))} =/, sql)
+    assert_match(/#{Regexp.escape(Sharded::BlogPost.lease_connection.quote_table_name("sharded_blog_posts.id"))} =/, sql)
+  end
+
+  def test_belongs_to_with_decoupled_qc_queries_record_using_all_constraints
+    comment = sharded_comments(:great_comment_blog_post_one)
+    expected_blog_post = sharded_blog_posts(:great_post_blog_one)
+
+    sql = capture_sql do
+      assert_equal expected_blog_post, comment.blog_post_with_decoupled_qc
+    end.first
+
+    assert_match(/#{Regexp.escape(Sharded::BlogPost.lease_connection.quote_table_name("sharded_blog_posts.blog_id"))} =/, sql)
+    assert_match(/#{Regexp.escape(Sharded::BlogPost.lease_connection.quote_table_name("sharded_blog_posts.id"))} =/, sql)
+  end
+
+  def test_belongs_to_association_preload_with_decoupled_qc
+    comment = sharded_comments(:great_comment_blog_post_one)
+    expected_blog_post = sharded_blog_posts(:great_post_blog_one)
+
+    sql = capture_sql do
+      comment = Sharded::Comment.where(id: comment.id).preload(:blog_post_with_decoupled_qc).to_a.first
+      loaded_blog_post = assert_no_queries { comment.blog_post_with_decoupled_qc }
+      assert_equal expected_blog_post, loaded_blog_post
+    end.last
+
+    assert_match(/#{Regexp.escape(Sharded::BlogPost.lease_connection.quote_table_name("sharded_blog_posts.blog_id"))} =/, sql)
+    assert_match(/#{Regexp.escape(Sharded::BlogPost.lease_connection.quote_table_name("sharded_blog_posts.id"))} =/, sql)
+  end
+
+  def test_belongs_to_association_join_with_decoupled_qc_uses_all_constraints
+    comment = sharded_comments(:great_comment_blog_post_one)
+
+    sql = capture_sql do
+      loaded_comment = Sharded::Comment.joins(:blog_post_with_decoupled_qc).where(id: comment.id).first
+      assert_equal comment, loaded_comment
+    end.first
+
+    assert_sql_join_constraint(sql, Sharded::BlogPost, "sharded_blog_posts.blog_id", Sharded::Comment, "sharded_comments.blog_id")
+    assert_sql_join_constraint(sql, Sharded::BlogPost, "sharded_blog_posts.id", Sharded::Comment, "sharded_comments.blog_post_id")
+  end
+
+  def test_belongs_to_association_eager_load_with_decoupled_qc_uses_all_constraints
+    comment = sharded_comments(:great_comment_blog_post_one)
+    expected_blog_post = sharded_blog_posts(:great_post_blog_one)
+
+    sql = capture_sql do
+      loaded_comment = Sharded::Comment.eager_load(:blog_post_with_decoupled_qc).where(id: comment.id).first
+      loaded_blog_post = assert_no_queries { loaded_comment.blog_post_with_decoupled_qc }
+      assert_equal expected_blog_post, loaded_blog_post
+    end.first
+
+    assert_sql_join_constraint(sql, Sharded::BlogPost, "sharded_blog_posts.blog_id", Sharded::Comment, "sharded_comments.blog_id")
+    assert_sql_join_constraint(sql, Sharded::BlogPost, "sharded_blog_posts.id", Sharded::Comment, "sharded_comments.blog_post_id")
+  end
+
+  def test_where_with_decoupled_query_constraints_uses_all_constraints
+    blog_post = sharded_blog_posts(:great_post_blog_one)
+    expected = Sharded::Comment.where(blog_id: blog_post.blog_id, blog_post_id: blog_post.id).to_a
+
+    sql = capture_sql do
+      assert_equal expected, Sharded::Comment.where(blog_post_with_decoupled_qc: blog_post).to_a
+    end.first
+
+    assert_match(/#{Regexp.escape(Sharded::Comment.lease_connection.quote_table_name("sharded_comments.blog_id"))} =/, sql)
+    assert_match(/#{Regexp.escape(Sharded::Comment.lease_connection.quote_table_name("sharded_comments.blog_post_id"))} =/, sql)
+  end
+
+  def test_find_by_with_decoupled_query_constraints_uses_all_constraints
+    blog_post = sharded_blog_posts(:great_post_blog_one)
+    comment = nil
+
+    sql = capture_sql do
+      comment = Sharded::Comment.find_by(blog_post_with_decoupled_qc: blog_post)
+    end.first
+
+    assert_equal blog_post.blog_id, comment.blog_id
+    assert_equal blog_post.id, comment.blog_post_id
+    assert_match(/#{Regexp.escape(Sharded::Comment.lease_connection.quote_table_name("sharded_comments.blog_id"))} =/, sql)
+    assert_match(/#{Regexp.escape(Sharded::Comment.lease_connection.quote_table_name("sharded_comments.blog_post_id"))} =/, sql)
+  end
+
+  def test_nullifying_belongs_to_association_with_decoupled_query_constraints_doesnt_reset_tenant_key
+    comment = sharded_comments(:great_comment_blog_post_one)
+    comment.blog_post_with_decoupled_qc = nil
+    comment.save!
+
+    assert comment.blog_id
+    assert_nil comment.blog_post_id
+  end
+
+  def test_setting_belongs_to_association_with_decoupled_query_constraints_doesnt_set_tenant_key
+    blog_post = sharded_blog_posts(:great_post_blog_one)
+    comment = Sharded::Comment.new(blog_post_with_decoupled_qc: blog_post)
+
+    assert_nil comment.blog_id
+    assert_equal comment.blog_post_id, blog_post.id
+
+    comment.blog_id = 123_456
+    assert_same blog_post, comment.blog_post_with_decoupled_qc
+    comment.save!
+
+    assert_equal 123_456, comment.blog_id
+    assert_equal comment.blog_post_id, blog_post.id
+  end
+
+  def test_saving_decoupled_query_constraints_belongs_to_autosaves_assigned_target_after_constraint_changes
+    blog = sharded_blogs(:sharded_blog_one)
+    blog_post = Sharded::BlogPost.new(blog: blog)
+    comment = Sharded::Comment.new(blog_post_with_decoupled_qc_autosave: blog_post)
+    comment.blog_id = blog.id
+
+    assert_same blog_post, comment.blog_post_with_decoupled_qc_autosave
+
+    comment.save!
+
+    assert_predicate blog_post, :persisted?
+    assert_equal blog_post.id, comment.blog_post_id
+    assert_equal blog_post, comment.reload.blog_post_with_decoupled_qc_autosave
+  end
+
+  def test_belongs_to_with_query_constraints_column_mapping
+    blog_post = sharded_blog_posts(:great_post_blog_one)
+    expected_comment = sharded_comments(:great_comment_blog_post_one)
+
+    assert_equal expected_comment.id, blog_post.featured_comment_id
+
+    sql = capture_sql do
+      loaded_comment = blog_post.featured_comment
+      assert_equal expected_comment, loaded_comment
+    end.first
+
+    # All three constraints must appear in the query
+    assert_match(/#{Regexp.escape(Sharded::Comment.lease_connection.quote_table_name("sharded_comments.blog_id"))} =/, sql)
+    assert_match(/#{Regexp.escape(Sharded::Comment.lease_connection.quote_table_name("sharded_comments.blog_post_id"))} =/, sql)
+    assert_match(/#{Regexp.escape(Sharded::Comment.lease_connection.quote_table_name("sharded_comments.id"))} =/, sql)
+  end
+
+  def test_belongs_to_join_with_query_constraints_column_mapping_uses_all_constraints
+    blog_post = sharded_blog_posts(:great_post_blog_one)
+    expected_comment = sharded_comments(:great_comment_blog_post_one)
+
+    sql = capture_sql do
+      loaded_blog_post = Sharded::BlogPost.joins(:featured_comment).where(id: blog_post.id).first
+      assert_equal expected_comment.id, loaded_blog_post.featured_comment_id
+    end.first
+
+    assert_sql_join_constraint(sql, Sharded::Comment, "sharded_comments.blog_id", Sharded::BlogPost, "sharded_blog_posts.blog_id")
+    assert_sql_join_constraint(sql, Sharded::Comment, "sharded_comments.blog_post_id", Sharded::BlogPost, "sharded_blog_posts.id")
+    assert_sql_join_constraint(sql, Sharded::Comment, "sharded_comments.id", Sharded::BlogPost, "sharded_blog_posts.featured_comment_id")
+  end
+
+  def test_belongs_to_eager_load_with_query_constraints_column_mapping_uses_all_constraints
+    blog_post = sharded_blog_posts(:great_post_blog_one)
+    expected_comment = sharded_comments(:great_comment_blog_post_one)
+
+    sql = capture_sql do
+      loaded_blog_post = Sharded::BlogPost.eager_load(:featured_comment).where(id: blog_post.id).first
+      loaded_comment = assert_no_queries { loaded_blog_post.featured_comment }
+      assert_equal expected_comment, loaded_comment
+    end.first
+
+    assert_sql_join_constraint(sql, Sharded::Comment, "sharded_comments.blog_id", Sharded::BlogPost, "sharded_blog_posts.blog_id")
+    assert_sql_join_constraint(sql, Sharded::Comment, "sharded_comments.blog_post_id", Sharded::BlogPost, "sharded_blog_posts.id")
+    assert_sql_join_constraint(sql, Sharded::Comment, "sharded_comments.id", Sharded::BlogPost, "sharded_blog_posts.featured_comment_id")
+  end
+
+  def test_preload_belongs_to_with_query_constraints_column_mapping
+    blog_post = sharded_blog_posts(:great_post_blog_one)
+    expected_comment = sharded_comments(:great_comment_blog_post_one)
+
+    sql = capture_sql do
+      bp = Sharded::BlogPost.where(id: blog_post.id).preload(:featured_comment).to_a.first
+      loaded_comment = assert_no_queries { bp.featured_comment }
+      assert_equal expected_comment, loaded_comment
+    end.last
+
+    assert_match(/#{Regexp.escape(Sharded::Comment.lease_connection.quote_table_name("sharded_comments.blog_id"))} =/, sql)
+    assert_match(/#{Regexp.escape(Sharded::Comment.lease_connection.quote_table_name("sharded_comments.blog_post_id"))} =/, sql)
+    assert_match(/#{Regexp.escape(Sharded::Comment.lease_connection.quote_table_name("sharded_comments.id"))} =/, sql)
+  end
+
+
+  def test_belongs_to_with_bare_hash_query_constraints_loads_correctly
+    blog_post = sharded_blog_posts(:great_post_blog_one)
+    expected_comment = sharded_comments(:great_comment_blog_post_one)
+
+    assert_equal expected_comment.id, blog_post.featured_comment_id
+
+    sql = capture_sql do
+      loaded_comment = blog_post.featured_comment_bare_hash_qc
+      assert_equal expected_comment, loaded_comment
+    end.first
+
+    # A bare Hash { blog_id: :blog_id } normalizes to a single constraint pair,
+    # combined with the foreign_key for the base PK/FK join.
+    assert_match(/#{Regexp.escape(Sharded::Comment.lease_connection.quote_table_name("sharded_comments.blog_id"))} =/, sql)
+    assert_match(/#{Regexp.escape(Sharded::Comment.lease_connection.quote_table_name("sharded_comments.id"))} =/, sql)
+  end
+
+  def test_changing_query_constraint_column_doesnt_invalidate_cached_belongs_to
+    comment = sharded_comments(:great_comment_blog_post_one)
+    loaded_blog_post = comment.blog_post_with_decoupled_qc
+
+    comment.blog_id = comment.blog_id + 1_000_000
+
+    assert_no_queries do
+      assert_same loaded_blog_post, comment.blog_post_with_decoupled_qc
+    end
+  end
+
+  def test_changing_foreign_key_invalidates_cached_belongs_to_with_decoupled_query_constraints
+    comment = sharded_comments(:great_comment_blog_post_one)
+    original_blog_post = sharded_blog_posts(:great_post_blog_one)
+    replacement_blog_post = sharded_blog_posts(:second_post_blog_one)
+
+    assert_equal original_blog_post, comment.blog_post_with_decoupled_qc
+
+    comment.blog_post_id = replacement_blog_post.id
+
+    assert_queries_count(1) do
+      assert_equal replacement_blog_post, comment.blog_post_with_decoupled_qc
+    end
+  end
+
+  def test_changing_query_constraint_column_doesnt_invalidate_cached_has_one_through
+    comment = sharded_comments(:great_comment_blog_post_one)
+    loaded_blog = comment.blog_through_post_with_decoupled_qc
+
+    comment.blog_id = comment.blog_id + 1_000_000
+
+    assert_no_queries do
+      assert_same loaded_blog, comment.blog_through_post_with_decoupled_qc
+    end
+  end
+
+  private
+    def assert_sql_join_constraint(sql, left_model, left_column_name, right_model, right_column_name)
+      left_column = Regexp.escape(left_model.lease_connection.quote_table_name(left_column_name))
+      right_column = Regexp.escape(right_model.lease_connection.quote_table_name(right_column_name))
+
+      assert_match(/#{left_column} = #{right_column}/, sql)
+    end
 end

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1741,7 +1741,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_nil book.order_id
   end
 
-  def test_ids_reader_with_composite_primary_key_on_source
+  def test_ids_reader_with_query_constraints_on_source
     blog = Sharded::Blog.create!
     post = Sharded::BlogPost.create!(blog_id: blog.id)
     comment = Sharded::Comment.create!(blog_id: blog.id, blog_post_id: post.id)
@@ -1749,7 +1749,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     ids = blog.comments_via_post_ids
 
     assert_kind_of Array, ids
-    assert_equal [[comment.blog_id, comment.id]], ids
+    assert_equal [comment.id], ids
   end
 
   private

--- a/activerecord/test/cases/associations/has_many_through_disable_joins_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_disable_joins_associations_test.rb
@@ -19,9 +19,11 @@ require "models/department"
 require "models/cpk/author"
 require "models/cpk/book"
 require "models/cpk/order"
+require "models/sharded"
 
 class HasManyThroughDisableJoinsAssociationsTest < ActiveRecord::TestCase
-  fixtures :posts, :authors, :comments, :pirates, :author_addresses
+  fixtures :posts, :authors, :comments, :pirates, :author_addresses,
+           :sharded_blogs, :sharded_blog_posts, :sharded_tags, :sharded_blog_posts_tags
 
   def setup
     @author = authors(:mary)
@@ -208,5 +210,58 @@ class HasManyThroughDisableJoinsAssociationsTest < ActiveRecord::TestCase
 
     assert_equal author.orders.to_a, author.no_joins_orders.to_a
     assert_equal [order2, order1], author.no_joins_orders.to_a
+  end
+  # Regression: a disable_joins has_many :through whose through and source
+  # reflections use explicit foreign_key plus decoupled query_constraints
+  # (tenant column). The pre-fix DisableJoinsAssociationScope queried each
+  # split hop on the scalar foreign key alone, dropping the tenant column and
+  # leaking records from another tenant that collided on that scalar key.
+  # The fix routes every hop through join_query_constraints_* so the tenant
+  # column survives in both split queries.
+  def test_disable_joins_through_with_decoupled_query_constraints_retains_tenant_in_both_split_queries
+    blog_one_id = ActiveRecord::FixtureSet.identify(:sharded_blog_one)
+    blog_two_id = ActiveRecord::FixtureSet.identify(:sharded_blog_two)
+
+    post = sharded_blog_posts(:great_post_blog_one)
+    expected_tag_ids = [
+      sharded_tags(:short_read_blog_one).id,
+      sharded_tags(:technical_blog_one).id,
+    ].sort
+
+    # A join-model row from another tenant that collides on the scalar
+    # foreign key (blog_post_id) but belongs to blog_two. Pre-fix, the first
+    # split query hit sharded_blog_posts_tags on blog_post_id alone and
+    # matched this row, then the second split query loaded its blog_two tag
+    # by id alone -- leaking a record across tenants. Post-fix both queries
+    # carry blog_id, so the row is excluded.
+    impostor_tag = Sharded::Tag.create!(blog_id: blog_two_id, name: "impostor")
+    Sharded::BlogPostTag.create!(blog_id: blog_two_id, blog_post_id: post.id, tag_id: impostor_tag.id)
+
+    loaded = nil
+    queries = capture_sql do
+      loaded = post.tags_with_decoupled_qc_without_joins.to_a
+    end
+
+    # Returned records: only this post's blog_one tags, no cross-tenant leak.
+    assert_equal expected_tag_ids, loaded.map(&:id).sort
+    assert(loaded.all? { |tag| tag.blog_id == blog_one_id },
+      "disable_joins through leaked a tag from another tenant")
+    assert_not_includes loaded.map(&:id), impostor_tag.id
+
+    # disable_joins issues one query per hop: through, then source.
+    assert_equal 2, queries.size
+
+    posts_tags_table = Regexp.escape(quote_table_name("sharded_blog_posts_tags"))
+    tags_table = Regexp.escape(quote_table_name("sharded_tags"))
+    blog_id_col = Regexp.escape(Sharded::Tag.lease_connection.quote_column_name("blog_id"))
+
+    through_query = queries.find { |sql| sql.match?(/FROM #{posts_tags_table}/) }
+    source_query  = queries.find { |sql| sql.match?(/FROM #{tags_table}/) }
+    assert(through_query, "expected a through query against sharded_blog_posts_tags")
+    assert(source_query,  "expected a source query against sharded_tags")
+
+    # Both split queries must retain the tenant column; pre-fix dropped it.
+    assert_match(/#{blog_id_col}/, through_query)
+    assert_match(/#{blog_id_col}/, source_query)
   end
 end

--- a/activerecord/test/cases/associations/has_many_through_disable_joins_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_disable_joins_associations_test.rb
@@ -19,9 +19,11 @@ require "models/department"
 require "models/cpk/author"
 require "models/cpk/book"
 require "models/cpk/order"
+require "models/sharded"
 
 class HasManyThroughDisableJoinsAssociationsTest < ActiveRecord::TestCase
-  fixtures :posts, :authors, :comments, :pirates, :author_addresses
+  fixtures :posts, :authors, :comments, :pirates, :author_addresses,
+           :sharded_blogs, :sharded_blog_posts, :sharded_tags, :sharded_blog_posts_tags
 
   def setup
     @author = authors(:mary)
@@ -208,5 +210,58 @@ class HasManyThroughDisableJoinsAssociationsTest < ActiveRecord::TestCase
 
     assert_equal author.orders.to_a, author.no_joins_orders.to_a
     assert_equal [order2, order1], author.no_joins_orders.to_a
+  end
+  # Regression: a disable_joins has_many :through whose through and source
+  # reflections use explicit foreign_key plus decoupled query_constraints
+  # (tenant column). The pre-fix DisableJoinsAssociationScope queried each
+  # split hop on the scalar foreign key alone, dropping the tenant column and
+  # leaking records from another tenant that collided on that scalar key.
+  # The fix routes every hop through query_* so the tenant
+  # column survives in both split queries.
+  def test_disable_joins_through_with_decoupled_query_constraints_retains_tenant_in_both_split_queries
+    blog_one_id = ActiveRecord::FixtureSet.identify(:sharded_blog_one)
+    blog_two_id = ActiveRecord::FixtureSet.identify(:sharded_blog_two)
+
+    post = sharded_blog_posts(:great_post_blog_one)
+    expected_tag_ids = [
+      sharded_tags(:short_read_blog_one).id,
+      sharded_tags(:technical_blog_one).id,
+    ].sort
+
+    # A join-model row from another tenant that collides on the scalar
+    # foreign key (blog_post_id) but belongs to blog_two. Pre-fix, the first
+    # split query hit sharded_blog_posts_tags on blog_post_id alone and
+    # matched this row, then the second split query loaded its blog_two tag
+    # by id alone -- leaking a record across tenants. Post-fix both queries
+    # carry blog_id, so the row is excluded.
+    impostor_tag = Sharded::Tag.create!(blog_id: blog_two_id, name: "impostor")
+    Sharded::BlogPostTag.create!(blog_id: blog_two_id, blog_post_id: post.id, tag_id: impostor_tag.id)
+
+    loaded = nil
+    queries = capture_sql do
+      loaded = post.tags_with_decoupled_qc_without_joins.to_a
+    end
+
+    # Returned records: only this post's blog_one tags, no cross-tenant leak.
+    assert_equal expected_tag_ids, loaded.map(&:id).sort
+    assert(loaded.all? { |tag| tag.blog_id == blog_one_id },
+      "disable_joins through leaked a tag from another tenant")
+    assert_not_includes loaded.map(&:id), impostor_tag.id
+
+    # disable_joins issues one query per hop: through, then source.
+    assert_equal 2, queries.size
+
+    posts_tags_table = Regexp.escape(quote_table_name("sharded_blog_posts_tags"))
+    tags_table = Regexp.escape(quote_table_name("sharded_tags"))
+    blog_id_col = Regexp.escape(Sharded::Tag.lease_connection.quote_column_name("blog_id"))
+
+    through_query = queries.find { |sql| sql.match?(/FROM #{posts_tags_table}/) }
+    source_query  = queries.find { |sql| sql.match?(/FROM #{tags_table}/) }
+    assert(through_query, "expected a through query against sharded_blog_posts_tags")
+    assert(source_query,  "expected a source query against sharded_tags")
+
+    # Both split queries must retain the tenant column; pre-fix dropped it.
+    assert_match(/#{blog_id_col}/, through_query)
+    assert_match(/#{blog_id_col}/, source_query)
   end
 end

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -485,27 +485,76 @@ class AssociationsTest < ActiveRecord::TestCase
     assert_empty(blog_post.reload.tags)
     assert_not_predicate Sharded::BlogPostTag.where(blog_post_id: blog_post.id, blog_id: blog_post.blog_id), :exists?
   end
+  def test_has_many_through_with_decoupled_query_constraints_uses_all_constraints_in_join
+    blog_post = sharded_blog_posts(:great_post_blog_one)
+    expected_tag_ids = [
+      sharded_tags(:short_read_blog_one).id,
+      sharded_tags(:technical_blog_one).id,
+    ].sort
 
-  def test_using_query_constraints_warns_about_changing_behavior
-    has_many_expected_message = <<~MSG.squish
-      Setting `query_constraints:` option on `Sharded::BlogPost.has_many :qc_deprecated_comments` is not allowed.
-      To get the same behavior, use the `foreign_key` option instead.
-    MSG
+    sql = capture_sql do
+      loaded_tags = blog_post.tags_with_decoupled_qc.to_a
+      assert_equal expected_tag_ids, loaded_tags.map(&:id).sort
+    end.first
 
-    assert_raises(ActiveRecord::ConfigurationError, match: has_many_expected_message) do
-      Sharded::BlogPost.has_many :qc_deprecated_comments,
-        class_name: "Sharded::Comment", query_constraints: [:blog_id, :blog_post_id]
+    # The through join between sharded_tags and sharded_blog_posts_tags must
+    # scope on blog_id (the decoupled query constraint), not just tag_id —
+    # otherwise tags from other blogs could match on tag_id alone.
+    tags_col = Regexp.escape(Sharded::Tag.lease_connection.quote_table_name("sharded_tags.blog_id"))
+    join_col = Regexp.escape(Sharded::BlogPostTag.lease_connection.quote_table_name("sharded_blog_posts_tags.blog_id"))
+    assert_match(/#{tags_col} = #{join_col}/, sql)
+
+    tags_col = Regexp.escape(Sharded::Tag.lease_connection.quote_table_name("sharded_tags.id"))
+    join_col = Regexp.escape(Sharded::BlogPostTag.lease_connection.quote_table_name("sharded_blog_posts_tags.tag_id"))
+    assert_match(/#{tags_col} = #{join_col}/, sql)
+  end
+
+  def test_has_many_through_with_decoupled_query_constraints_disable_joins_uses_all_constraints_in_each_hop
+    blog_post = sharded_blog_posts(:great_post_blog_one)
+    expected_tag_ids = [
+      sharded_tags(:short_read_blog_one).id,
+      sharded_tags(:technical_blog_one).id,
+    ].sort
+
+    sqls = capture_sql do
+      loaded_tags = blog_post.tags_with_decoupled_qc_without_joins.to_a
+      assert_equal expected_tag_ids, loaded_tags.map(&:id).sort
     end
 
-    belongs_to_expected_message = <<~MSG.squish
-      Setting `query_constraints:` option on `Sharded::Comment.belongs_to :qc_deprecated_blog_post` is not allowed.
-      To get the same behavior, use the `foreign_key` option instead.
-    MSG
+    # disable_joins issues one query per hop: the through table, then the target.
+    assert_equal 2, sqls.size
 
-    assert_raises(ActiveRecord::ConfigurationError, match: belongs_to_expected_message) do
-      Sharded::Comment.belongs_to :qc_deprecated_blog_post,
+    join_blog_id_col   = Sharded::BlogPostTag.lease_connection.quote_table_name("sharded_blog_posts_tags.blog_id")
+    join_blog_post_col = Sharded::BlogPostTag.lease_connection.quote_table_name("sharded_blog_posts_tags.blog_post_id")
+    tags_blog_id_col   = Sharded::Tag.lease_connection.quote_table_name("sharded_tags.blog_id")
+    tags_id_col        = Sharded::Tag.lease_connection.quote_table_name("sharded_tags.id")
+
+    through_sql = sqls.find { |sql| sql.include?(join_blog_id_col) }
+    target_sql  = sqls.find { |sql| sql.include?(tags_blog_id_col) }
+    assert(through_sql, "through-table query missing blog_id constraint in: #{sqls.inspect}")
+    assert(target_sql,  "target query missing blog_id constraint in: #{sqls.inspect}")
+
+    # The through-table hop must scope on blog_id (the decoupled query
+    # constraint) in addition to blog_post_id, not just blog_post_id alone.
+    assert_match(/#{Regexp.escape(join_blog_id_col)} =/, through_sql)
+    assert_match(/#{Regexp.escape(join_blog_post_col)} =/, through_sql)
+
+    # The target hop must also scope on blog_id in addition to id.
+    assert_match(/#{Regexp.escape(tags_blog_id_col)} =/, target_sql)
+    assert_match(/#{Regexp.escape(tags_id_col)} =/, target_sql)
+  end
+
+  def test_using_query_constraints_is_allowed
+    assert_nothing_raised do
+      Sharded::BlogPost.has_many :qc_configured_comments,
+        class_name: "Sharded::Comment", query_constraints: [:blog_id, :blog_post_id]
+
+      Sharded::Comment.belongs_to :qc_configured_blog_post,
         class_name: "Sharded::Blog", query_constraints: [:blog_id, :blog_post_id]
     end
+
+    assert Sharded::BlogPost.reflect_on_association(:qc_configured_comments)
+    assert Sharded::Comment.reflect_on_association(:qc_configured_blog_post)
   end
 end
 

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -485,27 +485,100 @@ class AssociationsTest < ActiveRecord::TestCase
     assert_empty(blog_post.reload.tags)
     assert_not_predicate Sharded::BlogPostTag.where(blog_post_id: blog_post.id, blog_id: blog_post.blog_id), :exists?
   end
+  def test_has_many_through_with_decoupled_query_constraints_uses_all_constraints_in_join
+    blog_post = sharded_blog_posts(:great_post_blog_one)
+    expected_tag_ids = [
+      sharded_tags(:short_read_blog_one).id,
+      sharded_tags(:technical_blog_one).id,
+    ].sort
 
-  def test_using_query_constraints_warns_about_changing_behavior
-    has_many_expected_message = <<~MSG.squish
-      Setting `query_constraints:` option on `Sharded::BlogPost.has_many :qc_deprecated_comments` is not allowed.
-      To get the same behavior, use the `foreign_key` option instead.
-    MSG
+    sql = capture_sql do
+      loaded_tags = blog_post.tags_with_decoupled_qc.to_a
+      assert_equal expected_tag_ids, loaded_tags.map(&:id).sort
+    end.first
 
-    assert_raises(ActiveRecord::ConfigurationError, match: has_many_expected_message) do
-      Sharded::BlogPost.has_many :qc_deprecated_comments,
-        class_name: "Sharded::Comment", query_constraints: [:blog_id, :blog_post_id]
+    # The through join between sharded_tags and sharded_blog_posts_tags must
+    # scope on blog_id (the decoupled query constraint), not just tag_id —
+    # otherwise tags from other blogs could match on tag_id alone.
+    tags_col = Regexp.escape(Sharded::Tag.lease_connection.quote_table_name("sharded_tags.blog_id"))
+    join_col = Regexp.escape(Sharded::BlogPostTag.lease_connection.quote_table_name("sharded_blog_posts_tags.blog_id"))
+    assert_match(/#{tags_col} = #{join_col}/, sql)
+
+    tags_col = Regexp.escape(Sharded::Tag.lease_connection.quote_table_name("sharded_tags.id"))
+    join_col = Regexp.escape(Sharded::BlogPostTag.lease_connection.quote_table_name("sharded_blog_posts_tags.tag_id"))
+    assert_match(/#{tags_col} = #{join_col}/, sql)
+  end
+
+  def test_using_query_constraints_without_foreign_key_derives_foreign_key
+    Sharded::BlogPost.has_many :qc_configured_comments,
+      class_name: "Sharded::Comment", query_constraints: :blog_id
+
+    reflection = Sharded::BlogPost.reflect_on_association(:qc_configured_comments)
+
+    assert_equal "blog_post_id", reflection.foreign_key
+    assert_equal ["blog_id", "id"], reflection.query_foreign_key
+    assert_equal ["blog_id", "blog_post_id"], reflection.query_primary_key
+
+    blog_post = sharded_blog_posts(:great_post_blog_one)
+    comment = Sharded::Comment.create!(blog_id: blog_post.blog_id, blog_post_id: blog_post.id)
+
+    assert_includes blog_post.qc_configured_comments, comment
+
+    blog_post.qc_configured_comments.delete(comment)
+
+    assert_nil comment.reload.blog_post_id
+    assert_equal blog_post.blog_id, comment.blog_id
+  end
+
+  # Additive query constraints are matched when querying an association, but only
+  # the foreign key is written. The association scope carries the constraints as
+  # ordinary equality conditions, and a scope's equality conditions otherwise
+  # become defaults on records built from it, which made these paths disagree with
+  # +<<+ and autosave.
+  def test_building_with_decoupled_query_constraints_writes_only_the_foreign_key
+    blog_post = sharded_blog_posts(:great_post_blog_one)
+
+    built = [
+      blog_post.comments_with_query_constraints.build,
+      blog_post.comments_with_query_constraints.new,
+      blog_post.comments_with_query_constraints.where.not(body: nil).new,
+      blog_post.build_top_comment_with_query_constraints,
+    ]
+
+    built.each do |comment|
+      assert_equal blog_post.id, comment.blog_post_id
+      assert_nil comment.blog_id
     end
+  end
 
-    belongs_to_expected_message = <<~MSG.squish
-      Setting `query_constraints:` option on `Sharded::Comment.belongs_to :qc_deprecated_blog_post` is not allowed.
-      To get the same behavior, use the `foreign_key` option instead.
-    MSG
+  def test_pushing_and_building_with_decoupled_query_constraints_write_the_same_columns
+    blog_post = sharded_blog_posts(:great_post_blog_one)
 
-    assert_raises(ActiveRecord::ConfigurationError, match: belongs_to_expected_message) do
-      Sharded::Comment.belongs_to :qc_deprecated_blog_post,
-        class_name: "Sharded::Blog", query_constraints: [:blog_id, :blog_post_id]
-    end
+    built = blog_post.comments_with_query_constraints.build
+    pushed = Sharded::Comment.new
+    blog_post.comments_with_query_constraints << pushed
+
+    assert_equal [built.blog_id, built.blog_post_id], [pushed.blog_id, pushed.blog_post_id]
+  end
+
+  def test_building_belongs_to_with_query_constraints_column_mapping_writes_nothing
+    blog_post = sharded_blog_posts(:great_post_blog_one)
+
+    comment = blog_post.build_featured_comment
+
+    assert_nil comment.blog_id
+    assert_nil comment.blog_post_id
+  end
+
+  # The columns a composite `foreign_key` covers are still written, whether it was
+  # given explicitly or derived from the owner's model-level `query_constraints`.
+  def test_building_with_composite_foreign_key_writes_every_foreign_key_column
+    blog_post = sharded_blog_posts(:great_post_blog_one)
+
+    comment = blog_post.comments.build
+
+    assert_equal blog_post.blog_id, comment.blog_id
+    assert_equal blog_post.id, comment.blog_post_id
   end
 end
 

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -452,6 +452,19 @@ class TestDefaultAutosaveAssociationOnABelongsToAssociation < ActiveRecord::Test
     assert_equal apple, final_cut.firm
   end
 
+  def test_direct_foreign_key_assignment_wins_over_a_stale_new_target
+    account = Account.new
+    new_firm = Firm.new(name: "New firm")
+    existing_firm = companies(:first_firm)
+
+    account.firm = new_firm
+    account.firm_id = existing_firm.id
+    account.save!(validate: false)
+
+    assert_not_predicate new_firm, :persisted?
+    assert_equal existing_firm.id, account.firm_id
+  end
+
   def test_store_two_association_with_one_save
     num_orders = Order.count
     num_customers = Customer.count

--- a/activerecord/test/cases/counter_cache_test.rb
+++ b/activerecord/test/cases/counter_cache_test.rb
@@ -39,6 +39,37 @@ class CounterCacheTest < ActiveRecord::TestCase
     belongs_to :special_topic, foreign_key: "parent_id", counter_cache: "replies_count"
   end
 
+  class ::Cpk::Order
+    has_many :books_with_decoupled_query_constraints,
+      class_name: "Cpk::BookWithDecoupledQueryConstraints",
+      primary_key: :status,
+      foreign_key: :title,
+      query_constraints: :shop_id
+  end
+
+  class ::Cpk::OrderWithOrderedShops < Cpk::Order
+    default_scope { order(shop_id: :desc) }
+  end
+
+  class ::Cpk::BookWithDecoupledQueryConstraints < ActiveRecord::Base
+    self.table_name = :cpk_books
+    self.primary_key = [:author_id, :id]
+
+    belongs_to :order_with_decoupled_query_constraints,
+      class_name: "Cpk::Order",
+      primary_key: :status,
+      foreign_key: :title,
+      query_constraints: :shop_id,
+      counter_cache: :books_count
+
+    belongs_to :order_with_decoupled_query_constraints_and_touch,
+      class_name: "Cpk::OrderWithOrderedShops",
+      primary_key: :status,
+      foreign_key: :title,
+      query_constraints: :shop_id,
+      touch: true
+  end
+
   setup do
     @topic = Topic.find(1)
   end
@@ -60,6 +91,69 @@ class CounterCacheTest < ActiveRecord::TestCase
     assert_difference -> { @topic.reload.replies_count } do
       ScopedCounterCacheChild.create!(title: "Counter cache child", parent_id: @topic.id, approved: true)
     end
+  end
+
+  test "belongs_to counter cache creation uses decoupled query constraints" do
+    matching_order, other_order = create_orders_with_same_status
+
+    create_book_with_decoupled_query_constraints(matching_order)
+
+    assert_equal 1, matching_order.reload.books_count
+    assert_equal 0, other_order.reload.books_count
+  end
+
+  test "belongs_to counter cache destruction uses decoupled query constraints" do
+    matching_order, other_order = create_orders_with_same_status
+    book = create_book_with_decoupled_query_constraints(matching_order)
+
+    Cpk::BookWithDecoupledQueryConstraints.find(book.id).destroy!
+
+    assert_equal 0, matching_order.reload.books_count
+    assert_equal 0, other_order.reload.books_count
+  end
+
+  test "belongs_to counter cache reassignment uses decoupled query constraints" do
+    old_order, other_old_order = create_orders_with_same_status(status: "old")
+    new_order, other_new_order = create_orders_with_same_status(status: "new")
+    book = create_book_with_decoupled_query_constraints(old_order)
+
+    Cpk::BookWithDecoupledQueryConstraints.find(book.id).update!(title: new_order.status)
+
+    assert_equal 0, old_order.reload.books_count
+    assert_equal 0, other_old_order.reload.books_count
+    assert_equal 1, new_order.reload.books_count
+    assert_equal 0, other_new_order.reload.books_count
+  end
+
+  test "reset counters uses decoupled query constraints" do
+    matching_order, other_order = create_orders_with_same_status
+    create_book_with_decoupled_query_constraints(matching_order)
+    matching_order.update_column(:books_count, 0)
+    other_order.update_column(:books_count, 0)
+
+    Cpk::Order.reset_counters(matching_order.id, :books_with_decoupled_query_constraints)
+    Cpk::Order.reset_counters(other_order.id, :books_with_decoupled_query_constraints)
+
+    assert_equal 1, matching_order.reload.books_count
+    assert_equal 0, other_order.reload.books_count
+  end
+
+  test "belongs_to touch uses decoupled query constraints for the old target" do
+    other_old_order = Cpk::Order.create!(shop_id: 202, status: "old")
+    old_order = Cpk::Order.create!(shop_id: 101, status: "old")
+    new_order = Cpk::Order.create!(shop_id: 101, status: "new")
+    book = create_book_with_decoupled_query_constraints(old_order)
+    timestamp = 1.day.ago
+    timestamps = [other_old_order, old_order, new_order].to_h do |order|
+      order.update_column(:updated_at, timestamp)
+      [order, order.reload.updated_at]
+    end
+
+    Cpk::BookWithDecoupledQueryConstraints.find(book.id).update!(title: new_order.status)
+
+    assert_operator old_order.reload.updated_at, :>, timestamps[old_order]
+    assert_equal timestamps[other_old_order], other_old_order.reload.updated_at
+    assert_operator new_order.reload.updated_at, :>, timestamps[new_order]
   end
 
   test "increment counter" do
@@ -575,6 +669,24 @@ class CounterCacheTest < ActiveRecord::TestCase
   end
 
   private
+    def create_orders_with_same_status(status: "paid")
+      [
+        Cpk::Order.create!(shop_id: 101, status: status),
+        Cpk::Order.create!(shop_id: 202, status: status),
+      ]
+    end
+
+    def create_book_with_decoupled_query_constraints(order)
+      book = Cpk::BookWithDecoupledQueryConstraints.new(
+        author_id: 303,
+        shop_id: order.shop_id,
+        title: order.status
+      )
+      book.write_attribute(:id, 404)
+      book.save!
+      book
+    end
+
     def assert_touching(record, *attributes)
       record.update_columns attributes.index_with(5.minutes.ago)
       touch_times = attributes.index_with { |attr| record.public_send(attr) }

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -689,12 +689,10 @@ class ReflectionTest < ActiveRecord::TestCase
     assert_equal "id", actual
   end
 
-  def test_through_reflection_association_primary_key_with_composite_key
+  def test_through_reflection_association_primary_key_with_query_constraints
     reflection = Sharded::Blog.reflect_on_association(:comments_via_posts)
-    actual = reflection.association_primary_key
 
-    assert_kind_of Array, actual
-    assert_equal ["blog_id", "id"], actual
+    assert_equal "id", reflection.association_primary_key
   end
 
   def test_belongs_to_reflection_with_query_constraints_infers_correct_foreign_key
@@ -717,33 +715,190 @@ class ReflectionTest < ActiveRecord::TestCase
     assert_equal ["blog_id", "tag_id"], reflection.association_foreign_key
   end
 
-  def test_using_query_constraints_warns_about_changing_behavior
-    has_many_expected_message = <<~MSG.squish
-      Setting `query_constraints:` option on `Firm.has_many :clients` is not allowed.
-      To get the same behavior, use the `foreign_key` option instead.
-    MSG
+  def test_array_foreign_key_remains_in_reflection_options
+    reflection = Sharded::LegacyComment.reflect_on_association(:blog_post)
 
-    assert_raises(ActiveRecord::ConfigurationError, match: has_many_expected_message) do
-      ActiveRecord::Reflection.create(:has_many, :clients, nil, { query_constraints: [:firm_id, :firm_name] }, Firm)
+    assert_equal [:blog_id, :blog_post_id], reflection.options[:foreign_key]
+    assert_not reflection.options.key?(:query_constraints)
+    assert_equal ["blog_id", "id"], reflection.association_primary_key
+  end
+
+  def test_array_foreign_key_and_query_constraints_remain_distinct
+    reflection = ActiveRecord::Reflection.create(
+      :has_many, :comments, nil,
+      {
+        foreign_key: [:blog_id, :blog_post_id],
+        query_constraints: :created_at,
+        class_name: "Sharded::Comment",
+      },
+      Sharded::BlogPost
+    )
+
+    assert_equal [:blog_id, :blog_post_id], reflection.options[:foreign_key]
+    assert_equal :created_at, reflection.options[:query_constraints]
+    assert_equal ["blog_id", "id"], reflection.active_record_primary_key
+    assert_equal ["created_at", "blog_id", "id"], reflection.query_foreign_key
+    assert_equal ["created_at", "blog_id", "blog_post_id"], reflection.query_primary_key
+  end
+
+  def test_query_constraints_without_foreign_key_derives_writable_foreign_key
+    has_many = ActiveRecord::Reflection.create(:has_many, :clients, nil, { query_constraints: :firm_name }, Firm)
+    has_one = ActiveRecord::Reflection.create(:has_one, :account, nil, { query_constraints: :firm_name }, Firm)
+    belongs_to = ActiveRecord::Reflection.create(:belongs_to, :client, nil, { query_constraints: :firm_name }, Firm)
+
+    assert_equal "firm_id", has_many.foreign_key
+    assert_equal ["firm_name", "id"], has_many.query_foreign_key
+    assert_equal ["firm_name", "firm_id"], has_many.query_primary_key
+
+    assert_equal "firm_id", has_one.foreign_key
+    assert_equal ["firm_name", "id"], has_one.query_foreign_key
+    assert_equal ["firm_name", "firm_id"], has_one.query_primary_key
+
+    assert_equal "client_id", belongs_to.foreign_key
+    assert_equal ["firm_name", "client_id"], belongs_to.query_foreign_key
+    assert_equal ["firm_name", "id"], belongs_to.query_primary_key
+  end
+
+  def test_query_key_mapping_with_symbols
+    mapping = Sharded::Comment.reflect_on_association(:blog_post_with_decoupled_qc).query_key_mapping
+
+    assert_equal [["blog_id", "blog_id"]], mapping.query_constraint_pairs
+  end
+
+  def test_query_key_mapping_preserves_belongs_to_pairs
+    reflection = Sharded::BlogPost.reflect_on_association(:featured_comment)
+    mapping = reflection.query_key_mapping
+
+    assert_equal [["blog_id", "blog_id"], ["id", "blog_post_id"]], mapping.query_constraint_pairs
+    assert_equal [["featured_comment_id", "id"]], mapping.foreign_key_pairs
+    assert_equal [
+      ["blog_id", "blog_id"],
+      ["id", "blog_post_id"],
+      ["featured_comment_id", "id"],
+    ], mapping.to_a
+    assert_equal ["blog_id", "id", "featured_comment_id"], mapping.active_record_columns
+    assert_equal ["blog_id", "blog_post_id", "id"], mapping.associated_record_columns
+
+    blog_post = Sharded::BlogPost.new(id: 2, blog_id: 1, featured_comment_id: 3)
+    assert_equal [1, 2, 3], mapping.values_for(blog_post)
+
+    assert_equal mapping.associated_record_columns, reflection.query_primary_key
+    assert_equal mapping.active_record_columns, reflection.query_foreign_key
+  end
+
+  def test_query_constraints_with_column_mapping_requires_foreign_key_when_hash_present
+    assert_raises(ArgumentError, match: /requires an explicit `foreign_key` option/) do
+      ActiveRecord::Reflection.create(
+        :belongs_to, :comment, nil,
+        { query_constraints: [:blog_id, { id: :blog_post_id }], class_name: "Sharded::Comment" },
+        Sharded::BlogPost
+      ).foreign_key
     end
+  end
 
-    has_one_expected_message = <<~MSG.squish
-      Setting `query_constraints:` option on `Firm.has_one :account` is not allowed.
-      To get the same behavior, use the `foreign_key` option instead.
-    MSG
+  def test_has_many_with_decoupled_query_constraints_active_record_primary_key_is_scalar
+    # When both foreign_key and query_constraints are specified, active_record_primary_key
+    # should return the scalar primary key, not the query_constraints_list array.
+    # This ensures .joins() works correctly.
+    reflection = ActiveRecord::Reflection.create(
+      :has_many, :comments, nil,
+      { foreign_key: :blog_post_id, query_constraints: :blog_id, class_name: "Sharded::Comment" },
+      Sharded::BlogPost
+    )
 
-    assert_raises(ActiveRecord::ConfigurationError, match: has_one_expected_message) do
-      ActiveRecord::Reflection.create(:has_one, :account, nil, { query_constraints: [:firm_id, :firm_name] }, Firm)
-    end
+    assert_equal "id", reflection.active_record_primary_key
+    assert_equal "id", reflection.join_foreign_key
+  end
 
-    belongs_to_expected_message = <<~MSG.squish
-      Setting `query_constraints:` option on `Firm.belongs_to :client` is not allowed.
-      To get the same behavior, use the `foreign_key` option instead.
-    MSG
+  def test_has_many_decoupled_query_constraints_query_keys
+    reflection = ActiveRecord::Reflection.create(
+      :has_many, :comments, nil,
+      { foreign_key: :blog_post_id, query_constraints: :blog_id, class_name: "Sharded::Comment" },
+      Sharded::BlogPost
+    )
+    mapping = reflection.query_key_mapping
 
-    assert_raises(ActiveRecord::ConfigurationError, match: belongs_to_expected_message) do
-      ActiveRecord::Reflection.create(:belongs_to, :client, nil, { query_constraints: [:firm_id, :firm_name] }, Firm)
-    end
+    assert_equal [["blog_id", "blog_id"], ["id", "blog_post_id"]], mapping.to_a
+    assert_equal [["id", "blog_post_id"]], mapping.foreign_key_pairs
+    assert_equal mapping.active_record_columns, reflection.query_foreign_key
+    assert_equal mapping.associated_record_columns, reflection.query_primary_key
+  end
+
+  def test_has_many_query_constraints_cannot_include_explicit_foreign_key
+    reflection = ActiveRecord::Reflection.create(
+      :has_many, :comments, nil,
+      { foreign_key: :blog_post_id, query_constraints: [:blog_id, :blog_post_id], class_name: "Sharded::Comment" },
+      Sharded::BlogPost
+    )
+
+    error = assert_raises(ArgumentError) { reflection.check_validity! }
+    assert_equal "`query_constraints` on `Sharded::BlogPost.has_many :comments` " \
+      "must not include the foreign key columns [\"blog_post_id\"].", error.message
+  end
+
+  def test_has_many_query_constraints_cannot_include_derived_foreign_key
+    reflection = ActiveRecord::Reflection.create(
+      :has_many, :comments, nil,
+      { query_constraints: [:blog_id, :blog_post_id], class_name: "Sharded::Comment" },
+      Sharded::BlogPost
+    )
+
+    error = assert_raises(ArgumentError) { reflection.check_validity! }
+    assert_equal "`query_constraints` on `Sharded::BlogPost.has_many :comments` " \
+      "must not include the foreign key columns [\"blog_post_id\"].", error.message
+  end
+
+  def test_belongs_to_query_constraints_cannot_include_explicit_foreign_key
+    reflection = ActiveRecord::Reflection.create(
+      :belongs_to, :blog_post, nil,
+      { foreign_key: :blog_post_id, query_constraints: [:blog_id, :blog_post_id], class_name: "Sharded::BlogPost" },
+      Sharded::Comment
+    )
+
+    error = assert_raises(ArgumentError) { reflection.check_validity! }
+    assert_equal "`query_constraints` on `Sharded::Comment.belongs_to :blog_post` " \
+      "must not include the foreign key columns [\"blog_post_id\"].", error.message
+  end
+
+  def test_belongs_to_query_constraints_cannot_include_derived_foreign_key
+    reflection = ActiveRecord::Reflection.create(
+      :belongs_to, :blog_post, nil,
+      { query_constraints: [:blog_id, :blog_post_id], class_name: "Sharded::BlogPost" },
+      Sharded::Comment
+    )
+
+    error = assert_raises(ArgumentError) { reflection.check_validity! }
+    assert_equal "`query_constraints` on `Sharded::Comment.belongs_to :blog_post` " \
+      "must not include the foreign key columns [\"blog_post_id\"].", error.message
+  end
+
+  def test_query_key_mapping_with_bare_hash
+    reflection = Sharded::BlogPost.reflect_on_association(:featured_comment_bare_hash_qc)
+
+    assert_equal [["blog_id", "blog_id"]], reflection.query_key_mapping.query_constraint_pairs
+  end
+
+  def test_belongs_to_bare_hash_query_constraints_join_keys_aligned
+    reflection = Sharded::BlogPost.reflect_on_association(:featured_comment_bare_hash_qc)
+
+    # target (Comment) columns: blog_id (from mapping) + id (association_primary_key)
+    assert_equal ["blog_id", "id"], reflection.query_primary_key
+    # self (BlogPost) columns: blog_id (from mapping) + featured_comment_id (foreign_key)
+    assert_equal ["blog_id", "featured_comment_id"], reflection.query_foreign_key
+  end
+
+  def test_belongs_to_query_constraints_without_foreign_key_are_additive
+    reflection = ActiveRecord::Reflection.create(
+      :belongs_to, :blog_post, nil,
+      { query_constraints: [:blog_id], class_name: "Sharded::BlogPost" },
+      Sharded::Comment
+    )
+
+    assert_equal [["blog_id", "blog_id"]], reflection.query_key_mapping.query_constraint_pairs
+    assert_equal "blog_post_id", reflection.foreign_key
+    assert_equal "id", reflection.association_primary_key
+    assert_equal ["blog_id", "blog_post_id"], reflection.query_foreign_key
+    assert_equal ["blog_id", "id"], reflection.query_primary_key
   end
 
   def test_counter_cache_column_defaults_when_counter_cache_is_true

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -689,12 +689,10 @@ class ReflectionTest < ActiveRecord::TestCase
     assert_equal "id", actual
   end
 
-  def test_through_reflection_association_primary_key_with_composite_key
+  def test_through_reflection_association_primary_key_with_query_constraints
     reflection = Sharded::Blog.reflect_on_association(:comments_via_posts)
-    actual = reflection.association_primary_key
 
-    assert_kind_of Array, actual
-    assert_equal ["blog_id", "id"], actual
+    assert_equal "id", reflection.association_primary_key
   end
 
   def test_belongs_to_reflection_with_query_constraints_infers_correct_foreign_key
@@ -717,33 +715,134 @@ class ReflectionTest < ActiveRecord::TestCase
     assert_equal ["blog_id", "tag_id"], reflection.association_foreign_key
   end
 
-  def test_using_query_constraints_warns_about_changing_behavior
-    has_many_expected_message = <<~MSG.squish
-      Setting `query_constraints:` option on `Firm.has_many :clients` is not allowed.
-      To get the same behavior, use the `foreign_key` option instead.
-    MSG
+  def test_using_query_constraints_is_allowed
+    has_many = ActiveRecord::Reflection.create(:has_many, :clients, nil, { query_constraints: [:firm_id, :firm_name] }, Firm)
+    has_one = ActiveRecord::Reflection.create(:has_one, :account, nil, { query_constraints: [:firm_id, :firm_name] }, Firm)
+    belongs_to = ActiveRecord::Reflection.create(:belongs_to, :client, nil, { query_constraints: [:firm_id, :firm_name] }, Firm)
 
-    assert_raises(ActiveRecord::ConfigurationError, match: has_many_expected_message) do
-      ActiveRecord::Reflection.create(:has_many, :clients, nil, { query_constraints: [:firm_id, :firm_name] }, Firm)
+    assert_equal ["firm_id", "firm_name"], has_many.query_constraints_foreign_key
+    assert_equal ["firm_id", "firm_name"], has_one.query_constraints_foreign_key
+    assert_equal ["firm_id", "firm_name"], belongs_to.query_constraints_foreign_key
+  end
+
+  def test_normalized_query_constraints_mapping_with_symbols
+    reflection = Sharded::Comment.reflect_on_association(:blog_post_with_decoupled_qc)
+
+    assert_equal [["blog_id", "blog_id"]], reflection.normalized_query_constraints_mapping
+  end
+
+  def test_normalized_query_constraints_mapping_with_hash
+    reflection = Sharded::BlogPost.reflect_on_association(:featured_comment)
+
+    assert_equal [["blog_id", "blog_id"], ["id", "blog_post_id"]], reflection.normalized_query_constraints_mapping
+  end
+
+  def test_belongs_to_join_keys_with_query_constraints_mapping
+    reflection = Sharded::BlogPost.reflect_on_association(:featured_comment)
+
+    # target (Comment) columns for WHERE clause
+    assert_equal ["blog_id", "blog_post_id", "id"], reflection.join_query_constraints_primary_key
+    # self (BlogPost) columns to read values from
+    assert_equal ["blog_id", "id", "featured_comment_id"], reflection.join_query_constraints_foreign_key
+  end
+
+  def test_query_constraints_mapping_requires_foreign_key_when_hash_present
+    assert_raises(ArgumentError, match: /requires an explicit `foreign_key` option/) do
+      ActiveRecord::Reflection.create(
+        :belongs_to, :comment, nil,
+        { query_constraints: [:blog_id, { id: :blog_post_id }], class_name: "Sharded::Comment" },
+        Sharded::BlogPost
+      ).foreign_key
     end
+  end
 
-    has_one_expected_message = <<~MSG.squish
-      Setting `query_constraints:` option on `Firm.has_one :account` is not allowed.
-      To get the same behavior, use the `foreign_key` option instead.
-    MSG
+  def test_has_many_with_decoupled_query_constraints_active_record_primary_key_is_scalar
+    # When both foreign_key and query_constraints are specified, active_record_primary_key
+    # should return the scalar primary key, not the query_constraints_list array.
+    # This ensures .joins() works correctly.
+    reflection = ActiveRecord::Reflection.create(
+      :has_many, :comments, nil,
+      { foreign_key: :blog_post_id, query_constraints: :blog_id, class_name: "Sharded::Comment" },
+      Sharded::BlogPost
+    )
 
-    assert_raises(ActiveRecord::ConfigurationError, match: has_one_expected_message) do
-      ActiveRecord::Reflection.create(:has_one, :account, nil, { query_constraints: [:firm_id, :firm_name] }, Firm)
-    end
+    assert_equal "id", reflection.active_record_primary_key
+    assert_equal "id", reflection.join_foreign_key
+  end
 
-    belongs_to_expected_message = <<~MSG.squish
-      Setting `query_constraints:` option on `Firm.belongs_to :client` is not allowed.
-      To get the same behavior, use the `foreign_key` option instead.
-    MSG
+  def test_has_many_decoupled_query_constraints_join_query_constraints_keys
+    reflection = ActiveRecord::Reflection.create(
+      :has_many, :comments, nil,
+      { foreign_key: :blog_post_id, query_constraints: :blog_id, class_name: "Sharded::Comment" },
+      Sharded::BlogPost
+    )
 
-    assert_raises(ActiveRecord::ConfigurationError, match: belongs_to_expected_message) do
-      ActiveRecord::Reflection.create(:belongs_to, :client, nil, { query_constraints: [:firm_id, :firm_name] }, Firm)
-    end
+    # For querying: parent columns (self) = [blog_id, id], child columns (target) = [blog_id, blog_post_id]
+    assert_equal ["blog_id", "id"], reflection.join_query_constraints_foreign_key
+    assert_equal ["blog_id", "blog_post_id"], reflection.join_query_constraints_primary_key
+  end
+
+  def test_query_constraints_allows_the_foreign_key_to_be_listed
+    # query_constraints are *additional* columns layered on the foreign key, so
+    # listing the foreign key itself is allowed (not rejected) and de-duplicated.
+    reflection = ActiveRecord::Reflection.create(
+      :has_many, :comments, nil,
+      { foreign_key: :blog_post_id, query_constraints: [:blog_id, :blog_post_id], class_name: "Sharded::Comment" },
+      Sharded::BlogPost
+    )
+
+    assert_equal ["blog_id", "blog_post_id"], reflection.query_constraints_foreign_key
+  end
+
+  def test_query_constraints_foreign_key_normalizes_schema_backed_column_mappings
+    reflection = Sharded::BlogPost.reflect_on_association(:featured_comment)
+
+    assert_equal [["blog_id", "blog_id"], ["id", "blog_post_id"]], reflection.normalized_query_constraints_mapping
+    assert_equal ["blog_id", "id", "featured_comment_id"], reflection.query_constraints_foreign_key
+  end
+
+  def test_belongs_to_query_constraints_allows_fk_listed_keeps_pairs_aligned
+    # Listing the writable foreign_key in query_constraints must not misalign the
+    # join key arrays. The FK is de-duplicated, so the belongs_to query still uses
+    # the base PK/FK pair: target [blog_id, id] ↔ owner [blog_id, blog_post_id].
+    reflection = ActiveRecord::Reflection.create(
+      :belongs_to, :blog_post, nil,
+      { foreign_key: :blog_post_id, query_constraints: [:blog_id, :blog_post_id], class_name: "Sharded::BlogPost" },
+      Sharded::Comment
+    )
+
+    assert_equal ["blog_id", "id"], reflection.join_query_constraints_primary_key
+    assert_equal ["blog_id", "blog_post_id"], reflection.join_query_constraints_foreign_key
+  end
+
+  def test_normalized_query_constraints_mapping_with_bare_hash
+    # A bare Hash (not wrapped in an Array) normalizes the same as the array form.
+    reflection = Sharded::BlogPost.reflect_on_association(:featured_comment_bare_hash_qc)
+
+    assert_equal [["blog_id", "blog_id"]], reflection.normalized_query_constraints_mapping
+  end
+
+  def test_belongs_to_bare_hash_query_constraints_join_keys_aligned
+    reflection = Sharded::BlogPost.reflect_on_association(:featured_comment_bare_hash_qc)
+
+    # target (Comment) columns: blog_id (from mapping) + id (association_primary_key)
+    assert_equal ["blog_id", "id"], reflection.join_query_constraints_primary_key
+    # self (BlogPost) columns: blog_id (from mapping) + featured_comment_id (foreign_key)
+    assert_equal ["blog_id", "featured_comment_id"], reflection.join_query_constraints_foreign_key
+  end
+
+  def test_belongs_to_standalone_symbol_array_query_constraints_returns_nil_mapping
+    # Standalone symbol-array query_constraints (no explicit foreign_key, no Hash)
+    # is the legacy form: normalized mapping returns nil, foreign_key is derived
+    # from the query_constraints array itself.
+    reflection = ActiveRecord::Reflection.create(
+      :belongs_to, :blog_post, nil,
+      { query_constraints: [:blog_id, :blog_post_id], class_name: "Sharded::BlogPost" },
+      Sharded::Comment
+    )
+
+    assert_nil reflection.normalized_query_constraints_mapping
+    assert_equal ["blog_id", "blog_post_id"], reflection.foreign_key
   end
 
   def test_counter_cache_column_defaults_when_counter_cache_is_true

--- a/activerecord/test/fixtures/sharded_blog_posts.yml
+++ b/activerecord/test/fixtures/sharded_blog_posts.yml
@@ -4,6 +4,7 @@ _fixture:
 great_post_blog_one:
   title: "My first post in my Blog1!"
   blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_one) %>
+  featured_comment_id: <%= ActiveRecord::FixtureSet.identify(:great_comment_blog_post_one) %>
 
 second_post_blog_one:
   title: "This is my second post in my Blog1!"

--- a/activerecord/test/models/sharded/blog.rb
+++ b/activerecord/test/models/sharded/blog.rb
@@ -13,6 +13,6 @@ module Sharded
 
     has_many :comments_via_posts,
       through: :blog_posts,
-      source: :comments_with_composite_pk
+      source: :comments_with_query_constraints
   end
 end

--- a/activerecord/test/models/sharded/blog_post.rb
+++ b/activerecord/test/models/sharded/blog_post.rb
@@ -13,6 +13,17 @@ module Sharded
 
     has_many :blog_post_tags
     has_many :tags, through: :blog_post_tags
+    has_many :blog_post_tags_with_decoupled_qc,
+      class_name: "Sharded::BlogPostTag",
+      foreign_key: :blog_post_id,
+      query_constraints: :blog_id
+    has_many :tags_with_decoupled_qc,
+      through: :blog_post_tags_with_decoupled_qc,
+      source: :tag_with_decoupled_qc
+    has_many :tags_with_decoupled_qc_without_joins,
+      through: :blog_post_tags_with_decoupled_qc,
+      source: :tag_with_decoupled_qc,
+      disable_joins: true
 
     has_and_belongs_to_many :tags_with_composite_fk,
       class_name: "Sharded::Tag",
@@ -20,13 +31,22 @@ module Sharded
       foreign_key: [:blog_id, :blog_post_id],
       association_foreign_key: [:blog_id, :tag_id]
 
-    has_many :comments_with_composite_pk,
+    has_many :comments_with_query_constraints,
       class_name: "Sharded::Comment",
-      primary_key: [:blog_id, :id],
-      foreign_key: [:blog_id, :blog_post_id]
+      foreign_key: :blog_post_id,
+      query_constraints: :blog_id
 
     has_many :comments_with_inverse,
       class_name: "Sharded::Comment",
       inverse_of: :blog_post_with_inverse
+
+    belongs_to :featured_comment,
+      class_name: "Sharded::Comment",
+      foreign_key: :featured_comment_id,
+      query_constraints: [:blog_id, { id: :blog_post_id }]
+    belongs_to :featured_comment_bare_hash_qc,
+      class_name: "Sharded::Comment",
+      foreign_key: :featured_comment_id,
+      query_constraints: { blog_id: :blog_id }
   end
 end

--- a/activerecord/test/models/sharded/blog_post.rb
+++ b/activerecord/test/models/sharded/blog_post.rb
@@ -13,6 +13,17 @@ module Sharded
 
     has_many :blog_post_tags
     has_many :tags, through: :blog_post_tags
+    has_many :blog_post_tags_with_decoupled_qc,
+      class_name: "Sharded::BlogPostTag",
+      foreign_key: :blog_post_id,
+      query_constraints: :blog_id
+    has_many :tags_with_decoupled_qc,
+      through: :blog_post_tags_with_decoupled_qc,
+      source: :tag_with_decoupled_qc
+    has_many :tags_with_decoupled_qc_without_joins,
+      through: :blog_post_tags_with_decoupled_qc,
+      source: :tag_with_decoupled_qc,
+      disable_joins: true
 
     has_and_belongs_to_many :tags_with_composite_fk,
       class_name: "Sharded::Tag",
@@ -20,13 +31,27 @@ module Sharded
       foreign_key: [:blog_id, :blog_post_id],
       association_foreign_key: [:blog_id, :tag_id]
 
-    has_many :comments_with_composite_pk,
+    has_many :comments_with_query_constraints,
       class_name: "Sharded::Comment",
-      primary_key: [:blog_id, :id],
-      foreign_key: [:blog_id, :blog_post_id]
+      foreign_key: :blog_post_id,
+      query_constraints: :blog_id
+
+    has_one :top_comment_with_query_constraints,
+      class_name: "Sharded::Comment",
+      foreign_key: :blog_post_id,
+      query_constraints: :blog_id
 
     has_many :comments_with_inverse,
       class_name: "Sharded::Comment",
       inverse_of: :blog_post_with_inverse
+
+    belongs_to :featured_comment,
+      class_name: "Sharded::Comment",
+      foreign_key: :featured_comment_id,
+      query_constraints: [:blog_id, { id: :blog_post_id }]
+    belongs_to :featured_comment_bare_hash_qc,
+      class_name: "Sharded::Comment",
+      foreign_key: :featured_comment_id,
+      query_constraints: { blog_id: :blog_id }
   end
 end

--- a/activerecord/test/models/sharded/blog_post_destroy_async.rb
+++ b/activerecord/test/models/sharded/blog_post_destroy_async.rb
@@ -6,9 +6,9 @@ module Sharded
     query_constraints :blog_id, :id
 
     belongs_to :blog
-    has_many :comments, dependent: :destroy_async, foreign_key: [:blog_id, :blog_post_id], class_name: "Sharded::CommentDestroyAsync"
+    has_many :comments, dependent: :destroy_async, foreign_key: :blog_post_id, query_constraints: :blog_id, class_name: "Sharded::CommentDestroyAsync"
 
-    has_many :blog_post_tags, foreign_key: [:blog_id, :blog_post_id], class_name: "Sharded::BlogPostTag"
+    has_many :blog_post_tags, foreign_key: :blog_post_id, query_constraints: :blog_id, class_name: "Sharded::BlogPostTag"
     has_many :tags, through: :blog_post_tags, dependent: :destroy_async, class_name: "Sharded::Tag"
   end
 end

--- a/activerecord/test/models/sharded/blog_post_tag.rb
+++ b/activerecord/test/models/sharded/blog_post_tag.rb
@@ -7,5 +7,6 @@ module Sharded
 
     belongs_to :blog_post
     belongs_to :tag
+    belongs_to :tag_with_decoupled_qc, class_name: "Sharded::Tag", foreign_key: :tag_id, query_constraints: :blog_id
   end
 end

--- a/activerecord/test/models/sharded/blog_post_with_revision.rb
+++ b/activerecord/test/models/sharded/blog_post_with_revision.rb
@@ -6,6 +6,6 @@ module Sharded
     self.table_name = :sharded_blog_posts
     query_constraints :blog_id, :revision, :id
 
-    has_many :comments, primary_key: [:blog_id, :id], foreign_key: [:blog_id, :blog_post_id]
+    has_many :comments, foreign_key: :blog_post_id, query_constraints: :blog_id
   end
 end

--- a/activerecord/test/models/sharded/comment.rb
+++ b/activerecord/test/models/sharded/comment.rb
@@ -9,9 +9,25 @@ module Sharded
     belongs_to :blog_post_by_id, class_name: "Sharded::BlogPost", foreign_key: :blog_post_id, primary_key: :id
     belongs_to :blog_post_with_inverse,
       class_name: "Sharded::BlogPost",
-      foreign_key: [:blog_id, :blog_post_id],
-      primary_key: [:blog_id, :id],
+      foreign_key: :blog_post_id,
+      query_constraints: :blog_id,
       inverse_of: :comments_with_inverse
+    belongs_to :blog_post_with_decoupled_qc, class_name: "Sharded::BlogPost", foreign_key: :blog_post_id, query_constraints: :blog_id
+    belongs_to :blog_post_with_decoupled_qc_autosave,
+      class_name: "Sharded::BlogPost",
+      foreign_key: :blog_post_id,
+      query_constraints: :blog_id,
+      autosave: true
+    has_one :blog_through_post_with_decoupled_qc, through: :blog_post_with_decoupled_qc, source: :blog
     belongs_to :blog
+  end
+
+  class LegacyComment < ActiveRecord::Base
+    self.table_name = :sharded_comments
+    self.primary_key = [:blog_id, :id]
+
+    belongs_to :blog_post,
+      class_name: "Sharded::BlogPost",
+      foreign_key: [:blog_id, :blog_post_id]
   end
 end

--- a/activerecord/test/models/sharded/comment.rb
+++ b/activerecord/test/models/sharded/comment.rb
@@ -9,9 +9,24 @@ module Sharded
     belongs_to :blog_post_by_id, class_name: "Sharded::BlogPost", foreign_key: :blog_post_id, primary_key: :id
     belongs_to :blog_post_with_inverse,
       class_name: "Sharded::BlogPost",
-      foreign_key: [:blog_id, :blog_post_id],
-      primary_key: [:blog_id, :id],
+      foreign_key: :blog_post_id,
+      query_constraints: :blog_id,
       inverse_of: :comments_with_inverse
+    belongs_to :blog_post_with_decoupled_qc, class_name: "Sharded::BlogPost", foreign_key: :blog_post_id, query_constraints: :blog_id
+    has_one :blog_through_post_with_decoupled_qc, through: :blog_post_with_decoupled_qc, source: :blog
+    belongs_to :blog_post_with_fk_in_qc,
+      class_name: "Sharded::BlogPost",
+      foreign_key: :blog_post_id,
+      query_constraints: [:blog_id, :blog_post_id]
     belongs_to :blog
+  end
+
+  class LegacyComment < ActiveRecord::Base
+    self.table_name = :sharded_comments
+    self.primary_key = [:blog_id, :id]
+
+    belongs_to :blog_post,
+      class_name: "Sharded::BlogPost",
+      foreign_key: [:blog_id, :blog_post_id]
   end
 end

--- a/activerecord/test/models/sharded/comment_destroy_async.rb
+++ b/activerecord/test/models/sharded/comment_destroy_async.rb
@@ -5,7 +5,7 @@ module Sharded
     self.table_name = :sharded_comments
     query_constraints :blog_id, :id
 
-    belongs_to :blog_post, dependent: :destroy_async, foreign_key: [:blog_id, :blog_post_id], class_name: "Sharded::BlogPostDestroyAsync"
+    belongs_to :blog_post, dependent: :destroy_async, foreign_key: :blog_post_id, query_constraints: :blog_id, class_name: "Sharded::BlogPostDestroyAsync"
     belongs_to :blog_post_by_id, class_name: "Sharded::BlogPostDestroyAsync", foreign_key: :blog_post_id
     belongs_to :blog
   end

--- a/activerecord/test/models/shipment.rb
+++ b/activerecord/test/models/shipment.rb
@@ -3,7 +3,7 @@
 class Shipment < ActiveRecord::Base
   has_many :adjustments,
     as: :adjustable,
-    foreign_key: [:region_id, :adjustable_id],
-    primary_key: [:region_id, :id],
+    foreign_key: :adjustable_id,
+    query_constraints: [:region_id],
     inverse_of: :adjustable
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -357,6 +357,7 @@ ActiveRecord::Schema.define do
     t.references :parent, polymorphic: true
     t.integer :blog_id
     t.integer :revision
+    t.integer :featured_comment_id
   end
 
   create_table :sharded_comments, force: true do |t|


### PR DESCRIPTION
## Introduce decoupled `query_constraints` for associations

Reintroduces `query_constraints` on associations, **decoupled from `foreign_key`**.

### Motivation

`query_constraints` is deprecated, and the way to scope a `belongs_to` by an
extra column (a shard or tenant) today is to list it inside `foreign_key` as an
array:

```ruby
belongs_to :post, foreign_key: [:account_id, :post_id]
```

Active Record treats every column in that array as part of the foreign key, so
the tenant column (`account_id`) gets **nulled on clear and reassigned on set**
(see #49671 and #57906).

This change reintroduces `query_constraints` as a **query-only** option layered
on top of `foreign_key`, separate from it. With the shard column expressed as
additive query scope rather than part of the foreign key, it is excluded from
nullification by construction: the column was never one of the things clearing
the association touches.

### Mental model

`query_constraints` declares **additional columns** to match when querying an
association's targets. They participate in loading, preloading, eager loading,
joins, and association predicates. The foreign key always participates because
an association cannot be queried without it.

- When only `foreign_key` is given, behavior is unchanged.
- When `query_constraints` is given, `foreign_key` handles writes while queries
  match on the foreign key plus the additional columns.
- When `query_constraints` is given without an explicit `foreign_key`, the
  foreign key is derived by convention.
- Query constraint columns must be distinct from explicit or derived foreign key
  columns; overlapping configurations raise `ArgumentError` when the reflection
  is validated.

**Nullify / assign behavior:** clearing an association nulls only the
`foreign_key`; `query_constraints` columns are never written or nulled because
they scope the owner rather than point at the target.

### The common case: the foreign key stays conventional

Because `query_constraints` no longer redefines the foreign key, the common case
only needs to name the additional query column:

```ruby
# post_id is derived and is the only column written or nulled;
# account_id is added purely to scope queries
belongs_to :post, query_constraints: :account_id
```

This is equivalent to spelling out the conventional key:

```ruby
belongs_to :post, foreign_key: :post_id, query_constraints: :account_id
```

An explicit `foreign_key` remains available for non-conventional associations.

### Two sides of a constraint (advanced)

A column can have a different name on each side. `query_constraints` accepts
symbols (same name on both sides) and hashes (`self_column => target_column`):

```ruby
class BlogPost < ApplicationRecord
  belongs_to :featured_comment,
    class_name: "Comment",
    foreign_key: :featured_comment_id,
    query_constraints: [:blog_id, { id: :blog_post_id }]
  #   :blog_id              -> blog_id on both tables
  #   { id: :blog_post_id } -> BlogPost#id matches Comment#blog_post_id
end
```

Resulting join keys:

- self (`BlogPost`) columns: `["blog_id", "id", "featured_comment_id"]`
- target (`Comment`) columns: `["blog_id", "blog_post_id", "id"]`

A Hash mapping requires an explicit `foreign_key` because a foreign key cannot
be derived from a renamed pair.

### Implementation

- New reflection methods `query_constraints_foreign_key`,
  `normalized_query_constraints_mapping`, and
  `join_query_constraints_{primary,foreign}_key` /
  `join_query_constraints_id_for` separate writable keys from query keys.
- Join (`join_scope`, `AssociationScope`) and preload paths resolve keys through
  the query-constraint methods, falling back to existing `join_*` behavior when
  no association query constraints are present.
- `foreign_key`, `active_record_primary_key`, and autosave continue to expose and
  write only the explicit or conventionally derived foreign key.
- Array-valued `foreign_key` options retain their composite writable-key
  semantics; their origin is tracked separately from user-supplied
  `query_constraints`.
- `ThroughReflection`, `PolymorphicReflection`, and `RuntimeReflection` delegate
  the new methods in lockstep with their `join_*` counterparts.

### Backward compatibility

Existing composite `foreign_key: [...]` associations, including composite
primary key associations, keep working as today: all columns remain part of the
foreign key and are written and nulled as a unit.

Associations without `query_constraints` are unchanged. When
`query_constraints` is present, decoupled behavior applies with either an
explicit or conventionally derived foreign key. Hash mappings still require an
explicit `foreign_key`.