### PR TITLE
`activerecord`: make sure tests do not rely on implicit `SELECT` order

### DIFF
--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1374,8 +1374,8 @@ class EagerAssociationTest < ActiveRecord::TestCase
     posts[0].categories[0].categorizations.length
 
     posts = Post.all.merge!(includes: { categories: :categorizations }, order: "posts.id").to_a
-    assert_no_queries { assert_equal 2, posts[0].categories[0].categorizations.length }
-    assert_no_queries { assert_equal 1, posts[0].categories[1].categorizations.length }
+    assert_no_queries { assert_equal 2, posts[0].categories.sort_by(&:id)[0].categorizations.length }
+    assert_no_queries { assert_equal 1, posts[0].categories.sort_by(&:id)[1].categorizations.length }
     assert_no_queries { assert_equal 2, posts[1].categories[0].categorizations.length }
   end
 
@@ -1418,9 +1418,9 @@ class EagerAssociationTest < ActiveRecord::TestCase
     comments = Post.find(1).comments.to_a
 
     Comment.where("1=0").scoping do
-      assert_equal comments, Post.find(1).comments
-      assert_equal comments, Post.preload(:comments).find(1).comments
-      assert_equal comments, Post.eager_load(:comments).find(1).comments
+      assert_equal_unordered comments, Post.find(1).comments
+      assert_equal_unordered comments, Post.preload(:comments).find(1).comments
+      assert_equal_unordered comments, Post.eager_load(:comments).find(1).comments
     end
   end
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2751,7 +2751,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     bulb2 = car.bulbs.create
     bulb3 = Bulb.create
 
-    assert_equal [bulb1, bulb2], car.bulbs
+    assert_equal_unordered [bulb1, bulb2], car.bulbs
     result = car.bulbs.replace([bulb3, bulb1])
     assert_equal [bulb1, bulb3], car.bulbs
     assert_equal [bulb1, bulb3], result
@@ -3302,7 +3302,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_ids_reader_on_preloaded_association_with_composite_primary_key
     great_author = cpk_authors(:cpk_great_author)
 
-    assert_equal great_author.books.ids, Cpk::Author.preload(:books).find(great_author.id).book_ids
+    assert_equal_unordered great_author.books.ids, Cpk::Author.preload(:books).find(great_author.id).book_ids
   end
 
   def test_ids_writer_with_composite_primary_key_and_string_ids

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -950,7 +950,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     author.author_favorites.create(favorite_author_id: 1)
     author.author_favorites.create(favorite_author_id: 2)
     author.author_favorites.create(favorite_author_id: 3)
-    assert_equal post.author.author_favorites, post.author_favorites
+    assert_equal_unordered post.author.author_favorites, post.author_favorites
   end
 
   def test_merge_join_association_with_has_many_through_association_proxy

--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -677,7 +677,7 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
   end
 
   def test_preload_polymorph_many_types
-    taggings = Tagging.all.merge!(includes: :taggable, where: ["taggable_type != ?", "FakeModel"]).to_a
+    taggings = Tagging.all.merge!(includes: :taggable, where: ["taggable_type != ?", "FakeModel"], order: "taggings.id").to_a
     assert_no_queries do
       taggings.first.taggable.id
       taggings[1].taggable.id

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -996,7 +996,7 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCa
     order.save
     order.reload
 
-    assert_equal order_agreements, order.order_agreement_ids
+    assert_equal_unordered order_agreements, order.order_agreement_ids
     assert_equal 2, order.order_agreements.length
     assert_includes order.order_agreements, cpk_order_agreements(:order_agreement_two)
   end

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -828,10 +828,10 @@ class InsertAllTest < ActiveRecord::TestCase
                             { city_id: "2", logdate: 2.days.ago, peaktemp: 2, unitsales: 2 },
                             { city_id: "2", logdate: 3.days.ago, peaktemp: 0, unitsales: 0 }],
                             unique_by: %i[logdate city_id])
-    assert_equal [[1.day.ago.to_date, 1, 1]],
-                 Measurement.where(city_id: 1).pluck(:logdate, :peaktemp, :unitsales)
-    assert_equal [[2.days.ago.to_date, 2, 2], [3.days.ago.to_date, 0, 0]],
-                 Measurement.where(city_id: 2).pluck(:logdate, :peaktemp, :unitsales)
+    assert_equal_unordered [[1.day.ago.to_date, 1, 1]],
+                           Measurement.where(city_id: 1).pluck(:logdate, :peaktemp, :unitsales)
+    assert_equal_unordered [[2.days.ago.to_date, 2, 2], [3.days.ago.to_date, 0, 0]],
+                           Measurement.where(city_id: 2).pluck(:logdate, :peaktemp, :unitsales)
   end
 
   def test_insert_all_with_enum_values

--- a/activerecord/test/cases/message_pack_test.rb
+++ b/activerecord/test/cases/message_pack_test.rb
@@ -32,7 +32,7 @@ class ActiveRecordMessagePackTest < ActiveRecord::TestCase
     post = Post.create!(title: "A Title", body: "A body.")
     post.create_author!(name: "An Author")
     post.comments.create!(body: "A comment.")
-    post.comments.create!(body: "Another comment.", author: post.author)
+    comment_with_author = post.comments.create!(body: "Another comment.", author: post.author)
     post.comments.load
 
     assert_no_queries do
@@ -45,7 +45,7 @@ class ActiveRecordMessagePackTest < ActiveRecord::TestCase
 
       assert_same roundtripped_post, roundtripped_post.comments[0].post
       assert_same roundtripped_post, roundtripped_post.comments[1].post
-      assert_same roundtripped_post.author, roundtripped_post.comments[1].author
+      assert_same roundtripped_post.author, roundtripped_post.comments.find { |comment| comment.id == comment_with_author.id }.author
     end
   end
 

--- a/activerecord/test/cases/relation/load_async_test.rb
+++ b/activerecord/test/cases/relation/load_async_test.rb
@@ -250,7 +250,7 @@ module ActiveRecord
 
     def test_pluck
       titles = Post.where(author_id: 1).pluck(:title)
-      assert_equal titles, Post.where(author_id: 1).load_async.pluck(:title)
+      assert_equal_unordered titles, Post.where(author_id: 1).load_async.pluck(:title)
     end
 
     def test_count
@@ -277,7 +277,7 @@ module ActiveRecord
     def test_load_async_pluck_with_query_cache
       titles = Post.where(author_id: 1).pluck(:title)
       Post.cache do
-        assert_equal titles, Post.where(author_id: 1).load_async.pluck(:title)
+        assert_equal_unordered titles, Post.where(author_id: 1).load_async.pluck(:title)
       end
     end
 
@@ -386,7 +386,7 @@ module ActiveRecord
 
       def test_pluck
         titles = Post.where(author_id: 1).pluck(:title)
-        assert_equal titles, Post.where(author_id: 1).load_async.pluck(:title)
+        assert_equal_unordered titles, Post.where(author_id: 1).load_async.pluck(:title)
       end
 
       def test_size
@@ -528,7 +528,7 @@ module ActiveRecord
 
       def test_pluck
         titles = Post.where(author_id: 1).pluck(:title)
-        assert_equal titles, Post.where(author_id: 1).load_async.pluck(:title)
+        assert_equal_unordered titles, Post.where(author_id: 1).load_async.pluck(:title)
       end
 
       def test_size

--- a/activerecord/test/cases/relation/or_test.rb
+++ b/activerecord/test/cases/relation/or_test.rb
@@ -13,7 +13,7 @@ module ActiveRecord
 
     def test_or_with_relation
       expected = Post.where("id = 1 or id = 2").to_a
-      assert_equal expected, Post.where("id = 1").or(Post.where("id = 2")).to_a
+      assert_equal_unordered expected, Post.where("id = 1").or(Post.where("id = 2")).to_a
     end
 
     def test_or_identity
@@ -112,7 +112,7 @@ module ActiveRecord
 
     def test_or_with_named_scope
       expected = Post.where("id = 1 or body LIKE '\%a\%'").to_a
-      assert_equal expected, Post.where("id = 1").or(Post.containing_the_letter_a)
+      assert_equal_unordered expected, Post.where("id = 1").or(Post.containing_the_letter_a)
     end
 
     def test_or_inside_named_scope
@@ -130,7 +130,7 @@ module ActiveRecord
       p = Post.where("id = 1")
       p.load
       assert_equal true, p.loaded?
-      assert_equal expected, p.or(Post.where("id = 2")).to_a
+      assert_equal_unordered expected, p.or(Post.where("id = 2")).to_a
     end
 
     def test_or_with_non_relation_object_raises_error

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -173,16 +173,16 @@ class RelationTest < ActiveRecord::TestCase
 
   def test_finding_with_subquery
     relation = Topic.where(approved: true)
-    assert_equal relation.to_a, Topic.select("*").from(relation).to_a
-    assert_equal relation.to_a, Topic.select("subquery.*").from(relation).to_a
-    assert_equal relation.to_a, Topic.select("a.*").from(relation, :a).to_a
+    assert_equal_unordered relation.to_a, Topic.select("*").from(relation).to_a
+    assert_equal_unordered relation.to_a, Topic.select("subquery.*").from(relation).to_a
+    assert_equal_unordered relation.to_a, Topic.select("a.*").from(relation, :a).to_a
   end
 
   def test_finding_with_subquery_with_binds
     relation = Post.first.comments
-    assert_equal relation.to_a, Comment.select("*").from(relation).to_a
-    assert_equal relation.to_a, Comment.select("subquery.*").from(relation).to_a
-    assert_equal relation.to_a, Comment.select("a.*").from(relation, :a).to_a
+    assert_equal_unordered relation.to_a, Comment.select("*").from(relation).to_a
+    assert_equal_unordered relation.to_a, Comment.select("subquery.*").from(relation).to_a
+    assert_equal_unordered relation.to_a, Comment.select("a.*").from(relation, :a).to_a
   end
 
   def test_finding_with_subquery_without_select_does_not_change_the_select
@@ -255,9 +255,9 @@ class RelationTest < ActiveRecord::TestCase
 
   def test_finding_with_subquery_with_eager_loading_in_from
     relation = Comment.includes(:post).where("posts.type": "Post").order(:id)
-    assert_equal relation.to_a, Comment.select("*").from(relation).to_a
-    assert_equal relation.to_a, Comment.select("subquery.*").from(relation).to_a
-    assert_equal relation.to_a, Comment.select("a.*").from(relation, :a).to_a
+    assert_equal_unordered relation.to_a, Comment.select("*").from(relation).to_a
+    assert_equal_unordered relation.to_a, Comment.select("subquery.*").from(relation).to_a
+    assert_equal_unordered relation.to_a, Comment.select("a.*").from(relation, :a).to_a
   end
 
   unless current_adapter?(:SQLite3Adapter)
@@ -267,8 +267,8 @@ class RelationTest < ActiveRecord::TestCase
       union = Arel::Nodes::Union.new(arel1, arel2)
       expected = [comments(:greetings), comments(:more_greetings)]
 
-      assert_equal expected, Comment.select("subquery.*").from(union).to_a
-      assert_equal expected, Comment.select("a.*").from(union, :a).to_a
+      assert_equal_unordered expected, Comment.select("subquery.*").from(union).to_a
+      assert_equal_unordered expected, Comment.select("a.*").from(union, :a).to_a
     end
   end
 
@@ -2220,13 +2220,13 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   test "relations show the records in #inspect" do
-    relation = Post.limit(2)
-    assert_equal "#<ActiveRecord::Relation [#{Post.limit(2).map(&:inspect).join(', ')}]>", relation.inspect
+    relation = Post.order(:id).limit(2)
+    assert_equal "#<ActiveRecord::Relation [#{Post.order(:id).limit(2).map(&:inspect).join(', ')}]>", relation.inspect
   end
 
   test "relations limit the records in #inspect at 10" do
-    relation = Post.limit(11)
-    assert_equal "#<ActiveRecord::Relation [#{Post.limit(10).map(&:inspect).join(', ')}, ...]>", relation.inspect
+    relation = Post.order(:id).limit(11)
+    assert_equal "#<ActiveRecord::Relation [#{Post.order(:id).limit(10).map(&:inspect).join(', ')}, ...]>", relation.inspect
   end
 
   test "relations don't load all records in #inspect" do

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -295,7 +295,7 @@ class DefaultScopingTest < ActiveRecord::TestCase
   def test_unscope_overrides_default_scope
     expected = Developer.all.collect { |dev| [dev.name, dev.id] }
     received = DeveloperCalledJamis.unscope(:where).collect { |dev| [dev.name, dev.id] }
-    assert_equal expected, received
+    assert_equal_unordered expected, received
   end
 
   def test_unscope_after_reordering_and_combining

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -647,7 +647,7 @@ class NamedScopingTest < ActiveRecord::TestCase
     end
 
     assert_queries_match(%r{/\* from-scope \*/}) do
-      assert_equal Topic.including_annotate_in_scope.to_a, Topic.all.to_a
+      assert_equal_unordered Topic.including_annotate_in_scope.to_a, Topic.all.to_a
     end
   end
 end

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -156,6 +156,19 @@ module ActiveRecord
       assert_not_includes model.column_names, column_name.to_s, msg
     end
 
+    def assert_equal_unordered(expected, actual, message = nil)
+      expected = expected.to_a
+      actual = actual.to_a
+
+      unmatched = actual.dup
+      aligned = expected.each_with_object([]) do |element, result|
+        index = unmatched.index(element)
+        result << unmatched.delete_at(index) if index
+      end
+
+      assert_equal expected, aligned + unmatched, message
+    end
+
     def with_has_many_inversing(model = ActiveRecord::Base)
       old = model.has_many_inversing
       model.has_many_inversing = true

--- a/activerecord/test/cases/unsafe_raw_sql_test.rb
+++ b/activerecord/test/cases/unsafe_raw_sql_test.rb
@@ -201,7 +201,7 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
 
     titles = Post.pluck("title")
 
-    assert_equal titles_expected, titles
+    assert_equal_unordered titles_expected, titles
   end
 
   test "pluck: allows string column name with function and alias" do
@@ -209,7 +209,7 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
 
     titles = Post.pluck("UPPER(title) AS title")
 
-    assert_equal titles_expected, titles
+    assert_equal_unordered titles_expected, titles
   end
 
   test "pluck: allows symbol column name" do
@@ -217,7 +217,7 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
 
     titles = Post.pluck(:title)
 
-    assert_equal titles_expected, titles
+    assert_equal_unordered titles_expected, titles
   end
 
   test "pluck: allows multiple column names" do
@@ -225,7 +225,7 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
 
     values = Post.pluck(:title, :id)
 
-    assert_equal values_expected, values
+    assert_equal_unordered values_expected, values
   end
 
   test "pluck: allows column names with includes" do
@@ -233,7 +233,7 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
 
     values = Post.includes(:comments).pluck(:title, :id)
 
-    assert_equal values_expected, values
+    assert_equal_unordered values_expected, values
   end
 
   test "pluck: allows auto-generated attributes" do
@@ -241,7 +241,7 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
 
     values = Post.pluck(:tags_count)
 
-    assert_equal values_expected, values
+    assert_equal_unordered values_expected, values
   end
 
   test "pluck: allows table and column names" do
@@ -249,7 +249,7 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
 
     titles = Post.pluck("posts.title")
 
-    assert_equal titles_expected, titles
+    assert_equal_unordered titles_expected, titles
   end
 
   test "pluck: allows quoted table and column names" do
@@ -257,7 +257,7 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
 
     titles = Post.pluck(quote_table_name("posts.title"))
 
-    assert_equal titles_expected, titles
+    assert_equal_unordered titles_expected, titles
   end
 
   test "pluck: allows nested functions" do
@@ -265,7 +265,7 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
 
     title_lengths = Post.pluck("length(trim(title))")
 
-    assert_equal title_lengths_expected, title_lengths
+    assert_equal_unordered title_lengths_expected, title_lengths
   end
 
   test "pluck: disallows invalid column name" do
@@ -290,7 +290,7 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
     excepted_values = Post.includes(:comments).pluck(:title).map { |title| [title, title.size] }
     values = Post.includes(:comments).pluck(:title, Arel.sql("length(title)"))
 
-    assert_equal excepted_values, values
+    assert_equal_unordered excepted_values, values
   end
 
   test "pluck: disallows dangerous query method" do


### PR DESCRIPTION
some tests rely on implicit MVCC-specific updation-based order, which is not guaranteed and might lead to flaky tests. In the places where it happens an explicit order is added.

found by the [`pg_disorder`](https://github.com/viralpraxis/pg_disorder) extension, in the "reverse" mode

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
