### PR TITLE
Remove psych version checks in YamlColumn

### DIFF
--- a/activerecord/lib/active_record/coders/yaml_column.rb
+++ b/activerecord/lib/active_record/coders/yaml_column.rb
@@ -11,21 +11,15 @@ module ActiveRecord
           @unsafe_load = unsafe_load
         end
 
-        if Gem::Version.new(Psych::VERSION) >= Gem::Version.new("5.1")
-          def dump(object)
-            if @unsafe_load.nil? ? ActiveRecord.use_yaml_unsafe_load : @unsafe_load
-              ::YAML.dump(object)
-            else
-              ::YAML.safe_dump(
-                object,
-                permitted_classes: @permitted_classes + ActiveRecord.yaml_column_permitted_classes,
-                aliases: true,
-              )
-            end
-          end
-        else
-          def dump(object)
-            YAML.dump(object)
+        def dump(object)
+          if @unsafe_load.nil? ? ActiveRecord.use_yaml_unsafe_load : @unsafe_load
+            ::YAML.dump(object)
+          else
+            ::YAML.safe_dump(
+              object,
+              permitted_classes: @permitted_classes + ActiveRecord.yaml_column_permitted_classes,
+              aliases: true,
+            )
           end
         end
 

--- a/activerecord/test/cases/coders/yaml_column_test.rb
+++ b/activerecord/test/cases/coders/yaml_column_test.rb
@@ -100,10 +100,6 @@ module ActiveRecord
       end
 
       def test_yaml_column_permitted_classes_are_consumed_by_safe_dump
-        if Gem::Version.new(Psych::VERSION) < Gem::Version.new("5.1")
-          skip "YAML.safe_dump is either missing on unavailable on #{Psych::VERSION}"
-        end
-
         coder = YAMLColumn.new("attr_name")
         assert_raises(Psych::DisallowedClass) do
           coder.dump([Time.new])


### PR DESCRIPTION
This Pull Request has been created because since minimum Ruby version is now 3.3.1 and this version ships with [psych 5.1.2](https://stdgems.org/3.3.1/) then we can remove the gem versions checks that were being performed in `activerecord/lib/active_record/coders/yaml_column.rb` as they now evaluate always to true make the `else` branch dead code.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
