### PR TITLE
Expand `Set` values in deterministic encryption queries

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Expand `Set` values in queries on deterministically encrypted attributes.
+
+    When `config.active_record.encryption.extend_queries` is enabled, queries on
+    deterministic attributes that support unencrypted data are expanded to match
+    both the encrypted and the unencrypted values. `String` and `Array` values
+    were expanded, but a `Set` was passed through untouched, so such queries only
+    matched already encrypted records:
+
+    ```ruby
+    Contact.where(email_address: Set["jorge@hey.com"])
+    ```
+
+    *Eric Barendt*
+
 *   Deprecate the `insert_returning` option in PostgreSQL database
     configurations, and the `PostgreSQLAdapter#use_insert_returning?` method.
 

--- a/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb
+++ b/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb
@@ -72,7 +72,7 @@ module ActiveRecord
               return value if check_for_additional_values && value.is_a?(Array) && value.last.is_a?(AdditionalValue)
 
               case value
-              when String, Array
+              when String, Array, Set
                 list = Array(value)
                 list + list.flat_map do |each_value|
                   if check_for_additional_values && each_value.is_a?(AdditionalValue)

--- a/activerecord/test/cases/encryption/extended_deterministic_queries_test.rb
+++ b/activerecord/test/cases/encryption/extended_deterministic_queries_test.rb
@@ -21,6 +21,22 @@ class ActiveRecord::Encryption::ExtendedDeterministicQueriesTest < ActiveRecord:
     assert EncryptedBook.where("id > 0").find_by(name: "Dune") # relation
   end
 
+  test "Finds records with an array of values, both encrypted and unencrypted" do
+    UnencryptedBook.create!(name: "Dune")
+    EncryptedBook.create!(name: "Ubik")
+
+    assert_equal 2, EncryptedBook.where(name: [ "Dune", "Ubik" ]).count # relation
+    assert EncryptedBook.find_by(name: [ "Dune" ]) # core
+  end
+
+  test "Finds records with a set of values, both encrypted and unencrypted" do
+    UnencryptedBook.create!(name: "Dune")
+    EncryptedBook.create!(name: "Ubik")
+
+    assert_equal 2, EncryptedBook.where(name: Set["Dune", "Ubik"]).count # relation
+    assert EncryptedBook.find_by(name: Set["Dune"]) # core
+  end
+
   test "Works well with downcased attributes" do
     EncryptedBookWithDowncaseName.create! name: "Dune"
     assert EncryptedBookWithDowncaseName.find_by(name: "DUNE")


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

With `config.active_record.encryption.extend_queries` enabled, equality queries on a deterministic attribute that supports unencrypted data are rewritten to match both the encrypted and the plaintext value, so queries keep working while data is being encrypted.

`EncryptedQuery.process_encrypted_query_argument` only expanded `String` and `Array` values. A `Set` fell through to the `else` branch and was passed along unexpanded, so the query matched only already encrypted rows and silently missed rows that are still plaintext:

```ruby
Contact.where(email_address: Set["jorge@hey.com"])
# => misses unencrypted rows; Contact.where(email_address: ["jorge@hey.com"]) does not
```

`Set` is a valid argument everywhere else in the query layer (`ActiveRecord::PredicateBuilder` registers it with the same handler as `Array`), so there is no indication anything is wrong. In a mid-migration backfill this reads as data loss.

### Additional information

Adds `Set` to the branch that expands values, alongside `String` and `Array`. `Array(value)` already yields the right list for a `Set`, so no other change is needed.

The early return for already expanded arguments keeps its `Array` check: expanded values are only ever the arrays this method builds, and `Set` does not respond to `last`.

Adds tests for both `Set` and `Array` arguments, covering the core (`find_by`) and relation (`where`) paths.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
