### PR TITLE
asset_path: strip the query/fragment tail without a second scan

### DIFF
--- a/actionview/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_url_helper.rb
@@ -191,7 +191,9 @@ module ActionView
         return "" if source.blank?
         return source if URI_REGEXP.match?(source)
 
-        tail, source = source[/([?#].+)$/], source.sub(/([?#].+)$/, "")
+        if (tail = source[/[?#].+$/])
+          source = source[0, source.length - tail.length]
+        end
 
         if extname = compute_asset_extname(source, options)
           source = "#{source}#{extname}"


### PR DESCRIPTION
### Motivation / Background

Every `asset_path` call — and therefore every `image_tag`, `javascript_include_tag`,
`stylesheet_link_tag`, `asset_url`, etc. — currently scans the source string twice to
strip the query/fragment (`?`/`#`) tail:

```ruby
tail, source = source[/([?#].+)$/], source.sub(/([?#].+)$/, "")
```

That is two full regexp scans, and `String#sub` allocates a fresh copy of the string even
when there is no match — while sources with a query or fragment are the rare case (asset
helpers are overwhelmingly called with plain paths like `"application.js"`).

### Detail

Keep the existing extraction and slice the tail off by length, rather than scanning a
second time to remove it:

```ruby
if (tail = source[/[?#].+$/])
  source = source[0, source.length - tail.length]
end
```

A source with no query or fragment now does a single scan and copies nothing.

The slice removes the last `tail.length` bytes rather than the matched range, so a source
carrying a newline after the tail (which `$` matches before) strips to `"app.js?"` instead
of `"app.js\n"`. Asset sources do not contain newlines; per review discussion this is not
worth defending against in code.

Covered by the existing `javascript_path` cases (`xmlhr.js?123`, `xmlhr.js#hash`,
`xmlhr.js?123#hash`) in `asset_tag_helper_test.rb`, which fail if the slice is off by a
byte in either direction.

### Benchmark

Objects allocated per call (`GC.stat(:total_allocated_objects)` delta over 1000 calls —
deterministic, identical in every round): **8 → 7** for both plain and nested sources.

`benchmark-ips`, best of 3 alternating 6s runs (Ruby 3.3.11, arm64-darwin):

| | main | patch | |
|---|---|---|---|
| `asset_path("application.js")` | 511.5k i/s | 552.7k i/s | **+8.0%** |
| `asset_path("images/logo-with-a-longer-name.png")` | 448.0k i/s | 484.4k i/s | **+8.1%** |

The patch was faster in every alternating pairing, but this machine was not quiet enough
to pin the magnitude tightly — round-to-round the delta ranged from +2.5% to +13%. Treat
the percentages as indicative and the allocation delta as the solid number.

<details>
  <summary>Benchmark source</summary>

```ruby
# frozen_string_literal: true

# Benchmark for "asset_path: strip the query/fragment tail without a second scan".
# Run from a Rails checkout root (or set RAILS_ROOT), once per branch:
#
#   git switch main && ruby bench_asset_path.rb
#   git switch <patch-branch> && ruby bench_asset_path.rb   # prints comparison
#
require "bundler/inline"

RAILS_ROOT = ENV.fetch("RAILS_ROOT", Dir.pwd)
LABEL = ENV["BRANCH"] || `git -C #{RAILS_ROOT} rev-parse --abbrev-ref HEAD`.strip

gemfile(true) do
  source "https://rubygems.org"
  gem "activesupport", path: RAILS_ROOT
  gem "actionview", path: RAILS_ROOT
  gem "benchmark-ips"
end

require "active_support"
require "action_view"

view_klass = ActionView::Base.with_empty_template_cache
lookup = ActionView::LookupContext.new(ActionView::PathSet.new([]))
view = view_klass.new(lookup, {}, nil)

# Sanity: query/fragment behavior is unchanged
raise "tail regression" unless view.asset_path("app.js?v=3", skip_pipeline: true) == "/app.js?v=3"
raise "tail regression" unless view.asset_path("app.css#print", skip_pipeline: true) == "/app.css#print"

plain = -> { view.asset_path("application.js", skip_pipeline: true) }
nested = -> { view.asset_path("images/logo-with-a-longer-name.png", skip_pipeline: true) }

allocs = lambda do |callable, n = 1000|
  callable.call
  before = GC.stat(:total_allocated_objects)
  n.times { callable.call }
  (GC.stat(:total_allocated_objects) - before) / n
end
puts format("OBJECTS per call (%s): plain=%d, nested=%d", LABEL, allocs.(plain), allocs.(nested))

require "benchmark/ips"
require "tmpdir"
hold = File.join(Dir.tmpdir, "asset_path_bench#{"_yjit" if defined?(RubyVM::YJIT) && RubyVM::YJIT.enabled?}.json")

Benchmark.ips do |x|
  x.config(time: Float(ENV.fetch("BENCH_TIME", "10")), warmup: Float(ENV.fetch("BENCH_WARMUP", "2")))
  x.report("asset_path plain source (#{LABEL})", &plain)
  x.report("asset_path nested source (#{LABEL})", &nested)
  unless ENV["NO_HOLD"]
    x.save!(hold)
    x.compare!
  end
end
```
</details>
