### PR TITLE
Fix the `Parameters#deep_transform_values` doc example

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -148,7 +148,7 @@
       user: { email: "  ALICE@EXAMPLE.COM  ", profile: { bio: "  Hello world  " } }
     )
     params.deep_transform_values { |v| v.is_a?(String) ? v.strip.downcase : v }
-    # => #<ActionController::Parameters {"user"=>#<ActionController::Parameters {"email"=>"alice@example.com", "profile"=>#<ActionController::Parameters {"bio"=>"hello world"} permitted: false>} permitted: false>} permitted: false>
+    # => #<ActionController::Parameters {"user"=>{"email"=>"alice@example.com", "profile"=>{"bio"=>"hello world"}}} permitted: false>
     ```
 
     *Edil Talantbek uulu*

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -977,7 +977,7 @@ module ActionController
     #       user: { email: "  ALICE@EXAMPLE.COM  ", profile: { bio: "  Hello world  " } }
     #     )
     #     params.deep_transform_values { |v| v.is_a?(String) ? v.strip.downcase : v }
-    #     # => #<ActionController::Parameters {"user"=>#<ActionController::Parameters {"email"=>"alice@example.com", "profile"=>#<ActionController::Parameters {"bio"=>"hello world"} permitted: false>} permitted: false>} permitted: false>
+    #     # => #<ActionController::Parameters {"user"=>{"email"=>"alice@example.com", "profile"=>{"bio"=>"hello world"}}} permitted: false>
     def deep_transform_values(&block)
       new_instance_with_inherited_permitted_status(
         _deep_transform_values_in_object(@parameters, &block)


### PR DESCRIPTION
The example documents a return value that cannot occur:

```ruby
params = ActionController::Parameters.new(
  user: { email: "  ALICE@EXAMPLE.COM  ", profile: { bio: "  Hello world  " } }
)
params.deep_transform_values { |v| v.is_a?(String) ? v.strip.downcase : v }

# documented
# => #<ActionController::Parameters {"user"=>#<ActionController::Parameters {"email"=>"alice@example.com", "profile"=>#<ActionController::Parameters {"bio"=>"hello world"} permitted: false>} permitted: false>} permitted: false>

# actual
# => #<ActionController::Parameters {"user"=>{"email"=>"alice@example.com", "profile"=>{"bio"=>"hello world"}}} permitted: false>
```

Nested hashes are wrapped in `ActionController::Parameters` lazily, when they are read, so the returned instance never inspects as nested `#<ActionController::Parameters ...>` values.

`deep_transform_values` is unreleased (#57340), so the example has never shipped.

### Verification

The example was run and compared against the file, after normalizing `" => "` to `"=>"` to keep the hash rocket spacing used throughout this file — exact match.