### PR TITLE
Fix Markdown doc check

### DIFF
--- a/.github/workflows/scripts/check-markdown-api.rb
+++ b/.github/workflows/scripts/check-markdown-api.rb
@@ -17,7 +17,7 @@ added_files.each do |path|
     if line == "# :markup: markdown"
       markdown = true
       break
-    elsif !line.start_with?("#")
+    elsif !line.empty? && !line.start_with?("#")
       break
     end
   end


### PR DESCRIPTION
The script introduced in #58257 had a fatal disagreement with Rubocop on what the top of the file should look like. Rubocop Layout/EmptyLineAfterMagicComment wants a blank line after the frozen string literal, but the Markdown doc check refuses to pass with the blank line. So let's make that blank line acceptable.

cc @fxn 