### PR TITLE
Allow prepared statements with query log tags

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Allow for prepared statements to remain enabled with query logs tags.
+
+    To keep prepared_statements enabled in conjunction with query log tags,
+    `config.active_record.disable_prepared_statements = false`.
+
+    *Brad Schrag*
+
 *   When `dump_schema_migrations` is enabled, the trailer gets now exactly the
     versions present in the `schema_migrations` table, without filtering by
     what's on disk.

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -413,7 +413,7 @@ To keep using the current cache store, you can turn off cache versioning entirel
             database:     ->(context) { context[:connection].pool.db_config.database },
             source_location: -> { QueryLogs.query_source_location }
           )
-          ActiveRecord.disable_prepared_statements = true
+          ActiveRecord.disable_prepared_statements = true if config.active_record.disable_prepared_statements.nil?
 
           if app.config.active_record.query_log_tags.present?
             ActiveRecord::QueryLogs.tags = app.config.active_record.query_log_tags

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1559,10 +1559,9 @@ The default value depends on the `config.load_defaults` target version:
 
 #### `config.active_record.query_log_tags_enabled`
 
-Specifies whether or not to enable adapter-level query comments. Defaults to
-`false`, but is set to `true` in the default generated `config/environments/development.rb` file.
+Specifies whether or not to enable adapter-level query comments. Defaults to `false`, but is set to `true` in the default generated `config/environments/development.rb` file.When this is set to `true` database prepared statements will be automatically disabled. If prepared statements are desired in conjunction with `query_log_tags` you must explicitly opt-out of ActiveRecords disabling mechanism: `config.active_record.disable_preprared_statments = false`.
 
-NOTE: When this is set to `true` database prepared statements will be automatically disabled.
+Note: High cardinality comments can cause degraded db performance as the database may not be able to rely on a query plan cache. If forcing prepared statements with query log tags high cardinality values should be avoided. For example, `:request_id` or `admin_id`. Even basic `controller#action` tags can cause high cardinality on basic queries such as a current_user lookup since it will happen across many endpoints.
 
 #### `config.active_record.query_log_tags`
 

--- a/railties/test/application/query_logs_test.rb
+++ b/railties/test/application/query_logs_test.rb
@@ -110,6 +110,31 @@ module ApplicationTests
       assert_includes comment, "controller:users"
     end
 
+    test "prepared statements will be disabled when query log tags are true" do
+      add_to_config "config.active_record.query_log_tags_enabled = true"
+
+      boot_app
+
+      assert ActiveRecord.disable_prepared_statements
+    end
+
+    test "prepared statements will be enabled disabled_prepared_statements is explictly set" do
+      add_to_config "config.active_record.query_log_tags_enabled = true"
+      add_to_config "config.active_record.disable_prepared_statements = false"
+      add_to_config "config.active_record.query_log_tags_format = :sqlcommenter"
+      add_to_config "config.active_record.query_log_tags = [ :pid ]"
+
+      boot_app
+
+      assert_not ActiveRecord.disable_prepared_statements
+
+      get "/", {}, { "HTTPS" => "on" }
+      comment = last_response.body.strip
+
+      assert_match(/pid='\d+'/, comment)
+      assert_includes comment, "controller='users'"
+    end
+
     test "sqlcommenter formatting works when specified" do
       add_to_config "config.active_record.query_log_tags_enabled = true"
       add_to_config "config.active_record.query_log_tags_format = :sqlcommenter"


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

This Pull Request has been created because by default, Rails disables prepared statements when query log tags are enabled. This feels like a safe and reasonable default as it helps to avoid the situation where high cardinality comments are generated. However, projects should be allowed to opt in to query log tags while maintaining prepared statements. 

### Detail

This Pull Request adds a third option for the `query_log_tags_enabled` configuration option of `:with_prepared_statements`. When `:with_prepared_statements` is set to true the `ActiveRecord` railtie will not set `disable_prepared_statements`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
