### PR TITLE
Don't swallow `::RangeError` on write queries

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/query_intent.rb
+++ b/activerecord/lib/active_record/connection_adapters/query_intent.rb
@@ -321,6 +321,7 @@ module ActiveRecord
         def run_query!
           adapter.execute_intent(self)
         rescue ::RangeError
+          raise if write_query?
           @cast_result = ActiveRecord::Result.empty
           @raw_result_available = true
         end

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -263,9 +263,31 @@ module ActiveRecord
         assert_not_nil error.cause
       end
 
-      def test_numeric_value_out_of_ranges_are_translated_to_specific_exception
+      def test_numeric_value_out_of_ranges_on_model_create_are_translated_to_specific_exception
+        assert_raises(ActiveModel::RangeError) do
+          Book.create(author_id: 9223372036854775808)
+        end
+      end
+
+      def test_numeric_value_out_of_ranges_on_model_update_are_translated_to_specific_exception
+        book = Book.create!
+        assert_raises(ActiveModel::RangeError) do
+          book.update(author_id: 9223372036854775808)
+        end
+      end
+
+      def test_numeric_value_out_of_ranges_on_connection_insert_are_translated_to_specific_exception
         error = assert_raises(ActiveRecord::RangeError) do
-          Book.lease_connection.create("INSERT INTO books(author_id) VALUES (9223372036854775808)")
+          Book.lease_connection.insert("INSERT INTO books(author_id) VALUES (9223372036854775808)")
+        end
+
+        assert_not_nil error.cause
+      end
+
+      def test_numeric_value_out_of_ranges_on_connection_update_are_translated_to_specific_exception
+        book = Book.create!
+        error = assert_raises(ActiveRecord::RangeError) do
+          Book.lease_connection.update("UPDATE books SET author_id = 9223372036854775808 WHERE id = #{book.id}")
         end
 
         assert_not_nil error.cause

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/unsigned_type_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/unsigned_type_test.rb
@@ -30,7 +30,7 @@ class UnsignedTypeTest < ActiveRecord::AbstractMysqlTestCase
     assert_equal expected, UnsignedType.find_by(unsigned_integer: 4294967295)
   end
 
-  test "minus value is out of range" do
+  test "minus value is out of range on create" do
     assert_raise(ActiveModel::RangeError) do
       UnsignedType.create(unsigned_integer: -10)
     end
@@ -42,6 +42,21 @@ class UnsignedTypeTest < ActiveRecord::AbstractMysqlTestCase
     end
     assert_raise(ActiveRecord::RangeError) do
       UnsignedType.create(unsigned_decimal: -10.0)
+    end
+  end
+
+  test "minus value is out of range on update" do
+    assert_raise(ActiveModel::RangeError) do
+      UnsignedType.create!.update(unsigned_integer: -10)
+    end
+    assert_raise(ActiveModel::RangeError) do
+      UnsignedType.create!.update(unsigned_bigint: -10)
+    end
+    assert_raise(ActiveRecord::RangeError) do
+      UnsignedType.create!.update(unsigned_float: -10.0)
+    end
+    assert_raise(ActiveRecord::RangeError) do
+      UnsignedType.create!.update(unsigned_decimal: -10.0)
     end
   end
 


### PR DESCRIPTION
`QueryIntent#run_query!` rescues `::RangeError` so that SELECT queries with out-of-range WHERE values return an empty result instead of raising. This rescue was originally scoped to `select_all` (see 0601a9f9aa "Catch the RangeError closer to the cause"), but was moved into `QueryIntent#execute!` in 9051bc4332 "Move async execution into QueryIntent" and later into `run_query!`, which made it apply to all queries including writes.

On write queries with an Arel node, arel compilation happens inside `run_query!` (via `execute_intent` -> `processed_sql` -> `compile_arel!`), so `ActiveModel::RangeError` (< `::RangeError`) raised by `serialize` was silently caught. As a result, `intent.affected_rows` subsequently failed with `RuntimeError: "Cannot call affected_rows after cast_result has been called"` instead of surfacing the `ActiveModel::RangeError`.

`_exec_insert` happens to avoid this because it eagerly reads `intent.raw_sql` before `intent.execute!`, so any error from arel compilation escapes the rescue. `update` / `update_with_result` / `delete` did not have that eager access.

Fix by re-raising `::RangeError` for write queries in `run_query!`. SELECT WHERE-out-of-range behavior is preserved.
