### PR TITLE
[8-0-stable] Avoid loading ActionController::Live early in initializer

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Avoid loading `ActionController::Live` early in initializer, and introduce
+    `action_controller_live` load hook.
+
+    *Adrianna Chang*
+
 *   Set the browser binary when preloading the Selenium driver for system tests.
 
     Selenium 4.45 stopped setting it as a side effect of getting the driver path,

--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -439,5 +439,7 @@ module ActionController
           "#{message}\n\n"
         end
       end
+
+      ActiveSupport.run_load_hooks(:action_controller_live, self)
   end
 end

--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -32,7 +32,9 @@ module ActionController
     end
 
     initializer "action_controller.live_streaming_excluded_keys" do |app|
-      ActionController::Live.live_streaming_excluded_keys = app.config.action_controller.live_streaming_excluded_keys
+      ActiveSupport.on_load(:action_controller_live) do
+        ActionController::Live.live_streaming_excluded_keys = app.config.action_controller.live_streaming_excluded_keys
+      end
     end
 
     initializer "action_controller.parameters_config" do |app|

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -3740,6 +3740,7 @@ These are the load hooks you can use in your own code. To hook into the initiali
 | `ActionController::API`              | `action_controller`                  |
 | `ActionController::Base`             | `action_controller_base`             |
 | `ActionController::Base`             | `action_controller`                  |
+| `ActionController::Live`             | `action_controller_live`             |
 | `ActionController::TestCase`         | `action_controller_test_case`        |
 | `ActionDispatch::IntegrationTest`    | `action_dispatch_integration_test`   |
 | `ActionDispatch::Response`           | `action_dispatch_response`           |

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -619,6 +619,31 @@ module ApplicationTests
       assert_equal [:password, :foo, "bar"], Rails.application.env_config["action_dispatch.parameter_filter"]
     end
 
+    test "config.action_dispatch.default_headers can be set in an initializer and is applied to responses" do
+      app_file "config/initializers/default_headers.rb", <<-RUBY
+        Rails.application.config.action_dispatch.default_headers = { "X-Custom-Header" => "custom" }
+      RUBY
+
+      app_file "app/controllers/pages_controller.rb", <<-RUBY
+        class PagesController < ApplicationController
+          def index
+            render plain: "OK"
+          end
+        end
+      RUBY
+
+      add_to_config <<-RUBY
+        routes.prepend do
+          get "/pages", to: "pages#index"
+        end
+      RUBY
+
+      app "development"
+
+      get "/pages"
+      assert_equal "custom", last_response.headers["X-Custom-Header"]
+    end
+
     test "filter_parameters is precompiled when config.precompile_filter_parameters is true" do
       filters = [/foo/, :bar, "baz.qux"]
 


### PR DESCRIPTION
Backports #58147 to `8-0-stable` branch.

Closes #58145

/cc @adrianna-chang-shopify @nurey