### PR TITLE
Remove unreachable single-version branch from `DefaultSchemaVersionsFormatter`

### DIFF
--- a/activerecord/lib/active_record/migration/default_schema_versions_formatter.rb
+++ b/activerecord/lib/active_record/migration/default_schema_versions_formatter.rb
@@ -13,14 +13,10 @@ module ActiveRecord
       def format(versions)
         sm_table = connection.quote_table_name(connection.pool.schema_migration.table_name)
 
-        if versions.is_a?(Array)
-          sql = +"INSERT INTO #{sm_table} (version) VALUES\n"
-          sql << versions.reverse.map { |v| "(#{connection.quote(v)})" }.join(",\n")
-          sql << ";"
-          sql
-        else
-          "INSERT INTO #{sm_table} (version) VALUES (#{connection.quote(versions)});"
-        end
+        sql = +"INSERT INTO #{sm_table} (version) VALUES\n"
+        sql << versions.reverse.map { |v| "(#{connection.quote(v)})" }.join(",\n")
+        sql << ";"
+        sql
       end
 
       private


### PR DESCRIPTION
`DefaultSchemaVersionsFormatter#format` carries a fallback for a non-Array `versions` argument that can never run. The formatter is only reached through `insert_versions_sql`, whose sole caller is `dump_schema_versions`, and that always passes the array of versions read back from the `schema_migrations` table. No call path passes a single version.

The conditional predates the class itself:

- fd87169eb1 introduced it, back when adapters without multi-row INSERT support dumped each version with a separate statement.
- d1a74c1e01 removed the last call path that passed a single version.
- 0cc1842d38 moved the code into this class, carrying the branch along.

This removes the dead fallback so the multi-row `VALUES` statement is the only path. Schema dumps produce exactly the same output as before.

The class is internal (`:nodoc:`). The public extension point, `config.active_record.schema_versions_formatter`, is unaffected: custom formatters keep receiving the array of versions, as documented in the configuring guide.