### PR TITLE
Fix LazyRouteSet thrashing when url_helpers are included into Object

### DIFF
--- a/railties/lib/rails/engine/lazy_route_set.rb
+++ b/railties/lib/rails/engine/lazy_route_set.rb
@@ -89,17 +89,22 @@ module Rails
         def method_missing_module
           @method_missing_module ||= Module.new do
             private
-              def method_missing(...)
-                if Rails.application&.reload_routes_unless_loaded
-                  public_send(...)
+              # NamedRouteCollection#define_url_helper only defines "#{name}_path"
+              # and "#{name}_url" in these modules, so other suffixes can never be
+              # lazy route helpers. Without this guard, including url_helpers into
+              # Object makes every respond_to?(:to_ary) (and similar) re-enter
+              # reload_routes_unless_loaded and thrash while routes are drawing.
+              def method_missing(method_name, ...)
+                if method_name.end_with?("_path", "_url") && Rails.application&.reload_routes_unless_loaded
+                  public_send(method_name, ...)
                 else
                   super
                 end
               end
 
-              def respond_to_missing?(...)
-                if Rails.application&.reload_routes_unless_loaded
-                  respond_to?(...)
+              def respond_to_missing?(method_name, include_private = false)
+                if method_name.end_with?("_path", "_url") && Rails.application&.reload_routes_unless_loaded
+                  respond_to?(method_name, include_private)
                 else
                   super
                 end

--- a/railties/test/engine/lazy_route_set_test.rb
+++ b/railties/test/engine/lazy_route_set_test.rb
@@ -42,6 +42,24 @@ module Rails
         assert_operator(engine_url_helpers, :respond_to?, :root_path)
       end
 
+      test "including url_helpers into Object does not load routes on unrelated methods" do
+        require "#{app_path}/config/environment"
+
+        Object.include Rails.application.routes.url_helpers
+
+        # Protocols like to_ary/to_hash must not trigger a routes load. Otherwise
+        # every respond_to? in the process re-enters the reloader while routes
+        # are drawing and the process appears hung.
+        assert_not Object.new.respond_to?(:to_ary)
+        assert_not_operator(:root_path, :in?, app_url_helpers.methods)
+
+        assert_raises(NoMethodError) { Object.new.not_a_route }
+        assert_not_operator(:root_path, :in?, app_url_helpers.methods)
+
+        assert_operator Object.new, :respond_to?, :root_path
+        assert_equal "/", Object.new.root_path
+      end
+
       test "app lazily loads routes when making a request" do
         require "#{app_path}/config/environment"
 


### PR DESCRIPTION
### Detail

Follow-up to #58252.

#52353 introduced LazyRouteSet's method_missing/respond_to_missing? hooks that call `reload_routes_unless_loaded` for every missing method so named route helpers can force the first routes draw.

That is correct for `foo_path / foo_url`, but including `Rails.application.routes.url_helpers` into Object (e.g. a top-level `include` in a script or inside a rails console) makes every `respond_to?(:to_ary) / to_hash` in the process re-enter the reloader while routes are drawing. On a large app this appears hung.

Only treat methods ending in _path / _url as candidates for a lazy routes load. #58252 fixed a related infinite redraw via after_routes_loaded; this closes the Object#include thrashing path left open by #52353.

cc @byroot 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
