### PR TITLE
Resolve the single best template without sorting the whole set

### DIFF
--- a/actionview/lib/action_view/path_set.rb
+++ b/actionview/lib/action_view/path_set.rb
@@ -38,7 +38,11 @@ module ActionView # :nodoc:
     end
 
     def find(path, prefixes, partial, details, details_key, locals)
-      find_all(path, prefixes, partial, details, details_key, locals).first
+      search_combinations(prefixes) do |resolver, prefix|
+        template = resolver.find(path, prefix, partial, details, details_key, locals)
+        return template if template
+      end
+      nil
     end
 
     def find!(path, prefixes, partial, details, details_key, locals)
@@ -55,7 +59,7 @@ module ActionView # :nodoc:
     end
 
     def exists?(path, prefixes, partial, details, details_key, locals)
-      find_all(path, prefixes, partial, details, details_key, locals).any?
+      !find(path, prefixes, partial, details, details_key, locals).nil?
     end
 
     private

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -56,9 +56,12 @@ module ActionView
     def clear_cache
     end
 
-    # Normalizes the arguments and passes it on to find_templates.
     def find_all(name, prefix = nil, partial = false, details = {}, key = nil, locals = [])
-      _find_all(name, prefix, partial, details, key, locals)
+      find_templates(name, prefix, partial, details, locals)
+    end
+
+    def find(name, prefix = nil, partial = false, details = {}, key = nil, locals = [])
+      find_all(name, prefix, partial, details, key, locals).first
     end
 
     def built_templates # :nodoc:
@@ -72,15 +75,10 @@ module ActionView
     end
 
   private
-    def _find_all(name, prefix, partial, details, key, locals)
-      find_templates(name, prefix, partial, details, locals)
-    end
-
     delegate :caching?, to: :class
 
-    # This is what child classes implement. No defaults are needed
-    # because Resolver guarantees that the arguments are present and
-    # normalized.
+    # Extension point for custom resolvers: implement this method, or
+    # override find_all/find directly.
     def find_templates(name, prefix, partial, details, locals = [])
       raise NotImplementedError, "Subclasses must implement a find_templates(name, prefix, partial, details, locals = []) method"
     end
@@ -127,19 +125,30 @@ module ActionView
       @unbound_templates.values.flatten.flat_map(&:built_templates)
     end
 
+    def find_all(name, prefix = nil, partial = false, details = {}, key = nil, locals = [])
+      requested_details = key || TemplateDetails::Requested.new(**details)
+      unbound_templates = unbound_templates_for(name, prefix, partial, !!key)
+
+      filter_and_sort_by_details(unbound_templates, requested_details).map do |unbound_template|
+        unbound_template.bind_locals(locals)
+      end
+    end
+
+    def find(name, prefix = nil, partial = false, details = {}, key = nil, locals = [])
+      requested_details = key || TemplateDetails::Requested.new(**details)
+      unbound_templates = unbound_templates_for(name, prefix, partial, !!key)
+
+      unbound_template = find_best_by_details(unbound_templates, requested_details)
+      return unless unbound_template
+      unbound_template.bind_locals(locals)
+    end
+
     private
-      def _find_all(name, prefix, partial, details, key, locals)
-        requested_details = key || TemplateDetails::Requested.new(**details)
-        cache = key ? @unbound_templates : Concurrent::Map.new
+      def unbound_templates_for(name, prefix, partial, cached)
+        return unbound_templates_from_path(TemplatePath.build(name, prefix, partial)) unless cached
 
-        unbound_templates =
-          cache.compute_if_absent(TemplatePath.virtual(name, prefix, partial)) do
-            path = TemplatePath.build(name, prefix, partial)
-            unbound_templates_from_path(path)
-          end
-
-        filter_and_sort_by_details(unbound_templates, requested_details).map do |unbound_template|
-          unbound_template.bind_locals(locals)
+        @unbound_templates.compute_if_absent(TemplatePath.virtual(name, prefix, partial)) do
+          unbound_templates_from_path(TemplatePath.build(name, prefix, partial))
         end
       end
 
@@ -175,6 +184,23 @@ module ActionView
           # Select for exact virtual path match, including case sensitivity
           template.virtual_path == path.virtual
         end
+      end
+
+      def find_best_by_details(templates, requested_details)
+        if templates.size == 1
+          template = templates.first
+          return template.details.matches?(requested_details) ? template : nil
+        end
+
+        best = best_rank = nil
+        templates.each do |template|
+          rank = template.details.rank_for(requested_details) or next
+          if best_rank.nil? || (rank <=> best_rank) < 0
+            best = template
+            best_rank = rank
+          end
+        end
+        best
       end
 
       def filter_and_sort_by_details(templates, requested_details)

--- a/actionview/lib/action_view/template_details.rb
+++ b/actionview/lib/action_view/template_details.rb
@@ -49,6 +49,16 @@ module ActionView
       ]
     end
 
+    # A single pass over matches? and sort_key_for: the sort key when the
+    # template matches +requested+, nil otherwise.
+    def rank_for(requested)
+      format  = requested.formats_idx[@format]   or return
+      locale  = requested.locale_idx[@locale]    or return
+      variant = requested.variants_idx[@variant] or return
+      handler = requested.handlers_idx[@handler] or return
+      [format, locale, variant, handler]
+    end
+
     def handler_class
       Template.handler_for_extension(handler)
     end


### PR DESCRIPTION
Resolver#find finds the best match in one pass over the candidates (TemplateDetails#rank_for, a fused matches?/sort_key_for) and binds locals for the winner only, instead of filtering, sorting and binding every match to keep the first. A virtual path with a single candidate skips ranking with a bare matches? check. PathSet#find asks resolvers for one template and PathSet#exists? returns on the first hit; only find_all still materialises the matching set (ActionMailer multipart).

Custom resolvers that override find_all keep working: the default Resolver#find goes through the public find_all.
