### PR TITLE
Resolve the implicit template with a single lookup

### DIFF
--- a/actionpack/lib/action_controller/metal/implicit_render.rb
+++ b/actionpack/lib/action_controller/metal/implicit_render.rb
@@ -35,8 +35,9 @@ module ActionController
     include BasicImplicitRender
 
     def default_render
-      if template_exists?(action_name.to_s, _prefixes, variants: request.variant)
-        render
+      lookup_context.variants = request.variant if request.variant.present?
+      if (template = lookup_context.find(action_name.to_s, _prefixes))
+        render(template: template)
       elsif any_templates?(action_name.to_s, _prefixes)
         message = "#{self.class.name}\##{action_name} is missing a template " \
           "for this request format and variant.\n" \


### PR DESCRIPTION
default_render checked template_exists? and then called render, which looked the same action template up a second time through determine_template. Find it once with lookup_context.find and pass the resolved Template to render, which uses it as-is.

This also fixes an inconsistency: if lookup_context.variants was set but not request.variant, the existence check overrode the context's variants and returned 406 for a variant template that an explicit render in the same action would have served.
