### PR TITLE
Move the LookupContext::DetailsKey caches to Ractor-local storage

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,7 +174,7 @@ GEM
       concurrent-ruby
     childprocess (5.1.0)
       logger (~> 1.5)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.8)
     connection_pool (3.0.2)
     crack (1.0.0)
       bigdecimal
@@ -801,7 +801,7 @@ CHECKSUMS
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   chef-utils (18.6.2) sha256=d4d0a08fc2d0fd1c490dba4f09dcd6b4e6ddc5c594231c05ff87d2e54a13834a
   childprocess (5.1.0) sha256=9a8d484be2fd4096a0e90a0cd3e449a05bc3aa33f8ac9e4d6dcef6ac1455b6ec
-  concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
+  concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crack (1.0.0) sha256=c83aefdb428cdc7b66c7f287e488c796f055c0839e6e545fec2c7047743c4a49
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -56,22 +56,19 @@ module ActionView
     class DetailsKey # :nodoc:
       alias :eql? :equal?
 
-      @details_keys = Concurrent::Map.new
-      @digest_cache = Concurrent::Map.new
-
       def self.digest_cache(details)
-        @digest_cache[details_cache_key(details)] ||= Concurrent::Map.new
+        digest_cache_store.compute_if_absent(details_cache_key(details)) { Concurrent::Map.new }
       end
 
       def self.details_cache_key(details)
-        @details_keys.fetch(details) do
+        details_keys.fetch(details) do
           if formats = details[:formats]
             if normalized = Template.normalized_formats(formats)
               details = details.dup
               details[:formats] = normalized
             end
           end
-          @details_keys[details] ||= TemplateDetails::Requested.new(**details)
+          details_keys[details] ||= TemplateDetails::Requested.new(**details)
         end
       end
 
@@ -80,13 +77,23 @@ module ActionView
           resolver.clear_cache
         end
         ActionView::LookupContext.reset_view_context_class
-        @details_keys.clear
-        @digest_cache.clear
+        details_keys.clear
+        digest_cache_store.clear
       end
 
       def self.digest_caches
-        @digest_cache.values
+        digest_cache_store.values
       end
+
+      def self.details_keys
+        ActiveSupport::Ractors.store_if_absent(:action_view_details_keys) { Concurrent::Map.new }
+      end
+      private_class_method :details_keys
+
+      def self.digest_cache_store
+        ActiveSupport::Ractors.store_if_absent(:action_view_digest_caches) { Concurrent::Map.new }
+      end
+      private_class_method :digest_cache_store
     end
 
     def self.reset_view_context_class

--- a/actionview/test/template/lookup_context_test.rb
+++ b/actionview/test/template/lookup_context_test.rb
@@ -2,6 +2,7 @@
 
 require "abstract_unit"
 require "abstract_controller/rendering"
+require "active_support/testing/ractors_assertions"
 
 class LookupContextTest < ActiveSupport::TestCase
   def setup
@@ -202,15 +203,24 @@ end
 if RUBY_VERSION >= "4.0"
   class LookupContextRactorTest < ActiveSupport::TestCase
     include ActiveSupport::Testing::Isolation
+    include ActiveSupport::Testing::RactorsAssertions
 
     test "view_context_class is Ractor-shareable" do
-      @original_experimental_warning = Warning[:experimental]
-      Warning[:experimental] = false
       ActionView::LookupContext.view_context_class # needs to be eager-loaded to be ractor-shareable
       assert_same ActionView::LookupContext.view_context_class,
-        Ractor.new { ActionView::LookupContext.view_context_class }.value
-    ensure
-      Warning[:experimental] = @original_experimental_warning
+        on_ractor { ActionView::LookupContext.view_context_class }
+    end
+
+    test "interns details keys and builds digest caches inside a non-main Ractor" do
+      interned, digest_cache = on_ractor do
+        details = { locale: [:en], formats: nil, variants: [], handlers: [:erb] }
+        key = ActionView::LookupContext::DetailsKey.details_cache_key(details)
+        cache = ActionView::LookupContext::DetailsKey.digest_cache(details)
+        [key.class.name, cache.class.name]
+      end
+
+      assert_equal "ActionView::TemplateDetails::Requested", interned
+      assert_equal "Concurrent::Map", digest_cache
     end
   end
 end

--- a/activesupport/lib/active_support/ractors.rb
+++ b/activesupport/lib/active_support/ractors.rb
@@ -67,7 +67,7 @@ module ActiveSupport
         end
       end
 
-      if defined?(Ractor) && RUBY_VERSION >= "4.0"
+      if RUBY_VERSION >= "4.0"
         def on_main(obj = nil, &block)
           if Ractor.main?
             obj.instance_eval(&block)
@@ -117,6 +117,7 @@ module ActiveSupport
         def shareable_lambda(...)
           Ractor.shareable_lambda(...)
         end
+
       else
         def main?
           Ractor.current == Ractor.main
@@ -141,6 +142,26 @@ module ActiveSupport
         def shareable_lambda(self: nil, &block)
           block
         end
+      end
+    end
+
+    if Ractor.respond_to?(:store_if_absent)
+      # Returns the value stored under +key+ in the current Ractor's local
+      # storage, running +block+ to compute and store it on first access, by
+      # delegating to +Ractor.store_if_absent+. Concurrent threads in the
+      # same Ractor initialize the value only once.
+      def self.store_if_absent(key, &block)
+        Ractor.store_if_absent(key, &block)
+      end
+    else
+      @local_storage_lock = Mutex.new
+
+      # Same contract as +Ractor.store_if_absent+ (Ruby 3.4) on top of the
+      # Ractor-local storage that predates it: the value is initialized at
+      # most once even when the Ractor's threads race, with an unsynchronized
+      # fast path for the common hit.
+      def self.store_if_absent(key, &block)
+        Ractor.current[key] || @local_storage_lock.synchronize { Ractor.current[key] ||= block.call }
       end
     end
   end

--- a/activesupport/test/ractors_test.rb
+++ b/activesupport/test/ractors_test.rb
@@ -18,6 +18,16 @@ class RactorsTest < ActiveSupport::TestCase
     assert_not value
   end
 
+  def test_store_if_absent_computes_once_and_returns_the_stored_value
+    calls = 0
+    first  = ActiveSupport::Ractors.store_if_absent(:as_ractors_test_once) { calls += 1; +"value" }
+    second = ActiveSupport::Ractors.store_if_absent(:as_ractors_test_once) { calls += 1; +"other" }
+
+    assert_equal "value", first
+    assert_same first, second
+    assert_equal 1, calls
+  end
+
   if RUBY_VERSION >= "4.0"
     def test_on_main_runs_block_on_main_ractor
       value = Ractor.new do
@@ -185,6 +195,16 @@ class RactorsTest < ActiveSupport::TestCase
       end
     ensure
       ActiveSupport::Ractors.unshareable_proc_action = old
+    end
+
+    def test_store_if_absent_is_ractor_local
+      main_value = ActiveSupport::Ractors.store_if_absent(:as_ractors_test_local) { "main" }
+      worker_value = Ractor.new do
+        ActiveSupport::Ractors.store_if_absent(:as_ractors_test_local) { "worker" }
+      end.value
+
+      assert_equal "main", main_value
+      assert_equal "worker", worker_value
     end
   end
 end


### PR DESCRIPTION
The interned TemplateDetails::Requested objects and the digest cache Concurrent::Maps cannot be shared across Ractors, which blocked template lookup from non-main Ractors. Both stores move to ActiveSupport::Ractors.store_if_absent: each Ractor interns its own details keys and fills its own digest caches. Digest values and external fragment cache keys are unchanged.

Requires concurrent-ruby 1.3.8, which froze the Concurrent::NULL sentinel; before that, reading it raises an IsolationError, so Concurrent::Map cannot be used inside non-main Ractors at all.

Introduces `ActiveSupport::Ractors.store_if_absent` to access Ractor-local storage and shim it with a `Concurrent::Map` for older Ruby versions.