### PR TITLE
Add `prefetch_primary_key?` test coverage on PostgreSQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -351,6 +351,10 @@ module ActiveRecord
           query_value("SELECT pg_get_serial_sequence(#{quote(table)}, #{quote(column)})")
         end
 
+        def next_sequence_value(sequence_name) # :nodoc:
+          query_value("SELECT nextval(#{quote(sequence_name)})", "SQL")
+        end
+
         # Sets the sequence of a table's primary key to the specified value.
         def set_pk_sequence!(table, value) # :nodoc:
           pk, sequence = pk_and_sequence_for(table)

--- a/activerecord/test/cases/adapters/postgresql/prefetched_primary_key_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/prefetched_primary_key_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+class PostgreSQLPrefetchedPrimaryKeyTest < ActiveRecord::PostgreSQLTestCase
+  class PrefetchedPost < ActiveRecord::Base
+    self.table_name = "posts"
+
+    def self.prefetch_primary_key?
+      true
+    end
+  end
+
+  def test_prefetched_pk_uses_sequence_value
+    post = PrefetchedPost.create!(title: "T", body: "B")
+    assert_not_nil post.id
+    assert PrefetchedPost.exists?(post.id)
+  end
+
+  def test_prefetched_pk_advances_sequence_per_insert
+    post1 = PrefetchedPost.create!(title: "T1", body: "B1")
+    post2 = PrefetchedPost.create!(title: "T2", body: "B2")
+    assert_equal post1.id + 1, post2.id
+  end
+
+  def test_explicit_id_takes_precedence_over_prefetched_id
+    post = PrefetchedPost.create!(id: 999_999, title: "Explicit", body: "Body")
+    assert_equal 999_999, post.id
+    assert PrefetchedPost.exists?(999_999)
+  end
+end


### PR DESCRIPTION
Implement `next_sequence_value` on the PostgreSQL adapter so a model overriding `prefetch_primary_key?` to true can use the real PG sequence for id generation (previously only Oracle enhanced adapter provided this).

Add a PostgreSQL test that exercises the `prefetch_primary_key?` path end-to-end: the sequence is advanced before the INSERT, the prefetched value ends up in the persisted row, and `||=` in `_insert_record` lets an explicit id take precedence over the prefetched one.

The test provides coverage for upcoming refactorings around `insert` / `_insert_record`, and helps verify that the oracle-enhanced adapter (https://github.com/rsim/oracle-enhanced), which relies on `prefetch_primary_key?`, isn't broken.
