### PR TITLE
Consolidate `returning_column_values` on the abstract adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -791,7 +791,11 @@ module ActiveRecord
         end
 
         def returning_column_values(result)
-          [last_inserted_id(result)]
+          if supports_insert_returning?
+            result.rows.first
+          else
+            [last_inserted_id(result)]
+          end
         end
 
         def single_value_from_rows(rows)

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -59,14 +59,6 @@ module ActiveRecord
             mariadb? && database_version >= "10.1.0"
           end
 
-          def returning_column_values(result)
-            if supports_insert_returning?
-              result.rows.first
-            else
-              super
-            end
-          end
-
           def combine_multi_statements(total_sql)
             total_sql.each_with_object([]) do |sql, total_sql_chunks|
               previous_packet = total_sql_chunks.last

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -246,10 +246,6 @@ module ActiveRecord
             ["TRUNCATE TABLE #{table_names.map(&method(:quote_table_name)).join(", ")}"]
           end
 
-          def returning_column_values(result)
-            result.rows.first
-          end
-
           def suppress_composite_primary_key(pk)
             pk unless pk.is_a?(Array)
           end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -163,10 +163,6 @@ module ActiveRecord
           def build_truncate_statement(table_name)
             "DELETE FROM #{quote_table_name(table_name)}"
           end
-
-          def returning_column_values(result)
-            result.rows.first
-          end
       end
     end
   end


### PR DESCRIPTION
Move the `supports_insert_returning?` branching into the abstract implementation and drop the identical `returning_column_values` overrides in PostgreSQL, SQLite3, and MySQL. When RETURNING is supported the abstract now returns `result.rows.first`; otherwise it falls back to `[last_inserted_id(result)]` for adapters that resolve the id from the driver (e.g. Trilogy / mysql2 via `LAST_INSERT_ID`).

Trilogy remains the only adapter whose `exec_insert` returns a raw driver result (`Trilogy::Result`) rather than `ActiveRecord::Result`, because its `last_inserted_id` reads `result.last_insert_id` off the raw object. `test_exec_insert` (added in #26002) asserts that `connection.send(:last_inserted_id, exec_insert(...))` works, which locks this adapter-specific return type in as a de facto contract and makes further refactoring (e.g. always returning `ActiveRecord::Result`) difficult until `exec_insert` itself is removed.
