### PR TITLE
Simplify `insert` callers to only pass what they need

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -771,7 +771,7 @@ module ActiveRecord
 
         def sql_for_insert(sql, pk, binds, returning) # :nodoc:
           if supports_insert_returning?
-            if pk.nil?
+            if returning.nil? && pk.nil?
               # Extract the table from the insert sql. Yuck.
               table_ref = extract_table_ref_from_insert_sql(sql)
               pk = schema_cache.primary_keys(table_ref) if table_ref

--- a/activerecord/lib/active_record/internal_metadata.rb
+++ b/activerecord/lib/active_record/internal_metadata.rb
@@ -136,7 +136,7 @@ module ActiveRecord
           [arel_table[:updated_at], current_time(connection)]
         ]
 
-        connection.insert(im, "#{self.class} Create", primary_key, key)
+        connection.insert(im, "#{self.class} Create")
       end
 
       def update_entry(connection, key, new_value)

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -237,13 +237,9 @@ module ActiveRecord
 
       def _insert_record(connection, values, returning) # :nodoc:
         primary_key = self.primary_key
-        primary_key_value = nil
 
         if prefetch_primary_key? && primary_key
-          values[primary_key] ||= begin
-            primary_key_value = next_sequence_value
-            _default_attributes[primary_key].with_cast_value(primary_key_value)
-          end
+          values[primary_key] ||= _default_attributes[primary_key].with_cast_value(next_sequence_value)
         end
 
         im = Arel::InsertManager.new(arel_table)
@@ -254,10 +250,7 @@ module ActiveRecord
           im.insert(values.transform_keys { |name| arel_table[name] })
         end
 
-        connection.insert(
-          im, "#{self} Create", primary_key || false, primary_key_value,
-          returning: returning
-        )
+        connection.insert(im, "#{self} Create", returning: returning)
       end
 
       def _update_record(values, constraints) # :nodoc:

--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -16,16 +16,9 @@ module ActiveRecord
       @arel_table = Arel::Table.new(name: table_name)
     end
 
-    #--
-    # This method cannot delegate to create_versions because callers expect
-    # the return value to be the inserted version.
-    #++
     def create_version(version)
-      im = Arel::InsertManager.new(arel_table)
-      im.insert(arel_table[primary_key] => version)
-      @pool.with_connection do |connection|
-        connection.insert(im, "#{self.class} Create", primary_key, version)
-      end
+      create_versions([version])
+      version.to_s
     end
 
     def create_versions(versions) # :nodoc:


### PR DESCRIPTION
Drop the `pk`, `id_value`, `sequence_name` positional arguments that `_insert_record`, `internal_metadata.create_entry`, and `schema_migration.create_version` were passing to `connection.insert`.

None of these callers relied on `id_value` for the return value:

* `_insert_record` always passes `returning:` (from `_returning_columns_for_insert`), so the id comes back through `returning_column_values`, not through `id_value`. The prefetched primary key value is already injected into `values[primary_key]`, so passing it again as `id_value` was redundant.

* `internal_metadata.create_entry` doesn't use the return value.

* `schema_migration.create_version` used the fact that `sql_for_insert` auto-appended `RETURNING <pk>` when both `pk` and `returning` were nil. It can just delegate to `create_versions` and return the version it was given — the value is known to the caller, no round-trip needed. This also lets the comment saying "This method cannot delegate to create_versions" go away.

Also tighten `sql_for_insert` to skip the primary-key auto-detection when `returning` is explicitly provided (an unnecessary `schema_cache.primary_keys` lookup otherwise).
