### PR TITLE
Expand encrypted queries in nested hash conditions

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Expand deterministically encrypted values in nested hash conditions.
+
+    When `config.active_record.encryption.extend_queries` is enabled, queries on
+    deterministically encrypted attributes that support unencrypted data are
+    expanded to match both the encrypted and the unencrypted values. This now
+    also happens for the nested hash form of `where`, so mid-migration queries
+    like the following no longer miss records that are not encrypted yet:
+
+    ```ruby
+    Author.joins(:books).where(books: { title: "Dune" })
+    ```
+
+    Both association names and table names are supported as the nested key.
+
+    *Eric Barendt*
+
 *   Deprecate the `insert_returning` option in PostgreSQL database
     configurations, and the `PostgreSQLAdapter#use_insert_returning?` method.
 

--- a/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb
+++ b/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb
@@ -41,33 +41,70 @@ module ActiveRecord
       module EncryptedQuery # :nodoc:
         class << self
           def process_arguments(owner, args, check_for_additional_values)
-            owner = owner.model if owner.is_a?(Relation)
+            return args unless args.is_a?(Array) && (options = args.first).is_a?(Hash)
 
-            return args if owner.deterministic_encrypted_attributes&.empty?
+            relation = owner if owner.is_a?(Relation)
+            owner = relation.model if relation
 
-            if args.is_a?(Array) && (options = args.first).is_a?(Hash)
-              options = options.transform_keys do |key|
-                if key.is_a?(Array)
-                  key.map(&:to_s)
-                else
-                  key.to_s
-                end
-              end
-              args[0] = options
+            deterministic_attributes = owner.deterministic_encrypted_attributes
 
-              owner.deterministic_encrypted_attributes&.each do |attribute_name|
-                attribute_name = attribute_name.to_s
-                type = owner.type_for_attribute(attribute_name)
-                if !type.previous_types.empty? && value = options[attribute_name]
-                  options[attribute_name] = process_encrypted_query_argument(value, check_for_additional_values, type)
-                end
+            nested_conditions = relation && options.any? { |_, value| value.is_a?(Hash) }
+
+            return args if deterministic_attributes.blank? && !nested_conditions
+
+            options = options.transform_keys do |key|
+              if key.is_a?(Array)
+                key.map(&:to_s)
+              else
+                key.to_s
               end
             end
+            args[0] = options
+
+            deterministic_attributes&.each do |attribute_name|
+              attribute_name = attribute_name.to_s
+              type = owner.type_for_attribute(attribute_name)
+              if !type.previous_types.empty? && value = options[attribute_name]
+                options[attribute_name] = process_encrypted_query_argument(value, check_for_additional_values, type)
+              end
+            end
+
+            process_nested_arguments(relation, options, check_for_additional_values) if nested_conditions
 
             args
           end
 
           private
+            def process_nested_arguments(relation, options, check_for_additional_values)
+              options.each do |key, nested_options|
+                next unless key.is_a?(String) && nested_options.is_a?(Hash)
+                next unless model = nested_model_for(relation, key)
+                next if (deterministic_attributes = model.deterministic_encrypted_attributes).blank?
+
+                expanded = nested_options
+
+                deterministic_attributes.each do |attribute_name|
+                  attribute_key = nested_options.key?(attribute_name) ? attribute_name : attribute_name.to_s
+                  next unless nested_options.key?(attribute_key)
+
+                  type = model.type_for_attribute(attribute_name)
+                  next if type.previous_types.empty?
+
+                  expanded = nested_options.dup if expanded.equal?(nested_options)
+                  expanded[attribute_key] = process_encrypted_query_argument(nested_options[attribute_key], check_for_additional_values, type)
+                end
+
+                options[key] = expanded unless expanded.equal?(nested_options)
+              end
+            end
+
+            def nested_model_for(relation, key)
+              table = TableMetadata.new(relation.model, relation.table)
+              return if table.has_column?(key)
+
+              table.associated_table(key) { |table_name| relation.send(:lookup_table_klass_from_join_dependencies, table_name) }.klass
+            end
+
             def process_encrypted_query_argument(value, check_for_additional_values, type)
               return value if check_for_additional_values && value.is_a?(Array) && value.last.is_a?(AdditionalValue)
 

--- a/activerecord/lib/active_record/table_metadata.rb
+++ b/activerecord/lib/active_record/table_metadata.rb
@@ -60,9 +60,6 @@ module ActiveRecord
       end
     end
 
-    attr_reader :arel_table
-
-    private
-      attr_reader :klass
+    attr_reader :arel_table, :klass
   end
 end

--- a/activerecord/test/cases/encryption/extended_deterministic_queries_test.rb
+++ b/activerecord/test/cases/encryption/extended_deterministic_queries_test.rb
@@ -95,4 +95,65 @@ class ActiveRecord::Encryption::ExtendedDeterministicQueriesTest < ActiveRecord:
       assert EncryptedBookWithUnencryptedDataOptedIn.where("id > 0").find_by(name: "Dune") # relation
     end
   end
+
+  test "Finds records when the deterministic attribute is on a joined table, keyed by table name" do
+    unencrypted_author, encrypted_author = authors_with_books_named("Dune")
+
+    assert_equal [ unencrypted_author, encrypted_author ],
+      EncryptedBookAuthor.joins(:encrypted_books).where(encrypted_books: { name: "Dune" }).order(:id).to_a
+  end
+
+  test "Finds records when the deterministic attribute is on a joined table, keyed by association name" do
+    unencrypted_author, encrypted_author = authors_with_books_named("Dune")
+
+    assert_equal [ unencrypted_author, encrypted_author ],
+      EncryptedBookAuthor.joins(:kept_books).where(kept_books: { name: "Dune" }).order(:id).to_a
+  end
+
+  test "Finds records when the deterministic attribute is on a table joined through an association" do
+    unencrypted_author, encrypted_author = authors_with_books_named("Dune")
+    unencrypted = EncryptedBookCategorization.create! author_id: unencrypted_author.id
+    encrypted = EncryptedBookCategorization.create! author_id: encrypted_author.id
+
+    assert_equal [ unencrypted, encrypted ],
+      EncryptedBookCategorization.joins(author: :encrypted_books).where(encrypted_books: { name: "Dune" }).order(:id).to_a
+  end
+
+  test "Finds records with the nested hash form when the deterministic attribute is on the model's own table" do
+    unencrypted_author, encrypted_author = authors_with_books_named("Dune")
+
+    assert_equal [ unencrypted_author.id, encrypted_author.id ],
+      EncryptedBook.where(encrypted_books: { name: "Dune" }).order(:author_id).pluck(:author_id)
+  end
+
+  test "find_by works with the nested hash form" do
+    unencrypted_author, _ = authors_with_books_named("Dune")
+
+    assert_equal unencrypted_author.id, EncryptedBook.order(:author_id).find_by(encrypted_books: { name: "Dune" }).author_id
+  end
+
+  test "Does not mutate nested arguments" do
+    props = { encrypted_books: { name: "Dune" } }
+
+    EncryptedBookAuthor.joins(:encrypted_books).where(props).to_a
+    assert_equal({ encrypted_books: { name: "Dune" } }, props)
+  end
+
+  test "Leaves nested arguments alone when the attribute is not deterministically encrypted" do
+    author = EncryptedBookAuthor.create! name: "Frank Herbert"
+    EncryptedBook.create! name: "Dune", format: "papyrus", author_id: author.id
+
+    assert_equal [ author ], EncryptedBookAuthor.joins(:encrypted_books).where(encrypted_books: { format: "papyrus" }).to_a
+  end
+
+  private
+    def authors_with_books_named(name)
+      unencrypted_author = EncryptedBookAuthor.create! name: "Unencrypted"
+      encrypted_author = EncryptedBookAuthor.create! name: "Encrypted"
+
+      UnencryptedBook.create! name: name, author_id: unencrypted_author.id
+      EncryptedBook.create! name: name, author_id: encrypted_author.id
+
+      [ unencrypted_author, encrypted_author ]
+    end
 end

--- a/activerecord/test/models/book_encrypted.rb
+++ b/activerecord/test/models/book_encrypted.rb
@@ -10,6 +10,19 @@ class EncryptedBook < ActiveRecord::Base
   encrypts :name, deterministic: true
 end
 
+class EncryptedBookAuthor < ActiveRecord::Base
+  self.table_name = "authors"
+
+  has_many :encrypted_books, class_name: "EncryptedBook", foreign_key: "author_id"
+  has_many :kept_books, class_name: "EncryptedBook", foreign_key: "author_id"
+end
+
+class EncryptedBookCategorization < ActiveRecord::Base
+  self.table_name = "categorizations"
+
+  belongs_to :author, class_name: "EncryptedBookAuthor", optional: true
+end
+
 class EncryptedBookWithUniquenessValidation < ActiveRecord::Base
   self.table_name = "encrypted_books"
 


### PR DESCRIPTION
### Motivation / Background

Fix #46809.

With `config.active_record.encryption.extend_queries` enabled, queries on a deterministic attribute that still supports unencrypted data are expanded to match both the encrypted and the plaintext value. That expansion was skipped for the nested hash form of `where`, so this matches only already-encrypted rows and silently misses rows that are not encrypted yet:

```ruby
Post.joins(:user).where(users: { email: "jorge@hey.com" })
```

Missing rows mid-backfill is exactly what the expansion exists to prevent. The workaround was to build the conditions on the joined model instead:

```ruby
Post.joins(:user).merge(User.where(email: "jorge@hey.com"))
```

### Detail

`EncryptedQuery.process_arguments` discarded the relation (`owner = owner.model`), so it had no join or reflection information, and it only looked at the top-level keys of the conditions hash.

The relation is now kept, and nested keys are resolved by reusing `TableMetadata#associated_table` — the same resolution `PredicateBuilder` performs when it expands the conditions — so association names, table names and tables reached through a nested join all work. `TableMetadata#klass` is public now so the resolved model can be read back; it was only private as a Ruby 2.2 warning workaround (21e5fd4a2a).

`ActiveRecord::Base.find_by` has no join information, so nested conditions are expanded through the relation, which is where `find_by` ends up for them anyway. Nothing is resolved unless the conditions contain a nested hash, so queries without one only pay for one scan of the conditions hash.

### Additional information

Supersedes #46812, which its author self-closed because matching against `joins_values` didn't feel like the right approach.

Query building overhead, `min` of 5 runs on sqlite3:

| | before | after |
| --- | --- | --- |
| `Post.where(id: 1)` | 5.23 µs | 5.08 µs |
| `Post.joins(:comments).where(comments: { body: "x" })` (no encryption) | 9.93 µs | 10.35 µs |
| nested table key needing the join dependency lookup (no encryption) | 20.70 µs | 28.19 µs |
| `EncryptedBook.where(name: "Dune")` | 8.94 ms | 8.68 ms |

The last row is the scale of the encryption work this sits next to. The join dependency lookup runs twice (here and in `build_where_clause`) and can be memoized later if it ever matters.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
