### PR TITLE
Fix Range#sum with a falsey initial value

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,7 +1,8 @@
 *   Fix `Range#sum` with a falsey initial value.
 
-    The integer-range optimization used `initial_value || 0`, so `sum(nil)` and
-    `sum(false)` treated the identity as `0` instead of matching `Array#sum`.
+    Summing an integer range with a falsey starting value (such as nil or false)
+    treated that value as zero. It now keeps the starting value as given, matching
+    array and enumerable sum.
 
     *Said Kaldybaev*
 

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix `Range#sum` with a falsey initial value.
+
+    The integer-range optimization used `initial_value || 0`, so `sum(nil)` and
+    `sum(false)` treated the identity as `0` instead of matching `Array#sum`.
+
+    *Said Kaldybaev*
+
 *   Add `ActiveSupport.raise_on_invalid_time_zone_parse`.
 
     Raise `ArgumentError` on `ActiveSupport::TimeZone#parse` for any invalid

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -256,10 +256,9 @@ class Range # :nodoc:
     else
       actual_last = exclude_end? ? (last - 1) : last
       if actual_last >= first
-        sum = initial_value || 0
-        sum + (actual_last - first + 1) * (actual_last + first) / 2
+        initial_value + (actual_last - first + 1) * (actual_last + first) / 2
       else
-        initial_value || 0
+        initial_value
       end
     end
   end

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -174,7 +174,9 @@ class EnumerableTests < ActiveSupport::TestCase
     assert_typed_equal 10.0, (1..4).sum(0.0), Float
     assert_typed_equal 20.0, (1..4).sum(10.0), Float
     assert_typed_equal 5.0, (10..0).sum(5.0), Float
-    # Falsey identities must not be coerced to 0 (matches Array#sum / Enumerable#sum).
+  end
+
+  def test_range_sum_falsey_initial_value
     assert_raises(NoMethodError) { (1..4).sum(nil) }
     assert_raises(NoMethodError) { (1..4).sum(false) }
     assert_nil (10..0).sum(nil)

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -174,6 +174,11 @@ class EnumerableTests < ActiveSupport::TestCase
     assert_typed_equal 10.0, (1..4).sum(0.0), Float
     assert_typed_equal 20.0, (1..4).sum(10.0), Float
     assert_typed_equal 5.0, (10..0).sum(5.0), Float
+    # Falsey identities must not be coerced to 0 (matches Array#sum / Enumerable#sum).
+    assert_raises(NoMethodError) { (1..4).sum(nil) }
+    assert_raises(NoMethodError) { (1..4).sum(false) }
+    assert_nil (10..0).sum(nil)
+    assert_equal false, (10..0).sum(false)
   end
 
   def test_array_sums


### PR DESCRIPTION
### Motivation / Background

Summing an integer range with a falsey starting value (like `nil` or `false`) did not behave the same as summing an array. The range path treated those values as zero.

### Detail

Range sum now keeps the starting value as given, matching array/enumerable sum.

Before:
```
(1..4).sum(nil)    # => 10  (treated as sum(0))
(10..0).sum(nil)   # => 0
(1..4).sum(false)  # => 10
```

After:
```
(1..4).sum(nil)    # => NoMethodError (same as [1,2,3,4].sum(nil))
(10..0).sum(nil)   # => nil
(1..4).sum(false)  # => NoMethodError
(10..0).sum(false) # => false
```

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.