### PR TITLE
Roll back when a before_commit callback raises a rollback error

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -622,7 +622,15 @@ module ActiveRecord
 
           dirty_current_transaction if transaction.dirty?
 
-          transaction.commit
+          begin
+            transaction.commit
+          rescue ActiveRecord::TransactionRollbackError
+            # A failed COMMIT has already ended the transaction, so the caller
+            # should skip the ROLLBACK it would otherwise issue.
+            transaction.invalidate! unless transaction.state.completed?
+            raise
+          end
+
           transaction.commit_records
         end
       end
@@ -659,12 +667,6 @@ module ActiveRecord
                   commit_transaction
                 rescue ActiveRecord::ConnectionFailed
                   transaction.invalidate! unless transaction.state.completed?
-                  raise
-                rescue ActiveRecord::TransactionRollbackError
-                  unless transaction.state.completed?
-                    transaction.invalidate!
-                    rollback_transaction(transaction)
-                  end
                   raise
                 rescue Exception
                   rollback_transaction(transaction) unless transaction.state.completed?

--- a/activerecord/test/cases/adapters/postgresql/transaction_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/transaction_test.rb
@@ -12,6 +12,18 @@ module ActiveRecord
       self.table_name = "samples"
     end
 
+    class DeadlockingSample < ActiveRecord::Base
+      self.table_name = "samples"
+
+      # Raising 40P01 from the server aborts the transaction for real, which a
+      # deadlock between two sessions cannot do deterministically.
+      before_commit do
+        self.class.lease_connection.execute(
+          "DO $$ BEGIN RAISE EXCEPTION 'deadlock' USING ERRCODE = '40P01'; END $$"
+        )
+      end
+    end
+
     setup do
       @abort, Thread.abort_on_exception = Thread.abort_on_exception, false
       Thread.report_on_exception, @original_report_on_exception = false, Thread.report_on_exception
@@ -26,6 +38,7 @@ module ActiveRecord
       end
 
       Sample.reset_column_information
+      DeadlockingSample.reset_column_information
     end
 
     teardown do
@@ -89,6 +102,15 @@ module ActiveRecord
         end
       end
       assert connections.all?(&:active?)
+    end
+
+    test "rolls back when a before_commit callback raises a rollback error" do
+      assert_raises(ActiveRecord::Deadlocked) do
+        DeadlockingSample.transaction { DeadlockingSample.create!(value: 1) }
+      end
+
+      # Raises PG::InFailedSqlTransaction if the transaction was left open.
+      assert_equal 0, Sample.count
     end
 
     test "raises LockWaitTimeout when lock wait timeout exceeded" do


### PR DESCRIPTION
Fixes #58288.

`within_new_transaction` rescues `TransactionRollbackError` around `commit_transaction` and skips the ROLLBACK, on the grounds that a failed COMMIT has already ended the transaction. That rescue also covers `before_commit_records`, which runs before COMMIT is sent — so an error raised by a `before_commit` callback left the transaction open and never rolled back, and the connection went back into the pool still inside it.

This moves the invalidation next to `transaction.commit`, so it only applies once COMMIT has actually been issued. Errors raised earlier fall through to the existing `rescue Exception`, which rolls back as it did before, so the special-case rescue in `within_new_transaction` goes away.

#56717's own case is unaffected: a COMMIT that itself returns a serialisation failure still skips the ROLLBACK.

---

**Alternative solution**

An alternative I tried was threading a `commit_attempted?` flag through `Transaction` and gating the existing rescue on it. It works equally well but adds state instead of removing a branch — happy to switch if you prefer that shape.