### PR TITLE
Support a single column name for `#insert`'s `returning:`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -185,13 +185,22 @@ module ActiveRecord
       # `nil` is the default value and maintains default behavior. If an array of column names is passed -
       # the result will contain values of the specified columns from the inserted row.
       def exec_insert(sql, name = nil, binds = [], pk = nil, sequence_name = nil, returning: nil)
+        # The `pk` positional argument is really the RETURNING column name.
+        # Translate it to `returning:` — including the legacy `false` sentinel
+        # meaning "no primary key / skip RETURNING".
+        if pk == false
+          returning ||= []
+        elsif pk
+          returning ||= pk
+        end
+
         intent = QueryIntent.new(adapter: self, raw_sql: sql, name: name, binds: binds)
 
-        _exec_insert(intent, pk, sequence_name, returning: returning)
+        _exec_insert(intent, sequence_name, returning: returning)
       end
 
-      def _exec_insert(intent, pk = nil, sequence_name = nil, returning: nil) # :nodoc:
-        sql, binds = sql_for_insert(intent.raw_sql, pk, intent.binds, returning)
+      def _exec_insert(intent, sequence_name = nil, returning: nil) # :nodoc:
+        sql, binds = sql_for_insert(intent.raw_sql, intent.binds, returning)
         intent.raw_sql = sql
         intent.binds = binds
 
@@ -237,17 +246,33 @@ module ActiveRecord
       #
       # If the next id was calculated in advance (as in Oracle), it should be
       # passed in as +id_value+.
-      # Some adapters support the `returning` keyword argument which allows defining the return value of the method:
-      # `nil` is the default value and maintains default behavior. If an array of column names is passed -
-      # an array of is returned from the method representing values of the specified columns from the inserted row.
+      #
+      # Some adapters support the `returning` keyword argument, which controls
+      # what the method returns: +nil+ (default) returns the id via
+      # +last_inserted_id+; a column name returns that column as a single
+      # value; an array of column names returns an Array of column values.
       def insert(arel, name = nil, pk = nil, id_value = nil, sequence_name = nil, binds = [], returning: nil)
+        # The `pk` positional argument is really the RETURNING column name.
+        # Translate it to `returning:` — including the legacy `false` sentinel
+        # meaning "no primary key / skip RETURNING".
+        if pk == false
+          returning ||= []
+        elsif pk
+          returning ||= pk
+        end
+
         intent = QueryIntent.new(adapter: self, arel: arel, name: name, binds: binds)
 
-        value = _exec_insert(intent, pk, sequence_name, returning: returning)
+        value = _exec_insert(intent, sequence_name, returning: returning)
 
-        return returning_column_values(value) unless returning.nil?
-
-        id_value || last_inserted_id(value)
+        case returning
+        when nil
+          id_value || last_inserted_id(value)
+        when Array
+          returning_column_values(value)
+        else
+          returning_column_values(value)&.first
+        end
       end
       alias create insert
 
@@ -769,15 +794,15 @@ module ActiveRecord
           total_sql.join(";\n")
         end
 
-        def sql_for_insert(sql, pk, binds, returning) # :nodoc:
+        def sql_for_insert(sql, binds, returning) # :nodoc:
           if supports_insert_returning?
-            if returning.nil? && pk.nil?
+            if returning.nil?
               # Extract the table from the insert sql. Yuck.
               table_ref = extract_table_ref_from_insert_sql(sql)
-              pk = schema_cache.primary_keys(table_ref) if table_ref
+              returning = schema_cache.primary_keys(table_ref) if table_ref
             end
 
-            returning_columns = returning || Array(pk)
+            returning_columns = Array(returning)
 
             returning_columns_statement = returning_columns.map { |c| quote_column_name(c) }.join(", ")
             sql = "#{sql} RETURNING #{returning_columns_statement}" if returning_columns.any?

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -29,22 +29,23 @@ module ActiveRecord
           !READ_QUERY.match?(sql.b)
         end
 
-        def _exec_insert(intent, pk = nil, sequence_name = nil, returning: nil) # :nodoc:
-          if @use_insert_returning || pk == false
+        def insert(arel, name = nil, pk = nil, id_value = nil, sequence_name = nil, binds = [], returning: nil) # :nodoc:
+          sequence_name, pk = resolve_currval_for_insert(arel, pk, sequence_name, returning)
+          super
+        end
+
+        def exec_insert(sql, name = nil, binds = [], pk = nil, sequence_name = nil, returning: nil) # :nodoc:
+          sequence_name, pk = resolve_currval_for_insert(sql, pk, sequence_name, returning)
+          super
+        end
+
+        def _exec_insert(intent, sequence_name = nil, returning: nil) # :nodoc:
+          if @use_insert_returning || !returning.nil?
             super
           else
             intent.execute!
             result = intent.cast_result
-            unless sequence_name
-              table_ref = extract_table_ref_from_insert_sql(intent.raw_sql)
-              if table_ref
-                pk = schema_cache.primary_keys(table_ref) if pk.nil?
-                pk = suppress_composite_primary_key(pk)
-                sequence_name = default_sequence_name(table_ref, pk)
-              end
-              return result unless sequence_name
-            end
-
+            return result unless sequence_name
             query_all("SELECT currval(#{quote(sequence_name)})", "SQL")
           end
         end
@@ -132,6 +133,34 @@ module ActiveRecord
         private
           IDLE_TRANSACTION_STATUSES = [PG::PQTRANS_IDLE, PG::PQTRANS_INTRANS, PG::PQTRANS_INERROR].freeze
           private_constant :IDLE_TRANSACTION_STATUSES
+
+          # When RETURNING is globally disabled, a positional `pk` was
+          # historically the signal to use the currval fallback in
+          # `_exec_insert`. Resolve `sequence_name` from the caller's `pk` (or
+          # the schema cache's primary key) so the fallback still runs against
+          # the intended sequence — including on tables where a `BEFORE INSERT`
+          # trigger short-circuits `RETURNING` (e.g. partitioned inheritance).
+          # Then drop `pk` to skip the abstract's translation into `returning:`
+          # (which would force the RETURNING path and bypass the fallback).
+          def resolve_currval_for_insert(arel_or_sql, pk, sequence_name, returning)
+            return [sequence_name, pk] if @use_insert_returning
+            return [sequence_name, pk] if !returning.nil? || pk == false
+
+            if sequence_name.nil?
+              table_ref = if arel_or_sql.is_a?(String)
+                extract_table_ref_from_insert_sql(arel_or_sql)
+              elsif arel_or_sql.respond_to?(:ast) && arel_or_sql.ast.respond_to?(:relation)
+                arel_or_sql.ast.relation.name
+              end
+              if table_ref
+                effective_pk = pk || schema_cache.primary_keys(table_ref)
+                effective_pk = suppress_composite_primary_key(effective_pk)
+                sequence_name = default_sequence_name(table_ref, effective_pk) if effective_pk
+              end
+            end
+
+            [sequence_name, nil]
+          end
 
           def cancel_any_running_query
             return if @raw_connection.nil? || IDLE_TRANSACTION_STATUSES.include?(@raw_connection.transaction_status)

--- a/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
@@ -4,8 +4,8 @@ module ActiveRecord
   module ConnectionAdapters
     module Trilogy
       module DatabaseStatements
-        def _exec_insert(intent, pk = nil, sequence_name = nil, returning: nil) # :nodoc:
-          sql, binds = sql_for_insert(intent.raw_sql, pk, intent.binds, returning)
+        def _exec_insert(intent, sequence_name = nil, returning: nil) # :nodoc:
+          sql, binds = sql_for_insert(intent.raw_sql, intent.binds, returning)
           intent.raw_sql = sql
           intent.binds = binds
 

--- a/activerecord/test/cases/database_statements_test.rb
+++ b/activerecord/test/cases/database_statements_test.rb
@@ -22,6 +22,19 @@ class DatabaseStatementsTest < ActiveRecord::TestCase
     assert_not_nil return_the_inserted_id(method: :create)
   end
 
+  def test_insert_with_scalar_returning_returns_scalar
+    sql = "INSERT INTO accounts (firm_id,credit_limit) VALUES (42,5000)"
+    id = @connection.insert(sql, returning: "id")
+    assert_kind_of Integer, id
+  end
+
+  def test_insert_with_array_returning_returns_array
+    sql = "INSERT INTO accounts (firm_id,credit_limit) VALUES (42,5000)"
+    values = @connection.insert(sql, returning: ["id"])
+    assert_kind_of Array, values
+    assert_equal 1, values.length
+  end
+
   def test_extract_table_ref_from_insert_sql_with_hyphen_in_table_name
     sql = "INSERT INTO \"table-with-hyphen\" (column1, column2) VALUES (value1, value2)"
     assert_equal "table-with-hyphen", @connection.send(:extract_table_ref_from_insert_sql, sql)


### PR DESCRIPTION
Preparation for deprecating the `pk` positional argument. `pk` returned the value of the selected column; `returning:` only accepted arrays and returned an Array — so migrating `pk = "id"` to `returning:` used to require unwrapping the one-element Array at the call site.

Accept a single column name in `returning:` and return that column's value directly:

* `returning: nil`      — `id_value || last_inserted_id(result)`
* `returning: "id"`     — single value from the inserted row
* `returning: ["id"]`   — one-element Array of column values
* `returning: [c1, c2]` — Array of column values

With that in place, drop `pk` from `_exec_insert` and `sql_for_insert` entirely. `insert` and `exec_insert` keep their legacy `pk` positional and translate it to `returning:` — `"id"` -> `"id"` and `false` -> `[]` — as a compatibility shim ahead of the public deprecation.

PostgreSQL keeps the `@use_insert_returning = false` currval fallback reachable by resolving `sequence_name` from the caller's `pk` (or the schema cache) in its `insert` / `exec_insert` overrides before dropping `pk`.
