### PR TITLE
Expand `insert_returning` deprecation note with migration path

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -15,6 +15,12 @@
     RETURNING when the database supports it, so the option cannot fully
     disable RETURNING and has become vestigial.
 
+    `insert_returning: false` was originally added in #5698 to support
+    trigger-based partitioning tables where a `BEFORE INSERT` trigger
+    makes `RETURNING` yield no rows. Use `prefetch_primary_key?` (also
+    used by the Oracle enhanced adapter) — which issues `SELECT nextval`
+    before the INSERT — as a replacement.
+
     *Ryuta Kamizono*
 
 *   Remove unused `rest` parameter from merge and merge!


### PR DESCRIPTION
`insert_returning: false` was originally added in #5698 to support trigger-based partitioning tables — a `BEFORE INSERT` trigger routes the row to a child table, so `RETURNING` on the parent yields no rows. The workaround was to suppress `RETURNING` and issue `INSERT` -> `SELECT currval` inside `insert`.

Use `prefetch_primary_key?` (also used by the Oracle enhanced adapter) — which issues `SELECT nextval` before the INSERT — as a replacement.

