### PR TITLE
Fix Integer#deserialize raising NoMethodError for boolean values

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Fix `ActiveModel::Type::Integer` raising `NoMethodError` when deserializing
+    a boolean value.
+
+    Overriding an attribute to `:integer` on a column whose database default is
+    a boolean (such as a MySQL `tinyint(1)`) raised `undefined method 'to_i' for
+    true` when reading the default. `true` and `false` now deserialize to `1`
+    and `0`, matching how the type already casts and serializes them.
+
+    Fixes #58292.
+
+    *Lazizbek Ergashev*
+
 *   Fix `normalizes` re-applying normalizations on every validation of an
     unpersisted record, and speed up validation of normalized attributes.
 

--- a/activemodel/lib/active_model/type/integer.rb
+++ b/activemodel/lib/active_model/type/integer.rb
@@ -60,8 +60,12 @@ module ActiveModel
       end
 
       def deserialize(value)
-        return if value.blank?
-        value.to_i
+        case value
+        when true then 1
+        when false then 0
+        else
+          value.to_i unless value.blank?
+        end
       end
 
       def serialize(value)

--- a/activemodel/test/cases/type/integer_test.rb
+++ b/activemodel/test/cases/type/integer_test.rb
@@ -44,6 +44,12 @@ module ActiveModel
         assert_equal 0, type.serialize(false)
       end
 
+      test "deserializing booleans" do
+        type = Type::Integer.new
+        assert_equal 1, type.deserialize(true)
+        assert_equal 0, type.deserialize(false)
+      end
+
       test "casting duration" do
         type = Type::Integer.new
         assert_equal 1800, type.cast(30.minutes)


### PR DESCRIPTION
### Motivation / Background

Overriding an attribute to `:integer` on a column whose database default is a boolean, such as a MySQL `tinyint(1)`, raises `undefined method 'to_i' for true` the first time the default is read:

```ruby
ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.boolean :status, default: true
  end
end

class Post < ActiveRecord::Base
  attribute :status, :integer
end

Post.new.status # NoMethodError: undefined method 'to_i' for true
```

This passes on Rails 8.0.5 and fails on 8.1.3.

### Detail

Rails 8.1 started eagerly deserializing immutable column defaults, so `column.default` for a boolean column is now `true`/`false` instead of the raw `"1"`/`"0"` string it was before. That value is kept as the attribute's `value_before_type_cast` and read back through `ActiveModel::Type::Integer#deserialize`, which called `to_i` on the value directly. Booleans do not respond to `to_i`, so the read raised.

`Integer#cast` and `#serialize` already map `true` and `false` to `1` and `0`. `#deserialize` now does the same, which restores the 8.0 behavior.

Fixes #58292.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.
