### PR TITLE
Allow to use `ActiveModel#to_partial_path` in a Ractor

### DIFF
--- a/activemodel/lib/active_model/conversion.rb
+++ b/activemodel/lib/active_model/conversion.rb
@@ -109,11 +109,11 @@ module ActiveModel
       # internal method and should not be accessed directly.
       def _to_partial_path # :nodoc:
         @_to_partial_path ||= if respond_to?(:model_name)
-          "#{model_name.collection}/#{model_name.element}"
+          "#{model_name.collection}/#{model_name.element}".freeze
         else
           element = ActiveSupport::Inflector.underscore(ActiveSupport::Inflector.demodulize(name))
           collection = ActiveSupport::Inflector.tableize(name)
-          "#{collection}/#{element}"
+          "#{collection}/#{element}".freeze
         end
       end
     end

--- a/activemodel/test/cases/conversion_test.rb
+++ b/activemodel/test/cases/conversion_test.rb
@@ -62,6 +62,20 @@ class ConversionTest < ActiveModel::TestCase
     assert_equal "attack_helicopters/ah-64", Helicopter::Apache.new.to_partial_path
   end
 
+  test "to_partial_path on a model implementing .model_name returns a frozen string" do
+    helicopter = Helicopter::Apache.new
+
+    assert_respond_to(helicopter.class, :model_name)
+    assert_predicate(helicopter.to_partial_path, :frozen?)
+  end
+
+  test "to_partial_path on a model not implementing .model_name returns a frozen string" do
+    helicopter = Helicopter::Comanche.new
+
+    assert_not_respond_to(helicopter.class, :model_name)
+    assert_predicate(helicopter.to_partial_path, :frozen?)
+  end
+
   test "#to_param_delimiter allows redefining the delimiter used in #to_param" do
     old_delimiter = Contact.param_delimiter
     Contact.param_delimiter = "_"


### PR DESCRIPTION
> [!NOTE]
>
> This patch doesn't fix the memoization happening in a Ractor. I'll follow up in another PR.

### Motivation / Background

I'd like to be able to call `ActiveModel#to_partial_path` in a Ractor.

### Detail

String interpolation doesn't return a frozen string so the memoized value can't be accessed inside a ractor. This patch fixes that.

### Additional information

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
