### PR TITLE
Return a Float from `Time#-` with a `DateTime`

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -314,8 +314,9 @@ class Time
     if other.is_a?(DateTime)
       # Prefer an exact rational difference: Float (to_f) cannot represent every
       # microsecond, so sub-second DateTime values lost precision (same class of
-      # issue as Time.at with DateTime).
-      to_r - other.to_i - other.sec_fraction
+      # issue as Time.at with DateTime). The difference is returned as a Float
+      # to match Time#-(Time) and ActiveSupport::TimeWithZone#-(DateTime).
+      (to_r - other.to_i - other.sec_fraction).to_f
     else
       minus_without_coercion(other)
     end

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -1255,14 +1255,17 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
 
   def test_minus_with_datetime
     assert_equal 86_400.0, Time.utc(2000, 1, 2) - DateTime.civil(2000, 1, 1)
+    assert_instance_of Float, Time.utc(2000, 1, 2) - DateTime.civil(2000, 1, 1)
   end
 
   def test_minus_with_datetime_sub_second_precision
     dt = DateTime.civil(2000, 1, 1, 0, 0, Rational(1, 1_000_000), "+0") # .000001s
     assert_equal Rational(999_999, 1_000_000), Time.utc(2000, 1, 1, 0, 0, 1) - dt
+    assert_instance_of Float, Time.utc(2000, 1, 1, 0, 0, 1) - dt
 
     dt = DateTime.civil(2000, 1, 1, 0, 0, Rational(123_457, 1_000_000), "+0")
     assert_equal Rational(876_543, 1_000_000), Time.utc(2000, 1, 1, 0, 0, 1) - dt
+    assert_instance_of Float, Time.utc(2000, 1, 1, 0, 0, 1) - dt
   end
 
   def test_time_created_with_local_constructor_cannot_represent_times_during_hour_skipped_by_dst


### PR DESCRIPTION
### Motivation

`Time#-` with a `DateTime` operand currently returns a `Rational`:

```ruby
elapsed = Time.utc(2000, 1, 2) - DateTime.civil(2000, 1, 1)
elapsed       #=> (86400/1)
elapsed.class #=> Rational

"#{elapsed} seconds"       #=> "86400/1 seconds"
elapsed.to_json            #=> "\"86400/1\""
elapsed.round(2)           #=> 86400/1  (Rational, not 86400.0)
```

Both `Time#-(Time)` and `ActiveSupport::TimeWithZone#-(DateTime)` return a `Float` for the same kind of operation, so this is an inconsistency introduced in 4d24a25acf.

### Solution

Coerce the result to `Float` at the end of the rational subtraction. The exact rational arithmetic from 4d24a25acf is preserved so sub-second `DateTime` values keep the precision it restored — only the final result is coerced.

```ruby
elapsed = Time.utc(2000, 1, 2) - DateTime.civil(2000, 1, 1)
elapsed       #=> 86400.0
elapsed.class #=> Float
```