### PR TITLE
Refactor insert `returning:` handling to take `QueryIntent` directly

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -200,10 +200,7 @@ module ActiveRecord
       end
 
       def _exec_insert(intent, sequence_name = nil, returning: nil) # :nodoc:
-        sql, binds = sql_for_insert(intent.raw_sql, intent.binds, returning)
-        intent.raw_sql = sql
-        intent.binds = binds
-
+        apply_returning_to!(intent, returning)
         intent.execute!
         intent.cast_result
       end
@@ -794,21 +791,35 @@ module ActiveRecord
           total_sql.join(";\n")
         end
 
-        def sql_for_insert(sql, binds, returning) # :nodoc:
-          if supports_insert_returning?
-            if returning.nil?
-              # Extract the table from the insert sql. Yuck.
-              table_ref = extract_table_ref_from_insert_sql(sql)
-              returning = schema_cache.primary_keys(table_ref) if table_ref
-            end
+        def apply_returning_to!(intent, returning)
+          return unless supports_insert_returning?
 
-            returning_columns = Array(returning)
+          arel_or_sql = intent.arel || intent.raw_sql
 
-            returning_columns_statement = returning_columns.map { |c| quote_column_name(c) }.join(", ")
-            sql = "#{sql} RETURNING #{returning_columns_statement}" if returning_columns.any?
+          returning ||= primary_key_for_insert(arel_or_sql)
+          returning = Array(returning)
+          return if returning.empty?
+
+          if arel_or_sql.is_a?(String)
+            returning_statement = returning.map { |c| quote_column_name(c) }.join(", ")
+            intent.raw_sql = "#{arel_or_sql} RETURNING #{returning_statement}"
+          else
+            arel_or_sql.returning(returning.map { |column| Arel.sql(quote_column_name(column)) })
           end
+        end
 
-          [sql, binds]
+        def primary_key_for_insert(arel_or_sql)
+          table_ref = table_ref_for_insert(arel_or_sql)
+          pk = schema_cache.primary_keys(table_ref) if table_ref
+          pk unless pk.is_a?(Array)
+        end
+
+        def table_ref_for_insert(arel_or_sql)
+          if arel_or_sql.is_a?(String)
+            extract_table_ref_from_insert_sql(arel_or_sql)
+          elsif arel_or_sql.respond_to?(:ast) && arel_or_sql.ast.respond_to?(:relation)
+            arel_or_sql.ast.relation.name
+          end
         end
 
         def last_inserted_id(result)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -146,17 +146,9 @@ module ActiveRecord
             return [sequence_name, pk] if @use_insert_returning
             return [sequence_name, pk] if !returning.nil? || pk == false
 
-            if sequence_name.nil?
-              table_ref = if arel_or_sql.is_a?(String)
-                extract_table_ref_from_insert_sql(arel_or_sql)
-              elsif arel_or_sql.respond_to?(:ast) && arel_or_sql.ast.respond_to?(:relation)
-                arel_or_sql.ast.relation.name
-              end
-              if table_ref
-                effective_pk = pk || schema_cache.primary_keys(table_ref)
-                effective_pk = suppress_composite_primary_key(effective_pk)
-                sequence_name = default_sequence_name(table_ref, effective_pk) if effective_pk
-              end
+            if sequence_name.nil? && (table_ref = table_ref_for_insert(arel_or_sql))
+              effective_pk = pk || schema_cache.primary_keys(table_ref)
+              sequence_name = default_sequence_name(table_ref, effective_pk) if effective_pk
             end
 
             [sequence_name, nil]
@@ -273,10 +265,6 @@ module ActiveRecord
 
           def build_truncate_statements(table_names)
             ["TRUNCATE TABLE #{table_names.map(&method(:quote_table_name)).join(", ")}"]
-          end
-
-          def suppress_composite_primary_key(pk)
-            pk unless pk.is_a?(Array)
           end
 
           def handle_warnings(result, sql)

--- a/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
@@ -5,9 +5,7 @@ module ActiveRecord
     module Trilogy
       module DatabaseStatements
         def _exec_insert(intent, sequence_name = nil, returning: nil) # :nodoc:
-          sql, binds = sql_for_insert(intent.raw_sql, intent.binds, returning)
-          intent.raw_sql = sql
-          intent.binds = binds
+          apply_returning_to!(intent, returning)
 
           # AbstractAdapter calls cast_result (returning an AR::Result), but
           # our last_inserted_id needs the raw Trilogy result object


### PR DESCRIPTION
`sql_for_insert(sql, binds, returning)` forced every insert — arel included — through raw-SQL string manipulation, and required a `binds` argument that only the Oracle enhanced adapter ever used.

Replace it with `apply_returning_to!(intent, returning)`, which passes the `QueryIntent` through so adapters can pull whichever piece they need. Arel inserts now set `RETURNING` on the AST via `arel.returning(...)` — mirroring `update_with_result` — with no raw-SQL round-trip. Raw-SQL inserts still append `RETURNING <cols>` textually.

When the caller omits `returning:`, the method defaults it to the table's primary key, skipping composite primary keys since they don't map to a single last-inserted id.

Along the way, factor out a shared `table_ref_for_insert` helper for the table-name lookup and drop PostgreSQL's now-redundant `suppress_composite_primary_key`.
