### PR TITLE
Deprecate positional `pk`, `id_value`, and `sequence_name` for `#insert`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Deprecate the `pk`, `id_value`, and `sequence_name` positional arguments to
+    `ActiveRecord::ConnectionAdapters::DatabaseStatements#insert`.
+
+    * `pk` — pass `returning:` instead. `insert(arel, name, "id")` becomes
+      `insert(arel, name, returning: "id")` (still a single value return).
+
+    * `id_value` — the caller usually already knows this value and can use it
+      directly rather than reading it back from `insert`'s return value.
+
+    * `sequence_name` — only used by PostgreSQL's `use_insert_returning?`
+      currval fallback, which is deprecated on its own.
+
+    *Ryuta Kamizono*
+
 *   Allow for prepared statements to remain enabled with query logs tags.
 
     To keep prepared_statements enabled in conjunction with query log tags,

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -241,20 +241,39 @@ module ActiveRecord
         raise NotImplementedError
       end
 
-      # Executes an INSERT query and returns the new record's ID
-      #
-      # +id_value+ will be returned unless the value is +nil+, in
-      # which case the database will attempt to calculate the last inserted
-      # id and return that value.
-      #
-      # If the next id was calculated in advance (as in Oracle), it should be
-      # passed in as +id_value+.
+      # Executes an INSERT query and returns the new record's ID.
       #
       # Some adapters support the `returning` keyword argument, which controls
       # what the method returns: +nil+ (default) returns the id via
       # +last_inserted_id+; a column name returns that column as a single
       # value; an array of column names returns an Array of column values.
       def insert(arel_or_sql, name = nil, pk = nil, id_value = nil, sequence_name = nil, binds = [], returning: nil)
+        unless pk.nil?
+          ActiveRecord.deprecator.warn(<<~MSG.squish)
+            Passing `pk` as a positional argument to `insert` is deprecated
+            and will be removed in Rails 8.3. Pass `returning:` instead —
+            `insert(arel, name, "id")` becomes `insert(arel, name, returning: "id")`.
+          MSG
+        end
+        unless id_value.nil?
+          ActiveRecord.deprecator.warn(<<~MSG.squish)
+            Passing `id_value` as a positional argument to `insert` is
+            deprecated and will be removed in Rails 8.3. `id_value` was
+            returned when the database couldn't compute the last inserted id;
+            callers that pass it already know the value and can use it
+            directly rather than reading it back from `insert`.
+          MSG
+        end
+        unless sequence_name.nil?
+          ActiveRecord.deprecator.warn(<<~MSG.squish)
+            Passing `sequence_name` as a positional argument to `insert` is
+            deprecated and will be removed in Rails 8.3. It was only used by
+            PostgreSQL's `use_insert_returning?` currval fallback, which is
+            deprecated on its own — drop the argument once the
+            `insert_returning` option is removed.
+          MSG
+        end
+
         # The `pk` positional argument is really the RETURNING column name.
         # Translate it to `returning:` — including the legacy `false` sentinel
         # meaning "no primary key / skip RETURNING".

--- a/activerecord/test/cases/adapter_prevent_writes_test.rb
+++ b/activerecord/test/cases/adapter_prevent_writes_test.rb
@@ -26,7 +26,7 @@ module ActiveRecord
     def test_errors_when_an_insert_query_is_called_while_preventing_writes
       ActiveRecord::Base.while_preventing_writes do
         assert_raises(ActiveRecord::ReadOnlyError) do
-          @connection.insert("INSERT INTO subscribers(nick) VALUES ('138853948594')", nil, false)
+          @connection.insert("INSERT INTO subscribers(nick) VALUES ('138853948594')")
         end
       end
     end
@@ -107,7 +107,7 @@ module ActiveRecord
     def test_errors_when_an_insert_query_prefixed_by_a_slash_star_comment_is_called_while_preventing_writes
       ActiveRecord::Base.while_preventing_writes do
         assert_raises(ActiveRecord::ReadOnlyError) do
-          @connection.insert("/* some comment */ INSERT INTO subscribers(nick) VALUES ('138853948594')", nil, false)
+          @connection.insert("/* some comment */ INSERT INTO subscribers(nick) VALUES ('138853948594')")
         end
       end
     end
@@ -124,7 +124,7 @@ module ActiveRecord
     def test_errors_when_an_insert_query_prefixed_by_a_double_dash_comment_is_called_while_preventing_writes
       ActiveRecord::Base.while_preventing_writes do
         assert_raises(ActiveRecord::ReadOnlyError) do
-          @connection.insert("-- some comment\nINSERT INTO subscribers(nick) VALUES ('138853948594')", nil, false)
+          @connection.insert("-- some comment\nINSERT INTO subscribers(nick) VALUES ('138853948594')")
         end
       end
     end
@@ -133,7 +133,7 @@ module ActiveRecord
       ActiveRecord::Base.while_preventing_writes do
         assert_raises(ActiveRecord::ReadOnlyError) do
           Timeout.timeout(0.1) do # should be fast to parse the query
-            @connection.insert("#{"-- comment\n" * 50}INSERT INTO subscribers(nick) VALUES ('138853948594')", nil, false)
+            @connection.insert("#{"-- comment\n" * 50}INSERT INTO subscribers(nick) VALUES ('138853948594')")
           end
         end
       end
@@ -142,7 +142,7 @@ module ActiveRecord
     def test_errors_when_an_insert_query_prefixed_by_a_slash_star_comment_containing_read_command_is_called_while_preventing_writes
       ActiveRecord::Base.while_preventing_writes do
         assert_raises(ActiveRecord::ReadOnlyError) do
-          @connection.insert("/* SELECT */ INSERT INTO subscribers(nick) VALUES ('138853948594')", nil, false)
+          @connection.insert("/* SELECT */ INSERT INTO subscribers(nick) VALUES ('138853948594')")
         end
       end
     end
@@ -150,7 +150,7 @@ module ActiveRecord
     def test_errors_when_an_insert_query_prefixed_by_a_double_dash_comment_containing_read_command_is_called_while_preventing_writes
       ActiveRecord::Base.while_preventing_writes do
         assert_raises(ActiveRecord::ReadOnlyError) do
-          @connection.insert("-- SELECT\nINSERT INTO subscribers(nick) VALUES ('138853948594')", nil, false)
+          @connection.insert("-- SELECT\nINSERT INTO subscribers(nick) VALUES ('138853948594')")
         end
       end
     end

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -535,7 +535,9 @@ module ActiveRecord
         with_example_table do
           sql = "INSERT INTO ex (number) VALUES (10)"
           idval = "vuvuzela"
-          id = @conn.insert(sql, nil, nil, idval)
+          id = assert_deprecated(ActiveRecord.deprecator) do
+            @conn.insert(sql, nil, nil, idval)
+          end
           assert_equal idval, id
         end
       end

--- a/activerecord/test/cases/database_statements_test.rb
+++ b/activerecord/test/cases/database_statements_test.rb
@@ -35,6 +35,29 @@ class DatabaseStatementsTest < ActiveRecord::TestCase
     assert_equal 1, values.length
   end
 
+  def test_insert_pk_positional_argument_is_deprecated
+    sql = "INSERT INTO accounts (firm_id,credit_limit) VALUES (42,5000)"
+    id = assert_deprecated(/Passing `pk`/, ActiveRecord.deprecator) do
+      @connection.insert(sql, nil, "id")
+    end
+    assert_kind_of Integer, id
+  end
+
+  def test_insert_id_value_positional_argument_is_deprecated
+    sql = "INSERT INTO accounts (firm_id,credit_limit) VALUES (42,5000)"
+    id = assert_deprecated(/Passing `id_value`/, ActiveRecord.deprecator) do
+      @connection.insert(sql, nil, nil, 12345)
+    end
+    assert_equal 12345, id
+  end
+
+  def test_insert_sequence_name_positional_argument_is_deprecated
+    sql = "INSERT INTO accounts (firm_id,credit_limit) VALUES (42,5000)"
+    assert_deprecated(/Passing `sequence_name`/, ActiveRecord.deprecator) do
+      @connection.insert(sql, nil, nil, nil, "accounts_id_seq")
+    end
+  end
+
   def test_extract_table_ref_from_insert_sql_with_hyphen_in_table_name
     sql = "INSERT INTO \"table-with-hyphen\" (column1, column2) VALUES (value1, value2)"
     assert_equal "table-with-hyphen", @connection.send(:extract_table_ref_from_insert_sql, sql)


### PR DESCRIPTION
* `pk` — passed to select the RETURNING column and made `insert` return that column's value. `returning:` now accepts a single column name and returns a single value, so `pk = "id"` maps to `returning: "id"` with the same return shape.

* `id_value` — was returned from `insert` when the database couldn't compute the last inserted id. Callers that pass it already know that value and can use it directly rather than read it back from `insert`.

* `sequence_name` — only reached PostgreSQL's `use_insert_returning?` currval fallback, which is deprecated on its own.

The three warnings are fired independently so each argument's migration path is called out on its own.

Note: on the deprecated `@use_insert_returning = false` path, PG's `insert` override resolves `sequence_name` from `pk` and re-triggers the `sequence_name` warning via `super`. Acceptable noise given the config is already deprecated.
