### PR TITLE
Make `ActiveModel#model_name` accessible from a Ractor:

### DIFF
--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -209,6 +209,13 @@ module ActiveModel
       @uncountable
     end
 
+    def freeze
+      i18n_keys
+      i18n_scope
+
+      super
+    end
+
     private
       MISSING_TRANSLATION = -(2**60) # :nodoc:
 
@@ -267,12 +274,13 @@ module ActiveModel
     #   Person.model_name.singular # => "person"
     #   Person.model_name.plural   # => "people"
     def model_name
-      @_model_name ||= begin
-        namespace = module_parents.detect do |n|
-          n.respond_to?(:use_relative_model_naming?) && n.use_relative_model_naming?
-        end
-        ActiveModel::Name.new(self, namespace)
+      return @_model_name if @_model_name
+
+      namespace = module_parents.detect do |n|
+        n.respond_to?(:use_relative_model_naming?) && n.use_relative_model_naming?
       end
+      @_model_name = ActiveModel::Name.new(self, namespace)
+      ActiveSupport::Ractors.make_shareable(@_model_name)
     end
 
     # Returns the plural class name of a record or class.

--- a/activemodel/test/cases/naming_test.rb
+++ b/activemodel/test/cases/naming_test.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_support/testing/ractors_assertions"
 require "cases/helper"
 require "models/contact"
 require "models/sheep"
@@ -181,6 +182,8 @@ class NamingWithSuppliedLocaleTest < ActiveModel::TestCase
 end
 
 class NamingUsingRelativeModelNameTest < ActiveModel::TestCase
+  include ActiveSupport::Testing::RactorsAssertions
+
   def setup
     @model_name = Blog::Post.model_name
   end
@@ -215,6 +218,29 @@ class NamingUsingRelativeModelNameTest < ActiveModel::TestCase
 
   def test_i18n_key
     assert_equal :"blog/post", @model_name.i18n_key
+  end
+
+  def test_accessible_from_a_ractor
+    fake_model = Class.new do
+      extend ActiveModel::Translation
+
+      def self.name
+        "FakePost"
+      end
+    end
+
+    fake_model.model_name
+
+    assert_nothing_raised do
+      on_ractor do
+        model_name = fake_model.model_name
+
+        # TODO: Unstub I18n once it is ractor safe.
+        I18n.stub(:translate, ->(*) { }) do
+          model_name.human
+        end
+      end
+    end
   end
 end
 


### PR DESCRIPTION
### Motivation / Background

In order to be able to call `AM#model_name` and then call methods on it, we need to freeze the instance and eagerly set values.

### Detail

The associated test is a bit unusual but basically does two things:

1. The test creates a new class model. This is to ensure no memoized values are set on a existing model used in previous tests.
2. We stub I18n because that library isn't ractor safe and the test would just fail.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
