### PR TITLE
Remove dead binds handling in AR log subscribers

### DIFF
--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -53,25 +53,6 @@ module ActiveRecord
     end
 
     private
-      def type_casted_binds(casted_binds)
-        casted_binds.respond_to?(:call) ? casted_binds.call : casted_binds
-      end
-
-      def render_bind(attr, value)
-        case attr
-        when ActiveModel::Attribute
-          if attr.type.binary? && attr.value
-            value = "<#{attr.value_for_database.to_s.bytesize} bytes of binary data>"
-          end
-        when Array
-          attr = attr.first
-        else
-          attr = nil
-        end
-
-        [attr&.name, value]
-      end
-
       def colorize_payload_name(name, payload_name)
         if payload_name.blank? || payload_name == "SQL" # SQL vs Model Load/Exists
           color(name, MAGENTA, bold: true)
@@ -131,10 +112,6 @@ module ActiveRecord
 
       def query_source_location
         backtrace_cleaner.first_clean_frame
-      end
-
-      def filter(name, value)
-        ActiveRecord::Base.inspection_filter.filter_param(name, value)
       end
   end
 end

--- a/activerecord/lib/active_record/structured_event_subscriber.rb
+++ b/activerecord/lib/active_record/structured_event_subscriber.rb
@@ -30,16 +30,8 @@ module ActiveRecord
 
         binds = []
         payload[:binds].each_with_index do |attr, i|
-          attribute_name = if attr.respond_to?(:name)
-            attr.name
-          elsif attr.respond_to?(:[]) && attr[i].respond_to?(:name)
-            attr[i].name
-          else
-            nil
-          end
-
+          attribute_name = attr.name if attr.is_a?(ActiveModel::Attribute)
           filtered_params = filter(attribute_name, casted_params[i])
-
           binds << render_bind(attr, filtered_params)
         end
       end
@@ -62,13 +54,10 @@ module ActiveRecord
       end
 
       def render_bind(attr, value)
-        case attr
-        when ActiveModel::Attribute
+        if attr.is_a?(ActiveModel::Attribute)
           if attr.type.binary? && attr.value
             value = "<#{attr.value_for_database.to_s.bytesize} bytes of binary data>"
           end
-        when Array
-          attr = attr.first
         else
           attr = nil
         end


### PR DESCRIPTION
Since #55900, `LogSubscriber#sql` just `.inspect`s the pre-formatted `payload[:binds]` from `StructuredEventSubscriber`. Drop the now-dead `render_bind`, `type_casted_binds`, and `filter` helpers.

In `StructuredEventSubscriber`, drop the fallbacks for the legacy `[[column, value], ...]` binds format (removed in Rails 7.0, 2d821ef0c5): the `when Array` branch in `render_bind` and the parallel branch in the `attribute_name` lookup.
