### PR TITLE
Honor exclude_end? in Range#to_fs(:db)

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Honor `exclude_end?` in `Range#to_fs(:db)`.
+
+    Exclusive ranges were formatted with inclusive `BETWEEN` / `<=` bounds.
+    Exclusive ends now use `>= ... AND < ...` or `< ...`.
+
+    *Said Kaldybaev*
+
 *   Fix `Range#sum` with a falsey initial value.
 
     Summing an integer range with a falsey starting value (such as nil or false)

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Honor `exclude_end?` in `Range#to_fs(:db)`.
+
+    Exclusive ranges were formatted with inclusive `BETWEEN` / `<=` bounds.
+    Exclusive ends now use `>= ... AND < ...` or `< ...`.
+
+    *Said Kaldybaev*
+
 *   Add `Pacific Time (Canada)` and `Alberta` to `ActiveSupport::TimeZone::MAPPING`.
 
     British Columbia and Alberta no longer share winter clocks with US Pacific

--- a/activesupport/lib/active_support/core_ext/range/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/range/conversions.rb
@@ -6,24 +6,30 @@ module ActiveSupport
   # ==================
   module RangeWithFormat
     RANGE_FORMATS = {
-      db: -> (start, stop) do
+      db: -> (range) do
+        start, stop = range.begin, range.end
+        exclusive = range.exclude_end?
+
+        format_bound = ->(value) do
+          case value
+          when String then value
+          else value.to_fs(:db)
+          end
+        end
+
         if start && stop
-          case start
-          when String then "BETWEEN '#{start}' AND '#{stop}'"
+          if exclusive
+            ">= '#{format_bound[start]}' AND < '#{format_bound[stop]}'"
           else
-            "BETWEEN '#{start.to_fs(:db)}' AND '#{stop.to_fs(:db)}'"
+            "BETWEEN '#{format_bound[start]}' AND '#{format_bound[stop]}'"
           end
         elsif start
-          case start
-          when String then ">= '#{start}'"
-          else
-            ">= '#{start.to_fs(:db)}'"
-          end
+          ">= '#{format_bound[start]}'"
         elsif stop
-          case stop
-          when String then "<= '#{stop}'"
+          if exclusive
+            "< '#{format_bound[stop]}'"
           else
-            "<= '#{stop.to_fs(:db)}'"
+            "<= '#{format_bound[stop]}'"
           end
         end
       end
@@ -39,25 +45,32 @@ module ActiveSupport
     # range.to_s                 # => "1..100"
     # range.to_fs(:db)           # => "BETWEEN '1' AND '100'"
     #
+    # range = (1...100)          # => 1...100
+    # range.to_fs(:db)           # => ">= '1' AND < '100'"
+    #
     # range = (1..)              # => 1..
     # range.to_fs(:db)           # => ">= '1'"
     #
     # range = (..100)            # => ..100
     # range.to_fs(:db)           # => "<= '100'"
+    #
+    # range = (...100)           # => ...100
+    # range.to_fs(:db)           # => "< '100'"
     # ```
     #
     # ## Adding your own range formats to `to_fs`
     #
     # You can add your own formats to the Range::RANGE_FORMATS hash.
     # Use the format name as the hash key and a Proc instance.
+    # The proc receives the range.
     #
     # ```ruby
     # # config/initializers/range_formats.rb
-    # Range::RANGE_FORMATS[:short] = ->(start, stop) { "Between #{start.to_fs(:db)} and #{stop.to_fs(:db)}" }
+    # Range::RANGE_FORMATS[:short] = ->(range) { "Between #{range.begin.to_fs(:db)} and #{range.end.to_fs(:db)}" }
     # ```
     def to_fs(format = :default)
       if formatter = RANGE_FORMATS[format]
-        formatter.call(self.begin, self.end)
+        formatter.call(self)
       else
         to_s
       end

--- a/activesupport/lib/active_support/core_ext/range/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/range/conversions.rb
@@ -4,24 +4,30 @@ module ActiveSupport
   # = \Range With Format
   module RangeWithFormat
     RANGE_FORMATS = {
-      db: -> (start, stop) do
+      db: -> (range) do
+        start, stop = range.begin, range.end
+        exclusive = range.exclude_end?
+
+        format_bound = ->(value) do
+          case value
+          when String then value
+          else value.to_fs(:db)
+          end
+        end
+
         if start && stop
-          case start
-          when String then "BETWEEN '#{start}' AND '#{stop}'"
+          if exclusive
+            ">= '#{format_bound[start]}' AND < '#{format_bound[stop]}'"
           else
-            "BETWEEN '#{start.to_fs(:db)}' AND '#{stop.to_fs(:db)}'"
+            "BETWEEN '#{format_bound[start]}' AND '#{format_bound[stop]}'"
           end
         elsif start
-          case start
-          when String then ">= '#{start}'"
-          else
-            ">= '#{start.to_fs(:db)}'"
-          end
+          ">= '#{format_bound[start]}'"
         elsif stop
-          case stop
-          when String then "<= '#{stop}'"
+          if exclusive
+            "< '#{format_bound[stop]}'"
           else
-            "<= '#{stop.to_fs(:db)}'"
+            "<= '#{format_bound[stop]}'"
           end
         end
       end
@@ -36,21 +42,20 @@ module ActiveSupport
     #   range.to_s                 # => "1..100"
     #   range.to_fs(:db)           # => "BETWEEN '1' AND '100'"
     #
+    #   range = (1...100)          # => 1...100
+    #   range.to_fs(:db)           # => ">= '1' AND < '100'"
+    #
     #   range = (1..)              # => 1..
     #   range.to_fs(:db)           # => ">= '1'"
     #
     #   range = (..100)            # => ..100
     #   range.to_fs(:db)           # => "<= '100'"
     #
-    # == Adding your own range formats to to_fs
-    # You can add your own formats to the Range::RANGE_FORMATS hash.
-    # Use the format name as the hash key and a Proc instance.
-    #
-    #   # config/initializers/range_formats.rb
-    #   Range::RANGE_FORMATS[:short] = ->(start, stop) { "Between #{start.to_fs(:db)} and #{stop.to_fs(:db)}" }
+    #   range = (...100)           # => ...100
+    #   range.to_fs(:db)           # => "< '100'"
     def to_fs(format = :default)
       if formatter = RANGE_FORMATS[format]
-        formatter.call(self.begin, self.end)
+        formatter.call(self)
       else
         to_s
       end

--- a/activesupport/test/core_ext/range_ext_test.rb
+++ b/activesupport/test/core_ext/range_ext_test.rb
@@ -12,6 +12,13 @@ class RangeTest < ActiveSupport::TestCase
     assert_equal "BETWEEN '2005-12-10' AND '2005-12-12'", date_range.to_formatted_s(:db)
   end
 
+  def test_to_fs_db_exclusive_end
+    assert_equal ">= '1' AND < '5'", (1...5).to_fs(:db)
+    assert_equal ">= 'a' AND < 'z'", ("a"..."z").to_fs(:db)
+    assert_equal "< '100'", (...100).to_fs(:db)
+    assert_equal "BETWEEN '1' AND '5'", (1..5).to_fs(:db)
+  end
+
   def test_to_fs_from_times
     date_range = Time.utc(2005, 12, 10, 15, 30)..Time.utc(2005, 12, 10, 17, 30)
     assert_equal "BETWEEN '2005-12-10 15:30:00' AND '2005-12-10 17:30:00'", date_range.to_fs(:db)


### PR DESCRIPTION
### Motivation / Background

Exclusive ranges (like 1...100) were formatted the same as inclusive ones for the database format. SQL `BETWEEN` includes both ends, so exclusive ranges were represented incorrectly.

### Detail

When the range excludes its end, emit greater-than-or-equal / less-than bounds instead of `BETWEEN` (or less-than alone for a beginless exclusive range). Inclusive ranges are unchanged.

**Before:**
```ruby
(1...100).to_fs(:db)  # => "BETWEEN '1' AND '100'"
(...100).to_fs(:db)   # => "<= '100'"
```

**After:**
```ruby
(1...100).to_fs(:db)  # => ">= '1' AND < '100'"
(...100).to_fs(:db)   # => "< '100'"
(1..100).to_fs(:db)   # => "BETWEEN '1' AND '100'"  (unchanged)
```

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.