### PR TITLE
Fix releaser_test with_env helper and GITHUB_ACTIONS isolation

### DIFF
--- a/tools/releaser/test/releaser_test.rb
+++ b/tools/releaser/test/releaser_test.rb
@@ -236,7 +236,9 @@ class TestReleaser < Minitest::Test
     sha = "abcdef"
     path = "pkg/activesupport-5.0.0.gem"
 
-    assert_equal "abcdef  pkg/activesupport-5.0.0.gem", releaser.checksum_line(sha, path)
+    with_env("GITHUB_ACTIONS" => nil) do
+      assert_equal "abcdef  pkg/activesupport-5.0.0.gem", releaser.checksum_line(sha, path)
+    end
   end
 
   def test_checksum_line_returns_a_notice_annotation_when_in_github_actions
@@ -252,10 +254,11 @@ class TestReleaser < Minitest::Test
 
   private
     def with_env(env)
-      previous = env.keys.index_with { |key| ENV[key] }
-      env.each { |key, value| ENV[key] = value }
+      # tools/releaser does not load Active Support, so index_with is unavailable.
+      previous = env.keys.to_h { |key| [key, ENV[key]] } # rubocop:disable Rails/IndexWith
+      env.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
       yield
     ensure
-      previous.each { |key, value| ENV[key] = value }
+      previous.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
     end
 end

--- a/tools/releaser/test/releaser_test.rb
+++ b/tools/releaser/test/releaser_test.rb
@@ -252,7 +252,7 @@ class TestReleaser < Minitest::Test
 
   private
     def with_env(env)
-      previous = env.keys.to_h { |key| [key, ENV[key]] }
+      previous = env.keys.index_with { |key| ENV[key] }
       env.each { |key, value| ENV[key] = value }
       yield
     ensure


### PR DESCRIPTION
### Motivation / Background

RuboCop failed on `tools/releaser/test/releaser_test.rb` for `Rails/IndexWith`. Using `index_with` is not an option here because the releaser test suite does not load Active Support, so the helper crashed in CI. The non-Actions checksum test also failed under GitHub Actions because `GITHUB_ACTIONS` was already set.

### Detail

- Keep a plain `to_h` snapshot with an inline `Rails/IndexWith` disable (no Active Support).
- Allow `with_env` to clear keys via `nil`.
- Unset `GITHUB_ACTIONS` when asserting the plain checksum line format.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.