### PR TITLE
Require concurrent before using in ActionCable

### DIFF
--- a/actioncable/lib/action_cable/channel/base.rb
+++ b/actioncable/lib/action_cable/channel/base.rb
@@ -4,6 +4,7 @@
 
 require "active_support/rescuable"
 require "active_support/parameter_filter"
+require "concurrent"
 
 module ActionCable
   module Channel

--- a/actioncable/lib/action_cable/server/base.rb
+++ b/actioncable/lib/action_cable/server/base.rb
@@ -2,6 +2,7 @@
 
 # :markup: markdown
 
+require "concurrent"
 require "monitor"
 
 module ActionCable


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created to address a crash when loading actioncable directly:

    ruby -Iactivesupport/lib -Iactioncable/lib \
      -e 'require "action_cable"; ActionCable.server.executor'

### Detail

This Pull Request address the bug by adding the relevant requires.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
