### PR TITLE
Fix releaser_test/rubocop

### DIFF
--- a/tools/releaser/test/releaser_test.rb
+++ b/tools/releaser/test/releaser_test.rb
@@ -251,11 +251,11 @@ class TestReleaser < Minitest::Test
   end
 
   private
-    def with_env(env)
-      previous = env.keys.to_h { |key| [key, ENV[key]] }
-      env.each { |key, value| ENV[key] = value }
+    def with_env(kv)
+      old_values = {}
+      kv.each { |key, value| old_values[key], ENV[key] = ENV[key], value }
       yield
     ensure
-      previous.each { |key, value| ENV[key] = value }
+      old_values.each { |key, value| ENV[key] = value }
     end
 end

--- a/tools/releaser/test/releaser_test.rb
+++ b/tools/releaser/test/releaser_test.rb
@@ -236,7 +236,9 @@ class TestReleaser < Minitest::Test
     sha = "abcdef"
     path = "pkg/activesupport-5.0.0.gem"
 
-    assert_equal "abcdef  pkg/activesupport-5.0.0.gem", releaser.checksum_line(sha, path)
+    with_env("GITHUB_ACTIONS" => "false") do
+      assert_equal "abcdef  pkg/activesupport-5.0.0.gem", releaser.checksum_line(sha, path)
+    end
   end
 
   def test_checksum_line_returns_a_notice_annotation_when_in_github_actions


### PR DESCRIPTION
Just copy the with_env implementation from Active Support tests

---

[Fix releaser test assuming GITHUB_ACTIONS is false](https://github.com/rails/rails/pull/58304/commits/153f6bf4bcfe4682640793529854c8bab78ecc6e)

The GITHUB_ACTIONS=true branch is covered by explicitly setting the ENV
(which works locally), but the GITHUB_ACTIONS=false branch also needs to
be explicitly set when running the tests in GIthub actions