### PR TITLE
Require `active_support/rails` in `rails/railtie`

### DIFF
--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_support/rails"
 require "rails/initializable"
 require "active_support/descendants_tracker"
 require "active_support/inflector"


### PR DESCRIPTION
`require "rails/railtie"` on its own raises `NoMethodError` on 8.1:

```
$ ruby -e 'require "rails/railtie"'
.../rails/initializable.rb:41:in '<class:Collection>': undefined method 'delegate_missing_to' for class Rails::Initializable::Collection (NoMethodError)

      delegate_missing_to :@collection
      ^^^^^^^^^^^^^^^^^^^
```

The same require loads on 8.0.5, so this is a regression that shipped in 8.1 (9c43c5bda5).

Gems that load their railtie before Rails itself is loaded reach it: `terser/railtie` loads on 8.0.5, raises the `NoMethodError` above on 8.1.3, and loads again with this change. `inline_svg/railtie`, `simple_form/railtie` and `scenic/railtie` raise the same way on 8.1.3.

`active_support/rails` is the prelude that provides `delegate_missing_to`, and it is what the other railties entry points needing it already require — `rails.rb` and `rails/command.rb`, both since 1db66c0d4e. `./tools/railspect requires .` produces identical output with and without this change.