### PR TITLE
Avoid redundant worker pool dispatch for default Action Cable streams

### DIFF
--- a/actioncable/lib/action_cable/channel/streams.rb
+++ b/actioncable/lib/action_cable/channel/streams.rb
@@ -163,8 +163,12 @@ module ActionCable
         def worker_pool_stream_handler(broadcasting, user_handler, coder: nil)
           handler = stream_handler(broadcasting, user_handler, coder: coder)
 
-          -> message do
-            connection.perform_work handler, :call, message
+          if user_handler
+            -> message do
+              connection.perform_work handler, :call, message
+            end
+          else
+            handler
           end
         end
 
@@ -193,24 +197,29 @@ module ActionCable
           stream_transmitter stream_decoder(coder: coder), broadcasting: broadcasting
         end
 
-        def stream_decoder(handler = identity_handler, coder:)
+        def stream_decoder(handler = nil, coder:)
           if coder
-            -> message { handler.(coder.decode(message)) }
+            -> message do
+              message = coder.decode(message)
+
+              if handler
+                handler.(message)
+              else
+                message
+              end
+            end
           else
             handler
           end
         end
 
-        def stream_transmitter(handler = identity_handler, broadcasting:)
+        def stream_transmitter(handler = nil, broadcasting:)
           via = "streamed from #{broadcasting}"
 
           -> (message) do
-            transmit handler.(message), via: via
+            message = handler.(message) if handler
+            transmit message, via: via
           end
-        end
-
-        def identity_handler
-          -> message { message }
         end
     end
   end

--- a/actioncable/test/channel/stream_test.rb
+++ b/actioncable/test/channel/stream_test.rb
@@ -377,6 +377,20 @@ module ActionCable::StreamTests
       end
     end
 
+    test "default stream handlers do not run through the worker pool" do
+      run_in_eventmachine do
+        open_connection
+        subscribe_to identifiers: { id: 1 }
+
+        assert_not_called socket, :perform_work do
+          server.broadcast "test_room_1", { foo: "bar" }
+          wait_for_async
+        end
+
+        assert_equal({ "foo" => "bar" }, socket.last_transmission.fetch("message"))
+      end
+    end
+
     test "subscription confirmation should only be sent out once with multiple stream_from" do
       run_in_eventmachine do
         open_connection


### PR DESCRIPTION
While working on my Rails World talk for Solid Cable, i've been running various benchmarks on the adapters. One such benchmark was spinning up 750 subscribers that all subscribe to the same channel and then n messages a second are sent out on that channel for 300 seconds. I then measure the time between publishing a message and its delivery to each subscriber.

At 10 msgs/sec, neither Redis nor Solid Cable could deliver every message within an acceptable latency window. (after a minute some messages still hadnt delivered) Reducing the msgs/sec to 7 allowed both adapters to complete within a reasonable delivery latency.

At 10 msgs/sec there are only 3000 messages in our data store but it has to deliver those messages 2,250,000 times.

In other benchmarks i'd seen all the adapters can handle far more than 3000 messages in the data store and since all adapters started failing I went looking inside Action Cable for a bottleneck.

Looking through the delivery path, I found that adapters already enqueue subscriber callbacks onto Action Cable’s executor. The stream handler then immediately enqueues the work again onto the connection worker pool. That second dispatch is important for user-supplied callbacks, which may execute arbitrary application code. A default stream only decodes and forwards the payload. Passing every default delivery through both queues adds significant overhead without providing the same isolation benefit. This change executes default handlers on the executor where they are already running, while user callbacks continue to use the worker pool.

750 vus at 7 messages/s from main
| Metric  |  Redis | Solid Cable SQLite  |
| ------- | -----: | -------: |
| Average | 106 ms |   289 ms |
| p95     | 156 ms |               437 ms |

750 vus at 7 messages/s with this change
| Metric  |  Redis | Solid Cable SQLite  |
| ------- | -----: | -------: |
| Average | 90 ms |   127ms  |
| p95     | 123 ms |               180 ms |

This change allows sending 10 msg/s instead of 7 offering an uplift of 35% more messages broadcast with the possibility of a higher ceiling. (I didnt try more than 10 messages)

750 vus at 10 messages/second from main
| Metric  |  Redis | Solid Cable SQLite  |
| ------- | -----: | -------: |
| Average | fails |   fails |
| p95     | fails |             fails |

750 vus at 10 messages/second with this change
| Metric  |  Redis | Solid Cable SQLite  |
| ------- | -----: | -------: |
| Average | 84ms |   160ms |
| p95     | 116ms |             269ms |


### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
