### PR TITLE
Disable GC in autoload initilization

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -346,6 +346,10 @@ it must be set in `config/application.rb` or `config/environments/#{Rails.env}.r
 
 Sets the format used in responses when errors occur in the development environment. Defaults to `:api` for API only apps and `:default` for normal apps.
 
+#### `config.disable_gc`
+
+Disables garbage collection during initialization to reduce boot time, then re-enables it after initialization completes. Defaults to `true` in local environments, and `false` in `production`.
+
 #### `config.disable_sandbox`
 
 Controls whether or not someone can start a console in sandbox mode. This is helpful to avoid a long running session of sandbox console, that could lead a database server to run out of memory. Defaults to `false`.

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,6 +1,7 @@
-*   Disable garbage collection during initialization when the application is
-    autoloaded, and re-enable it after initialization
-    completes. This reduces boot time by avoiding GC.
+*   Add `config.disable_gc` to disable garbage collection during
+    initialization, and re-enable it after initialization completes. This
+    reduces boot time by avoiding GC. Disabled by default; enable with
+    `config.disable_gc = true`.
 
     *Gannon McGibbon*
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Disable garbage collection during initialization when the application is
+    autoloaded, and re-enable it after initialization
+    completes. This reduces boot time by avoiding GC.
+
+    *Gannon McGibbon*
+
 *   Don't filter nonexistent i18n paths on initialize. This negatively impacts
     applications with lots of translation files.
 

--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -30,9 +30,10 @@ module Rails
         end
       end
 
-      # Disable garbage collection during boot for autoloaded environments.
+      # Disable garbage collection during boot to reduce boot time by avoiding
+      # GC. Disabled by default; enable with +config.disable_gc = true+.
       initializer :disable_gc, after: :set_eager_load, before: :bootstrap_hook do
-        GC.disable unless config.eager_load
+        GC.disable if config.disable_gc
       end
 
       # Initialize the logger early in the stack in case we need to log some deprecation.

--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -30,6 +30,11 @@ module Rails
         end
       end
 
+      # Disable garbage collection during boot for autoloaded environments.
+      initializer :disable_gc, after: :set_eager_load, before: :bootstrap_hook do
+        GC.disable unless config.eager_load
+      end
+
       # Initialize the logger early in the stack in case we need to log some deprecation.
       initializer :initialize_logger, group: :all do
         Rails.logger ||= config.logger || begin

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -25,7 +25,8 @@ module Rails
                     :content_security_policy_nonce_auto,
                     :require_master_key, :credentials, :disable_sandbox, :sandbox_by_default,
                     :add_autoload_paths_to_load_path, :rake_eager_load, :server_timing, :log_file_size,
-                    :dom_testing_default_html_version, :yjit, :action_on_early_load_hook
+                    :dom_testing_default_html_version, :yjit, :action_on_early_load_hook,
+                    :disable_gc
 
       attr_reader :encoding, :api_only, :loaded_config_version, :log_level
 
@@ -87,6 +88,7 @@ module Rails
         @dom_testing_default_html_version        = :html4
         @yjit                                    = false
         @action_on_early_load_hook               = :log
+        @disable_gc                              = false
       end
 
       # Loads default configuration values for a target version. This includes

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -236,7 +236,7 @@ module Rails
       end
 
       initializer :enable_gc do
-        GC.enable unless config.eager_load
+        GC.enable if config.disable_gc
       end
     end
   end

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -234,6 +234,10 @@ module Rails
           RubyVM::YJIT.enable(**options)
         end
       end
+
+      initializer :enable_gc do
+        GC.enable unless config.eager_load
+      end
     end
   end
 end

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -9,6 +9,9 @@ Rails.application.configure do
   # Do not eager load code on boot.
   config.eager_load = false
 
+  # Disable garbage collection during boot to reduce boot time.
+  config.disable_gc = true
+
   # Show full error reports.
   config.consider_all_requests_local = true
 

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -19,6 +19,9 @@ Rails.application.configure do
   # from config.rake_eager_load.
   config.rake_eager_load = ENV["CI"].present?
 
+  # Disable garbage collection during boot to reduce boot time.
+  config.disable_gc = ENV["CI"].present?
+
   # Configure public file server for tests with cache-control for performance.
   config.public_file_server.headers = { "cache-control" => "public, max-age=3600" }
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1497,8 +1497,10 @@ module ApplicationTests
       end
     end
 
-    test "gc is disabled during autoload init" do
+    test "gc is disabled when config.disable_gc is true" do
       add_to_config <<-RUBY
+        config.disable_gc = true
+
         initializer :check_gc_enabled, after: :disable_gc do
           ::GC_WAS_DISABLED = GC.disable
         end
@@ -1507,20 +1509,6 @@ module ApplicationTests
       app "development"
 
       assert GC_WAS_DISABLED
-    end
-
-    test "gc is enabled during eager load init" do
-      add_to_config <<-RUBY
-        config.eager_load = true
-
-        initializer :check_gc_enabled, after: :disable_gc do
-          ::GC_WAS_ENABLED = !GC.enable
-        end
-      RUBY
-
-      app "development"
-
-      assert GC_WAS_ENABLED
     end
 
     test "valid beginning of week is setup correctly" do

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1497,6 +1497,32 @@ module ApplicationTests
       end
     end
 
+    test "gc is disabled during autoload init" do
+      add_to_config <<-RUBY
+        initializer :check_gc_enabled, after: :disable_gc do
+          ::GC_WAS_DISABLED = GC.disable
+        end
+      RUBY
+
+      app "development"
+
+      assert GC_WAS_DISABLED
+    end
+
+    test "gc is enabled during eager load init" do
+      add_to_config <<-RUBY
+        config.eager_load = true
+
+        initializer :check_gc_enabled, after: :disable_gc do
+          ::GC_WAS_ENABLED = !GC.enable
+        end
+      RUBY
+
+      app "development"
+
+      assert GC_WAS_ENABLED
+    end
+
     test "valid beginning of week is setup correctly" do
       add_to_config <<-RUBY
         config.root = "#{app_path}"

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -88,6 +88,7 @@ module SharedGeneratorTests
     assert_file "#{application_path}/config/environments/development.rb" do |content|
       assert_match(/config\.action_mailer\.raise_delivery_errors = false/, content)
       assert_match(/config\.active_storage/, content)
+      assert_match(/config\.disable_gc = true/, content)
     end
     assert_file "#{application_path}/config/environments/test.rb" do |content|
       assert_match(/config\.action_mailer\.delivery_method = :test/, content)


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I noticed my app is spending a lot of time in GC when it doesn't necessarily need to be. In autoloaded contexts, you shouldn't have a lot of code to load upfront, so disabling GC should be safe, and save some time on large applications.

### Detail

This Pull Request adds two initializers to disable GC when eager loading is false, and turn it back on again, when eager loading is false. __It may be worth hiding this behind a configuration instead, as to not disrupt poorly optimized Rails applications.__

Here's what my time looks like before and after this patch:

Before:
<img width="241" height="115" alt="Screenshot 2026-07-29 at 11 23 22 PM" src="https://github.com/user-attachments/assets/67174f5a-6735-4f51-abd5-af12ca4d03c7" />

After:
<img width="270" height="84" alt="Screenshot 2026-07-29 at 11 17 55 PM" src="https://github.com/user-attachments/assets/bd995411-7d45-4c12-b933-52befebb10c2" />

The overall time seems faster. Some time is still spend in GC before Rails initialization. Mostly gem loading.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
