### PR TITLE
Rename `arel` to `arel_or_sql`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -9,18 +9,18 @@ module ActiveRecord
       end
 
       # Converts an arel AST to SQL
-      def to_sql(arel_or_sql_string, binds = [])
-        sql, _ = to_sql_and_binds(arel_or_sql_string, binds)
+      def to_sql(arel_or_sql, binds = [])
+        sql, _ = to_sql_and_binds(arel_or_sql, binds)
         sql
       end
 
-      def to_sql_and_binds(arel_or_sql_string, binds = [], preparable = nil, allow_retry = false) # :nodoc:
+      def to_sql_and_binds(arel_or_sql, binds = [], preparable = nil, allow_retry = false) # :nodoc:
         # Arel::TreeManager -> Arel::Node
-        if arel_or_sql_string.respond_to?(:ast)
-          arel_or_sql_string = arel_or_sql_string.ast
+        if arel_or_sql.respond_to?(:ast)
+          arel_or_sql = arel_or_sql.ast
         end
 
-        if Arel.arel_node?(arel_or_sql_string) && !(String === arel_or_sql_string)
+        if Arel.arel_node?(arel_or_sql) && !(String === arel_or_sql)
           unless binds.empty?
             raise "Passing bind parameters with an arel AST is forbidden. " \
               "The values must be stored on the AST directly"
@@ -31,22 +31,22 @@ module ActiveRecord
 
           if prepared_statements
             collector.preparable = true
-            sql, binds = visitor.compile(arel_or_sql_string, collector)
+            sql, binds = visitor.compile(arel_or_sql, collector)
 
             if binds.length > bind_params_length
               unprepared_statement do
-                return to_sql_and_binds(arel_or_sql_string)
+                return to_sql_and_binds(arel_or_sql)
               end
             end
             preparable = collector.preparable
           else
-            sql = visitor.compile(arel_or_sql_string, collector)
+            sql = visitor.compile(arel_or_sql, collector)
           end
           allow_retry = collector.retryable
           [sql.freeze, binds, preparable, allow_retry]
         else
-          arel_or_sql_string = arel_or_sql_string.dup.freeze unless arel_or_sql_string.frozen?
-          [arel_or_sql_string, binds, preparable, allow_retry]
+          arel_or_sql = arel_or_sql.dup.freeze unless arel_or_sql.frozen?
+          [arel_or_sql, binds, preparable, allow_retry]
         end
       end
 
@@ -231,7 +231,7 @@ module ActiveRecord
         intent.cast_result
       end
 
-      def explain(arel, binds = [], options = []) # :nodoc:
+      def explain(arel_or_sql, binds = [], options = []) # :nodoc:
         raise NotImplementedError
       end
 
@@ -248,7 +248,7 @@ module ActiveRecord
       # what the method returns: +nil+ (default) returns the id via
       # +last_inserted_id+; a column name returns that column as a single
       # value; an array of column names returns an Array of column values.
-      def insert(arel, name = nil, pk = nil, id_value = nil, sequence_name = nil, binds = [], returning: nil)
+      def insert(arel_or_sql, name = nil, pk = nil, id_value = nil, sequence_name = nil, binds = [], returning: nil)
         # The `pk` positional argument is really the RETURNING column name.
         # Translate it to `returning:` — including the legacy `false` sentinel
         # meaning "no primary key / skip RETURNING".
@@ -258,7 +258,7 @@ module ActiveRecord
           returning ||= pk
         end
 
-        intent = QueryIntent.new(adapter: self, arel: arel, name: name, binds: binds)
+        intent = QueryIntent.new(adapter: self, arel: arel_or_sql, name: name, binds: binds)
 
         value = _exec_insert(intent, sequence_name, returning: returning)
 
@@ -274,8 +274,8 @@ module ActiveRecord
       alias create insert
 
       # Executes the update statement and returns the number of rows affected.
-      def update(arel, name = nil, binds = [])
-        intent = QueryIntent.new(adapter: self, arel: arel, name: name, binds: binds)
+      def update(arel_or_sql, name = nil, binds = [])
+        intent = QueryIntent.new(adapter: self, arel: arel_or_sql, name: name, binds: binds)
 
         intent.execute!
         intent.affected_rows
@@ -293,8 +293,8 @@ module ActiveRecord
       end
 
       # Executes the delete statement and returns the number of rows affected.
-      def delete(arel, name = nil, binds = [])
-        intent = QueryIntent.new(adapter: self, arel: arel, name: name, binds: binds)
+      def delete(arel_or_sql, name = nil, binds = [])
+        intent = QueryIntent.new(adapter: self, arel: arel_or_sql, name: name, binds: binds)
 
         intent.execute!
         intent.affected_rows

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -24,8 +24,8 @@ module ActiveRecord
           HIGH_PRECISION_CURRENT_TIMESTAMP
         end
 
-        def explain(arel, binds = [], options = [])
-          sql     = build_explain_clause(options) + " " + to_sql(arel, binds)
+        def explain(arel_or_sql, binds = [], options = [])
+          sql     = build_explain_clause(options) + " " + to_sql(arel_or_sql, binds)
           start   = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           result  = select_all(sql, "EXPLAIN", binds)
           elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -4,8 +4,8 @@ module ActiveRecord
   module ConnectionAdapters
     module PostgreSQL
       module DatabaseStatements
-        def explain(arel, binds = [], options = [])
-          sql    = build_explain_clause(options) + " " + to_sql(arel, binds)
+        def explain(arel_or_sql, binds = [], options = [])
+          sql    = build_explain_clause(options) + " " + to_sql(arel_or_sql, binds)
           result = select_all(sql, "EXPLAIN", binds)
           PostgreSQL::ExplainPrettyPrinter.new.pp(result)
         end
@@ -29,8 +29,8 @@ module ActiveRecord
           !READ_QUERY.match?(sql.b)
         end
 
-        def insert(arel, name = nil, pk = nil, id_value = nil, sequence_name = nil, binds = [], returning: nil) # :nodoc:
-          sequence_name, pk = resolve_currval_for_insert(arel, pk, sequence_name, returning)
+        def insert(arel_or_sql, name = nil, pk = nil, id_value = nil, sequence_name = nil, binds = [], returning: nil) # :nodoc:
+          sequence_name, pk = resolve_currval_for_insert(arel_or_sql, pk, sequence_name, returning)
           super
         end
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -15,8 +15,8 @@ module ActiveRecord
           !READ_QUERY.match?(sql.b)
         end
 
-        def explain(arel, binds = [], _options = [])
-          sql    = "EXPLAIN QUERY PLAN " + to_sql(arel, binds)
+        def explain(arel_or_sql, binds = [], _options = [])
+          sql    = "EXPLAIN QUERY PLAN " + to_sql(arel_or_sql, binds)
           result = query_rows(sql, "EXPLAIN")
           SQLite3::ExplainPrettyPrinter.new.pp(result)
         end


### PR DESCRIPTION
`insert`, `update`, `delete`, `explain`, `to_sql`, and `to_sql_and_binds` all accept both an Arel manager and a raw SQL string, but the parameter names — `arel` on most, `arel_or_sql_string` on the last two — either understate the acceptable types or spell them inconsistently.

Unify on `arel_or_sql`, matching the convention already used in the internal `primary_key_for_insert` / `table_ref_for_insert` helpers. `update_with_result`, which is arel-only, keeps `arel`.
