### PR TITLE
Deprecate passing `binds` to `to_sql`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Deprecate passing `binds` to
+    `ActiveRecord::ConnectionAdapters::DatabaseStatements#to_sql`.
+
+    The argument has been unused since bind parameters were moved into the
+    Arel AST in Rails 5.2 (rails/rails@213796fb49). `to_sql(arel)` returns
+    the same SQL regardless of what is passed as `binds`.
+
+    *Ryuta Kamizono*
+
 *   Deprecate `ActiveRecord::ConnectionAdapters::TransactionState#fully_committed?`,
     `#fully_rolledback?`, `#fully_completed?`, and `#nullify!`.
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -8,9 +8,15 @@ module ActiveRecord
         reset_transaction
       end
 
-      # Converts an arel AST to SQL
-      def to_sql(arel_or_sql, binds = [])
-        sql, _ = to_sql_and_binds(arel_or_sql, binds)
+      def to_sql(arel_or_sql, binds = nil)
+        unless binds.nil?
+          ActiveRecord.deprecator.warn(<<~MSG)
+            Passing `binds` to `to_sql` is deprecated and will be removed in Rails 8.3.
+            The `binds` argument has been unused since bind parameters were moved into
+            the Arel AST in Rails 5.2.
+          MSG
+        end
+        sql, _ = to_sql_and_binds(arel_or_sql)
         sql
       end
 

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -25,7 +25,7 @@ module ActiveRecord
         end
 
         def explain(arel_or_sql, binds = [], options = [])
-          sql     = build_explain_clause(options) + " " + to_sql(arel_or_sql, binds)
+          sql     = build_explain_clause(options) + " " + to_sql(arel_or_sql)
           start   = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           result  = select_all(sql, "EXPLAIN", binds)
           elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     module PostgreSQL
       module DatabaseStatements
         def explain(arel_or_sql, binds = [], options = [])
-          sql    = build_explain_clause(options) + " " + to_sql(arel_or_sql, binds)
+          sql    = build_explain_clause(options) + " " + to_sql(arel_or_sql)
           result = select_all(sql, "EXPLAIN", binds)
           PostgreSQL::ExplainPrettyPrinter.new.pp(result)
         end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -16,7 +16,7 @@ module ActiveRecord
         end
 
         def explain(arel_or_sql, binds = [], _options = [])
-          sql    = "EXPLAIN QUERY PLAN " + to_sql(arel_or_sql, binds)
+          sql    = "EXPLAIN QUERY PLAN " + to_sql(arel_or_sql)
           result = query_rows(sql, "EXPLAIN")
           SQLite3::ExplainPrettyPrinter.new.pp(result)
         end

--- a/activerecord/test/cases/database_statements_test.rb
+++ b/activerecord/test/cases/database_statements_test.rb
@@ -40,6 +40,13 @@ class DatabaseStatementsTest < ActiveRecord::TestCase
     assert_equal "table-with-hyphen", @connection.send(:extract_table_ref_from_insert_sql, sql)
   end
 
+  def test_to_sql_binds_arg_is_deprecated
+    sql = "SELECT 1"
+    assert_deprecated(/Passing `binds` to `to_sql`/, ActiveRecord.deprecator) do
+      assert_equal sql, @connection.to_sql(sql, [])
+    end
+  end
+
   private
     def return_the_inserted_id(method:)
       @connection.send(method, "INSERT INTO accounts (firm_id,credit_limit) VALUES (42,5000)")


### PR DESCRIPTION
Since Rails 5.2 (rails/rails@213796fb49), bind parameters live on the Arel AST — `to_sql_and_binds` no longer uses `binds` for SQL construction, and `to_sql` discards the output binds either way.

`to_sql` was originally extracted as an internal utility (rails/rails@7db90aa7c7) but is documented as public API, so remove via deprecation rather than dropping the argument outright.
