### PR TITLE
Fix `connection.explain(arel)` for Arel input with AST binds

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -25,7 +25,8 @@ module ActiveRecord
         end
 
         def explain(arel_or_sql, binds = [], options = [])
-          sql     = build_explain_clause(options) + " " + to_sql(arel_or_sql)
+          sql, binds = to_sql_and_binds(arel_or_sql, binds)
+          sql = build_explain_clause(options) + " " + sql
           start   = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           result  = select_all(sql, "EXPLAIN", binds)
           elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -5,7 +5,8 @@ module ActiveRecord
     module PostgreSQL
       module DatabaseStatements
         def explain(arel_or_sql, binds = [], options = [])
-          sql    = build_explain_clause(options) + " " + to_sql(arel_or_sql)
+          sql, binds = to_sql_and_binds(arel_or_sql, binds)
+          sql = build_explain_clause(options) + " " + sql
           result = select_all(sql, "EXPLAIN", binds)
           PostgreSQL::ExplainPrettyPrinter.new.pp(result)
         end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -16,7 +16,8 @@ module ActiveRecord
         end
 
         def explain(arel_or_sql, binds = [], _options = [])
-          sql    = "EXPLAIN QUERY PLAN " + to_sql(arel_or_sql)
+          sql, _ = to_sql_and_binds(arel_or_sql, binds)
+          sql = "EXPLAIN QUERY PLAN " + sql
           result = query_rows(sql, "EXPLAIN")
           SQLite3::ExplainPrettyPrinter.new.pp(result)
         end

--- a/activerecord/test/cases/explain_test.rb
+++ b/activerecord/test/cases/explain_test.rb
@@ -153,6 +153,12 @@ if ActiveRecord::Base.lease_connection.supports_explain?
       end
     end
 
+    def test_explain_with_arel
+      message = lease_connection.explain(Car.where(name: "honda").arel)
+      assert_not_empty message
+      assert_match(/cars/i, message)
+    end
+
     private
       def stub_explain_for_query_plans(query_plans = ["query plan foo", "query plan bar"])
         explain_called = 0


### PR DESCRIPTION
`to_sql` compiles Arel to SQL but discards the extracted binds, so the PostgreSQL, SQLite3, and MySQL `explain` overrides ran EXPLAIN with placeholders and no binds — on PostgreSQL:

```
ActiveRecord::StatementInvalid: PG::UndefinedParameter: ERROR:  there is no parameter $1
LINE 1: EXPLAIN SELECT "cars".* FROM "cars" WHERE "cars"."name" = $1
```

Use `to_sql_and_binds` and forward the extracted binds to `select_all`. Raw SQL callers (the current path via `exec_explain`) are unaffected.
