### PR TITLE
Show parameter marker for casted binds in SQL logs and EXPLAIN

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Improve bind parameter rendering for casted binds in SQL logs and EXPLAIN output.
+
+    Queries built with casted binds (an array of values instead of
+    `ActiveModel::Attribute`s) previously rendered the position as `nil`:
+
+    ```
+    SELECT * FROM topics WHERE title = $1  [[nil, "abcd"]]
+    ```
+
+    They now render the position as a numbered parameter marker:
+
+    ```
+    SELECT * FROM topics WHERE title = $1  [["$1", "abcd"]]
+    ```
+
+    *Ryuta Kamizono*
+
 *   Deprecate passing `binds` to
     `ActiveRecord::ConnectionAdapters::DatabaseStatements#to_sql`.
 

--- a/activerecord/lib/active_record/explain.rb
+++ b/activerecord/lib/active_record/explain.rb
@@ -22,7 +22,7 @@ module ActiveRecord
           msg = +"#{build_explain_clause(c, options)} #{sql}"
           unless binds.empty?
             msg << " "
-            msg << binds.map { |attr| render_bind(c, attr) }.inspect
+            msg << binds.map.with_index { |attr, i| render_bind(c, attr, i) }.inspect
           end
           msg << "\n"
           msg << c.explain(sql, binds, options)
@@ -37,19 +37,17 @@ module ActiveRecord
     end
 
     private
-      def render_bind(connection, attr)
+      def render_bind(connection, attr, i)
         if ActiveModel::Attribute === attr
           value = if attr.type.binary? && attr.value
             "<#{attr.value_for_database.to_s.bytesize} bytes of binary data>"
           else
             connection.type_cast(attr.value_for_database)
           end
+          [attr.name, value]
         else
-          value = connection.type_cast(attr)
-          attr  = nil
+          ["$#{i + 1}", connection.type_cast(attr)]
         end
-
-        [attr&.name, value]
       end
 
       def build_explain_clause(connection, options = [])

--- a/activerecord/lib/active_record/structured_event_subscriber.rb
+++ b/activerecord/lib/active_record/structured_event_subscriber.rb
@@ -32,7 +32,7 @@ module ActiveRecord
         payload[:binds].each_with_index do |attr, i|
           attribute_name = attr.name if attr.is_a?(ActiveModel::Attribute)
           filtered_params = filter(attribute_name, casted_params[i])
-          binds << render_bind(attr, filtered_params)
+          binds << render_bind(attr, filtered_params, i)
         end
       end
 
@@ -53,16 +53,15 @@ module ActiveRecord
         casted_binds.respond_to?(:call) ? casted_binds.call : casted_binds
       end
 
-      def render_bind(attr, value)
+      def render_bind(attr, value, i)
         if attr.is_a?(ActiveModel::Attribute)
           if attr.type.binary? && attr.value
             value = "<#{attr.value_for_database.to_s.bytesize} bytes of binary data>"
           end
+          [attr.name, value]
         else
-          attr = nil
+          ["$#{i + 1}", value]
         end
-
-        [attr&.name, value]
       end
 
       def filter(name, value)

--- a/activerecord/test/cases/bind_parameter_test.rb
+++ b/activerecord/test/cases/bind_parameter_test.rb
@@ -322,7 +322,7 @@ if ActiveRecord::Base.lease_connection.prepared_statements
           old_logger = ActiveRecord::LogSubscriber.logger
           ActiveRecord::LogSubscriber.logger = logger = ActiveSupport::LogSubscriber::TestHelper::MockLogger.new
           StructuredEventSubscriber.new.sql(event)
-          assert_match %r(\[\[nil, "abcd"\]\]\z), logger.logged(:debug).last
+          assert_match %r(\[\["\$1", "abcd"\]\]\z), logger.logged(:debug).last
         ensure
           ActiveRecord::LogSubscriber.logger = old_logger
         end

--- a/activerecord/test/cases/explain_test.rb
+++ b/activerecord/test/cases/explain_test.rb
@@ -159,6 +159,23 @@ if ActiveRecord::Base.lease_connection.supports_explain?
       assert_match(/cars/i, message)
     end
 
+    def test_exec_explain_with_casted_binds
+      sqls    = ["foo", "bar"]
+      binds   = [[1, "abcd"], [2]]
+      queries = sqls.zip(binds)
+
+      stub_explain_for_query_plans(["query plan foo\n", "query plan bar\n"]) do
+        expected = <<~SQL
+          #{expected_explain_clause} #{sqls[0]} [["$1", 1], ["$2", "abcd"]]
+          query plan foo
+
+          #{expected_explain_clause} #{sqls[1]} [["$1", 2]]
+          query plan bar
+        SQL
+        assert_equal expected, base.exec_explain(queries)
+      end
+    end
+
     private
       def stub_explain_for_query_plans(query_plans = ["query plan foo", "query plan bar"])
         explain_called = 0

--- a/activerecord/test/cases/log_subscriber_test.rb
+++ b/activerecord/test/cases/log_subscriber_test.rb
@@ -250,6 +250,13 @@ class LogSubscriberTest < ActiveRecord::TestCase
       assert_match(%{["id", 1], ["id", 2], ["id", 3], ["id", 4], ["id", 5]}, @logger.logged(:debug).last)
     end
 
+    def test_casted_binds_logging_uses_parameter_marker
+      bind_param = Arel::Nodes::BindParam.new(nil)
+      sql = "SELECT id FROM developers WHERE name = #{bind_param.to_sql}"
+      ActiveRecord::Base.lease_connection.select_all(sql, "SQL", ["David"])
+      assert_match(%{[["$1", "David"]]}, @logger.logged(:debug).last)
+    end
+
     def test_binary_data_is_not_logged
       Binary.create(data: "some binary data")
       assert_match(/<16 bytes of binary data>/, @logger.logged(:debug).join)


### PR DESCRIPTION
Casted binds (a plain array of values) were introduced in #39106 as a migration target away from the legacy `[[column, value], ...]` binds format, but log readability was not part of that change: without a column name to pair with each value,
`StructuredEventSubscriber#sql` and `Explain#exec_explain` have been rendering the binds as `[[nil, value], ...]`.

Use the parameter position instead:

```
SELECT * FROM topics WHERE title = $1  [["$1", "abcd"]]
```

The `$1` notation mirrors PostgreSQL's parameter markers and makes the log line self-describing regardless of which adapter emitted the `?` in the SQL — the reader can match log entries to positions in the query at a glance.
