### PR TITLE
Run image analysis when the variant processor is disabled

### DIFF
--- a/activestorage/lib/active_storage/analyzer/image_analyzer/image_magick.rb
+++ b/activestorage/lib/active_storage/analyzer/image_analyzer/image_magick.rb
@@ -14,7 +14,7 @@ module ActiveStorage
   # the {ImageMagick}[http://www.imagemagick.org] system library.
   class Analyzer::ImageAnalyzer::ImageMagick < Analyzer::ImageAnalyzer
     def self.accept?(blob)
-      super && ActiveStorage.variant_processor == :mini_magick
+      super && (ActiveStorage.variant_processor == :mini_magick || (ActiveStorage.variant_processor == :disabled && MINIMAGICK_AVAILABLE))
     end
 
     private

--- a/activestorage/lib/active_storage/analyzer/image_analyzer/vips.rb
+++ b/activestorage/lib/active_storage/analyzer/image_analyzer/vips.rb
@@ -7,7 +7,7 @@ module ActiveStorage
   # the {libvips}[https://libvips.github.io/libvips/] system library.
   class Analyzer::ImageAnalyzer::Vips < Analyzer::ImageAnalyzer
     def self.accept?(blob)
-      super && ActiveStorage.variant_processor == :vips
+      super && (ActiveStorage.variant_processor == :vips || (ActiveStorage.variant_processor == :disabled && VIPS_AVAILABLE))
     end
 
     private

--- a/activestorage/test/analyzer/image_analyzer/image_magick_test.rb
+++ b/activestorage/test/analyzer/image_analyzer/image_magick_test.rb
@@ -78,6 +78,22 @@ class ActiveStorage::Analyzer::ImageAnalyzer::ImageMagickTest < ActiveSupport::T
     end
   end
 
+  test "analyzing with variant processing disabled and ruby-vips unavailable" do
+    stub_const(ActiveStorage, :VIPS_AVAILABLE, false) do
+      previous_processor, ActiveStorage.variant_processor = ActiveStorage.variant_processor, :disabled
+
+      blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+      metadata = extract_metadata_from(blob)
+
+      assert_equal 4104, metadata[:width]
+      assert_equal 2736, metadata[:height]
+    rescue LoadError
+      ENV["BUILDKITE"] ? raise : skip("Variant processor image_magick is not installed")
+    ensure
+      ActiveStorage.variant_processor = previous_processor
+    end
+  end
+
   test "instrumenting analysis" do
     blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
 

--- a/activestorage/test/analyzer/image_analyzer/vips_test.rb
+++ b/activestorage/test/analyzer/image_analyzer/vips_test.rb
@@ -79,6 +79,20 @@ class ActiveStorage::Analyzer::ImageAnalyzer::VipsTest < ActiveSupport::TestCase
     end
   end
 
+  test "analyzing with variant processing disabled" do
+    previous_processor, ActiveStorage.variant_processor = ActiveStorage.variant_processor, :disabled
+
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+    metadata = extract_metadata_from(blob)
+
+    assert_equal 4104, metadata[:width]
+    assert_equal 2736, metadata[:height]
+  rescue LoadError
+    ENV["BUILDKITE"] ? raise : skip("Variant processor vips is not installed")
+  ensure
+    ActiveStorage.variant_processor = previous_processor
+  end
+
   test "instrumenting analysis" do
     analyze_with_vips do
       blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")


### PR DESCRIPTION
`config.active_storage.variant_processor = :disabled` is only meant to silence the startup warning about missing image gems. But the image analyzers gate `accept?` on the processor being `:vips` or `:mini_magick`, so disabling it also stopped analysis from running, and `width`/`height` were no longer recorded. This lets the Vips and ImageMagick analyzers accept a blob while the processor is disabled as long as their library is loaded, which restores the 8.0 behavior and keeps the explicit vips/mini_magick selection.

Fixes #58313
