### PR TITLE
Fix belongs_to `touch` option incorrectly triggering on models with composite primary keys

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Fix previous-parent lookup in a composite-key `belongs_to ..., touch: true`
+    callback when there was no previous parent.
+
+    For a composite foreign key, the touch callback built the previous
+    key out of the old attribute values and issued a lookup whenever any foreign
+    key column changed. A first-time association produces a key with `nil`
+    components (e.g. `[nil, shop_id]`), which is a non-empty and therefore truthy
+    Array, so Rails ran a `WHERE ... IS NULL` query for a parent that cannot exist
+    on every insert of such an association. This mirrors the scalar branch, which
+    already skips the lookup when the previous value is `nil`.
+
+    *Martin Samson*
+
 *   Deprecate passing `binds` to
     `ActiveRecord::ConnectionAdapters::DatabaseStatements#to_sql`.
 

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -46,9 +46,10 @@ module ActiveRecord::Associations::Builder # :nodoc:
       old_foreign_id =
         if foreign_key.is_a?(Array)
           if foreign_key.any? { |fk| changes[fk] }
-            foreign_key.map do |fk|
+            old_ids = foreign_key.map do |fk|
               changes[fk] ? changes[fk].first : o.read_attribute(fk)
             end
+            old_ids unless old_ids.any?(&:nil?)
           end
         elsif changes[foreign_key]
           changes[foreign_key].first

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -1807,6 +1807,40 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert book.order_previously_changed?
   end
 
+  test "composite foreign key touch skips the previous-parent lookup when there is no previous parent" do
+    order = Cpk::Order.create!(id: [1, 2])
+
+    assert_no_queries_match(/FROM #{Regexp.escape(Cpk::Order.quoted_table_name)}.*IS NULL/i) do
+      Cpk::TouchableBook.create!(id: [3, 4], order: order)
+    end
+  end
+
+  test "composite foreign key touch skips the previous-parent lookup when only some key columns were set" do
+    order = Cpk::Order.create!(id: [1, 2])
+    book = Cpk::TouchableBook.create!(id: [3, 4], shop_id: order.shop_id)
+    book.reload
+
+    assert_no_queries_match(/FROM #{Regexp.escape(Cpk::Order.quoted_table_name)}.*IS NULL/i) do
+      book.order = order
+      book.save!
+    end
+  end
+
+  test "composite foreign key touch still touches a genuine previous parent on reparent" do
+    old_order = Cpk::Order.create!(id: [1, 2])
+    new_order = Cpk::Order.create!(id: [1, 3])
+    book = Cpk::TouchableBook.create!(id: [3, 4], order: old_order)
+    book.reload
+
+    time = 1.day.ago
+    old_order.touch(time: time)
+
+    book.order = new_order
+    book.save!
+
+    assert_operator old_order.reload.updated_at, :>, time
+  end
+
   class ShipRequired < ActiveRecord::Base
     self.table_name = "ships"
     belongs_to :developer, required: true

--- a/activerecord/test/models/cpk/book.rb
+++ b/activerecord/test/models/cpk/book.rb
@@ -59,4 +59,10 @@ module Cpk
     self.table_name = :cpk_books
     belongs_to :order, class_name: "Cpk::Order", foreign_key: [:shop_id, :order_id], primary_key: [:shop_id, :id], optional: false
   end
+
+  class TouchableBook < ActiveRecord::Base
+    self.table_name = :cpk_books
+    belongs_to :order, class_name: "Cpk::Order", foreign_key: [:shop_id, :order_id],
+      primary_key: [:shop_id, :id], touch: true, optional: true
+  end
 end


### PR DESCRIPTION
### Motivation / Background
This Pull Request has been created because a `belongs_to` association with a composite foreign key and `touch: true` issues a spurious previous-parent lookups, a `WHERE ... IS NULL` query for a parent that cannot exist, on every insert of a new association.

When a foreign-key column changes, the touch callback reconstructs the previous key from the old attribute values and looks up the old parent so it can be touched. For a composite key, a first-time association produces a key with `nil` components (e.g. `[nil, shop_id]`). Because that reconstructed key is a non-empty `Array`, it is truthy, so Active Record runs a `find_by` against a `null` key on every insert of such a record.

The scalar-key branch already guards against this: `changes[foreign_key].first` returns `nil` and short-circuits the lookup. The composite branch was missing the equivalent guard.

### Detail

This Pull Request changes `ActiveRecord::Associations::Builder::BelongsTo.touch_record` to skip the previous-parent lookup when the reconstructed composite key contains any nil component:

```ruby
  old_ids = foreign_key.map do |fk|
    changes[fk] ? changes[fk].first : o.read_attribute(fk)
  end
  old_ids unless old_ids.any?(&:nil?)
```

Returning `nil` instead of the array makes `old_foreign_id` `falsy`, so the lookup is skipped, mirroring the scalar branch. This is safe because a parent record's primary-key columns are never nullable, so a partially-nil key can never match a real parent; no legitimate touch is lost. 

New test coverage in `activerecord/test/cases/associations/belongs_to_associations_test.rb` (with a new `Cpk::TouchableBook` fixture in `test/models/cpk/book.rb`):

 1. No previous parent: a first-time association issues zero `IS NULL` lookups.
 2. Partial key set: only some key columns present still issues zero lookups.
 3. Genuine reparent: a real previous parent is still touched (guards against over-skipping).

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
