### PR TITLE
Add ActiveJob::Debouncing: debounce job enqueues with a class macro

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,28 @@
+*   Add `debounce`, a class macro for debouncing job enqueues.
+
+    A burst of `perform_later` calls collapses into at most two jobs per
+    window: a leading job that runs immediately and a trailing job that
+    sweeps up whatever happened during the window. Callers just enqueue
+    at will.
+
+    ```ruby
+    class BadgeCountPushJob < ApplicationJob
+      debounce within: 30.seconds, by: ->(user) { user.id }
+
+      def perform(user)
+        user.push_badge_count
+      end
+    end
+    ```
+
+    Claims are won through an adapter-agnostic store, defaulting to
+    `Rails.cache.write(..., unless_exist: true)`, and debouncing fails
+    open when the store is unavailable. Each decision emits a
+    `debounce.active_job` event with a `:leading`, `:trailing`,
+    `:suppressed`, or `:failed_open` outcome.
+
+    *Jeremy Daer*
+
 *   Add `ActiveJob::DeserializationError::RecordNotFound`, raised when argument
     deserialization fails because a referenced record could not be found, and not
     for any other reason.

--- a/activejob/lib/active_job/base.rb
+++ b/activejob/lib/active_job/base.rb
@@ -8,6 +8,7 @@ require "active_job/enqueuing"
 require "active_job/execution"
 require "active_job/callbacks"
 require "active_job/exceptions"
+require "active_job/debouncing"
 require "active_job/log_subscriber"
 require "active_job/structured_event_subscriber"
 require "active_job/logging"
@@ -69,6 +70,7 @@ module ActiveJob # :nodoc:
     include Execution
     include Callbacks
     include Exceptions
+    include Debouncing
     include Instrumentation
     include Logging
     include ExecutionState

--- a/activejob/lib/active_job/debouncing.rb
+++ b/activejob/lib/active_job/debouncing.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+# :markup: markdown
+
+module ActiveJob
+  # # Active Job Debouncing
+  #
+  # Provides a class macro for debouncing job enqueues. A burst of
+  # `perform_later` calls collapses into at most two jobs per window: a leading
+  # job that runs immediately and a trailing job that sweeps up whatever
+  # happened during the window. Callers just enqueue at will.
+  #
+  #     class BadgeCountPushJob < ApplicationJob
+  #       debounce within: 30.seconds, by: ->(user) { user.id }
+  #
+  #       def perform(user)
+  #         user.push_badge_count
+  #       end
+  #     end
+  module Debouncing
+    extend ActiveSupport::Concern
+
+    # Default claim store, backed by `Rails.cache.write(..., unless_exist: true)`.
+    # A `nil` write result — an outage, on stores that can signal one, like
+    # RedisCacheStore's failsafe — stays `nil`, so debouncing fails open.
+    # Stores that can't tell an outage apart from a lost claim report a lost
+    # claim, and suppress instead.
+    module CacheStore
+      extend self
+
+      def claim(key, expires_in:)
+        result = Rails.cache.write(key, true, unless_exist: true, expires_in: expires_in)
+        !!result unless result.nil?
+      end
+    end
+
+    included do
+      class_attribute :debounce_options, instance_accessor: false, default: nil
+      class_attribute :debounce_store, instance_writer: false, default: CacheStore
+    end
+
+    module ClassMethods
+      # Debounces enqueues of this job class. Bursts of `perform_later` calls
+      # within the window of time given by `within:` collapse into a leading
+      # job, enqueued immediately, and a trailing job, scheduled a full window
+      # after the first coalesced call. Further calls within the window are
+      # suppressed: their enqueue is aborted and `perform_later` returns
+      # `false`. (Enqueues deferred until transaction commit decide at commit
+      # time instead, so their `perform_later` returns the job either way.)
+      #
+      # Enqueues are debounced per the identity given by `by:` — a callable
+      # evaluated in the context of the job and passed the job's arguments, or
+      # a method name (as a symbol) called on the job. If the result responds
+      # to `cache_key`, its value is used as the key; otherwise `to_param` is.
+      # Without `by:`, the whole class shares one debounce.
+      #
+      # `leading: false` turns off the immediate leading edge: the first call
+      # is itself scheduled a full window out, a classic trailing debounce, and
+      # further calls are suppressed — the scheduled job sweeps them up.
+      # `trailing: false` turns off the trailing sweep: calls after the leading
+      # enqueue are suppressed until the window expires.
+      #
+      # Claims live in `store:`, any object responding to
+      # `claim(key, expires_in:)` and returning `true` when the claim is won,
+      # `false` when it was already claimed, or `nil` when the store is
+      # unavailable — in which case debouncing fails open and the job enqueues
+      # immediately. Defaults to `debounce_store` (CacheStore over
+      # Rails.cache), resolved at enqueue time. Claim keys are scoped by
+      # `scope:`, defaulting to the underscored class name.
+      #
+      # Jobs enqueued with an explicit `set(wait:)`/`set(wait_until:)` bypass
+      # debouncing, as do retries: they always enqueue.
+      #
+      # Every decision emits a `debounce.active_job` notification with the
+      # job, the claim key, and the outcome: `:leading`, `:trailing`,
+      # `:suppressed`, or `:failed_open`.
+      def debounce(within:, by: nil, leading: true, trailing: true, store: nil, scope: nil)
+        raise ArgumentError, "debounce is already declared on #{self}" if debounce_options
+        raise ArgumentError, "debounce requires a leading or trailing edge" unless leading || trailing
+
+        self.debounce_options = { within: within, by: by, leading: leading, trailing: trailing, store: store, scope: scope || to_s.underscore }
+        before_enqueue :debounce_enqueue
+      end
+    end
+
+    private
+      def debounce_enqueue
+        if scheduled_at.nil? && executions.zero?
+          options = self.class.debounce_options
+          phase, key, claim = claim_debounce(options)
+
+          if claim == false
+            ActiveSupport::Notifications.instrument "debounce.active_job", job: self, key: key, outcome: :suppressed
+            logger.debug "Suppressed debounced #{self.class} enqueue: #{key}"
+            throw :abort
+          else
+            if phase == :trailing || (claim && !options[:leading])
+              self.scheduled_at = options[:within].from_now
+            end
+
+            ActiveSupport::Notifications.instrument "debounce.active_job", job: self, key: key, outcome: debounce_outcome(phase, claim)
+          end
+        end
+      end
+
+      def claim_debounce(options)
+        store = options[:store] || self.class.debounce_store
+        by = debounce_by(options)
+
+        phase = :leading
+        key = debounce_key(phase, by, options)
+        claim = store.claim(key, expires_in: options[:within])
+
+        if claim == false && options[:leading] && options[:trailing]
+          phase = :trailing
+          key = debounce_key(phase, by, options)
+          claim = store.claim(key, expires_in: options[:within])
+        end
+
+        [ phase, key, claim ]
+      end
+
+      def debounce_by(options)
+        case by = options[:by]
+        when nil
+          nil
+        when Symbol
+          debounce_key_component send(by)
+        else
+          debounce_key_component instance_exec(*arguments, &by)
+        end
+      end
+
+      def debounce_key_component(value)
+        if value.respond_to?(:cache_key)
+          value.cache_key
+        else
+          value.to_param
+        end
+      end
+
+      def debounce_key(phase, by, options)
+        [ "debounce", options[:scope], by, phase ].compact.join(":")
+      end
+
+      def debounce_outcome(phase, claim)
+        if claim.nil?
+          :failed_open
+        else
+          phase
+        end
+      end
+  end
+end

--- a/activejob/test/cases/debouncing_test.rb
+++ b/activejob/test/cases/debouncing_test.rb
@@ -1,0 +1,295 @@
+# frozen_string_literal: true
+
+require "helper"
+require "active_support/core_ext/time"
+require "models/person"
+
+class DebouncingTest < ActiveJob::TestCase
+  class MemoryClaimStore
+    def initialize
+      @claims = {}
+    end
+
+    def claim(key, expires_in:)
+      prune
+      if @claims.key?(key)
+        false
+      else
+        @claims[key] = Time.now + expires_in
+        true
+      end
+    end
+
+    def claimed?(key)
+      prune
+      @claims.key?(key)
+    end
+
+    def reset
+      @claims.clear
+    end
+
+    private
+      def prune
+        @claims.delete_if { |_key, expires_at| expires_at <= Time.now }
+      end
+  end
+
+  module UnavailableStore
+    def self.claim(key, expires_in:)
+      nil
+    end
+  end
+
+  STORE = MemoryClaimStore.new
+
+  class DebouncedJob < ActiveJob::Base
+    debounce within: 30.seconds, by: ->(key) { key }, store: STORE
+
+    def perform(key)
+    end
+  end
+
+  class OtherDebouncedJob < ActiveJob::Base
+    debounce within: 30.seconds, by: ->(key) { key }, store: STORE
+
+    def perform(key)
+    end
+  end
+
+  class ArgumentKeyedJob < ActiveJob::Base
+    debounce within: 30.seconds, by: :first_argument, store: STORE
+
+    def perform(key)
+    end
+
+    private
+      def first_argument
+        arguments.first
+      end
+  end
+
+  class RecordKeyedJob < ActiveJob::Base
+    debounce within: 30.seconds, by: ->(record) { record }, store: STORE
+
+    def perform(record)
+    end
+  end
+
+  class ScopedJob < ActiveJob::Base
+    debounce within: 30.seconds, scope: "shared_scope", store: STORE
+
+    def perform(key)
+    end
+  end
+
+  class UnkeyedJob < ActiveJob::Base
+    debounce within: 30.seconds, store: STORE
+
+    def perform(key)
+    end
+  end
+
+  class TrailingDebounceJob < ActiveJob::Base
+    debounce within: 30.seconds, by: ->(key) { key }, leading: false, store: STORE
+
+    def perform(key)
+    end
+  end
+
+  class LeadingDebounceJob < ActiveJob::Base
+    debounce within: 30.seconds, by: ->(key) { key }, trailing: false, store: STORE
+
+    def perform(key)
+    end
+  end
+
+  class FailingOpenJob < ActiveJob::Base
+    debounce within: 30.seconds, by: ->(key) { key }, store: UnavailableStore
+
+    def perform(key)
+    end
+  end
+
+  setup do
+    STORE.reset
+  end
+
+  def queue_adapter_for_test
+    ActiveJob::QueueAdapters::TestAdapter.new
+  end
+
+  test "the leading call enqueues immediately and later calls coalesce into one trailing job" do
+    freeze_time do
+      leading = assert_enqueued_with(job: DebouncedJob, args: [ "badge" ]) { DebouncedJob.perform_later("badge") }
+      assert_nil leading.scheduled_at
+
+      assert_enqueued_with job: DebouncedJob, args: [ "badge" ], at: 30.seconds.from_now do
+        DebouncedJob.perform_later("badge")
+      end
+
+      assert_no_enqueued_jobs only: DebouncedJob do
+        assert_equal false, DebouncedJob.perform_later("badge")
+      end
+    end
+  end
+
+  test "a trailing job waits a full window from the trailing call, not the leading one" do
+    freeze_time
+    DebouncedJob.perform_later("badge")
+
+    travel 10.seconds
+    assert_enqueued_with job: DebouncedJob, args: [ "badge" ], at: 30.seconds.from_now do
+      DebouncedJob.perform_later("badge")
+    end
+  end
+
+  test "leads again once the window expires" do
+    freeze_time
+    2.times { DebouncedJob.perform_later("badge") }
+
+    travel 31.seconds
+    leading = assert_enqueued_with(job: DebouncedJob, args: [ "badge" ]) { DebouncedJob.perform_later("badge") }
+    assert_nil leading.scheduled_at
+  end
+
+  test "debounces are keyed independently per identity and per job class" do
+    DebouncedJob.perform_later("badge")
+
+    other_identity = assert_enqueued_with(job: DebouncedJob, args: [ "tray" ]) { DebouncedJob.perform_later("tray") }
+    assert_nil other_identity.scheduled_at
+
+    other_class = assert_enqueued_with(job: OtherDebouncedJob, args: [ "badge" ]) { OtherDebouncedJob.perform_later("badge") }
+    assert_nil other_class.scheduled_at
+  end
+
+  test "a symbol by: resolves against the job" do
+    ArgumentKeyedJob.perform_later("badge")
+
+    assert STORE.claimed?("debounce:debouncing_test/argument_keyed_job:badge:leading")
+  end
+
+  test "a by: result with a cache_key is keyed by it" do
+    person = Person.new(7)
+    def person.cache_key
+      "people/7"
+    end
+
+    RecordKeyedJob.perform_later(person)
+
+    assert STORE.claimed?("debounce:debouncing_test/record_keyed_job:people/7:leading")
+  end
+
+  test "scope: overrides the class-name key scope" do
+    ScopedJob.perform_later("badge")
+
+    assert STORE.claimed?("debounce:shared_scope:leading")
+  end
+
+  test "without by: the whole class shares one debounce" do
+    freeze_time do
+      leading = assert_enqueued_with(job: UnkeyedJob, args: [ "one" ]) { UnkeyedJob.perform_later("one") }
+      assert_nil leading.scheduled_at
+
+      assert_enqueued_with job: UnkeyedJob, args: [ "two" ], at: 30.seconds.from_now do
+        UnkeyedJob.perform_later("two")
+      end
+
+      assert STORE.claimed?("debounce:debouncing_test/unkeyed_job:leading")
+    end
+  end
+
+  test "an explicit set(wait:) bypasses debouncing" do
+    freeze_time do
+      3.times { DebouncedJob.perform_later("badge") }
+
+      assert_enqueued_with job: DebouncedJob, args: [ "badge" ], at: 5.minutes.from_now do
+        DebouncedJob.set(wait: 5.minutes).perform_later("badge")
+      end
+    end
+  end
+
+  test "retries are never absorbed" do
+    3.times { DebouncedJob.perform_later("badge") }
+
+    retried = DebouncedJob.new("badge")
+    retried.executions = 1
+    assert_enqueued_with(job: DebouncedJob, args: [ "badge" ]) { retried.enqueue }
+    assert_nil retried.scheduled_at
+  end
+
+  test "fails open to immediate enqueues when the store is unavailable" do
+    2.times do
+      job = assert_enqueued_with(job: FailingOpenJob, args: [ "badge" ]) { FailingOpenJob.perform_later("badge") }
+      assert_nil job.scheduled_at
+    end
+  end
+
+  test "leading: false schedules one sweep a full window out and suppresses the rest" do
+    freeze_time do
+      assert_enqueued_with job: TrailingDebounceJob, args: [ "badge" ], at: 30.seconds.from_now do
+        TrailingDebounceJob.perform_later("badge")
+      end
+
+      assert_no_enqueued_jobs only: TrailingDebounceJob do
+        assert_equal false, TrailingDebounceJob.perform_later("badge")
+        assert_equal false, TrailingDebounceJob.perform_later("badge")
+      end
+    end
+  end
+
+  test "trailing: false suppresses calls after the leading enqueue" do
+    leading = assert_enqueued_with(job: LeadingDebounceJob, args: [ "badge" ]) { LeadingDebounceJob.perform_later("badge") }
+    assert_nil leading.scheduled_at
+
+    assert_no_enqueued_jobs only: LeadingDebounceJob do
+      assert_equal false, LeadingDebounceJob.perform_later("badge")
+    end
+  end
+
+  test "the default CacheStore wins a claim once per key and passes an outage nil through" do
+    previous_rails = Object.send(:remove_const, :Rails) if defined?(::Rails)
+    Object.const_set(:Rails, Struct.new(:cache).new(ActiveSupport::Cache::MemoryStore.new))
+
+    assert_equal true, ActiveJob::Debouncing::CacheStore.claim("debounce:cache_store_test:leading", expires_in: 30.seconds)
+    assert_equal false, ActiveJob::Debouncing::CacheStore.claim("debounce:cache_store_test:leading", expires_in: 30.seconds)
+
+    Rails.cache = Class.new do
+      def write(*, **)
+        nil
+      end
+    end.new
+    assert_nil ActiveJob::Debouncing::CacheStore.claim("debounce:cache_store_test:leading", expires_in: 30.seconds)
+  ensure
+    Object.send(:remove_const, :Rails)
+    Object.const_set(:Rails, previous_rails) if previous_rails
+  end
+
+  test "debounce can be declared only once and requires an edge" do
+    assert_raises ArgumentError do
+      Class.new(ActiveJob::Base) do
+        debounce within: 1.minute, store: STORE
+        debounce within: 2.minutes, store: STORE
+      end
+    end
+
+    assert_raises ArgumentError do
+      Class.new(ActiveJob::Base) { debounce within: 1.minute, leading: false, trailing: false }
+    end
+  end
+
+  test "instruments each debounce decision" do
+    payloads = []
+    record_payload = ->(*, payload) { payloads << payload }
+
+    ActiveSupport::Notifications.subscribed record_payload, "debounce.active_job" do
+      3.times { DebouncedJob.perform_later("badge") }
+      FailingOpenJob.perform_later("badge")
+    end
+
+    assert_equal [ :leading, :trailing, :suppressed, :failed_open ], payloads.map { |payload| payload[:outcome] }
+    assert_kind_of DebouncedJob, payloads.first[:job]
+    assert_equal "debounce:debouncing_test/debounced_job:badge:leading", payloads.first[:key]
+    assert_equal "debounce:debouncing_test/debounced_job:badge:trailing", payloads.third[:key]
+  end
+end

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -553,6 +553,54 @@ bulk enqueuing with the `GoodJob::Bulk.enqueue` method.
 If the queue backend does *not* support bulk enqueuing, `perform_all_later` will
 enqueue jobs one by one.
 
+### Debouncing Jobs
+
+Some jobs are enqueued far more often than their work needs doing: pushing a
+badge count on every notification, reindexing a record on every save. Use
+`debounce` to collapse a burst of `perform_later` calls into at most two jobs
+per window of time — a leading job that runs immediately, so the effect feels
+instant, and a trailing job scheduled a full window out that sweeps up whatever
+happened during the burst. Callers just enqueue at will:
+
+```ruby
+class BadgeCountPushJob < ApplicationJob
+  debounce within: 30.seconds, by: ->(user) { user.id }
+
+  def perform(user)
+    user.push_badge_count
+  end
+end
+
+BadgeCountPushJob.perform_later(user) # enqueued immediately (leading)
+BadgeCountPushJob.perform_later(user) # scheduled 30 seconds out (trailing)
+BadgeCountPushJob.perform_later(user) # suppressed; returns false
+```
+
+Enqueues are debounced per the identity given by `by:` — a callable evaluated
+in the context of the job and passed the job's arguments, or a method name (as
+a symbol) called on the job. Without `by:`, the whole class shares one
+debounce.
+
+Pass `leading: false` for a classic trailing debounce, where the first call is
+itself scheduled a full window out, or `trailing: false` to suppress everything
+after the leading enqueue until the window expires.
+
+Debouncing works at enqueue time, so it is queue-backend agnostic. Claims are
+won through a store, defaulting to `Rails.cache.write(..., unless_exist: true)`;
+supply any object responding to `claim(key, expires_in:)` with the `store:`
+option. A store that returns `nil` (for example, when its backing service is
+unreachable) makes debouncing fail open: the job enqueues immediately rather
+than risk being lost.
+
+Suppressed calls abort the enqueue, so their `perform_later` returns `false` —
+except when [`enqueue_after_transaction_commit`](#transactional-integrity-on-jobs)
+defers the enqueue, in which case the debounce decision happens at commit time,
+after `perform_later` has already returned the job. Jobs enqueued with an
+explicit `set(wait:)` or `set(wait_until:)` bypass debouncing, as do retries. Every decision emits a
+[`debounce.active_job`](active_support_instrumentation.html#debounce-active-job)
+event with its outcome: `:leading`, `:trailing`, `:suppressed`, or
+`:failed_open`.
+
 Callbacks
 ---------
 

--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -496,6 +496,14 @@ The `:cache_hits` key is only included if the collection is rendered with `cache
 | `:error`     | The error that caused the retry        |
 | `:wait`      | The delay of the retry                 |
 
+#### `debounce.active_job`
+
+| Key        | Value                                                          |
+| ---------- | -------------------------------------------------------------- |
+| `:job`     | Job object                                                     |
+| `:key`     | The claim key the debounce decision was made against           |
+| `:outcome` | `:leading`, `:trailing`, `:suppressed`, or `:failed_open`      |
+
 #### `enqueue_all.active_job`
 
 | Key          | Value                                  |


### PR DESCRIPTION
### Motivation / Background

Some jobs are enqueued far more often than their work needs doing: pushing a badge count on every notification, reindexing a record on every save. The ecosystem answers are adapter-specific — Sidekiq debounce middleware, uniqueness locks — so Active Job itself has no way to say "a burst of these collapses into one or two runs." This PR adds an adapter-agnostic leading+trailing debounce as a class macro:

```ruby
class BadgeCountPushJob < ApplicationJob
  debounce within: 30.seconds, by: ->(user) { user.id }

  def perform(user)
    user.push_badge_count
  end
end
```

A burst of `perform_later` calls collapses into at most two jobs per window: a **leading** job enqueued immediately, so the effect feels instant, and a **trailing** job scheduled a full window out that sweeps up whatever happened during the burst. Callers just enqueue at will.

Production evidence: Basecamp debounces its per-user badge-count pushes with exactly this implementation; on day one it suppressed ~22% of pushes at ~11k pushes/min, with the badge still feeling instant (leading edge) and always ending correct (trailing sweep).

### Detail

- `debounce within:, by:, leading:, trailing:, store:, scope:` — identity from `by:` (callable over the job's arguments, or a symbol method name; `cache_key`/`to_param` for the key), key scope from `scope:` (defaults to the underscored class name).
- Works at `before_enqueue`, so every queue backend gets it. Suppressed calls abort the enqueue: `perform_later` returns `false`. Explicit `set(wait:)`/`set(wait_until:)` and retries bypass debouncing entirely.
- Claims are won through a store — any object with `claim(key, expires_in:)` returning true/false/nil — defaulting to `Rails.cache.write(..., unless_exist: true)`. A `nil` claim signals a store outage and debouncing **fails open**: the job enqueues immediately rather than risk being lost.
- Every decision emits a `debounce.active_job` event with outcome `:leading`, `:trailing`, `:suppressed`, or `:failed_open`.
- `leading: false` gives a classic trailing debounce; `trailing: false` a pure leading throttle.

Includes tests (full semantics: edges, keying, expiry, bypasses, fail-open, instrumentation), a section in the Active Job guide, and the event table in the instrumentation guide.

### Checklist

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated if you fix a bug, refactor something, or add a feature.
- [x] Tests and lint checks are passing locally.