### PR TITLE
Keep the relation scope in `Relation#update` and `#update!`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   `ActiveRecord::Relation#update` and `#update!` no longer escape the relation
+    when given ids.
+
+    Passing ids used to delegate to the model class, which looks the records up
+    with an unscoped `find`:
+
+    ```ruby
+    post.comments.update!(comment_id, body: "...") # could update any comment
+    Comment.where(id: 1).update!(2, body: "...")   # updated comment 2
+    ```
+
+    The records are now looked up through the relation, so an id outside of it
+    raises `ActiveRecord::RecordNotFound` before anything is written. This makes
+    `update`/`update!` consistent with `update_all`, `#delete` and `#destroy`,
+    which have always been scoped, and with `update(:all, ...)`, which was
+    already scoped.
+
+    *Jean Mendonça*
+
 *   Let the schema readers answer for many tables at once.
 
     `columns`, `indexes`, `primary_keys`, `foreign_keys`, `check_constraints`,

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   `ActiveRecord::Relation#update` and `#update!` no longer escape the relation
+    when given ids.
+
+    Passing ids used to delegate to the model class, which looks the records up
+    with an unscoped `find`:
+
+    ```ruby
+    post.comments.update!(comment_id, body: "...") # could update any comment
+    Comment.where(id: 1).update!(2, body: "...")   # updated comment 2
+    ```
+
+    The records are now looked up through the relation, so an id outside of it
+    raises `ActiveRecord::RecordNotFound` before anything is written. This makes
+    `update`/`update!` consistent with `update_all`, `#delete` and `#destroy`,
+    which have always been scoped, and with `update(:all, ...)`, which was
+    already scoped.
+
+    *Jean Mendonça*
+
 *   Fix `pluck` ignoring records assigned to a new record's association.
 
     ```ruby

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -130,53 +130,13 @@ module ActiveRecord
       # it is preferred to use {update_all}[rdoc-ref:Relation#update_all]
       # for updating all records in a single query.
       def update(id = :all, attributes)
-        if update_multiple_ids?(id)
-          if id.any?(ActiveRecord::Base)
-            raise ArgumentError,
-              "You are passing an array of ActiveRecord::Base instances to `update`. " \
-              "Please pass the ids of the objects by calling `pluck(:id)` or `map(&:id)`."
-          end
-          id.map { |one_id| find(one_id) }.each_with_index { |object, idx|
-            object.update(attributes[idx])
-          }
-        elsif id == :all
-          all.each { |record| record.update(attributes) }
-        else
-          if ActiveRecord::Base === id
-            raise ArgumentError,
-              "You are passing an instance of ActiveRecord::Base to `update`. " \
-              "Please pass the id of the object by calling `.id`."
-          end
-          object = find(id)
-          object.update(attributes)
-          object
-        end
+        all.update(id, attributes)
       end
 
       # Updates the object (or multiple objects) just like #update but calls #update! instead
       # of +update+, so an exception is raised if the record is invalid and saving will fail.
       def update!(id = :all, attributes)
-        if update_multiple_ids?(id)
-          if id.any?(ActiveRecord::Base)
-            raise ArgumentError,
-              "You are passing an array of ActiveRecord::Base instances to `update!`. " \
-              "Please pass the ids of the objects by calling `pluck(:id)` or `map(&:id)`."
-          end
-          id.map { |one_id| find(one_id) }.each_with_index { |object, idx|
-            object.update!(attributes[idx])
-          }
-        elsif id == :all
-          all.each { |record| record.update!(attributes) }
-        else
-          if ActiveRecord::Base === id
-            raise ArgumentError,
-              "You are passing an instance of ActiveRecord::Base to `update!`. " \
-              "Please pass the id of the object by calling `.id`."
-          end
-          object = find(id)
-          object.update!(attributes)
-          object
-        end
+        all.update!(id, attributes)
       end
 
       # Accepts a list of attribute names to be used in the WHERE clause
@@ -295,18 +255,6 @@ module ActiveRecord
           subclass.class_eval do
             @query_constraints_list = nil
             @has_query_constraints = false
-          end
-        end
-
-        # +update+/+update!+ accept either a single id or an array of ids. For a
-        # composite primary key a single id is itself an array, so an array of
-        # ids is an array of arrays, mirroring how +Relation#destroy+ tells the
-        # two apart.
-        def update_multiple_ids?(id)
-          if composite_primary_key?
-            id.is_a?(Array) && (id.empty? || id.first.is_a?(Array))
-          else
-            id.is_a?(Array)
           end
         end
 

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -130,53 +130,13 @@ module ActiveRecord
       # it is preferred to use {update_all}[rdoc-ref:Relation#update_all]
       # for updating all records in a single query.
       def update(id = :all, attributes)
-        if update_multiple_ids?(id)
-          if id.any?(ActiveRecord::Base)
-            raise ArgumentError,
-              "You are passing an array of ActiveRecord::Base instances to `update`. " \
-              "Please pass the ids of the objects by calling `pluck(:id)` or `map(&:id)`."
-          end
-          id.map { |one_id| find(one_id) }.each_with_index { |object, idx|
-            object.update(attributes[idx])
-          }
-        elsif id == :all
-          all.each { |record| record.update(attributes) }
-        else
-          if ActiveRecord::Base === id
-            raise ArgumentError,
-              "You are passing an instance of ActiveRecord::Base to `update`. " \
-              "Please pass the id of the object by calling `.id`."
-          end
-          object = find(id)
-          object.update(attributes)
-          object
-        end
+        all.update(id, attributes)
       end
 
       # Updates the object (or multiple objects) just like #update but calls #update! instead
       # of +update+, so an exception is raised if the record is invalid and saving will fail.
       def update!(id = :all, attributes)
-        if update_multiple_ids?(id)
-          if id.any?(ActiveRecord::Base)
-            raise ArgumentError,
-              "You are passing an array of ActiveRecord::Base instances to `update!`. " \
-              "Please pass the ids of the objects by calling `pluck(:id)` or `map(&:id)`."
-          end
-          id.map { |one_id| find(one_id) }.each_with_index { |object, idx|
-            object.update!(attributes[idx])
-          }
-        elsif id == :all
-          all.each { |record| record.update!(attributes) }
-        else
-          if ActiveRecord::Base === id
-            raise ArgumentError,
-              "You are passing an instance of ActiveRecord::Base to `update!`. " \
-              "Please pass the id of the object by calling `.id`."
-          end
-          object = find(id)
-          object.update!(attributes)
-          object
-        end
+        all.update!(id, attributes)
       end
 
       # Accepts a list of attribute names to be used in the WHERE clause
@@ -293,18 +253,6 @@ module ActiveRecord
           subclass.class_eval do
             @query_constraints_list = nil
             @has_query_constraints = false
-          end
-        end
-
-        # +update+/+update!+ accept either a single id or an array of ids. For a
-        # composite primary key a single id is itself an array, so an array of
-        # ids is an array of arrays, mirroring how +Relation#destroy+ tells the
-        # two apart.
-        def update_multiple_ids?(id)
-          if composite_primary_key?
-            id.is_a?(Array) && (id.empty? || id.first.is_a?(Array))
-          else
-            id.is_a?(Array)
           end
         end
 

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -638,18 +638,50 @@ module ActiveRecord
     end
 
     def update(id = :all, attributes) # :nodoc:
-      if id == :all
+      if update_multiple_ids?(id)
+        if id.any?(ActiveRecord::Base)
+          raise ArgumentError,
+            "You are passing an array of ActiveRecord::Base instances to `update`. " \
+            "Please pass the ids of the objects by calling `pluck(:id)` or `map(&:id)`."
+        end
+        id.map { |one_id| find(one_id) }.each_with_index { |object, idx|
+          object.update(attributes[idx])
+        }
+      elsif id == :all
         each { |record| record.update(attributes) }
       else
-        model.update(id, attributes)
+        if ActiveRecord::Base === id
+          raise ArgumentError,
+            "You are passing an instance of ActiveRecord::Base to `update`. " \
+            "Please pass the id of the object by calling `.id`."
+        end
+        object = find(id)
+        object.update(attributes)
+        object
       end
     end
 
     def update!(id = :all, attributes) # :nodoc:
-      if id == :all
+      if update_multiple_ids?(id)
+        if id.any?(ActiveRecord::Base)
+          raise ArgumentError,
+            "You are passing an array of ActiveRecord::Base instances to `update!`. " \
+            "Please pass the ids of the objects by calling `pluck(:id)` or `map(&:id)`."
+        end
+        id.map { |one_id| find(one_id) }.each_with_index { |object, idx|
+          object.update!(attributes[idx])
+        }
+      elsif id == :all
         each { |record| record.update!(attributes) }
       else
-        model.update!(id, attributes)
+        if ActiveRecord::Base === id
+          raise ArgumentError,
+            "You are passing an instance of ActiveRecord::Base to `update!`. " \
+            "Please pass the id of the object by calling `.id`."
+        end
+        object = find(id)
+        object.update!(attributes)
+        object
       end
     end
 
@@ -1360,6 +1392,17 @@ module ActiveRecord
       end
 
     private
+      # +update+/+update!+ accept either a single id or an array of ids. For a
+      # composite primary key a single id is itself an array, so an array of
+      # ids is an array of arrays, mirroring how +#destroy+ tells the two apart.
+      def update_multiple_ids?(id)
+        if model.composite_primary_key?
+          id.is_a?(Array) && (id.empty? || id.first.is_a?(Array))
+        else
+          id.is_a?(Array)
+        end
+      end
+
       def already_in_scope?(registry)
         @delegate_to_model && registry.current_scope(model, true)
       end

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -638,18 +638,50 @@ module ActiveRecord
     end
 
     def update(id = :all, attributes) # :nodoc:
-      if id == :all
+      if update_multiple_ids?(id)
+        if id.any?(ActiveRecord::Base)
+          raise ArgumentError,
+            "You are passing an array of ActiveRecord::Base instances to `update`. " \
+            "Please pass the ids of the objects by calling `pluck(:id)` or `map(&:id)`."
+        end
+        id.map { |one_id| find(one_id) }.each_with_index { |object, idx|
+          object.update(attributes[idx])
+        }
+      elsif id == :all
         each { |record| record.update(attributes) }
       else
-        model.update(id, attributes)
+        if ActiveRecord::Base === id
+          raise ArgumentError,
+            "You are passing an instance of ActiveRecord::Base to `update`. " \
+            "Please pass the id of the object by calling `.id`."
+        end
+        object = find(id)
+        object.update(attributes)
+        object
       end
     end
 
     def update!(id = :all, attributes) # :nodoc:
-      if id == :all
+      if update_multiple_ids?(id)
+        if id.any?(ActiveRecord::Base)
+          raise ArgumentError,
+            "You are passing an array of ActiveRecord::Base instances to `update!`. " \
+            "Please pass the ids of the objects by calling `pluck(:id)` or `map(&:id)`."
+        end
+        id.map { |one_id| find(one_id) }.each_with_index { |object, idx|
+          object.update!(attributes[idx])
+        }
+      elsif id == :all
         each { |record| record.update!(attributes) }
       else
-        model.update!(id, attributes)
+        if ActiveRecord::Base === id
+          raise ArgumentError,
+            "You are passing an instance of ActiveRecord::Base to `update!`. " \
+            "Please pass the id of the object by calling `.id`."
+        end
+        object = find(id)
+        object.update!(attributes)
+        object
       end
     end
 
@@ -1359,6 +1391,17 @@ module ActiveRecord
       end
 
     private
+      # +update+/+update!+ accept either a single id or an array of ids. For a
+      # composite primary key a single id is itself an array, so an array of
+      # ids is an array of arrays, mirroring how +#destroy+ tells the two apart.
+      def update_multiple_ids?(id)
+        if model.composite_primary_key?
+          id.is_a?(Array) && (id.empty? || id.first.is_a?(Array))
+        else
+          id.is_a?(Array)
+        end
+      end
+
       def already_in_scope?(registry)
         @delegate_to_model && registry.current_scope(model, true)
       end

--- a/activerecord/test/cases/relation/update_all_test.rb
+++ b/activerecord/test/cases/relation/update_all_test.rb
@@ -338,7 +338,7 @@ class UpdateAllTest < ActiveRecord::TestCase
   def test_update_with_ids_on_relation
     topic1 = TopicWithCallbacks.create!(title: "arel", author_name: nil)
     topic2 = TopicWithCallbacks.create!(title: "activerecord", author_name: nil)
-    topics = TopicWithCallbacks.none
+    topics = TopicWithCallbacks.where(id: [topic1.id, topic2.id])
     topics.update(
       [topic1.id, topic2.id],
       [{ title: "adequaterecord" }, { title: "adequaterecord" }]
@@ -351,6 +351,77 @@ class UpdateAllTest < ActiveRecord::TestCase
     # Testing that the before_update callbacks have run
     assert_equal "David", topic1.reload.author_name
     assert_equal "David", topic2.reload.author_name
+  end
+
+  def test_update_with_ids_outside_of_the_relation_does_not_update_anything
+    topic1 = TopicWithCallbacks.create!(title: "arel", author_name: nil)
+    topic2 = TopicWithCallbacks.create!(title: "activerecord", author_name: nil)
+    topics = TopicWithCallbacks.where(id: topic1.id)
+
+    assert_raises(ActiveRecord::RecordNotFound) do
+      topics.update(
+        [topic1.id, topic2.id],
+        [{ title: "adequaterecord" }, { title: "adequaterecord" }]
+      )
+    end
+
+    # The ids are resolved before anything is written, so nothing is updated
+    assert_equal "arel", topic1.reload.title
+    assert_equal "activerecord", topic2.reload.title
+  end
+
+  def test_update_with_a_single_id_outside_of_the_relation_does_not_update_anything
+    topic1 = TopicWithCallbacks.create!(title: "arel", author_name: nil)
+    topic2 = TopicWithCallbacks.create!(title: "activerecord", author_name: nil)
+
+    assert_raises(ActiveRecord::RecordNotFound) do
+      TopicWithCallbacks.where(id: topic1.id).update(topic2.id, title: "adequaterecord")
+    end
+
+    assert_equal "activerecord", topic2.reload.title
+  end
+
+  def test_update_bang_with_ids_outside_of_the_relation_does_not_update_anything
+    topic1 = TopicWithCallbacks.create!(title: "arel", author_name: nil)
+    topic2 = TopicWithCallbacks.create!(title: "activerecord", author_name: nil)
+    topics = TopicWithCallbacks.where(id: topic1.id)
+
+    assert_raises(ActiveRecord::RecordNotFound) do
+      topics.update!(
+        [topic1.id, topic2.id],
+        [{ title: "adequaterecord" }, { title: "adequaterecord" }]
+      )
+    end
+
+    assert_equal "arel", topic1.reload.title
+    assert_equal "activerecord", topic2.reload.title
+  end
+
+  def test_update_bang_with_a_single_id_outside_of_the_relation_does_not_update_anything
+    topic1 = TopicWithCallbacks.create!(title: "arel", author_name: nil)
+    topic2 = TopicWithCallbacks.create!(title: "activerecord", author_name: nil)
+
+    assert_raises(ActiveRecord::RecordNotFound) do
+      TopicWithCallbacks.where(id: topic1.id).update!(topic2.id, title: "adequaterecord")
+    end
+
+    assert_equal "activerecord", topic2.reload.title
+  end
+
+  def test_update_on_an_association_does_not_reach_outside_of_the_association
+    post = posts(:welcome)
+    comment_of_another_post = comments(:does_it_hurt)
+    assert_not_equal post.id, comment_of_another_post.post_id
+
+    assert_raises(ActiveRecord::RecordNotFound) do
+      post.comments.update(comment_of_another_post.id, body: "hijacked")
+    end
+
+    assert_raises(ActiveRecord::RecordNotFound) do
+      post.comments.update!([comment_of_another_post.id], [{ body: "hijacked" }])
+    end
+
+    assert_not_equal "hijacked", comment_of_another_post.reload.body
   end
 
   def test_update_on_relation_passing_active_record_object_is_not_permitted

--- a/activerecord/test/cases/relation/update_all_test.rb
+++ b/activerecord/test/cases/relation/update_all_test.rb
@@ -339,7 +339,7 @@ class UpdateAllTest < ActiveRecord::TestCase
   def test_update_with_ids_on_relation
     topic1 = TopicWithCallbacks.create!(title: "arel", author_name: nil)
     topic2 = TopicWithCallbacks.create!(title: "activerecord", author_name: nil)
-    topics = TopicWithCallbacks.none
+    topics = TopicWithCallbacks.where(id: [topic1.id, topic2.id])
     topics.update(
       [topic1.id, topic2.id],
       [{ title: "adequaterecord" }, { title: "adequaterecord" }]
@@ -352,6 +352,77 @@ class UpdateAllTest < ActiveRecord::TestCase
     # Testing that the before_update callbacks have run
     assert_equal "David", topic1.reload.author_name
     assert_equal "David", topic2.reload.author_name
+  end
+
+  def test_update_with_ids_outside_of_the_relation_does_not_update_anything
+    topic1 = TopicWithCallbacks.create!(title: "arel", author_name: nil)
+    topic2 = TopicWithCallbacks.create!(title: "activerecord", author_name: nil)
+    topics = TopicWithCallbacks.where(id: topic1.id)
+
+    assert_raises(ActiveRecord::RecordNotFound) do
+      topics.update(
+        [topic1.id, topic2.id],
+        [{ title: "adequaterecord" }, { title: "adequaterecord" }]
+      )
+    end
+
+    # The ids are resolved before anything is written, so nothing is updated
+    assert_equal "arel", topic1.reload.title
+    assert_equal "activerecord", topic2.reload.title
+  end
+
+  def test_update_with_a_single_id_outside_of_the_relation_does_not_update_anything
+    topic1 = TopicWithCallbacks.create!(title: "arel", author_name: nil)
+    topic2 = TopicWithCallbacks.create!(title: "activerecord", author_name: nil)
+
+    assert_raises(ActiveRecord::RecordNotFound) do
+      TopicWithCallbacks.where(id: topic1.id).update(topic2.id, title: "adequaterecord")
+    end
+
+    assert_equal "activerecord", topic2.reload.title
+  end
+
+  def test_update_bang_with_ids_outside_of_the_relation_does_not_update_anything
+    topic1 = TopicWithCallbacks.create!(title: "arel", author_name: nil)
+    topic2 = TopicWithCallbacks.create!(title: "activerecord", author_name: nil)
+    topics = TopicWithCallbacks.where(id: topic1.id)
+
+    assert_raises(ActiveRecord::RecordNotFound) do
+      topics.update!(
+        [topic1.id, topic2.id],
+        [{ title: "adequaterecord" }, { title: "adequaterecord" }]
+      )
+    end
+
+    assert_equal "arel", topic1.reload.title
+    assert_equal "activerecord", topic2.reload.title
+  end
+
+  def test_update_bang_with_a_single_id_outside_of_the_relation_does_not_update_anything
+    topic1 = TopicWithCallbacks.create!(title: "arel", author_name: nil)
+    topic2 = TopicWithCallbacks.create!(title: "activerecord", author_name: nil)
+
+    assert_raises(ActiveRecord::RecordNotFound) do
+      TopicWithCallbacks.where(id: topic1.id).update!(topic2.id, title: "adequaterecord")
+    end
+
+    assert_equal "activerecord", topic2.reload.title
+  end
+
+  def test_update_on_an_association_does_not_reach_outside_of_the_association
+    post = posts(:welcome)
+    comment_of_another_post = comments(:does_it_hurt)
+    assert_not_equal post.id, comment_of_another_post.post_id
+
+    assert_raises(ActiveRecord::RecordNotFound) do
+      post.comments.update(comment_of_another_post.id, body: "hijacked")
+    end
+
+    assert_raises(ActiveRecord::RecordNotFound) do
+      post.comments.update!([comment_of_another_post.id], [{ body: "hijacked" }])
+    end
+
+    assert_not_equal "hijacked", comment_of_another_post.reload.body
   end
 
   def test_update_on_relation_passing_active_record_object_is_not_permitted

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -56,6 +56,21 @@ class DefaultScopingTest < ActiveRecord::TestCase
     assert_nil DeveloperCalledJamis.unscoped.create!.name
   end
 
+  def test_default_scope_is_unscoped_on_update
+    jamis = developers(:jamis)
+
+    assert_raises(ActiveRecord::RecordNotFound) do
+      DeveloperCalledDavid.update(jamis.id, name: "Not Jamis")
+    end
+    assert_raises(ActiveRecord::RecordNotFound) do
+      DeveloperCalledDavid.update!(jamis.id, name: "Not Jamis")
+    end
+    assert_equal "Jamis", jamis.reload.name
+
+    DeveloperCalledDavid.unscoped.update(jamis.id, name: "Not Jamis")
+    assert_equal "Not Jamis", jamis.reload.name
+  end
+
   def test_default_scope_with_conditions_string
     assert_equal Developer.where(name: "David").map(&:id).sort, DeveloperCalledDavid.all.map(&:id).sort
     assert_nil DeveloperCalledDavid.create!.name


### PR DESCRIPTION
`Relation#update` and `#update!` don't respect the relation scope. A call that reads as scoped by the association:

```ruby
post.comments.update!(comment_id, body: "…")
```

Writes a row that may belong to a different parent, because the id is resolved by the class-level `find`, so the relation's conditions never reach the query. When the association *is* the tenant boundary (`buyer.suppliers`, `account.users`) and the id comes off a request, that is a silent cross-tenant write from code that looks like it cannot do one. The neighbouring, already-scoped `update_all` makes it easy to assume `update!` is scoped too.

This aligns `update`/`update!` with the operations that already respect the scope (`update_all`, `delete`, `destroy`, `find`) by moving the implementation down to `Relation`. Full mechanism, the forced direction, and the breaking change below.

---

### Motivation / Background

`update_all` is scoped. `#delete` and `#destroy` are scoped. `update(:all, …)` is scoped. `update(ids, …)` is not:

```ruby
def update(id = :all, attributes) # :nodoc:
  if id == :all
    each { |record| record.update(attributes) }
  else
    model.update(id, attributes)   # <- leaves the relation
  end
end
```

The class method then resolves the ids with its own `find`, so the relation's conditions never make it into the query.

`CollectionProxy` does not override `update`/`update!`, so this is reachable from every association:

```ruby
post.comments.update!(comment_id, body: "…")
# UPDATE "comments" SET "body" = '…' WHERE "comments"."id" = ?
#                                          ^ no post_id
```

A call that reads as scoped by the association will write a row belonging to a different parent. When the tenant boundary *is* the association (`buyer.suppliers`, `account.users`) and the id comes off a request, that is a cross-tenant write from code that looks like it cannot do one. The neighbouring `update_all` is scoped, which makes it easy to assume `update!` is too.

The current test suite states the problem better than I can:

```ruby
def test_update_with_ids_on_relation
  topic1 = TopicWithCallbacks.create!(title: "arel", author_name: nil)
  topic2 = TopicWithCallbacks.create!(title: "activerecord", author_name: nil)
  topics = TopicWithCallbacks.none
  topics.update([topic1.id, topic2.id], [{ title: "adequaterecord" }, { title: "adequaterecord" }])
  # ...
  assert_equal "adequaterecord", topic1.reload.title
  assert_equal "adequaterecord", topic2.reload.title
end
```

`none.update(ids, …)` updates two records.

### Detail

`Persistence::ClassMethods#update` is already written entirely in terms of `find` and `all`, and both mean the right thing on a `Relation`. The implementation is not class-specific. It just lives on the class.

The direction is forced rather than stylistic. From the class you can always reach the relation (`all`), but from a relation there is no way to run the class method scoped, short of `scoping` (which leaks; see below) or a second copy of the body. A single copy can only live on `Relation`.

So this moves it there, and defines the class method as what it always meant:

```ruby
def update(id = :all, attributes)
  all.update(id, attributes)
end
```

`update`/`update!` are also the last write-by-id methods still implemented on the class. `ActiveRecord::Querying::QUERYING_METHODS` already delegates `delete`, `destroy`, `delete_all`, `destroy_all`, `update_all`, `touch_all`, `insert_all` and `upsert_all`, among others, to `all`. `:update` and `:update!` are the only ones missing from that list. That absence is the bug rather than an analogy for it: `Model.delete(id)` is `all.delete(id)`, scoped by construction, while `update` living on the class left `Relation#update` nowhere to go but back to it. It is why `post.comments.destroy(id)` respects the association and `post.comments.update!(id, …)` does not.

`Model.update` is unaffected: class-level `find` is `all.find`, and the `:all` branch already went through `all.each`.

Everything else is moved verbatim rather than rewritten: the two `ArgumentError` guards, their messages, and `update_multiple_ids?`. No `raise` is added, removed or reworded, and the logic still exists in exactly one place.

Ids are resolved before any record is written, so a request carrying one id from outside the relation raises `RecordNotFound` without a partial update.

The moved code keeps the coverage it already had: the class-level tests in `persistence_test.rb` (argument guards, composite primary keys, `test_class_level_update_is_affected_by_scoping`) now exercise the delegation, and the existing `Relation#update` tests already lived in `relation/update_all_test.rb`, next to the new ones.

### Additional information

This supersedes #49332, which proposed the same fix and stalled with conflicts in 2023. Credit to @raszi for raising it first. Two review points from that PR are addressed by construction rather than by argument:

- @adrianna-chang-shopify asked to split the input validation out of the scope fix, because that PR *copied* the guards from `Persistence` into a new `_update_each`. Moving the implementation instead of duplicating it means the guards never show up as a change.
- @zzak asked whether a new exception was being introduced. No: no `raise` is touched.

I also considered `scoping { model.update(id, attributes) }`, which is a one-line fix and matches what `Delegation` does for undefined class methods. It leaks `current_scope` into the callbacks and validations that run during the update, which is the very thing the `NotImplementedError` guard in `Delegation::ClassSpecificRelation#method_missing` warns about, so I didn't take it.

### Breaking change

`relation.update(ids, …)` with an id outside the relation now raises `RecordNotFound` instead of updating the record. Callers that want the old behaviour should call `Model.update` directly. `Model.unscoped.update(id, …)` also stops applying the default scope, which is the same bug seen from the other side. Both are in the CHANGELOG, and `test_default_scope_is_unscoped_on_update` pins them.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.