### PR TITLE
Add Pacific Time (Canada) and Alberta Time zone mappings

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Add `Pacific Time (Canada)` and `Alberta Time` to `ActiveSupport::TimeZone::MAPPING`.
+
+    British Columbia and Alberta no longer share winter clocks with US Pacific
+    and Mountain time. The existing `Pacific Time (US & Canada)` and
+    `Mountain Time (US & Canada)` entries remain mapped to `America/Los_Angeles`
+    and `America/Denver` for compatibility. Prefer `Pacific Time (Canada)` /
+    `Alberta Time` (or the IANA identifiers `America/Vancouver` /
+    `America/Edmonton`) for users in those regions.
+
+    *Said Kaldybaev*
+
 *   Fix `Range#sum` with a falsey initial value.
 
     Summing an integer range with a falsey starting value (such as nil or false)

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,10 +1,10 @@
-*   Add `Pacific Time (Canada)` and `Alberta Time` to `ActiveSupport::TimeZone::MAPPING`.
+*   Add `Pacific Time (Canada)` and `Alberta` to `ActiveSupport::TimeZone::MAPPING`.
 
     British Columbia and Alberta no longer share winter clocks with US Pacific
     and Mountain time. The existing `Pacific Time (US & Canada)` and
     `Mountain Time (US & Canada)` entries remain mapped to `America/Los_Angeles`
     and `America/Denver` for compatibility. Prefer `Pacific Time (Canada)` /
-    `Alberta Time` (or the IANA identifiers `America/Vancouver` /
+    `Alberta` (or the IANA identifiers `America/Vancouver` /
     `America/Edmonton`) for users in those regions.
 
     *Said Kaldybaev*

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -41,7 +41,7 @@ module ActiveSupport
       "Pacific Time (Canada)"        => "America/Vancouver",
       "Tijuana"                      => "America/Tijuana",
       "Mountain Time (US & Canada)"  => "America/Denver",
-      "Alberta Time"                 => "America/Edmonton",
+      "Alberta"                      => "America/Edmonton",
       "Arizona"                      => "America/Phoenix",
       "Chihuahua"                    => "America/Chihuahua",
       "Mazatlan"                     => "America/Mazatlan",

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -10,7 +10,7 @@ module ActiveSupport
   # The TimeZone class serves as a wrapper around +TZInfo::Timezone+ instances.
   # It allows us to do the following:
   #
-  # * Limit the set of zones provided by TZInfo to a meaningful subset of 134
+  # * Limit the set of zones provided by TZInfo to a meaningful subset of 154
   #   zones.
   # * Retrieve and display zones with a friendlier name
   #   (e.g., "Eastern \Time (US & Canada)" instead of "America/New_York").
@@ -38,8 +38,10 @@ module ActiveSupport
       "Hawaii"                       => "Pacific/Honolulu",
       "Alaska"                       => "America/Juneau",
       "Pacific Time (US & Canada)"   => "America/Los_Angeles",
+      "Pacific Time (Canada)"        => "America/Vancouver",
       "Tijuana"                      => "America/Tijuana",
       "Mountain Time (US & Canada)"  => "America/Denver",
+      "Alberta Time"                 => "America/Edmonton",
       "Arizona"                      => "America/Phoenix",
       "Chihuahua"                    => "America/Chihuahua",
       "Mazatlan"                     => "America/Mazatlan",

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -974,26 +974,26 @@ class TimeZoneTest < ActiveSupport::TestCase
     assert_equal "America/Toronto", ActiveSupport::TimeZone["America/Toronto"].standard_name
   end
 
-  def test_pacific_time_canada_and_alberta_time_mappings
+  def test_pacific_time_canada_and_alberta_mappings
     pacific_canada = ActiveSupport::TimeZone["Pacific Time (Canada)"]
-    alberta_time = ActiveSupport::TimeZone["Alberta Time"]
+    alberta = ActiveSupport::TimeZone["Alberta"]
     pacific_us = ActiveSupport::TimeZone["Pacific Time (US & Canada)"]
     mountain_us = ActiveSupport::TimeZone["Mountain Time (US & Canada)"]
 
     assert_equal "America/Vancouver", pacific_canada.standard_name
-    assert_equal "America/Edmonton", alberta_time.standard_name
+    assert_equal "America/Edmonton", alberta.standard_name
     assert_equal "America/Los_Angeles", pacific_us.standard_name
     assert_equal "America/Denver", mountain_us.standard_name
 
     assert_equal "America/Vancouver", pacific_canada.tzinfo.name
-    assert_equal "America/Edmonton", alberta_time.tzinfo.name
+    assert_equal "America/Edmonton", alberta.tzinfo.name
   end
 
-  def test_country_zones_include_pacific_time_canada_and_alberta_time
+  def test_country_zones_include_pacific_time_canada_and_alberta
     ca_zones = ActiveSupport::TimeZone.country_zones(:ca)
 
     assert_includes ca_zones, ActiveSupport::TimeZone["Pacific Time (Canada)"]
-    assert_includes ca_zones, ActiveSupport::TimeZone["Alberta Time"]
+    assert_includes ca_zones, ActiveSupport::TimeZone["Alberta"]
     assert_not_includes ca_zones.map(&:name), "America/Vancouver"
     assert_not_includes ca_zones.map(&:name), "America/Edmonton"
   end

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -973,4 +973,28 @@ class TimeZoneTest < ActiveSupport::TestCase
     assert_equal "America/Montevideo", ActiveSupport::TimeZone["Montevideo"].standard_name
     assert_equal "America/Toronto", ActiveSupport::TimeZone["America/Toronto"].standard_name
   end
+
+  def test_pacific_time_canada_and_alberta_time_mappings
+    pacific_canada = ActiveSupport::TimeZone["Pacific Time (Canada)"]
+    alberta_time = ActiveSupport::TimeZone["Alberta Time"]
+    pacific_us = ActiveSupport::TimeZone["Pacific Time (US & Canada)"]
+    mountain_us = ActiveSupport::TimeZone["Mountain Time (US & Canada)"]
+
+    assert_equal "America/Vancouver", pacific_canada.standard_name
+    assert_equal "America/Edmonton", alberta_time.standard_name
+    assert_equal "America/Los_Angeles", pacific_us.standard_name
+    assert_equal "America/Denver", mountain_us.standard_name
+
+    assert_equal "America/Vancouver", pacific_canada.tzinfo.name
+    assert_equal "America/Edmonton", alberta_time.tzinfo.name
+  end
+
+  def test_country_zones_include_pacific_time_canada_and_alberta_time
+    ca_zones = ActiveSupport::TimeZone.country_zones(:ca)
+
+    assert_includes ca_zones, ActiveSupport::TimeZone["Pacific Time (Canada)"]
+    assert_includes ca_zones, ActiveSupport::TimeZone["Alberta Time"]
+    assert_not_includes ca_zones.map(&:name), "America/Vancouver"
+    assert_not_includes ca_zones.map(&:name), "America/Edmonton"
+  end
 end


### PR DESCRIPTION
### Motivation / Background

Fixes #58316.

British Columbia and Alberta no longer share winter clocks with US Pacific and Mountain time. The existing `Pacific Time (US & Canada)` and `Mountain Time (US & Canada)` mappings still resolve to `America/Los_Angeles` and `America/Denver`, so apps and users treating those names as a proxy for BC or Alberta will be an hour off every winter.

### Detail

This Pull Request adds two friendly zone mappings:

- `Pacific Time (Canada)` → `America/Vancouver`
- `Alberta` → `America/Edmonton`

The existing `US & Canada` entries are left unchanged for compatibility.

### Additional information

Follows the same pattern as other regional divergences (`Arizona`, `Saskatchewan`, `Atlantic Time (Canada)`). Actual DST/offset rules still come from IANA tzdb (BC in [2026a](https://www.iana.org/time-zones/releases/2026a), [2026b](https://www.iana.org/time-zones/releases/2026b), Alberta in [2026c](https://www.iana.org/time-zones/releases/2026c)).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.