### PR TITLE
Remove migrations filter from the schema dump

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   When `dump_schema_migrations` is enabled, the trailer gets now exactly the
+    versions present in the `schema_migrations` table, without filtering by
+    what's on disk.
+
+    *Xavier Noria*
+
 *   Improve bind parameter rendering for casted binds in SQL logs and EXPLAIN output.
 
     Queries built with casted binds (an array of values instead of

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -118,20 +118,13 @@ module ActiveRecord
       end
 
       def versions(stream)
-        pool = @connection.pool
-
-        versions_in_schema_migrations = pool.migration_context.get_all_versions
-        versions_in_db_migrate = pool.migration_context.migrations.map(&:version)
-        versions_to_dump = versions_in_schema_migrations & versions_in_db_migrate
-
-        if versions_to_dump.any?
-          versions_to_dump.map!(&:to_s)
-          versions_to_dump.sort_by!(&ActiveRecord.dump_schema_migrations_sort_by)
+        if (versions = @connection.pool.schema_migration.versions).any?
+          versions.sort_by!(&ActiveRecord.dump_schema_migrations_sort_by)
 
           stream.puts
           stream.puts "ActiveRecord::Schema.load_schema_migrations(__FILE__)"
           stream.puts "__END__"
-          stream.puts versions_to_dump
+          stream.puts versions
         end
       end
 

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -47,21 +47,25 @@ class SchemaDumperTest < ActiveRecord::TestCase
     assert_match %r{ActiveRecord::Schema\[#{ActiveRecord::Migration.current_version}\]\.define}, output
   end
 
-  def test_schema_dump_includes_applied_migrations_when_configured
+  def test_schema_dump_includes_all_recorded_migrations_when_configured
     original_migrations_paths = ActiveRecord::Migrator.migrations_paths
     ActiveRecord::Migrator.migrations_paths = File.expand_path("../migrations/valid", __dir__)
 
-    versions = ActiveRecord::Base.connection_pool.migration_context.migrations.first(2).map(&:version)
-    version_without_file = 4
+    migrations_on_disk = ActiveRecord::Base.connection_pool.migration_context.migrations.map(&:version)
+
+    # By introducing this version we ensure that schema_migrations is dumped as
+    # is, including versions that are not on disk.
+    version_without_file = (migrations_on_disk.max || 0) + 1
+    versions = (migrations_on_disk + [version_without_file]).map(&:to_s)
 
     @schema_migration.delete_all_versions
-    @schema_migration.create_versions((versions + [version_without_file]).map(&:to_s))
+    @schema_migration.create_versions(versions)
 
     output = ActiveRecord.stub(:dump_schema_migrations, true) do
       dump_all_table_schema
     end
 
-    expected_versions = versions.map(&:to_s).sort_by(&:reverse)
+    expected_versions = versions.sort_by(&ActiveRecord.dump_schema_migrations_sort_by)
     expected = [
       "ActiveRecord::Schema.load_schema_migrations(__FILE__)",
       "__END__",
@@ -70,7 +74,6 @@ class SchemaDumperTest < ActiveRecord::TestCase
 
     assert_match %r{ActiveRecord::Schema\[.+\]\.define do}, output
     assert_includes output, expected
-    assert_no_match(/^#{version_without_file}$/, output)
   ensure
     @schema_migration.delete_all_versions
     ActiveRecord::Migrator.migrations_paths = original_migrations_paths

--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -1499,9 +1499,8 @@ config.active_record.dump_schema_migrations = true
 The `:dump_schema_migrations` database configuration key allows you to override
 the global flag per database.
 
-The dump includes only versions with an existing migration file, so projects
-that prune old migrations keep the table in sync automatically just by
-regenerating the schema with `bin/rails db:schema:dump`.
+The dump includes every version recorded in the `schema_migrations` table,
+whether or not its migration file still exists on disk.
 
 By default, versions are ordered by their reversed strings to help avoid merge
 conflicts, but this can be customized:


### PR DESCRIPTION
In my first implementation of this feature I thought we could filter the dumped migration versions by what's on disk. Rationale:

1. Do not include something that does not exist locally, sounds clean.
2. To prune old migrations you just delete the file and regenerate `db/schema.rb`.

However, this approach has two cons that seem to outweigh that:

1. If you switch branches and dump the schema, migrations from other branches are not included in the trailer, but their side-effects are (say, they created a table). In a sense, the resulting `db/schema.rb` is kind of inconsistent or not self-contained.
2. Does not match what the `:sql` format does.

Let's remove the filtering, seems a better compromise.