### PR TITLE
Deprecate passing `binds` to `insert`, `update`, and `delete`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,27 @@
+*   Deprecate passing `binds` to `#insert`, `#update`, and `#delete` on
+    `ActiveRecord::ConnectionAdapters::DatabaseStatements`.
+
+    The `binds` positional was restored in #29944 to keep raw-SQL callers
+    working after bind parameters moved into the Arel AST. Now that
+    `Arel.sql(sql_with_placeholders, *binds)` wraps SQL and its binds
+    together as an `Arel::Nodes::BoundSqlLiteral` — the same idiom
+    `Model.where("... = ?", value)` already uses — the separate positional
+    is no longer needed:
+
+    ```ruby
+    # Before
+    connection.insert("INSERT INTO topics (title) VALUES (?)", nil, nil, nil, nil, ["hello"])
+    connection.update("UPDATE topics SET title = ? WHERE id = 1", nil, ["hi"])
+    connection.delete("DELETE FROM topics WHERE id = ?", nil, [1])
+
+    # After
+    connection.insert(Arel.sql("INSERT INTO topics (title) VALUES (?)", "hello"))
+    connection.update(Arel.sql("UPDATE topics SET title = ? WHERE id = 1", "hi"))
+    connection.delete(Arel.sql("DELETE FROM topics WHERE id = ?", 1))
+    ```
+
+    *Ryuta Kamizono*
+
 *   Deprecate the `pk`, `id_value`, and `sequence_name` positional arguments to
     `ActiveRecord::ConnectionAdapters::DatabaseStatements#insert`.
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -273,6 +273,16 @@ module ActiveRecord
             `insert_returning` option is removed.
           MSG
         end
+        if binds.any?
+          ActiveRecord.deprecator.warn(<<~MSG.squish)
+            Passing `binds` as a positional argument to `insert` is
+            deprecated and will be removed in Rails 8.3. Use
+            `Arel.sql(sql_with_placeholders, *binds)` to carry bind values
+            inside the arel node instead —
+            `insert(sql, name, nil, nil, nil, binds)` becomes
+            `insert(Arel.sql(sql, *binds), name)`.
+          MSG
+        end
 
         # The `pk` positional argument is really the RETURNING column name.
         # Translate it to `returning:` — including the legacy `false` sentinel
@@ -300,6 +310,17 @@ module ActiveRecord
 
       # Executes the update statement and returns the number of rows affected.
       def update(arel_or_sql, name = nil, binds = [])
+        if binds.any?
+          ActiveRecord.deprecator.warn(<<~MSG.squish)
+            Passing `binds` as a positional argument to `update` is
+            deprecated and will be removed in Rails 8.3. Use
+            `Arel.sql(sql_with_placeholders, *binds)` to carry bind values
+            inside the arel node instead —
+            `update(sql, name, binds)` becomes
+            `update(Arel.sql(sql, *binds), name)`.
+          MSG
+        end
+
         intent = QueryIntent.new(adapter: self, arel: arel_or_sql, name: name, binds: binds)
 
         intent.execute!
@@ -319,6 +340,17 @@ module ActiveRecord
 
       # Executes the delete statement and returns the number of rows affected.
       def delete(arel_or_sql, name = nil, binds = [])
+        if binds.any?
+          ActiveRecord.deprecator.warn(<<~MSG.squish)
+            Passing `binds` as a positional argument to `delete` is
+            deprecated and will be removed in Rails 8.3. Use
+            `Arel.sql(sql_with_placeholders, *binds)` to carry bind values
+            inside the arel node instead —
+            `delete(sql, name, binds)` becomes
+            `delete(Arel.sql(sql, *binds), name)`.
+          MSG
+        end
+
         intent = QueryIntent.new(adapter: self, arel: arel_or_sql, name: name, binds: binds)
 
         intent.execute!
@@ -819,7 +851,10 @@ module ActiveRecord
         def apply_returning_to!(intent, returning)
           return unless supports_insert_returning?
 
-          arel_or_sql = intent.arel || intent.raw_sql
+          # Only `Arel::InsertManager` has `#returning` on the AST; other arel
+          # nodes (e.g. `Arel::Nodes::BoundSqlLiteral` from `Arel.sql("... ?", value)`)
+          # are compiled to raw SQL first and take the string append path.
+          arel_or_sql = intent.arel.is_a?(Arel::InsertManager) ? intent.arel : intent.raw_sql
 
           returning ||= primary_key_for_insert(arel_or_sql)
           returning = Array(returning)

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -325,16 +325,22 @@ module ActiveRecord
         binds = [Event.type_for_attribute("id").serialize(1)]
         bind_param = Arel::Nodes::BindParam.new(nil)
 
-        id = @connection.insert("INSERT INTO events(id) VALUES (#{bind_param.to_sql})", nil, nil, nil, nil, binds)
+        id = assert_deprecated(/Passing `binds`/, ActiveRecord.deprecator) do
+          @connection.insert("INSERT INTO events(id) VALUES (#{bind_param.to_sql})", nil, nil, nil, nil, binds)
+        end
         assert_equal 1, id
 
-        updated = @connection.update("UPDATE events SET title = 'foo' WHERE id = #{bind_param.to_sql}", nil, binds)
+        updated = assert_deprecated(/Passing `binds`/, ActiveRecord.deprecator) do
+          @connection.update("UPDATE events SET title = 'foo' WHERE id = #{bind_param.to_sql}", nil, binds)
+        end
         assert_equal 1, updated
 
         result = @connection.select_all("SELECT * FROM events WHERE id = #{bind_param.to_sql}", nil, binds)
         assert_equal({ "id" => 1, "title" => "foo" }, result.first)
 
-        deleted = @connection.delete("DELETE FROM events WHERE id = #{bind_param.to_sql}", nil, binds)
+        deleted = assert_deprecated(/Passing `binds`/, ActiveRecord.deprecator) do
+          @connection.delete("DELETE FROM events WHERE id = #{bind_param.to_sql}", nil, binds)
+        end
         assert_equal 1, deleted
 
         result = @connection.select_all("SELECT * FROM events WHERE id = #{bind_param.to_sql}", nil, binds)
@@ -345,16 +351,22 @@ module ActiveRecord
         binds = [Relation::QueryAttribute.new("id", 1, Event.type_for_attribute("id"))]
         bind_param = Arel::Nodes::BindParam.new(nil)
 
-        id = @connection.insert("INSERT INTO events(id) VALUES (#{bind_param.to_sql})", nil, nil, nil, nil, binds)
+        id = assert_deprecated(/Passing `binds`/, ActiveRecord.deprecator) do
+          @connection.insert("INSERT INTO events(id) VALUES (#{bind_param.to_sql})", nil, nil, nil, nil, binds)
+        end
         assert_equal 1, id
 
-        updated = @connection.update("UPDATE events SET title = 'foo' WHERE id = #{bind_param.to_sql}", nil, binds)
+        updated = assert_deprecated(/Passing `binds`/, ActiveRecord.deprecator) do
+          @connection.update("UPDATE events SET title = 'foo' WHERE id = #{bind_param.to_sql}", nil, binds)
+        end
         assert_equal 1, updated
 
         result = @connection.select_all("SELECT * FROM events WHERE id = #{bind_param.to_sql}", nil, binds)
         assert_equal({ "id" => 1, "title" => "foo" }, result.first)
 
-        deleted = @connection.delete("DELETE FROM events WHERE id = #{bind_param.to_sql}", nil, binds)
+        deleted = assert_deprecated(/Passing `binds`/, ActiveRecord.deprecator) do
+          @connection.delete("DELETE FROM events WHERE id = #{bind_param.to_sql}", nil, binds)
+        end
         assert_equal 1, deleted
 
         result = @connection.select_all("SELECT * FROM events WHERE id = #{bind_param.to_sql}", nil, binds)

--- a/activerecord/test/cases/database_statements_test.rb
+++ b/activerecord/test/cases/database_statements_test.rb
@@ -70,6 +70,41 @@ class DatabaseStatementsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_insert_with_arel_sql_carrying_binds
+    arel = Arel.sql("INSERT INTO accounts (firm_id,credit_limit) VALUES (?,?)", 42, 5000)
+    id = @connection.insert(arel)
+    assert_kind_of Integer, id
+  end
+
+  if ActiveRecord::Base.lease_connection.prepared_statements
+    def test_insert_binds_arg_is_deprecated
+      sub = Arel::Nodes::BindParam.new(nil).to_sql
+      sql = "INSERT INTO accounts (firm_id) VALUES (#{sub})"
+      id = assert_deprecated(/Passing `binds`/, ActiveRecord.deprecator) do
+        @connection.insert(sql, nil, nil, nil, nil, [42])
+      end
+      assert_kind_of Integer, id
+    end
+
+    def test_update_binds_arg_is_deprecated
+      id = @connection.insert("INSERT INTO accounts (firm_id) VALUES (42)")
+      sub = Arel::Nodes::BindParam.new(nil).to_sql
+      affected = assert_deprecated(/Passing `binds`/, ActiveRecord.deprecator) do
+        @connection.update("UPDATE accounts SET firm_id = 99 WHERE id = #{sub}", nil, [id])
+      end
+      assert_equal 1, affected
+    end
+
+    def test_delete_binds_arg_is_deprecated
+      id = @connection.insert("INSERT INTO accounts (firm_id) VALUES (42)")
+      sub = Arel::Nodes::BindParam.new(nil).to_sql
+      affected = assert_deprecated(/Passing `binds`/, ActiveRecord.deprecator) do
+        @connection.delete("DELETE FROM accounts WHERE id = #{sub}", nil, [id])
+      end
+      assert_equal 1, affected
+    end
+  end
+
   private
     def return_the_inserted_id(method:)
       @connection.send(method, "INSERT INTO accounts (firm_id,credit_limit) VALUES (42,5000)")


### PR DESCRIPTION
The `binds` positional was restored in #29944 to keep raw-SQL callers working after bind parameters moved into the Arel AST. Now that `Arel.sql("... ?", *binds)` wraps SQL and its binds together as an `Arel::Nodes::BoundSqlLiteral` — the same idiom `Model.where("... = ?", value)` already uses — callers can just pass that arel node and let `to_sql_and_binds` extract the binds from the AST:

```ruby
connection.insert(Arel.sql("INSERT INTO topics (title) VALUES (?)", "hello"))
connection.update(Arel.sql("UPDATE topics SET title = ? WHERE id = 1", "hi"))
connection.delete(Arel.sql("DELETE FROM topics WHERE id = ?", 1))
```

Deprecate the `binds` positional on all three so the migration can proceed via a formal deprecation cycle.
