### PR TITLE
Fix `String#parameterize` raising `TypeError` when separator is nil

### DIFF
--- a/activesupport/lib/active_support/inflector/transliterate.rb
+++ b/activesupport/lib/active_support/inflector/transliterate.rb
@@ -108,6 +108,11 @@ module ActiveSupport
     #   parameterize("Donald E. Knuth", separator: '_') # => "donald_e_knuth"
     #   parameterize("^très|Jolie__ ", separator: '_')  # => "tres_jolie"
     #
+    # To remove the unwanted characters instead of replacing them, pass an
+    # empty separator. +nil+ is treated the same way.
+    #
+    #   parameterize("Donald E. Knuth", separator: '') # => "donaldeknuth"
+    #
     # To preserve the case of the characters in a string, use the +preserve_case+ argument.
     #
     #   parameterize("Donald E. Knuth", preserve_case: true) # => "Donald-E-Knuth"
@@ -124,13 +129,15 @@ module ActiveSupport
     # By default, this parameter is set to <tt>nil</tt> and it will use
     # the configured <tt>I18n.locale</tt>.
     def parameterize(string, separator: "-", preserve_case: false, locale: nil)
+      separator ||= ""
+
       # Replace accented chars with their ASCII equivalents.
       parameterized_string = transliterate(string, locale: locale)
 
       # Turn unwanted chars into the separator.
       parameterized_string.gsub!(/[^a-z0-9\-_]+/i, separator)
 
-      unless separator.nil? || separator.empty?
+      unless separator.empty?
         # No more than one of the separator in a row.
         if separator.length == 1
           parameterized_string.squeeze!(separator)

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -213,6 +213,18 @@ class StringInflectionsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_string_parameterized_nil_separator
+    StringToParameterizeWithNoSeparator.each do |normal, slugged|
+      assert_equal(slugged, normal.parameterize(separator: nil))
+    end
+  end
+
+  def test_string_parameterized_nil_separator_preserve_case
+    StringToParameterizePreserveCaseWithNoSeparator.each do |normal, slugged|
+      assert_equal(slugged, normal.parameterize(separator: nil, preserve_case: true))
+    end
+  end
+
   def test_string_parameterized_underscore
     StringToParameterizeWithUnderscore.each do |normal, slugged|
       assert_equal(slugged, normal.parameterize(separator: "_"))


### PR DESCRIPTION
### Summary

`ActiveSupport::Inflector#parameterize` contains a guard that explicitly handles a `nil` separator:

```ruby
unless separator.nil? || separator.empty?
  # No more than one of the separator in a row.
  # Remove leading/trailing separator.
end
```

But three lines earlier the separator is passed straight to `String#gsub!`:

```ruby
parameterized_string.gsub!(/[^a-z0-9\-_]+/i, separator)
```

so a `nil` separator raises before the guard is ever reached, and the `separator.nil?` branch is unreachable:

```ruby
"Donald E. Knuth".parameterize(separator: nil)
# => TypeError: no implicit conversion of nil into String
```

### Fix

Treat a `nil` separator like an empty one — which is exactly what the existing guard already implies — and drop the now-redundant `separator.nil?` check:

```ruby
"Donald E. Knuth".parameterize(separator: nil) # => "donaldeknuth"
"Donald E. Knuth".parameterize(separator: "")  # => "donaldeknuth"
```

The alternative reading — that `nil` was never meant to be supported — would mean deleting the `separator.nil?` branch instead. Making it work seemed like the smaller surprise for callers that pass a separator through from configuration or params, but happy to flip it to the removal if maintainers prefer that.

Both `separator: nil` and `separator: ""` now go down the same path, so no behavior changes for any currently-working input.

### Tests

Added `separator: nil` cases mirroring the existing `separator: ""` tests, including the `preserve_case: true` variant, reusing the existing `StringToParameterizeWithNoSeparator` and `StringToParameterizePreserveCaseWithNoSeparator` fixtures.

`activesupport` — `string_ext_test.rb`, `inflector_test.rb`, `transliterate_test.rb`: 645 runs, 3207 assertions, 0 failures, 0 errors. RuboCop clean.