### PR TITLE
Add test coverage for `NameError#missing_name` branches

### DIFF
--- a/activesupport/test/core_ext/name_error_test.rb
+++ b/activesupport/test/core_ext/name_error_test.rb
@@ -22,4 +22,29 @@ class NameErrorTest < ActiveSupport::TestCase
     assert_nil exc.missing_name
     assert_equal self, exc.receiver
   end
+
+  def test_missing_top_level_constant_is_not_namespaced
+    exc = assert_raise NameError do
+      ::SomeTopLevelNameThatNobodyWillUse____Really ? 1 : 0
+    end
+    assert_equal Object, exc.receiver
+    assert_equal "SomeTopLevelNameThatNobodyWillUse____Really", exc.missing_name
+    assert exc.missing_name?(:SomeTopLevelNameThatNobodyWillUse____Really)
+    assert exc.missing_name?("SomeTopLevelNameThatNobodyWillUse____Really")
+  end
+
+  def test_missing_name_falls_back_to_the_message_without_a_receiver
+    exc = NameError.new("uninitialized constant Foo::Bar")
+
+    assert_raise(ArgumentError) { exc.receiver }
+    assert_equal "Foo::Bar", exc.missing_name
+    assert exc.missing_name?("Foo::Bar")
+  end
+
+  def test_missing_name_ignores_a_message_that_is_not_about_a_constant
+    exc = NameError.new("undefined local variable or method 'foo'")
+
+    assert_nil exc.missing_name
+    assert_not exc.missing_name?("foo")
+  end
 end


### PR DESCRIPTION
### Summary

`NameError#missing_name` branches on the exception's receiver:

```ruby
receiver = begin
  self.receiver
rescue ArgumentError
  nil
end

if receiver == Object
  name.to_s
elsif receiver
  "#{real_mod_name(receiver)}::#{self.name}"
else
  if match = message.match(/((::)?([A-Z]\w*)(::[A-Z]\w*)*)$/)
    match[1]
  end
end
```

Of these, only the `elsif receiver` branch and the early return for non-constant errors were exercised. Line coverage over `activesupport/test/core_ext/` showed the `receiver == Object` branch, the `rescue ArgumentError` branch, and the message-matching fallback all unreached.

Notably the `receiver == Object` case is the example in the method's own documentation:

```ruby
begin
  HelloWorld
rescue NameError => e
  e.missing_name
end
# => "HelloWorld"
```

### Tests added

* `test_missing_top_level_constant_is_not_namespaced` — a missing top-level constant has `Object` as its receiver and returns the name unqualified, matching the documented example.
* `test_missing_name_falls_back_to_the_message_without_a_receiver` — a `NameError` built without a receiver raises `ArgumentError` from `#receiver`, so the name is recovered from the message.
* `test_missing_name_ignores_a_message_that_is_not_about_a_constant` — `missing_name` is `nil` and `missing_name?` is false for a non-constant message.

No behavior changes — tests only, so no CHANGELOG entry.

`active_support/core_ext/name_error.rb` goes from 17/21 to full line coverage. `activesupport/test/core_ext/`: 1474 runs, 6124 assertions, 0 failures, 0 errors. RuboCop clean.