### PR TITLE
Define Tags#field_type when the class is loaded

### DIFF
--- a/actionview/lib/action_view/helpers/tags/datetime_local_field.rb
+++ b/actionview/lib/action_view/helpers/tags/datetime_local_field.rb
@@ -9,11 +9,7 @@ module ActionView
           super
         end
 
-        class << self
-          def field_type
-            @field_type ||= "datetime-local"
-          end
-        end
+        @field_type = "datetime-local"
 
         private
           def format_datetime(value)

--- a/actionview/lib/action_view/helpers/tags/text_field.rb
+++ b/actionview/lib/action_view/helpers/tags/text_field.rb
@@ -19,9 +19,16 @@ module ActionView
 
         class << self
           def field_type
-            @field_type ||= name.split("::").last.sub("Field", "").downcase
+            @field_type ||= name.split("::").last.sub("Field", "").downcase.dedup
+          end
+
+          def inherited(subclass)
+            super
+            subclass.field_type if subclass.name
           end
         end
+
+        field_type
 
         private
           def field_type

--- a/actionview/test/template/tags_ractor_test.rb
+++ b/actionview/test/template/tags_ractor_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+class TagsRactorTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::Isolation
+
+  if defined?(Ractor) && RUBY_VERSION >= "4.0"
+    test "field_type is computed at load time and readable from a non-main Ractor" do
+      field_types = Ractor.new do
+        [
+          ActionView::Helpers::Tags::TextField.field_type,          # class body memoization
+          ActionView::Helpers::Tags::SearchField.field_type,        # direct subclass: inherited
+          ActionView::Helpers::Tags::RangeField.field_type,         # indirect subclass: inherited
+          ActionView::Helpers::Tags::DatetimeLocalField.field_type, # custom: class body instance variable
+        ]
+      end.value
+
+      assert_equal ["text", "search", "range", "datetime-local"], field_types
+    end
+  end
+end


### PR DESCRIPTION
Currently, `field_type` is lazily memoized in a class instance variable, so the first form field rendered inside a non-main Ractor raises.

Call `field_type` from the `TextField` class body to memoize it when the class is loaded, and implement `TextField.inherited` to do the same for (non-anonymous) subclasses.

`DatetimeLocalField` overrides `field_type`, instead define the instance variable directly from the class body.

Also call `freeze` when memoizing to ensure `field_type` is Ractor-shareable.
