### PR TITLE
Allow ActiveSupport::ProxyLogger to ignore messages by pattern

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -63,7 +63,16 @@
 
     Almost all of the standard Logger interface is supported.
 
-    *Jean Boussier*
+    In addition it can be set to ignore messages matching given patterns.
+
+    Useful to silence noisy logs from gems that your application may not care
+    about, without needing to change the log level and losing other useful logs.
+
+    ```ruby
+    SomeLibrary.logger = ActiveSupport::ProxyLogger.new(Rails.logger).ignore(/Noisy/)
+    ```
+
+    *Jean Boussier*, *Federico Carrocera*
 
 *   Include call options in `Cache#exist?` instrumentation payload,
     consistent with `read`, `write`, and `delete`.

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Allow `ActiveSupport::ProxyLogger` to ignore messages matching given patterns.
+
+    Useful to silence noisy logs from gems that your application may not care
+    about, without needing to change the log level and losing other useful logs.
+
+    ```ruby
+    SomeLibrary.logger = ActiveSupport::ProxyLogger.new(Rails.logger).ignore(/Noisy/)
+    ```
+
+    *Federico Carrocera*
+
 *   Add `#this_quarter?` to Date/Time.
 
     It returns true if the date/time falls within the current quarter.

--- a/activesupport/lib/active_support/proxy_logger.rb
+++ b/activesupport/lib/active_support/proxy_logger.rb
@@ -15,6 +15,11 @@ module ActiveSupport
   #
   #   SomeLibrary.logger = ActiveSupport::ProxyLogger.new(Rails.logger, :error)
   #
+  # It can also ignore individual messages matching given patterns, when a
+  # library is only noisy on some logs your application doesn't care about:
+  #
+  #   SomeLibrary.logger = ActiveSupport::ProxyLogger.new(Rails.logger).ignore(/Noisy/)
+  #
   # Almost all of the standard Logger interface is supported.
   #
   # Note that the proxy logger can only suppress some logs, if the proxy severity is lower
@@ -27,6 +32,28 @@ module ActiveSupport
       super()
       @logger = logger
       @level = ::Logger::Severity.coerce(level)
+      @ignored_patterns = []
+      @ignored = nil
+    end
+
+    # Registers patterns of messages to ignore. Ignored messages aren't
+    # forwarded to the underlying logger, whatever their severity. Returns
+    # +self+, so it can be chained on the constructor.
+    #
+    # Regexps are matched against the message, strings are matched literally:
+    #
+    #   logger.ignore(/Noisy/, 'Also noisy')
+    #   logger.error('Noisy message') # not forwarded
+    #   logger.error('Also noisy')    # not forwarded
+    #
+    # Patterns are matched against +message.to_s+, so lazily generated messages
+    # are evaluated even when they end up ignored.
+    def ignore(*patterns)
+      return self if patterns.empty?
+
+      @ignored_patterns.concat(patterns)
+      @ignored = Regexp.union(@ignored_patterns)
+      self
     end
 
     # Logging severity threshold (e.g. <tt>Logger::INFO</tt>).
@@ -116,13 +143,26 @@ module ActiveSupport
     # - #fatal.
     # - #unknown.
     #
-    def add(severity, ...)
+    def add(severity, message = nil, progname = nil, &block)
       severity ||= UNKNOWN
-      if @logger && severity >= level
-        @logger.add(severity, ...)
-      else
-        true
+      return true unless @logger && severity >= level
+
+      if @ignored
+        if message.nil?
+          if block_given?
+            message = yield
+            block = nil
+          else
+            message = progname
+            progname = nil
+          end
+        end
+
+        text = message.to_s
+        return true if text.valid_encoding? && @ignored.match?(text)
       end
+
+      @logger.add(severity, message, progname, &block)
     end
     alias_method :log, :add
 

--- a/activesupport/test/proxy_logger_test.rb
+++ b/activesupport/test/proxy_logger_test.rb
@@ -74,6 +74,54 @@ module ActiveSupport
       assert_equal %w(LOG DEBUG INFO WARN ERROR FATAL UNKNOWN), @io.string.split("\n")
     end
 
+    def test_ignore
+      assert_same @logger, @logger.ignore(/IGNORED/)
+      @logger.ignore(/DROPPED/, "SKIPPED")
+
+      @logger.error("IGNORED-1")
+      @logger.add(::Logger::ERROR, "DROPPED-2")
+      @logger.error("SKIPPED")
+      @logger.error("PASSES")
+
+      assert_equal %w(PASSES), @io.string.split("\n")
+    end
+
+    def test_ignore_only_affects_the_receiver
+      other = ProxyLogger.new(@real_logger)
+      @logger.ignore(/IGNORED/)
+
+      other.error("IGNORED")
+
+      assert_equal %w(IGNORED), @io.string.split("\n")
+    end
+
+    def test_ignore_forwards_messages_with_an_invalid_encoding
+      @logger.ignore(/IGNORED/)
+
+      @logger.error("PASSES \xE9".dup.force_encoding(Encoding::UTF_8))
+
+      assert_includes @io.string.b, "PASSES"
+    end
+
+    def test_ignore_matches_non_string_messages
+      @logger.ignore(/IGNORED/)
+
+      @logger.error([:IGNORED, 1])
+      @logger.error([:PASSES, 1])
+
+      assert_equal ["[:PASSES, 1]"], @io.string.split("\n")
+    end
+
+    def test_ignore_preserves_progname
+      @real_logger.formatter = ->(severity, _time, progname, msg) { "#{severity}|#{progname}|#{msg}\n" }
+      @logger.ignore(/IGNORED/)
+
+      @logger.error("PASSES-1")
+      @logger.add(::Logger::ERROR, "PASSES-2", "PROG")
+
+      assert_equal ["ERROR||PASSES-1", "ERROR|PROG|PASSES-2"], @io.string.split("\n")
+    end
+
     def test_all_block_delegators
       @logger.log(::Logger::DEBUG) { "LOG" }
       @logger.debug { "DEBUG" }


### PR DESCRIPTION
ProxyLogger can only filter by severity, so silencing one noisy message from a gem means raising the level and losing every message below it.
``` 
SomeLibrary.logger = ActiveSupport::ProxyLogger.new(Rails.logger).ignore(/Noisy/)
```
Regexps are matched against the message, strings are matched literally. Patterns are compiled into a single Regexp.union at registration time, and matching only happens after the severity check, so proxies without patterns are unaffected.

add now takes Logger#add's explicit signature rather than forwarding `...`, because the message has to be resolved before it can be matched.