### PR TITLE
Fix `LocalCache` crash when instantiated from an anonymous subclass

### DIFF
--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -65,7 +65,11 @@ module ActiveSupport
 
         def initialize(...)
           super
-          @local_cache_key = "#{self.class.name.underscore}_local_cache_#{object_id}".gsub(/[\/-]/, "_").to_sym
+          # Compute the key eagerly for named stores so the store can later be
+          # made shareable (frozen) without triggering a lazy assignment. An
+          # anonymous subclass has no name yet, so fall back to lazy computation
+          # once it has been assigned to a constant.
+          @local_cache_key = build_local_cache_key if self.class.name
         end
 
         # Use a local cache for the duration of block.
@@ -161,7 +165,13 @@ module ActiveSupport
         end
 
         private
-          attr_reader :local_cache_key
+          def local_cache_key
+            @local_cache_key ||= build_local_cache_key
+          end
+
+          def build_local_cache_key
+            "#{self.class.name.underscore}_local_cache_#{object_id}".gsub(/[\/-]/, "_").to_sym
+          end
 
           def read_serialized_entry(key, raw: false, **options)
             if cache = local_cache

--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -68,7 +68,11 @@ module ActiveSupport
 
         def initialize(...)
           super
-          @local_cache_key = "#{self.class.name.underscore}_local_cache_#{object_id}".gsub(/[\/-]/, "_").to_sym
+          # Compute the key eagerly for named stores so the store can later be
+          # made shareable (frozen) without triggering a lazy assignment. An
+          # anonymous subclass has no name yet, so fall back to lazy computation
+          # once it has been assigned to a constant.
+          @local_cache_key = build_local_cache_key if self.class.name
         end
 
         # Use a local cache for the duration of block.
@@ -145,7 +149,13 @@ module ActiveSupport
         end
 
         private
-          attr_reader :local_cache_key
+          def local_cache_key
+            @local_cache_key ||= build_local_cache_key
+          end
+
+          def build_local_cache_key
+            "#{self.class.name.underscore}_local_cache_#{object_id}".gsub(/[\/-]/, "_").to_sym
+          end
 
           def read_serialized_entry(key, raw: false, **options)
             if cache = local_cache

--- a/activesupport/test/cache/stores/memory_store_test.rb
+++ b/activesupport/test/cache/stores/memory_store_test.rb
@@ -101,6 +101,12 @@ class MemoryStoreTest < StoreTest
     assert_equal true, @cache.write(1, "bbbb", expires_in: 1.second, unless_exist: true)
   end
 
+  def test_can_be_instantiated_from_an_anonymous_subclass
+    store = Class.new(ActiveSupport::Cache::MemoryStore).new
+    store.write("foo", "bar")
+    assert_equal "bar", store.read("foo")
+  end
+
   private
     def compression_always_disabled_by_default?
       true


### PR DESCRIPTION
### Motivation / Background

Since #58061 (c6127f884e), building a cache store from an anonymous subclass raises during construction:

```ruby
Class.new(ActiveSupport::Cache::MemoryStore).new
# => NoMethodError: undefined method `underscore' for nil
#      .../cache/strategy/local_cache.rb:66:in `initialize'
```

`Strategy::LocalCache` is prepended by `MemoryStore`, `MemCacheStore`, `RedisCacheStore`, and `NullStore`, so this affects anonymous subclasses of any of them — an idiom used in tests and libraries that build a store class on the fly.

#58061 changed `Strategy::LocalCache#initialize` to compute the local cache key eagerly, so that a ractorized application can freeze `Rails.cache` without hitting a later lazy assignment:

```ruby
@local_cache_key = "#{self.class.name.underscore}_local_cache_#{object_id}"...
```

For an anonymous class `self.class.name` is `nil`, so `nil.underscore` raises. Previously the key was computed lazily, so constructing and using such a store for ordinary reads/writes worked; the eager computation moved the failure to `.new`.

### Detail

Compute the key eagerly only when the class is named — preserving the reason it was made eager — and fall back to lazy computation otherwise:

```ruby
def initialize(...)
  super
  @local_cache_key = build_local_cache_key if self.class.name
end

private
  def local_cache_key
    @local_cache_key ||= build_local_cache_key
  end

  def build_local_cache_key
    "#{self.class.name.underscore}_local_cache_#{object_id}".gsub(/[\/-]/, "_").to_sym
  end
```

Named stores are unchanged: the key is computed eagerly with the same expression at the same time as on main, and `railties/test/application/ractors_test.rb` (the test added in #58061) passes with this change, so the ractorize! scenario that motivated the eager computation keeps working.

### Additional information

- As was the case before #58061, a store that is *still* anonymous at the point where the local cache is actually engaged (`with_local_cache` or the middleware) raises there; once the class has been assigned to a constant, the lazy path works. This PR intentionally restores the previous behavior for anonymous subclasses rather than inventing a name for them.
- Regression test: constructing an anonymous `MemoryStore` subclass and performing a write/read round-trip. Red before the fix (`NoMethodError` at `.new`), green after.
- Unreleased regression (#58061), so no released version is affected — no CHANGELOG entry.