### PR TITLE
Fix `model_name` crashing when a model has an anonymous ancestor

### DIFF
--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -225,7 +225,11 @@ module ActiveModel
 
       def i18n_keys
         @i18n_keys ||= if @klass.respond_to?(:lookup_ancestors)
-          @klass.lookup_ancestors.map { |klass| klass.model_name.i18n_key }
+          # Anonymous ancestors have no model name to derive a key from, so
+          # skip them rather than letting Name.new raise on their blank name.
+          @klass.lookup_ancestors.filter_map do |klass|
+            klass.model_name.i18n_key unless klass.name.blank?
+          end
         else
           []
         end

--- a/activemodel/test/cases/naming_test.rb
+++ b/activemodel/test/cases/naming_test.rb
@@ -327,6 +327,23 @@ class NamingMethodDelegationTest < ActiveModel::TestCase
   def test_model_name
     assert_equal Blog::Post.model_name, Blog::Post.new.model_name
   end
+
+  def test_model_name_can_be_frozen_with_an_anonymous_ancestor
+    anonymous = Class.new do
+      extend ActiveModel::Naming
+      extend ActiveModel::Translation
+    end
+    named = Class.new(anonymous) do
+      def self.name
+        "NamedModelWithAnonymousAncestor"
+      end
+    end
+
+    # Freezing eagerly computes the i18n keys by walking lookup_ancestors,
+    # which includes the anonymous ancestor. That must not raise.
+    assert_nothing_raised { named.model_name.freeze }
+    assert_equal "NamedModelWithAnonymousAncestor", named.model_name.name
+  end
 end
 
 class OverridingAccessorsTest < ActiveModel::TestCase


### PR DESCRIPTION
### Motivation / Background

Since #58298 (c4dcf552cf), calling `model_name` on a model whose ancestor chain includes an anonymous class raises:

```ruby
base   = Class.new(ActiveRecord::Base)   # anonymous intermediate base
Widget = Class.new(base)                 # named concrete model
Widget.model_name
# => ArgumentError: Class name cannot be blank. You need to supply a name
#    argument when anonymous class given
```

Because `model_name` powers `form_for`, `url_for`, `to_partial_path`, serialization, etc., such a model becomes unusable across the framework.

`Name#freeze` (added in #58298 so `model_name` can be made Ractor-shareable) eagerly computes the i18n keys by walking `lookup_ancestors` and building each ancestor's `model_name`, which raises for an anonymous ancestor (`Name.new` rejects a blank name). Previously the keys were computed lazily, so `model_name` succeeded and only `human` walked the ancestors.

### Detail

Skip anonymous ancestors when building the i18n keys — they have no model name to contribute a key from anyway:

```ruby
@klass.lookup_ancestors.filter_map do |klass|
  klass.model_name.i18n_key unless klass.name.blank?
end
```

This restores `model_name` for models with anonymous ancestors and is also a strict improvement for `human`, which raised on the same ancestor even before the eager freeze. Named ancestors are unaffected, so the translation lookup order for ordinary models is unchanged.

### Additional information

- The regression test triggers `Name#freeze` → `i18n_keys` directly, so it reproduces on any Ruby version (the eager freeze only bites via `Ractor.make_shareable` on Rubies with real Ractor support, but freezing the `Name` directly exercises the same path everywhere). Red before the fix (`ArgumentError`), green after.
- Calling `model_name` on an anonymous class itself still raises, as it always has — this PR only fixes named models with anonymous ancestors.
- Unreleased regression (#58298), so no released version is affected — no CHANGELOG entry.