### PR TITLE
Revert "Remove migrations filter from the schema dump"

### DIFF
--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -118,13 +118,20 @@ module ActiveRecord
       end
 
       def versions(stream)
-        if (versions = @connection.pool.schema_migration.versions).any?
-          versions.sort_by!(&ActiveRecord.dump_schema_migrations_sort_by)
+        pool = @connection.pool
+
+        versions_in_schema_migrations = pool.migration_context.get_all_versions
+        versions_in_db_migrate = pool.migration_context.migrations.map(&:version)
+        versions_to_dump = versions_in_schema_migrations & versions_in_db_migrate
+
+        if versions_to_dump.any?
+          versions_to_dump.map!(&:to_s)
+          versions_to_dump.sort_by!(&ActiveRecord.dump_schema_migrations_sort_by)
 
           stream.puts
           stream.puts "ActiveRecord::Schema.load_schema_migrations(__FILE__)"
           stream.puts "__END__"
-          stream.puts versions
+          stream.puts versions_to_dump
         end
       end
 

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -47,25 +47,21 @@ class SchemaDumperTest < ActiveRecord::TestCase
     assert_match %r{ActiveRecord::Schema\[#{ActiveRecord::Migration.current_version}\]\.define}, output
   end
 
-  def test_schema_dump_includes_all_recorded_migrations_when_configured
+  def test_schema_dump_includes_applied_migrations_when_configured
     original_migrations_paths = ActiveRecord::Migrator.migrations_paths
     ActiveRecord::Migrator.migrations_paths = File.expand_path("../migrations/valid", __dir__)
 
-    migrations_on_disk = ActiveRecord::Base.connection_pool.migration_context.migrations.map(&:version)
-
-    # By introducing this version we ensure that schema_migrations is dumped as
-    # is, including versions that are not on disk.
-    version_without_file = (migrations_on_disk.max || 0) + 1
-    versions = (migrations_on_disk + [version_without_file]).map(&:to_s)
+    versions = ActiveRecord::Base.connection_pool.migration_context.migrations.first(2).map(&:version)
+    version_without_file = 4
 
     @schema_migration.delete_all_versions
-    @schema_migration.create_versions(versions)
+    @schema_migration.create_versions((versions + [version_without_file]).map(&:to_s))
 
     output = ActiveRecord.stub(:dump_schema_migrations, true) do
       dump_all_table_schema
     end
 
-    expected_versions = versions.sort_by(&ActiveRecord.dump_schema_migrations_sort_by)
+    expected_versions = versions.map(&:to_s).sort_by(&:reverse)
     expected = [
       "ActiveRecord::Schema.load_schema_migrations(__FILE__)",
       "__END__",
@@ -74,6 +70,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
 
     assert_match %r{ActiveRecord::Schema\[.+\]\.define do}, output
     assert_includes output, expected
+    assert_no_match(/^#{version_without_file}$/, output)
   ensure
     @schema_migration.delete_all_versions
     ActiveRecord::Migrator.migrations_paths = original_migrations_paths

--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -1499,8 +1499,9 @@ config.active_record.dump_schema_migrations = true
 The `:dump_schema_migrations` database configuration key allows you to override
 the global flag per database.
 
-The dump includes every version recorded in the `schema_migrations` table,
-whether or not its migration file still exists on disk.
+The dump includes only versions with an existing migration file, so projects
+that prune old migrations keep the table in sync automatically just by
+regenerating the schema with `bin/rails db:schema:dump`.
 
 By default, versions are ordered by their reversed strings to help avoid merge
 conflicts, but this can be customized:


### PR DESCRIPTION
This reverts https://github.com/rails/rails/pull/58322.

While coherent with what we have, I am not fully convinced this is right, it is not clear how can you prune old migrations cleanly without this filter.

You would delete the old files, edit the trailer, and ship that. But then your team of 50 people have the versions in their local databases. When you `db:migrate` the old versions get added back to the trailer.

If the code that prunes old migrations ships a data migration that deletes the versions from `schema_versions`, it enters the circle, it is a migration! Someone on vacation may miss one cycle and get the data migration deleted, so their table won't be fixed.

You could keep around the deleted versions some way or another for automations to kick in when the schema is dumped, but doesn't that defeat the whole purpose of pruning? You want them out of the repo without a trace!

On the other hand, with the filter you have to do nothing.

Regarding the reasons to remove the filter I mentioned in the PR:

* The problem with inconsistencies when you switch branches... could be said that you get a "dirty" `db/schema.rb` anyway, and documentation explains why the version is not there. You have to discard that edit anyway.
* It does not agree with the `:sql` format, yes, but what if the `:sql` format is the one that does not have the right trade-off in practice? Maybe?

Deleting old migrations is an important use case I want to have well solved. Prefer to not commit to this change until I figure it out, or decide that the right trade-off is precisely this revert, all things considered.