### PR TITLE
Add group and step filtering to bin/ci

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add group and step filtering to `ActiveSupport::ContinuousIntegration`.
+
+    Use `bin/ci --group NAME` (`-g`) to run a named group or
+    `bin/ci --step NAME` (`-s`) to run a named step. Names match exactly and
+    case-insensitively. Use `bin/ci --help` (`-h`) to see all options.
+
+    *Thibaud Guillaume-Gentil*
+
 *   Fix `Range#sum` with a falsey initial value.
 
     Summing an integer range with a falsey starting value (such as nil or false)

--- a/activesupport/lib/active_support/continuous_integration.rb
+++ b/activesupport/lib/active_support/continuous_integration.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "optparse"
+
 module ActiveSupport
   # Provides a DSL for declaring a continuous integration workflow that can be run either locally or in the cloud.
   # Each step is timed, reports success/error, and is aggregated into a collective report that reports total runtime,
@@ -39,7 +41,12 @@ module ActiveSupport
     #
     # Sets the CI environment variable to "true" to allow for conditional behavior in the app, like enabling eager loading and disabling logging.
     #
-    # A 'fail fast' option can be passed as a CLI argument (-f or --fail-fast). This exits with a non-zero status directly after a step fails.
+    # Use +-g+ or +--group+ to run all steps in a named group, and +-s+ or +--step+ to run a named step.
+    # Names are matched exactly and case-insensitively. Options can be repeated, and group and step filters can be combined.
+    # A filtered run exits with a non-zero status if no steps match.
+    #
+    # A 'fail fast' option can be passed as a CLI argument (+-f+ or +--fail-fast+). This exits with a non-zero status directly after a step fails.
+    # Use +-h+ or +--help+ to see all available options.
     #
     # Example:
     #
@@ -61,14 +68,23 @@ module ActiveSupport
     end
 
     def run(title, subtitle, &block)
+      options = parse_options
+      return puts(options) if @show_help
+
       heading title, subtitle, padding: false
       success, seconds = execute(title, &block)
+      ensure_steps_ran!
       result_line(title, success, seconds)
       abort unless success?
     end
 
     def initialize
       @results = []
+      @groups = []
+      @steps = []
+      @fail_fast = false
+      @show_help = false
+      @group_selected = false
     end
 
     # Declare a step with a title and a command. The command can either be given as a single string or as multiple
@@ -79,14 +95,18 @@ module ActiveSupport
     #   step "Setup", "bin/setup"
     #   step "Single test", "bin/rails", "test", "--name", "test_that_is_one"
     def step(title, *command)
+      return unless selected_step?(title, group_selected: @group_selected)
+
       previous_trap = Signal.trap("INT") { abort colorize("\n❌ #{title} interrupted", :error) }
-      report_step(title, command) do
-        started = Time.now.to_f
-        [system(*command), Time.now.to_f - started]
+      begin
+        report_step(title, command) do
+          started = Time.now.to_f
+          [system(*command), Time.now.to_f - started]
+        end
+        abort if failing_fast?
+      ensure
+        Signal.trap("INT", previous_trap || "-")
       end
-      abort if failing_fast?
-    ensure
-      Signal.trap("INT", previous_trap || "-")
     end
 
     # Declare a group of steps that can be run in parallel. Steps within the group are collected first,
@@ -110,10 +130,11 @@ module ActiveSupport
     #     step "System tests", "bin/rails test:system"
     #   end
     def group(name, parallel: 1, &block)
+      group_selected = selected_group?(name, parent_selected: @group_selected)
       if parallel <= 1
-        instance_eval(&block)
+        within_group(group_selected, &block)
       else
-        Group.new(self, name, parallel: parallel, &block).run
+        Group.new(self, name, parallel: parallel, group_selected: group_selected, &block).run
       end
       abort if failing_fast?
     end
@@ -168,8 +189,18 @@ module ActiveSupport
     end
 
     # :nodoc:
+    def selected_group?(name, parent_selected:)
+      parent_selected || @groups.empty? || selected?(@groups, name)
+    end
+
+    # :nodoc:
+    def selected_step?(name, group_selected:)
+      (@groups.empty? || group_selected) && (@steps.empty? || selected?(@steps, name))
+    end
+
+    # :nodoc:
     def fail_fast?
-      ARGV.include?("-f") || ARGV.include?("--fail-fast")
+      @fail_fast
     end
 
     # :nodoc:
@@ -178,6 +209,53 @@ module ActiveSupport
     end
 
     private
+      def parse_options
+        @groups = []
+        @steps = []
+        @fail_fast = false
+        @show_help = false
+
+        parser = OptionParser.new do |options|
+          options.banner = "Usage: bin/ci [options]"
+          options.on("-g", "--group NAME", "Run all steps in the named group (case-insensitive).") { |name| @groups << name }
+          options.on("-s", "--step NAME", "Run the named step (case-insensitive).") { |name| @steps << name }
+          options.on("-f", "--fail-fast", "Abort after the first failure.") { @fail_fast = true }
+          options.on("-h", "--help", "Show this help.") { @show_help = true }
+        end
+        parser.parse!(ARGV.dup)
+        parser
+      rescue OptionParser::ParseError => error
+        abort "#{error.message}\n\n#{parser}"
+      end
+
+      def ensure_steps_ran!
+        if filtered? && results.empty?
+          abort colorize("No CI steps matched #{selection}.", :error)
+        end
+      end
+
+      def filtered?
+        @groups.any? || @steps.any?
+      end
+
+      def selected?(names, candidate)
+        names.any? { |name| candidate.to_s.casecmp?(name) }
+      end
+
+      def selection
+        selectors = @groups.map { |group| "--group #{group.inspect}" }
+        selectors.concat @steps.map { |step| "--step #{step.inspect}" }
+        selectors.join(" and ")
+      end
+
+      def within_group(group_selected, &block)
+        previous_group_selected = @group_selected
+        @group_selected = group_selected
+        instance_eval(&block)
+      ensure
+        @group_selected = previous_group_selected
+      end
+
       def failures
         results.reject(&:first)
       end

--- a/activesupport/lib/active_support/continuous_integration/group.rb
+++ b/activesupport/lib/active_support/continuous_integration/group.rb
@@ -8,26 +8,32 @@ module ActiveSupport
       class TaskCollector
         attr_reader :tasks
 
-        def initialize(&block)
+        def initialize(ci, group_selected:, &block)
+          @ci = ci
+          @group_selected = group_selected
           @tasks = []
           instance_eval(&block)
         end
 
         def step(title, *command)
-          @tasks << [:step, title, command]
+          if @ci.selected_step?(title, group_selected: @group_selected)
+            @tasks << [:step, title, command]
+          end
         end
 
         def group(name, **options, &block)
           raise ArgumentError, "Sub-groups cannot be parallelized. Remove the `parallel:` option from the #{name.inspect} group." if options.key?(:parallel)
-          @tasks << [:group, name, block]
+
+          group_selected = @ci.selected_group?(name, parent_selected: @group_selected)
+          @tasks << [:group, name, [group_selected, block]]
         end
       end
 
-      def initialize(ci, name, parallel:, &block)
+      def initialize(ci, name, parallel:, group_selected:, &block)
         @ci = ci
         @name = name
         @parallel = parallel
-        @tasks = TaskCollector.new(&block).tasks
+        @tasks = TaskCollector.new(ci, group_selected: group_selected, &block).tasks
         @start_time = Time.now.to_f
         @mutex = Mutex.new
         @running = {}
@@ -96,9 +102,10 @@ module ActiveSupport
           success
         end
 
-        def execute_group(block)
+        def execute_group(payload)
+          group_selected, block = payload
           all_success = true
-          TaskCollector.new(&block).tasks.each do |type, title, payload|
+          TaskCollector.new(@ci, group_selected: group_selected, &block).tasks.each do |type, title, payload|
             unless execute_task(type, title, payload)
               all_success = false
               break if @ci.fail_fast?

--- a/activesupport/test/continuous_integration_test.rb
+++ b/activesupport/test/continuous_integration_test.rb
@@ -287,6 +287,148 @@ class ContinuousIntegrationTest < ActiveSupport::TestCase
     assert_equal temp_files_before, temp_files_after
   end
 
+  %w[-g --group].each do |flag|
+    test "#{flag} selects a group by exact case-insensitive name" do
+      output = run_ci([flag, "style"]) do
+        step "Setup", "true"
+        group "Style", parallel: 2 do
+          step "Style check", "true"
+          group "Nested" do
+            step "Nested style check", "true"
+          end
+        end
+        group "Styles" do
+          step "Plural style check", "true"
+        end
+      end
+
+      assert_match(/Style check passed/, output)
+      assert_match(/Nested style check passed/, output)
+      assert_no_match(/Setup passed/, output)
+      assert_no_match(/Plural style check passed/, output)
+    end
+  end
+
+  %w[-s --step].each do |flag|
+    test "#{flag} selects a step by exact case-insensitive name" do
+      output = run_ci([flag, "security: gem audit"]) do
+        group "Checks", parallel: 2 do
+          step "Security: Gem audit", "true"
+          step "Security: Gem audit update", "true"
+          step "Style: Ruby", "true"
+        end
+      end
+
+      assert_match(/Security: Gem audit passed/, output)
+      assert_no_match(/Security: Gem audit update passed/, output)
+      assert_no_match(/Style: Ruby passed/, output)
+    end
+  end
+
+  test "repeated group and step selectors are ORed within type and ANDed across types" do
+    output = run_ci([
+      "--group", "style", "-g", "security",
+      "--step", "style check", "-s", "security check"
+    ]) do
+      group "Style", parallel: 2 do
+        step "Style check", "true"
+        step "Extra style check", "true"
+      end
+      group "Security", parallel: 2 do
+        step "Security check", "true"
+      end
+      group "Tests" do
+        step "Style check", "true"
+      end
+    end
+
+    assert_equal 1, output.scan(/Style check passed/).size
+    assert_match(/Security check passed/, output)
+    assert_no_match(/Extra style check passed/, output)
+  end
+
+  test "group selector finds nested groups within unmatched sequential and parallel groups" do
+    output = run_ci(["--group", "tests"]) do
+      group "Sequential checks" do
+        step "Sequential direct check", "true"
+        group "Tests" do
+          step "Sequential nested test", "true"
+        end
+      end
+
+      group "Parallel checks", parallel: 2 do
+        step "Parallel direct check", "true"
+        group "Tests" do
+          step "Parallel nested test", "true"
+        end
+      end
+    end
+
+    assert_match(/Sequential nested test passed/, output)
+    assert_match(/Parallel nested test passed/, output)
+    assert_no_match(/Sequential direct check passed/, output)
+    assert_no_match(/Parallel direct check passed/, output)
+  end
+
+  test "filtered run exits with an error when no step matches" do
+    output = with_argv(["--step", "security"]) do
+      capture_io do
+        assert_raises SystemExit do
+          @CI.run("CI", nil) do
+            step "Security: Gem audit", "true"
+          end
+        end
+      end
+    end.to_s
+
+    assert_match(/No CI steps matched/, output)
+    assert_match(/security/, output)
+    assert_no_match(/Security: Gem audit passed/, output)
+    assert_no_match(/CI passed/, output)
+  end
+
+  %w[-h --help].each do |flag|
+    test "#{flag} prints help without running CI" do
+      executed = false
+      output = with_argv([flag]) do
+        capture_io do
+          @CI.run("CI", nil) do
+            executed = true
+          end
+        end
+      end.to_s
+
+      assert_not executed
+      assert_match(/Usage: bin\/ci \[options\]/, output)
+      assert_match(/--group NAME/, output)
+      assert_match(/--step NAME/, output)
+      assert_no_match(/CI passed/, output)
+    end
+  end
+
+  test "invalid option exits with usage" do
+    output = with_argv(["--unknown"]) do
+      capture_io do
+        assert_raises SystemExit do
+          @CI.run("CI", nil) { flunk "CI should not run" }
+        end
+      end
+    end.to_s
+
+    assert_match(/invalid option: --unknown/, output)
+    assert_match(/Usage: bin\/ci \[options\]/, output)
+  end
+
+  test "fail fast ignores unselected failing steps" do
+    output = run_ci(["--fail-fast", "--step", "Selected"]) do
+      step "Not selected", "false"
+      step "Selected", "true"
+    end
+
+    assert_match(/Selected passed/, output)
+    assert_no_match(/Not selected failed/, output)
+  end
+
   %w[-f --fail-fast].each do |flag|
     test "run aborts immediately on failure with #{flag} flag" do
       output = with_argv([flag]) do
@@ -327,6 +469,12 @@ class ContinuousIntegrationTest < ActiveSupport::TestCase
   end
 
   private
+    def run_ci(argv, &block)
+      with_argv(argv) do
+        capture_io { @CI.run("CI", nil, &block) }
+      end.to_s
+    end
+
     def with_argv(argv)
       original_argv = ARGV.dup
       ARGV.replace(argv)


### PR DESCRIPTION
### Motivation / Background

`config/ci.rb` is the canonical declaration of an application's CI commands, but `bin/ci` currently runs the entire workflow. Developers who want to rerun one category or failed step must either run unrelated checks or repeat the command outside the CI declaration.

This is more noticeable with parallel groups. A `Style` group can run several independent linters concurrently, but there is no way to invoke just that group locally.

### Detail

Add exact, case-insensitive selection by group or step:

```sh
bin/ci --group style
bin/ci -g Style
bin/ci --step "Style: Ruby"
bin/ci -s "style: ruby"
```

A selected group runs all descendant steps using its existing sequential or parallel behavior. A selected step runs wherever it is declared. Options can be repeated; when group and step selectors are combined, both filters apply.

Selection is exact rather than pattern-based so similarly named groups or steps added later do not silently change a local or CI-provider command. A filtered run that selects no steps exits nonzero.

The existing `--fail-fast` / `-f` behavior is preserved, and `--help` / `-h` documents the available options.

### Additional information

Posted on rubyonrails-core: https://discuss.rubyonrails.org/t/filter-bin-ci-by-group-or-step/91447

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
