### PR TITLE
Report guarded load hooks triggered before application creation

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Report guarded load hooks that run before `Rails.application` exists once
+    application configuration is available.
+
+    Fixes #58327.
+
+    *Jose Solás Moreno*
+
 *   Don't filter nonexistent i18n paths on initialize. This negatively impacts
     applications with lots of translation files.
 

--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -12,6 +12,10 @@ module Rails
 
       initializer :load_environment_hook, group: :all do end
 
+      initializer :run_load_hook_guards, after: :load_environment_hook, before: :bootstrap_hook, group: :all do |app|
+        Rails::Railtie.run_load_hook_guards(app)
+      end
+
       initializer :load_active_support, group: :all do
         require "active_support/all" unless config.active_support.bare
       end

--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -219,21 +219,45 @@ module Rails
       # load hooks to defer code until the application is fully loaded.
       def guard_load_hooks(*components)
         components.each do |component|
+          # ActiveSupport.on_load immediately runs hooks for components that
+          # were loaded before their guard was registered.
+          registering_load_hook = true
           ActiveSupport.on_load(component) do
-            if Rails.try(:application) && !Rails.configuration.eager_load && !Rails.application.initialized?
-              case Rails.configuration.action_on_early_load_hook
-              when :log
-                (Rails.logger || ActiveSupport::Logger.new($stdout)).warn <<~MSG
-                  #{Railtie.load_hook_guard_message_for(component)}
-
-                  Called from:
-                  #{caller.join("\n")}
-                MSG
-              when :raise
-                raise LoadError, Railtie.load_hook_guard_message_for(component)
-              end
+            if application = Rails.try(:application)
+              Railtie.run_load_hook_guard(application, component, caller)
+            elsif !registering_load_hook
+              Railtie.defer_load_hook_guard(component, caller)
             end
           end
+          registering_load_hook = false
+        end
+      end
+
+      def defer_load_hook_guard(component, call_stack) # :nodoc:
+        (@pending_load_hook_guards ||= []) << [component, call_stack]
+      end
+
+      def run_load_hook_guards(application) # :nodoc:
+        guards = @pending_load_hook_guards
+        @pending_load_hook_guards = nil
+        guards&.each do |component, call_stack|
+          run_load_hook_guard(application, component, call_stack)
+        end
+      end
+
+      def run_load_hook_guard(application, component, call_stack) # :nodoc:
+        return if application.config.eager_load || application.initialized?
+
+        case application.config.action_on_early_load_hook
+        when :log
+          (Rails.logger || ActiveSupport::Logger.new($stdout)).warn <<~MSG
+            #{Railtie.load_hook_guard_message_for(component)}
+
+            Called from:
+            #{call_stack.join("\n")}
+          MSG
+        when :raise
+          raise LoadError, Railtie.load_hook_guard_message_for(component)
         end
       end
 

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -140,6 +140,8 @@ module TestHelpers
         config.session_store :cookie_store, key: "_myapp_session"
         config.cache_store = :mem_cache_store
         config.active_support.deprecation = :log
+        # The test process may have loaded components before the generated application exists.
+        config.action_on_early_load_hook = nil
         config.action_controller.allow_forgery_protection = false
       RUBY
 

--- a/railties/test/railties/railtie_test.rb
+++ b/railties/test/railties/railtie_test.rb
@@ -68,6 +68,25 @@ module RailtiesTest
       assert_equal "hello", Rails.application.config.foo.greetings
     end
 
+    test "load hook guards defer violations until application configuration has loaded" do
+      Class.new(Rails::Railtie) do
+        guard_load_hooks :early_component
+      end
+      ActiveSupport.run_load_hooks(:early_component)
+
+      application_class = Class.new(Rails::Application) do
+        initializer :configure_load_hook_guard, before: :load_environment_hook, group: :all do |app|
+          app.config.eager_load = false
+          app.config.action_on_early_load_hook = :raise
+        end
+      end
+
+      error = assert_raises(LoadError) do
+        application_class.instance.initialize!(:load_hook_guard_test)
+      end
+      assert_match ":early_component was loaded before application initialization", error.message
+    end
+
     test "railtie can add to_prepare callbacks" do
       $to_prepare = false
       class Foo < Rails::Railtie ; config.to_prepare { $to_prepare = true } ; end


### PR DESCRIPTION
### Motivation / Background

Fixes #58327.

The load hook guard currently skips guarded components loaded while
`Rails.application` is `nil`. This is the case during the standard boot sequence
when a Gemfile dependency is required after `rails/all` but before the application
class is defined, so those premature loads are neither logged nor raised.

### Detail

This Pull Request records guarded load hooks triggered before the application is
created, preserving the component and its original call stack. A bootstrap
initializer processes them after the environment configuration has loaded, when
both `config.eager_load` and `config.action_on_early_load_hook` have their final
values.

The existing guard behavior is shared between immediate and deferred checks.
Hooks that had already run before their guard was registered retain the previous
behavior and are not treated as new violations.

### Additional information

The regression test triggers a guarded hook without an application, configures
the guard action before `load_environment_hook`, and verifies that application
initialization raises the expected `LoadError`.

Railties isolation tests explicitly disable the guard for their generated
applications because the host test process intentionally loads framework
components before those applications exist.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
