### PR TITLE
Add test coverage for `ActiveModel::Type::Binary`

### DIFF
--- a/activemodel/test/cases/type/binary_test.rb
+++ b/activemodel/test/cases/type/binary_test.rb
@@ -23,6 +23,44 @@ module ActiveModel
         assert_equal "ƒée".b, type.serialize("ƒée")
         assert_not_equal "ƒée", type.serialize("ƒée")
       end
+
+      def test_type_and_binary_predicate
+        type = Type::Binary.new
+
+        assert_equal :binary, type.type
+        assert_predicate type, :binary?
+      end
+
+      def test_serialize_returns_binary_data
+        type = Type::Binary.new
+
+        assert_nil type.serialize(nil)
+        assert_instance_of Type::Binary::Data, type.serialize("ƒée")
+      end
+
+      def test_cast_binary_data_returns_the_underlying_string
+        type = Type::Binary.new
+        data = type.serialize("ƒée")
+
+        assert_equal "ƒée".b, type.cast(data)
+        assert_equal Encoding::BINARY, type.cast(data).encoding
+      end
+
+      def test_changed_in_place
+        type = Type::Binary.new
+
+        assert type.changed_in_place?("old value", "new value")
+        assert_not type.changed_in_place?("same value", "same value")
+      end
+
+      def test_data_hex_and_string_conversion
+        data = Type::Binary::Data.new("\xFF\x00")
+
+        assert_equal "ff00", data.hex
+        assert_equal "\xFF\x00".b, data.to_s
+        assert_equal "\xFF\x00".b, data.to_str
+        assert_equal data, "\xFF\x00".b
+      end
     end
   end
 end


### PR DESCRIPTION
### Summary

`ActiveModel::Type::Binary`'s own test file covered `cast` and `serialize` only. Running line coverage over `activemodel/test/cases/` showed `active_model/type/binary.rb` at 25/31 lines, with these unreached:

* `type` and `binary?`
* the `Data` branch of `cast`:
  ```ruby
  def cast(value)
    if value.is_a?(Data)
      value.to_s   # <- unreached
  ```
* `changed_in_place?`
* `Data#hex`

### Tests added

* `test_type_and_binary_predicate` — `type` is `:binary` and `binary?` is true.
* `test_serialize_returns_binary_data` — `nil` passes through; other values come back wrapped in `Binary::Data`.
* `test_cast_binary_data_returns_the_underlying_string` — round-trips a serialized value back through `cast`, asserting the `Data` branch returns the binary-encoded string.
* `test_changed_in_place` — true when the deserialized old value differs, false when it matches.
* `test_data_hex_and_string_conversion` — `Data#hex` on non-UTF-8 bytes, plus `to_s`/`to_str` and comparison against a raw string.

No behavior changes — tests only, so no CHANGELOG entry.

`active_model/type/binary.rb` goes from 25/31 to full line coverage. `activemodel/test/cases/`: 1199 runs, 5375 assertions, 0 failures, 0 errors. RuboCop clean.