### PR TITLE
Fix `search_field` raising `NameError` when passed `autosave: true`

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `search_field` raising `NameError` when passed `autosave: true`.
+
+    *Hammad Khan*
+
 *   Deprecate registering dependency trackers after application initialization.
 
     Calling `ActionView::DependencyTracker.register_tracker` after application initialization will

--- a/actionview/lib/action_view/helpers/tags/search_field.rb
+++ b/actionview/lib/action_view/helpers/tags/search_field.rb
@@ -9,7 +9,7 @@ module ActionView
 
           if options["autosave"]
             if options["autosave"] == true
-              options["autosave"] = request.host.split(".").reverse.join(".")
+              options["autosave"] = @template_object.request.host.split(".").reverse.join(".")
             end
             options["results"] ||= 10
           end

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -1189,6 +1189,26 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal(expected, search_field("contact", "notes_query", onsearch: true))
   end
 
+  def test_search_field_with_autosave_true_uses_the_reversed_host
+    expected = %{<input autosave="host.test" results="10" type="search" name="contact[notes_query]" id="contact_notes_query" />}
+    assert_dom_equal(expected, search_field("contact", "notes_query", autosave: true))
+  end
+
+  def test_search_field_with_autosave_string_is_left_alone
+    expected = %{<input autosave="com.example.www" results="10" type="search" name="contact[notes_query]" id="contact_notes_query" />}
+    assert_dom_equal(expected, search_field("contact", "notes_query", autosave: "com.example.www"))
+  end
+
+  def test_search_field_with_autosave_does_not_override_given_results
+    expected = %{<input autosave="host.test" results="3" type="search" name="contact[notes_query]" id="contact_notes_query" />}
+    assert_dom_equal(expected, search_field("contact", "notes_query", autosave: true, results: 3))
+  end
+
+  def test_search_field_with_autosave_false_omits_results
+    expected = %{<input autosave="false" type="search" name="contact[notes_query]" id="contact_notes_query" />}
+    assert_dom_equal(expected, search_field("contact", "notes_query", autosave: false))
+  end
+
   def test_telephone_field
     expected = %{<input id="user_cell" name="user[cell]" type="tel" />}
     assert_dom_equal(expected, telephone_field("user", "cell"))


### PR DESCRIPTION
### Summary

`search_field` documents an `autosave: true` form that resolves to the reversed request host:

```ruby
# request.host returns "www.example.com"
search_field(:user, :name, autosave: true)
# => <input autosave="com.example.www" id="user_name" name="user[name]" results="10" type="search" />
```

That form has never worked. `ActionView::Helpers::Tags::SearchField#render` does:

```ruby
options["autosave"] = request.host.split(".").reverse.join(".")
```

but `Tags::Base` neither defines `request` nor delegates missing methods to the view, so every call raises:

```
NameError: undefined local variable or method 'request' for an instance of ActionView::Helpers::Tags::SearchField
```

This isn't context-dependent — the tag object has no `request` in any context, so the documented example raises for everyone. I found it while writing coverage for the `autosave` branch, which turned out to be entirely untested; the two existing `search_field` tests only cover the plain call and `onsearch: true`.

### Fix

Read the request from the view context, which is what the tag already holds:

```ruby
options["autosave"] = @template_object.request.host.split(".").reverse.join(".")
```

### Tests

Added coverage for the whole `autosave` branch:

* `autosave: true` resolves to the reversed host and defaults `results` to `10`.
* An explicit `autosave` string is passed through untouched, still defaulting `results`.
* An explicit `results:` is not overridden.
* `autosave: false` renders `autosave="false"` and omits `results`, matching the documented output.

`actionview` — `form_helper_test.rb`, `form_with_test.rb`, `form_options_helper_test.rb`, `form_tag_helper_test.rb`: 832 runs, 1022 assertions, 0 failures, 0 errors. RuboCop clean.