### PR TITLE
Add alternative text to Action Text attachments

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Add alternative text to Action Text attachments.
+
+    Attachments could only be described by their caption, which is always shown
+    alongside the attachment. An image could not be described for people using a
+    screen reader without that description also appearing on the page, and the
+    default blob partial rendered images with no `alt` attribute at all.
+
+    Attachments now accept an `alt` attribute, exposed as `ActionText::Attachment#alt`
+    and rendered as the image's alternative text. It is independent of the caption,
+    so an attachment may have either, both, or neither.
+
+        ActionText::Attachment.from_attachable(blob, alt: "A racecar on a track")
+
+    Images with no alternative text are unchanged and still render without an
+    `alt` attribute, since Action Text does not infer descriptions.
+
+    *Olly Headey*
+
 *   Dispatch all Active Storage `direct-upload:`-prefixed events
 
     Add support for `direct-upload:before-blob-request` and `direct-upload:before-storage-request`.

--- a/actiontext/app/views/active_storage/blobs/_blob.html.erb
+++ b/actiontext/app/views/active_storage/blobs/_blob.html.erb
@@ -1,6 +1,6 @@
 <figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>">
   <% if blob.representable? %>
-    <%= image_tag blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]) %>
+    <%= image_tag blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]), alt: blob.try(:alt) %>
   <% end %>
 
   <figcaption class="attachment__caption">

--- a/actiontext/lib/action_text/attachment.rb
+++ b/actiontext/lib/action_text/attachment.rb
@@ -22,7 +22,7 @@ module ActionText
 
     mattr_accessor :tag_name, default: "action-text-attachment"
 
-    ATTRIBUTES = %w( sgid content-type url href filename filesize width height previewable presentation caption content ).freeze
+    ATTRIBUTES = %w( sgid content-type url href filename filesize width height previewable presentation caption alt content ).freeze
 
     class << self
       def fragment_by_canonicalizing_attachments(content)
@@ -73,6 +73,19 @@ module ActionText
 
     def caption
       node_attributes["caption"].presence
+    end
+
+    # Returns the alternative text describing the attachment, used as the `alt`
+    # attribute when rendering an image.
+    #
+    # A caption is shown alongside the attachment, whereas alternative text
+    # describes it for people who cannot see it. They serve different purposes,
+    # so an attachment may have either, both, or neither.
+    #
+    #     attachment = ActionText::Attachment.from_attachable(attachable, alt: "A racecar on a track")
+    #     attachment.alt # => "A racecar on a track"
+    def alt
+      node_attributes["alt"].presence
     end
 
     def full_attributes

--- a/actiontext/test/integration/controller_render_test.rb
+++ b/actiontext/test/integration/controller_render_test.rb
@@ -33,6 +33,26 @@ class ActionText::ControllerRenderTest < ActionDispatch::IntegrationTest
     assert_match %r" class=\S+mentionable-person\b", form_html
   end
 
+  test "renders an image attachment with its alt text" do
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+    message = Message.create!(content: ActionText::Content.new(
+      %Q(<action-text-attachment sgid="#{blob.attachable_sgid}" alt="A racecar on a track"></action-text-attachment>)
+    ))
+
+    get message_path(message)
+    assert_select "#content img:match('alt', ?)", "A racecar on a track"
+  end
+
+  test "renders an image attachment without an alt attribute when it has no alt text" do
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+    message = Message.create!(content: ActionText::Content.new.append_attachables(blob))
+
+    get message_path(message)
+    assert_select "#content img" do |imgs|
+      imgs.each { |img| assert_nil img["alt"] }
+    end
+  end
+
   test "resolves partials when controller is namespaced" do
     blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
     message = Message.create!(content: ActionText::Content.new.append_attachables(blob))

--- a/actiontext/test/unit/attachment_test.rb
+++ b/actiontext/test/unit/attachment_test.rb
@@ -9,6 +9,26 @@ class ActionText::AttachmentTest < ActiveSupport::TestCase
     assert_equal "Captioned", attachment.caption
   end
 
+  test "from_attachable with alt" do
+    attachment = ActionText::Attachment.from_attachable(attachable, alt: "A racecar on a track")
+    assert_equal "A racecar on a track", attachment.alt
+  end
+
+  test "alt is nil when unset" do
+    assert_nil ActionText::Attachment.from_attachable(attachable).alt
+  end
+
+  test "alt and caption are independent" do
+    attachment = ActionText::Attachment.from_attachable(attachable, alt: "A racecar on a track", caption: "Vroom vroom")
+    assert_equal "A racecar on a track", attachment.alt
+    assert_equal "Vroom vroom", attachment.caption
+  end
+
+  test "alt survives being rebuilt with full attributes" do
+    attachment = attachment_from_html(%Q(<action-text-attachment sgid="#{attachable.attachable_sgid}" alt="A racecar on a track"></action-text-attachment>))
+    assert_equal "A racecar on a track", attachment.with_full_attributes.alt
+  end
+
   test "proxies missing methods to attachable" do
     attachable.instance_eval { def proxied; "proxied"; end }
     attachment = ActionText::Attachment.from_attachable(attachable)


### PR DESCRIPTION
### Motivation / Background

Action Text has no support for alternative text on attachments. Images can only be described by their caption, which is always rendered alongside the attachment, so an image cannot be described for people using a screen reader without that description also appearing on the page. Captions and alternative text serve different purposes and frequently differ.

The default blob partial compounds this. It renders:

```erb
<%= image_tag blob.representation(resize_to_limit: ...) %>
```

`image_tag` has not generated alt text since 5.1, and there is currently no occurrence of `alt` anywhere in `actiontext/lib` or `actiontext/app`. Every application using the shipped partial therefore renders Action Text images with no `alt` attribute at all, which fails WCAG 1.1.1 for any image that conveys content.

There is no way for an editor to fill that gap either. Lexxy already carries an `alt` attribute through its attachment pipeline: it is in the attachment attribute allowlist, it is read back on import, and `exportDOM` writes it into the HTML submitted to Rails.

```js
// basecamp/lexxy, src/nodes/action_text_attachment_node.js
exportDOM() {
  const attachment = createElement(this.tagName, {
    sgid: this.sgid,
    alt: this.altText,
    caption: this.caption,
    ...
```

Action Text stores that attribute and then drops it on render, because `render_attachments` rebuilds every node through `with_full_attributes` and `process_attributes` slices against `ATTRIBUTES`. No editor can meaningfully offer alternative text while the server silently discards it.

To be clear about what this change does and does not achieve for editors: Lexxy currently seeds `altText` from the blob filename and offers no UI for authoring a description, so honoring the attribute would not by itself produce good alternative text from the editor, and a filename would be a poor description of the kind removed in #30096. That default is fixable on the editor side, and it can only sensibly be fixed once the attribute survives a round trip. Defining the attribute in Action Text is the prerequisite, not the whole feature.

Applications creating content programmatically hit the same wall today with nothing to work around it. Pagecord accepts posts over its API and via Micropub, where an image's description and its caption are supplied separately by the client and genuinely differ. There is currently no way to store the description, so the only options are to force it to appear as a visible caption or to discard it.

The existing workaround is to reopen the frozen `ATTRIBUTES` constant in an initializer. This is what applications and editor authors are doing today, and it is what discussion #54179 asks to replace with something supported.

### Detail

This Pull Request adds `alt` as an attachment attribute:

- `alt` is added to `ActionText::Attachment::ATTRIBUTES`, so it round-trips through storage and survives the rebuild performed during rendering.
- `ActionText::Attachment#alt` is added alongside `#caption`.
- The default blob partial passes it to `image_tag`.

```ruby
ActionText::Attachment.from_attachable(blob, alt: "A racecar on a track", caption: "Vroom vroom")
```

The two are independent, so an attachment may have either, both, or neither.

Attachments with no alternative text are unchanged and still render without an `alt` attribute. Action Text does not infer a description, which keeps this consistent with #30096, where filename-derived alt text was removed as harmful to screen reader users. An absent attribute is an honest omission that auditing tools report, whereas `alt=""` asserts that the image is decorative and hides genuine content.

`ActionText::TrixAttachment` is deliberately untouched, as it is deprecated.

### Additional information

Related: #54179 (discussion requesting hooks for additional attachment attributes), #30096 (removal of filename-derived alt text).

Tests cover the attribute in isolation, its independence from `caption`, its survival through `with_full_attributes`, and the rendered output in both the present and absent cases. The rendering tests exercise Rails' own blob partial, as the Action Text dummy application does not override it.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.