### PR TITLE
Add a bang reader to `has_one` and `belongs_to` associations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Add a bang reader to `has_one` and `belongs_to` associations.
+
+    Singular associations now generate an `association!` method that returns the
+    associated record, or raises `ActiveRecord::RecordNotFound` when there is
+    none. This removes the need for a `nil` check when the association is
+    expected to be present.
+
+    ```ruby
+    class Order < ActiveRecord::Base
+      belongs_to :account
+    end
+
+    order.account  # => nil
+    order.account! # => raises ActiveRecord::RecordNotFound
+    ```
+
+    *Alex Tan*
+
 *   Deprecate passing `binds` to `#insert`, `#update`, and `#delete` on
     `ActiveRecord::ConnectionAdapters::DatabaseStatements`.
 

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -118,6 +118,7 @@ module ActiveRecord
       #
       #   project = Project.first
       #   project.portfolio
+      #   project.portfolio!
       #   project.portfolio = Portfolio.first
       #   project.reload_portfolio
       #
@@ -157,6 +158,7 @@ module ActiveRecord
       #   generated methods                 | belongs_to | :polymorphic | has_one
       #   ----------------------------------+------------+--------------+---------
       #   other                             |     X      |      X       |    X
+      #   other!                            |     X      |      X       |    X
       #   other=(other)                     |     X      |      X       |    X
       #   build_other(attributes={})        |     X      |              |    X
       #   create_other(attributes={})       |     X      |              |    X
@@ -1442,6 +1444,11 @@ module ActiveRecord
         #
         # [<tt>association</tt>]
         #   Returns the associated object. +nil+ is returned if none is found.
+        # [<tt>association!</tt>]
+        #   Does the same as <tt>association</tt>, but raises ActiveRecord::RecordNotFound
+        #   if there is no associated object. Because it uses the same reader, a record
+        #   excluded by the association's scope or by a default scope on the associated
+        #   model raises as well, even though the row exists.
         # [<tt>association=(associate)</tt>]
         #   Assigns the associate object, extracts the primary key, sets it as the foreign key,
         #   and saves the associate object. To avoid database inconsistencies, permanently deletes an existing
@@ -1474,6 +1481,7 @@ module ActiveRecord
         #   beneficiary = Beneficiary.find(8)
         #
         #   account.beneficiary               # similar to Beneficiary.find_by(account_id: 5)
+        #   account.beneficiary!              # similar to Beneficiary.find_by!(account_id: 5)
         #   account.beneficiary = beneficiary # similar to beneficiary.update(account_id: 5)
         #   account.build_beneficiary         # similar to Beneficiary.new(account_id: 5)
         #   account.create_beneficiary        # similar to Beneficiary.create(account_id: 5)
@@ -1644,6 +1652,11 @@ module ActiveRecord
         #
         # [<tt>association</tt>]
         #   Returns the associated object. +nil+ is returned if none is found.
+        # [<tt>association!</tt>]
+        #   Does the same as <tt>association</tt>, but raises ActiveRecord::RecordNotFound
+        #   if there is no associated object. Because it uses the same reader, a record
+        #   excluded by the association's scope or by a default scope on the associated
+        #   model raises as well, even though the row exists.
         # [<tt>association=(associate)</tt>]
         #   Assigns the associate object, extracts the primary key, and sets it as the foreign key.
         #   No modification or deletion of existing records takes place.
@@ -1677,7 +1690,8 @@ module ActiveRecord
         #   post = Post.find(7)
         #   author = Author.find(19)
         #
-        #   post.author           # similar to Author.find(post.author_id)
+        #   post.author           # similar to Author.find_by(id: post.author_id)
+        #   post.author!          # similar to Author.find(post.author_id)
         #   post.author = author  # similar to post.author_id = author.id
         #   post.build_author     # similar to post.author = Author.new
         #   post.create_author    # similar to post.author = Author.new; post.author.save; post.author

--- a/activerecord/lib/active_record/associations/builder/singular_association.rb
+++ b/activerecord/lib/active_record/associations/builder/singular_association.rb
@@ -30,6 +30,22 @@ module ActiveRecord::Associations::Builder # :nodoc:
       CODE
     end
 
+    # Defines the reader methods for belongs_to or has_one association, e.g.
+    # +account+ and +account!+ for <tt>belongs_to :account</tt>. The bang
+    # version raises ActiveRecord::RecordNotFound when there is no
+    # associated record.
+    def self.define_readers(mixin, name)
+      super
+
+      mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
+        def #{name}!
+          association = association(:#{name})
+          deprecated_associations_api_guard(association, __method__)
+          association.reader!
+        end
+      CODE
+    end
+
     # Defines the (build|create)_association methods for belongs_to or has_one association
     def self.define_constructors(mixin, name)
       mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
@@ -71,6 +87,6 @@ module ActiveRecord::Associations::Builder # :nodoc:
       end
     end
 
-    private_class_method :valid_options, :define_accessors, :define_constructors
+    private_class_method :valid_options, :define_accessors, :define_readers, :define_constructors
   end
 end

--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -14,6 +14,12 @@ module ActiveRecord
         target
       end
 
+      # Implements the bang reader method, e.g. foo.bar! for Foo.has_one :bar.
+      # Raises ActiveRecord::RecordNotFound when there is no associated record.
+      def reader!
+        reader || raise_association_not_found
+      end
+
       # Resets the \loaded flag to +false+ and sets the \target to +nil+.
       def reset
         super
@@ -40,6 +46,16 @@ module ActiveRecord
       end
 
       private
+        def raise_association_not_found
+          message = +"Couldn't find the #{reflection.name} association for #{owner.class.name}"
+
+          if (primary_key = owner.class.primary_key) && !(id = owner.id).nil?
+            message << " with #{primary_key}=#{id.inspect}"
+          end
+
+          raise RecordNotFound.new(message, klass&.name, klass&.primary_key)
+        end
+
         def scope_for_create
           super.except!(*Array(klass.primary_key))
         end

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -57,6 +57,55 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_belongs_to_bang
+    client = Client.find(3)
+    assert_equal companies(:first_firm), client.firm!
+  end
+
+  def test_belongs_to_bang_raises_record_not_found_when_the_foreign_key_is_nil
+    client = Client.create!(name: "Without a firm")
+
+    error = assert_raises(ActiveRecord::RecordNotFound) { client.firm! }
+    assert_equal "Couldn't find the firm association for Client with id=#{client.id}", error.message
+    assert_equal "Firm", error.model
+    assert_equal "id", error.primary_key
+  end
+
+  def test_belongs_to_bang_raises_record_not_found_when_the_record_is_missing
+    client = Client.find(3)
+    client.update_columns(client_of: 0)
+
+    assert_raises(ActiveRecord::RecordNotFound) { client.reload.firm! }
+  end
+
+  def test_belongs_to_bang_does_not_reload_a_loaded_association
+    client = Client.find(3)
+    client.firm
+
+    assert_no_queries { client.firm! }
+  end
+
+  def test_belongs_to_bang_with_composite_primary_key_owner
+    book = Cpk::Book.create!(id: [100, 200], title: "Ruby on Rails")
+
+    error = assert_raises(ActiveRecord::RecordNotFound) { book.order! }
+    assert_equal %(Couldn't find the order association for Cpk::Book with ["author_id", "id"]=[100, 200]), error.message
+    assert_equal ["shop_id", "id"], error.primary_key
+  end
+
+  def test_polymorphic_belongs_to_bang_raises_record_not_found_when_the_foreign_key_is_nil
+    sponsor = Sponsor.new
+
+    error = assert_raises(ActiveRecord::RecordNotFound) { sponsor.sponsorable! }
+    assert_equal "Couldn't find the sponsorable association for Sponsor", error.message
+    assert_nil error.model
+  end
+
+  def test_polymorphic_belongs_to_bang
+    sponsor = sponsors(:moustache_club_sponsor_for_groucho)
+    assert_equal sponsor.sponsorable, sponsor.sponsorable!
+  end
+
   def test_where_with_custom_primary_key
     assert_equal [authors(:david)], Author.where(owned_essay: essays(:david_modest_proposal))
   end
@@ -1989,6 +2038,16 @@ class DeprecatedBelongsToAssociationsTest < ActiveRecord::TestCase
 
     assert_deprecated_association(:deprecated_car, context: context_for_method(:deprecated_car)) do
       assert_equal @car, @bulb.deprecated_car
+    end
+  end
+
+  test "<association>!" do
+    assert_not_deprecated_association(:car) do
+      @bulb.car!
+    end
+
+    assert_deprecated_association(:deprecated_car, context: context_for_method(:deprecated_car!)) do
+      assert_equal @car, @bulb.deprecated_car!
     end
   end
 

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -52,6 +52,44 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_has_one_bang
+    firm = companies(:first_firm)
+    assert_equal Account.find(1), firm.account!
+  end
+
+  def test_has_one_bang_raises_record_not_found_when_there_is_no_associated_record
+    firm = companies(:another_firm)
+
+    error = assert_raises(ActiveRecord::RecordNotFound) { firm.account! }
+    assert_equal "Couldn't find the account association for Firm with id=#{firm.id}", error.message
+    assert_equal "Account", error.model
+    assert_equal "id", error.primary_key
+  end
+
+  def test_has_one_bang_on_new_record
+    error = assert_raises(ActiveRecord::RecordNotFound) { Firm.new.account! }
+    assert_equal "Couldn't find the account association for Firm", error.message
+  end
+
+  def test_has_one_bang_raises_when_the_association_scope_excludes_an_existing_record
+    firm = companies(:first_firm)
+
+    # The row exists, but its credit_limit is outside the association's scope.
+    assert_equal Account.find(1), firm.account
+    assert_nil firm.account_limit_500_with_hash_conditions
+
+    assert_raises(ActiveRecord::RecordNotFound) do
+      firm.account_limit_500_with_hash_conditions!
+    end
+  end
+
+  def test_has_one_bang_does_not_reload_a_loaded_association
+    firm = companies(:first_firm)
+    firm.account
+
+    assert_no_queries { firm.account! }
+  end
+
   def test_has_one_does_not_use_order_by
     sql_log = capture_sql { companies(:first_firm).account }
     assert sql_log.all? { |sql| !/order by/i.match?(sql) }, "ORDER BY was used in the query: #{sql_log}"
@@ -1075,6 +1113,18 @@ class DeprecatedHasOneAssociationsTest < ActiveRecord::TestCase
 
     assert_deprecated_association(:deprecated_bulb, context: context_for_method(:deprecated_bulb)) do
       assert_equal @bulb, @car.deprecated_bulb
+    end
+  end
+
+  test "<association>!" do
+    create_bulb!
+
+    assert_not_deprecated_association(:bulb) do
+      @car.bulb!
+    end
+
+    assert_deprecated_association(:deprecated_bulb, context: context_for_method(:deprecated_bulb!)) do
+      assert_equal @bulb, @car.deprecated_bulb!
     end
   end
 

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -38,6 +38,18 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal clubs(:boring_club), @member.club
   end
 
+  def test_has_one_through_bang_with_has_one
+    assert_equal clubs(:boring_club), @member.club!
+  end
+
+  def test_has_one_through_bang_raises_record_not_found_when_there_is_no_associated_record
+    member = Member.create!(name: "Solo")
+
+    error = assert_raises(ActiveRecord::RecordNotFound) { member.club! }
+    assert_equal "Couldn't find the club association for Member with id=#{member.id}", error.message
+    assert_equal "Club", error.model
+  end
+
   def test_has_one_through_executes_limited_query
     boring_club = clubs(:boring_club)
     assert_queries_match(/LIMIT|ROWNUM <=|FETCH FIRST/) do

--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -252,6 +252,7 @@ when it's not NULL, it must still reference a valid record in the authors table.
 When you declare a `belongs_to` association, the declaring class automatically
 gains numerous methods related to the association. Some of these are:
 
+* `association!`
 * `association=(associate)`
 * `build_association(attributes = {})`
 * `create_association(attributes = {})`
@@ -284,6 +285,7 @@ end
 An instance of the `Book` model will have the following methods:
 
 * `author`
+* `author!`
 * `author=`
 * `build_author`
 * `create_author`
@@ -306,6 +308,20 @@ object is found, it returns `nil`.
 ```ruby
 @author = @book.author
 ```
+
+The `association!` method behaves the same way, except that it raises
+`ActiveRecord::RecordNotFound` when there is no associated object, which saves
+you from a `nil` check when the association is expected to be present.
+
+```ruby
+@author = @book.author! # raises ActiveRecord::RecordNotFound if the book has no author
+```
+
+NOTE: `association!` goes through the same reader as `association`, so it raises
+in every case where the reader would return `nil`. That includes a record
+excluded by a [scope on the association](#scopes) or by a `default_scope` on the
+associated model: the row can exist in the database and `association!` will
+still raise.
 
 If the associated object has already been retrieved from the database for this
 object, the cached version will be returned. To override this behavior (and
@@ -479,6 +495,7 @@ When you declare a `has_one` association,  the declaring class automatically
 gains numerous methods related to the association. Some of these are:
 
 * `association`
+* `association!`
 * `association=(associate)`
 * `build_association(attributes = {})`
 * `create_association(attributes = {})`
@@ -510,6 +527,7 @@ end
 Each instance of the `Supplier` model will have these methods:
 
 * `account`
+* `account!`
 * `account=`
 * `build_account`
 * `create_account`
@@ -530,6 +548,19 @@ object is found, it returns `nil`.
 ```ruby
 @account = @supplier.account
 ```
+
+The `association!` method behaves the same way, except that it raises
+`ActiveRecord::RecordNotFound` when there is no associated object.
+
+```ruby
+@account = @supplier.account! # raises ActiveRecord::RecordNotFound if the supplier has no account
+```
+
+NOTE: `association!` goes through the same reader as `association`, so it raises
+in every case where the reader would return `nil`. That includes a record
+excluded by a [scope on the association](#scopes) or by a `default_scope` on the
+associated model: the row can exist in the database and `association!` will
+still raise.
 
 If the associated object has already been retrieved from the database for this
 object, the cached version will be returned. To override this behavior (and


### PR DESCRIPTION
### Motivation / Background

Originally proposed as a feature on [discuss](https://discuss.rubyonrails.org/t/feature-proposal-belongs-to-and-has-one-bang-methods/89597).

Finder methods in Rails commonly have a bang method equivalent. These raise `RecordNotFound` exceptions in case you want to fail quickly out of a method.

- find_by/find_by!
- take/take!
- first/first!
- last/last!
- second/second!
- third/third!

However there is currently no equivalent if you want to do the same for belongs_to/has_one relationships.

Beyond being useful in normal Rails projects, for those of us that use typecheckers like Sorbet, adding in bang equivalents allows us to have methods with signatures that are non-nilable. This allows us to change code like this:

```ruby
T.must(T.must(post.author).company).name
```

to

```ruby
post.author!.company!.name
```

### Detail

Singular associations now generate an `association!` method alongside the regular reader. It returns the associated record, or raises `ActiveRecord::RecordNotFound` when there is none, removing the need for a `nil` check when the association is expected to be present.

    class Order < ActiveRecord::Base
      belongs_to :account
    end

    order.account  # => nil
    order.account! # => raises ActiveRecord::RecordNotFound

The raised error carries the target class and primary key in `#model` and `#primary_key`, matching what `find` raises, and the message names both the association and the owner.

Because the method is defined by the singular association builder, `has_one :through` gets it as well.

### Additional information

N/A

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
