### PR TITLE
Transform keys in place in `ActionController::Parameters#deep_transform_keys!`

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -960,7 +960,7 @@ module ActionController
     # This includes the keys from the root hash and from all nested hashes and
     # arrays. The values are unchanged.
     def deep_transform_keys!(&block)
-      @parameters = _deep_transform_keys_in_object(@parameters, &block).to_unsafe_h
+      @parameters = _deep_transform_keys_in_object!(@parameters, &block)
       self
     end
 


### PR DESCRIPTION
`ActionController::Parameters#deep_transform_keys!` rebuilt the whole parameters hash rather than mutating it, so the in-place `_deep_transform_keys_in_object!` added alongside it in 32587c3bdd was left without a caller. `deep_transform_values!` does resolve through `_deep_transform_values_in_object!`, so the sibling pair was asymmetric.

Wiring the bang variant up, as suggested in review, keeps the returned parameters identical:

| params shape | before | after |
| --- | --- | --- |
| 200 entries, 3 levels deep | 5,825 allocations | 1,612 allocations |

> [!NOTE]
>
> ### Behaviour
>
> The returned parameters are unchanged.
>
> As with `deep_transform_values!`, nested hashes that the caller still shares with the receiver are now transformed in place.