### PR TITLE
Fix deprecation proxy doc examples that raise `ArgumentError`

### DIFF
--- a/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
@@ -57,14 +57,14 @@ module ActiveSupport
     end
 
     # DeprecatedInstanceVariableProxy transforms an instance variable into a deprecated one. It takes an instance of a
-    # class, a method on that class, an instance variable, and a deprecator as the last argument.
+    # class, a method on that class, an instance variable, and a deprecator as a keyword argument.
     #
     # Trying to use the deprecated instance variable will result in a deprecation warning, pointing to the method as a
     # replacement.
     #
     #   class Example
     #     def initialize
-    #       @request = ActiveSupport::Deprecation::DeprecatedInstanceVariableProxy.new(self, :request, :@request, ActiveSupport::Deprecation.new)
+    #       @request = ActiveSupport::Deprecation::DeprecatedInstanceVariableProxy.new(self, :request, :@request, deprecator: ActiveSupport::Deprecation.new)
     #       @_request = :special_request
     #     end
     #
@@ -153,7 +153,7 @@ module ActiveSupport
       # Returns the class of the new constant.
       #
       #   PLANETS_POST_2006 = %w(mercury venus earth mars jupiter saturn uranus neptune)
-      #   PLANETS = ActiveSupport::Deprecation::DeprecatedConstantProxy.new('PLANETS', 'PLANETS_POST_2006')
+      #   PLANETS = ActiveSupport::Deprecation::DeprecatedConstantProxy.new('PLANETS', 'PLANETS_POST_2006', ActiveSupport::Deprecation.new)
       #   PLANETS.class # => Array
       def class
         target.class


### PR DESCRIPTION
Two documented examples in `active_support/deprecation/proxy_wrappers.rb` cannot be run. fc2dc7c8d3 made the deprecator mandatory — as a keyword argument for `DeprecatedInstanceVariableProxy` and as a required positional for `DeprecatedConstantProxy` — but both examples still pass it the way it was accepted before.

Copying them verbatim raises:

```ruby
ActiveSupport::Deprecation::DeprecatedInstanceVariableProxy.new(self, :request, :@request, ActiveSupport::Deprecation.new)
# => ArgumentError: wrong number of arguments (given 4, expected 2..3; required keyword: deprecator)

ActiveSupport::Deprecation::DeprecatedConstantProxy.new('PLANETS', 'PLANETS_POST_2006')
# => ArgumentError: wrong number of arguments (given 2, expected 3)
```

The prose above the first example also still describes the deprecator as "the last argument", which reads as positional.

`DeprecatedObjectProxy`, whose deprecator stayed positional, is already correct and is left alone.

>[!NOTE]
>
> ### Behaviour
> 
> With this change both examples run and produce exactly the output the documentation claims:
> 
> ```
> example.old_request.to_s
> # DEPRECATION WARNING: @request is deprecated! Call request.to_s instead of @request.to_s
> # => "special_request"
> 
> example.request.to_s   # => "special_request"
> 
> PLANETS.class          # => Array
> ```