### PR TITLE
Refreeze the controller middleware stack for every mutating method

### DIFF
--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -25,7 +25,7 @@ module ActionController
         @stack = @controller.middleware_stack
       end
 
-      %w(unshift insert swap delete move move_after use).each do |method|
+      %w(unshift insert insert_before insert_after swap delete delete! move move_before move_after use).each do |method|
         class_eval(<<~CODE, __FILE__, __LINE__ + 1)
           def #{method}(...)
             @controller.middleware_stack = @controller.middleware_stack.dup

--- a/actionpack/test/controller/new_base/middleware_test.rb
+++ b/actionpack/test/controller/new_base/middleware_test.rb
@@ -113,8 +113,13 @@ module MiddlewareTest
       RactorController.middleware.unshift(BlockMiddleware)
       RactorController.middleware.insert(0, ExclaimerMiddleware)
       RactorController.middleware.swap(ExclaimerMiddleware, MyMiddleware)
+      RactorController.middleware.insert_before(MyMiddleware, BlockMiddleware)
+      RactorController.middleware.insert_after(MyMiddleware, ExclaimerMiddleware)
       RactorController.middleware.move(0, MyMiddleware)
+      RactorController.middleware.move_before(ExclaimerMiddleware, MyMiddleware)
       RactorController.middleware.move_after(ExclaimerMiddleware, MyMiddleware)
+      RactorController.middleware.delete(MyMiddleware)
+      RactorController.middleware.delete!(BlockMiddleware)
 
       assert_ractor_shareable(RactorController.middleware_stack)
     ensure

--- a/actionpack/test/controller/new_base/middleware_test.rb
+++ b/actionpack/test/controller/new_base/middleware_test.rb
@@ -115,6 +115,10 @@ module MiddlewareTest
       RactorController.middleware.swap(ExclaimerMiddleware, MyMiddleware)
       RactorController.middleware.move(0, MyMiddleware)
       RactorController.middleware.move_after(ExclaimerMiddleware, MyMiddleware)
+      RactorController.middleware.insert_before(MyMiddleware, BlockMiddleware)
+      RactorController.middleware.insert_after(MyMiddleware, ExclaimerMiddleware)
+      RactorController.middleware.move_before(ExclaimerMiddleware, MyMiddleware)
+      RactorController.middleware.delete!(BlockMiddleware)
 
       assert_ractor_shareable(RactorController.middleware_stack)
     ensure


### PR DESCRIPTION
`ActionController::MiddlewareStack::Proxy` enumerates the stack's mutating methods so each call copies the stack and makes the copy shareable again. Four of the stack's mutating methods are absent from that list — `insert_before`, `insert_after`, `delete!` and `move_before` — so they fall through `delegate_missing_to` and mutate the frozen stack in place:

```ruby
ActiveSupport::Ractors.unshareable_proc_action = :raise

class PostsController < ActionController::Metal; end

PostsController.middleware.use(Mw)             # ok, stack is copied and refrozen
PostsController.middleware.insert_before(Mw, Other)
# => FrozenError: can't modify frozen Array
```

`insert_after` and `delete!` are defined on `ActionDispatch::MiddlewareStack` alongside the ones already listed; `insert_before` and `move_before` are aliases of `insert` and `move`.

The stack is only frozen when `ActiveSupport::Ractors.unshareable_proc_action` is set, so this is limited to Ractor-safe mode.

Introduced in dd67a577d9, whose intent was for the proxy to refreeze "anytime a method on the stack is called".

>[!NOTE]
>
> ### Behaviour
> 
> Before: those four methods raise `FrozenError` in Ractor-safe mode.
> 
> After: they copy and refreeze the stack like the other mutators.