### PR TITLE
Build codecs for unused salts after a rotation coordinator is frozen

### DIFF
--- a/activesupport/lib/active_support/messages/rotation_coordinator.rb
+++ b/activesupport/lib/active_support/messages/rotation_coordinator.rb
@@ -14,14 +14,25 @@ module ActiveSupport
         @rotate_options = []
         @on_rotation = nil
         @codecs = {}
+        @ractor_key = nil
+      end
+
+      def freeze
+        return self if frozen?
+
+        @ractor_key = "_rotation_coordinator_#{object_id}".to_sym
+        cached_codecs, @codecs = @codecs, nil
+        ActiveSupport::Ractors.store_if_absent(@ractor_key) { cached_codecs }
+
+        super
       end
 
       def [](salt)
-        @codecs[salt] ||= build_with_rotations(salt)
+        codecs[salt] ||= build_with_rotations(salt)
       end
 
       def []=(salt, codec)
-        @codecs[salt] = codec
+        codecs[salt] = codec
       end
 
       def rotate(**options, &block)
@@ -58,13 +69,20 @@ module ActiveSupport
       end
 
       private
+        # After the coordinator is frozen the codec cache moves into Ractor-local
+        # storage, so that codecs for salts that were not used before freezing can
+        # still be built.
+        def codecs
+          @codecs || ActiveSupport::Ractors.store_if_absent(@ractor_key) { {} }
+        end
+
         def changing_configuration!
-          if @codecs.any?
+          if codecs.any?
             raise <<~MESSAGE
               Cannot change #{self.class} configuration after it has already been applied.
 
               The configuration has been applied with the following salts:
-              #{@codecs.keys.map { |salt| "- #{salt.inspect}" }.join("\n")}
+              #{codecs.keys.map { |salt| "- #{salt.inspect}" }.join("\n")}
             MESSAGE
           end
         end

--- a/activesupport/lib/active_support/messages/rotation_coordinator.rb
+++ b/activesupport/lib/active_support/messages/rotation_coordinator.rb
@@ -13,14 +13,25 @@ module ActiveSupport
         @rotate_options = []
         @on_rotation = nil
         @codecs = {}
+        @ractor_key = nil
+      end
+
+      def freeze
+        return self if frozen?
+
+        @ractor_key = "_rotation_coordinator_#{object_id}".to_sym
+        cached_codecs, @codecs = @codecs, nil
+        ActiveSupport::Ractors.store_if_absent(@ractor_key) { cached_codecs }
+
+        super
       end
 
       def [](salt)
-        @codecs[salt] ||= build_with_rotations(salt)
+        codecs[salt] ||= build_with_rotations(salt)
       end
 
       def []=(salt, codec)
-        @codecs[salt] = codec
+        codecs[salt] = codec
       end
 
       def rotate(**options, &block)
@@ -57,13 +68,20 @@ module ActiveSupport
       end
 
       private
+        # After the coordinator is frozen the codec cache moves into Ractor-local
+        # storage, so that codecs for salts that were not used before freezing can
+        # still be built.
+        def codecs
+          @codecs || ActiveSupport::Ractors.store_if_absent(@ractor_key) { {} }
+        end
+
         def changing_configuration!
-          if @codecs.any?
+          if codecs.any?
             raise <<~MESSAGE
               Cannot change #{self.class} configuration after it has already been applied.
 
               The configuration has been applied with the following salts:
-              #{@codecs.keys.map { |salt| "- #{salt.inspect}" }.join("\n")}
+              #{codecs.keys.map { |salt| "- #{salt.inspect}" }.join("\n")}
             MESSAGE
           end
         end

--- a/activesupport/test/message_verifiers_test.rb
+++ b/activesupport/test/message_verifiers_test.rb
@@ -31,8 +31,10 @@ class MessageVerifiersTest < ActiveSupport::TestCase
   end
 
   private
+    SECRET_GENERATOR = proc { |salt| salt * 10 }
+
     def make_coordinator
-      ActiveSupport::MessageVerifiers.new { |salt| salt * 10 }
+      ActiveSupport::MessageVerifiers.new(&SECRET_GENERATOR)
     end
 
     def roundtrip(message, signer, verifier = signer)

--- a/activesupport/test/rotation_coordinator_tests.rb
+++ b/activesupport/test/rotation_coordinator_tests.rb
@@ -25,6 +25,19 @@ module RotationCoordinatorTests
       assert_same @coordinator["salt"], @coordinator["other salt"]
     end
 
+    test "builds codecs for salts that were not used before being made shareable" do
+      codec = @coordinator["salt"]
+      ActiveSupport::Ractors.make_shareable(@coordinator)
+
+      assert_same codec, @coordinator["salt"]
+      assert_equal "message", roundtrip("message", @coordinator["other salt"])
+    end
+
+    test "can be frozen more than once" do
+      @coordinator.freeze
+      assert_nothing_raised { @coordinator.freeze }
+    end
+
     test "configures codecs with rotations" do
       @coordinator.rotate(digest: "MD5")
       codec = @coordinator["salt"]


### PR DESCRIPTION
### Summary

`ActiveSupport::Messages::RotationCoordinator` — the base of `MessageVerifiers` and `MessageEncryptors` — memoizes one codec per salt in a plain Hash. Making the coordinator Ractor-shareable freezes that Hash along with it, so the first use of any salt that was not already cached raises:

```ruby
verifiers = ActiveSupport::MessageVerifiers.new { |salt| "x" * 32 }
verifiers.rotate_defaults
verifiers["boot_salt"]                        # cached during boot

ActiveSupport::Ractors.make_shareable(verifiers)

verifiers["boot_salt"]                        # ok, already cached
verifiers["signed_id"]
# => FrozenError: can't modify frozen Hash
```

This is reachable through `Rails.application.ractorize!`, which calls `Ractor.make_shareable(self)` on the application. Salts such as the ones behind signed ids and signed cookies are first used while serving a request rather than during boot, so they are not in the cache by the time the application is frozen.

`ActiveSupport::CachingKeyGenerator` already solves exactly this — it moves `@cache_keys` into Ractor-local storage in `freeze` — so this follows the same shape.

### Behaviour

Before: a salt that was not used before freezing raises `FrozenError` on first use.

After: codecs are still memoized, codecs built before freezing are preserved, and salts first used after freezing are built normally.

Two details worth calling out:

* Assigning through `#[]=` on a frozen coordinator previously raised `FrozenError` and now writes to the calling Ractor's cache. That is the same trade-off the cache read side makes, but it means such an assignment is not visible to other Ractors.
* `#freeze` stays idempotent, and is a no-op with respect to the cache on Rubies without `Ractor.[]=` (added in 3.4), so it keeps working on the 3.3 that `required_ruby_version` still allows. On those versions the original `FrozenError` remains, matching today's behaviour — `ActiveSupport::Ractors.make_shareable` is itself a no-op there, so Rails never freezes the coordinator on its own.