### PR TITLE
Pin redis below 6 in the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -108,7 +108,7 @@ end
 group :cable do
   gem "puma", ">= 5.0.3", require: false
 
-  gem "redis", ">= 4.0.1", require: false
+  gem "redis", ">= 4.0.1", "< 6", require: false
 
   gem "redis-namespace"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -723,7 +723,7 @@ DEPENDENCIES
   rails!
   rake (>= 13)
   redcarpet (~> 3.6.1)
-  redis (>= 4.0.1)
+  redis (>= 4.0.1, < 6)
   redis-namespace
   releaser!
   resque


### PR DESCRIPTION
### Motivation / Background

redis 6.0.0 was released on July 31, 2026. The Action Cable redis subscription adapter declares `gem "redis", ">= 4", "< 6"` at require time, so every test that loads it fails:

```
Gem::LoadError: Error loading the 'redis' Action Cable pubsub adapter. Missing a gem it depends on? can't activate redis (>= 4, < 6), already activated redis-6.0.0. Make sure all dependencies are added to Gemfile.
```

https://buildkite.com/rails/rails/builds/131861#019fbb44-6779-4ff8-af5f-102d919ad65d/L1764

### Detail

Raising the adapter's upper bound instead would diverge from main, where the adapter is based on redis-client (ef812c2652).

### Additional information

The `>= 4, < 6` declaration comes from #45856.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
