### PR TITLE
Deprecate `write_attribute(:id, value)` writing to the primary key

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Deprecate `write_attribute(:id, value)` writing to the primary key.
+
+    `read_attribute(:id)` was deprecated in Rails 7.1 and removed in
+    Rails 7.2 to make `:id` refer to the `id` column, not the primary
+    key. Apply the same deprecation to `write_attribute`; use `#id=` on
+    a model whose primary key is not named `id`.
+
+    *Ryuta Kamizono*
+
 *   Make `ActiveRecord::Migration::CommandRecorder#record` and
     `#inverse_of` private.
 

--- a/activerecord/lib/active_record/attribute_methods/write.rb
+++ b/activerecord/lib/active_record/attribute_methods/write.rb
@@ -32,8 +32,19 @@ module ActiveRecord
         name = attr_name.to_s
         name = self.class.attribute_aliases[name] || name
 
-        name = @primary_key if name == "id" && @primary_key
-        @attributes.write_from_user(name, value)
+        return @attributes.write_from_user(name, value) unless name == "id" && @primary_key
+
+        if self.class.composite_primary_key?
+          @attributes.write_from_user("id", value)
+        else
+          if @primary_key != "id"
+            ActiveRecord.deprecator.warn(<<-MSG.squish)
+              Using write_attribute(:id, value) to write the primary key value is deprecated
+              and will be removed in Rails 9.0. Use #id= instead.
+            MSG
+          end
+          @attributes.write_from_user(@primary_key, value)
+        end
       end
 
       # This method exists to avoid the expensive primary_key check internally, without

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -61,6 +61,34 @@ class PrimaryKeysTest < ActiveRecord::TestCase
     assert_equal 2, id
   end
 
+  def test_write_attribute_id
+    topic = Topic.find(1)
+    assert_not_deprecated(ActiveRecord.deprecator) do
+      topic.write_attribute(:id, 2)
+    end
+
+    assert_equal 2, topic.id
+  end
+
+  def test_write_attribute_with_custom_primary_key
+    keyboard = Keyboard.create!
+    msg = "Using write_attribute(:id, value) to write the primary key value is deprecated and will be removed in Rails 9.0. Use #id= instead."
+    assert_deprecated(msg, ActiveRecord.deprecator) do
+      keyboard.write_attribute(:id, 42)
+    end
+
+    assert_equal 42, keyboard.key_number
+  end
+
+  def test_write_attribute_with_composite_primary_key
+    book = Cpk::Book.new
+    assert_not_deprecated(ActiveRecord.deprecator) do
+      book.write_attribute(:id, 42)
+    end
+
+    assert_equal 42, book.read_attribute(:id)
+  end
+
   def test_to_key_with_primary_key_after_destroy
     topic = Topic.find(1)
     topic.destroy


### PR DESCRIPTION
Follow-up to #49019, which deprecated (and later removed) `read_attribute(:id)` returning the custom primary key value. `write_attribute(:id, value)` still translates `:id` to `@primary_key`, most likely as an oversight. Apply the same deprecation on the write side; for composite primary keys, follow the read-side precedent and write to the `id` column directly.
