### PR TITLE
Restore `alias_attribute` support in associations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Restore `alias_attribute` support in associations.
+
+    Since Rails 4.2, association reads have bypassed the public
+    `read_attribute` in favor of an internal fast path that skips
+    alias resolution. An `alias_attribute` on the owner's foreign key
+    or on the target's primary key was silently ignored; production
+    applications worked around this by overriding `_read_attribute`
+    itself.
+
+    The performance gap that justified the bypass has since closed
+    enough that association FK/PK reads and writes can go through the
+    public methods again — and `alias_attribute` declarations are now
+    honored.
+
+    *Ryuta Kamizono*
+
 *   Deprecate `write_attribute(:id, value)` writing to the primary key.
 
     `read_attribute(:id)` was deprecated in Rails 7.1 and removed in

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -371,7 +371,7 @@ module ActiveRecord
         # Returns true if record contains the foreign_key
         def foreign_key_for?(record)
           foreign_key = Array(reflection.foreign_key)
-          foreign_key.all? { |key| record._has_attribute?(key) }
+          foreign_key.all? { |key| record.has_attribute?(key) }
         end
 
         # This should be implemented to return the values of the relevant key(s) on the owner,

--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -63,7 +63,7 @@ module ActiveRecord
           table = reflection.aliased_table
           primary_key_foreign_key_pairs = primary_key.zip(foreign_key)
           primary_key_foreign_key_pairs.each do |join_key, foreign_key|
-            value = transform_value(owner._read_attribute(foreign_key))
+            value = transform_value(owner.read_attribute(foreign_key))
             scope = apply_scope(scope, table, join_key, value)
           end
 

--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -138,14 +138,14 @@ module ActiveRecord
               owner_pk = Array(owner.class.primary_key)
               reflection_fk.each_with_index do |key, index|
                 next if record.nil? && owner_pk.include?(key)
-                owner[key] = target_key_values[index]
+                owner.write_attribute(key, target_key_values[index])
               end
             end
           else
             target_key_value = record ? record.read_attribute(primary_key(record.class)) : nil
 
             if force || owner.read_attribute(reflection_fk) != target_key_value
-              owner[reflection_fk] = target_key_value
+              owner.write_attribute(reflection_fk, target_key_value)
             end
           end
         end

--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -111,7 +111,7 @@ module ActiveRecord
             if target && !stale_target?
               target.increment!(reflection.counter_cache_column, by, touch: reflection.options[:touch])
             else
-              update_counters_via_scope(klass, owner._read_attribute(reflection.foreign_key), by)
+              update_counters_via_scope(klass, owner.read_attribute(reflection.foreign_key), by)
             end
           end
         end
@@ -132,9 +132,9 @@ module ActiveRecord
         def replace_keys(record, force: false)
           reflection_fk = reflection.foreign_key
           if reflection_fk.is_a?(Array)
-            target_key_values = record ? Array(primary_key(record.class)).map { |key| record._read_attribute(key) } : []
+            target_key_values = record ? Array(primary_key(record.class)).map { |key| record.read_attribute(key) } : []
 
-            if force || reflection_fk.map { |fk| owner._read_attribute(fk) } != target_key_values
+            if force || reflection_fk.map { |fk| owner.read_attribute(fk) } != target_key_values
               owner_pk = Array(owner.class.primary_key)
               reflection_fk.each_with_index do |key, index|
                 next if record.nil? && owner_pk.include?(key)
@@ -142,9 +142,9 @@ module ActiveRecord
               end
             end
           else
-            target_key_value = record ? record._read_attribute(primary_key(record.class)) : nil
+            target_key_value = record ? record.read_attribute(primary_key(record.class)) : nil
 
-            if force || owner._read_attribute(reflection_fk) != target_key_value
+            if force || owner.read_attribute(reflection_fk) != target_key_value
               owner[reflection_fk] = target_key_value
             end
           end
@@ -155,7 +155,7 @@ module ActiveRecord
         end
 
         def foreign_key_present?
-          Array(reflection.foreign_key).all? { |fk| owner._read_attribute(fk) }
+          Array(reflection.foreign_key).all? { |fk| owner.read_attribute(fk) }
         end
 
         def invertible_for?(record)
@@ -167,11 +167,11 @@ module ActiveRecord
           foreign_key = reflection.foreign_key
           if foreign_key.is_a?(Array)
             attributes = foreign_key.map do |fk|
-              owner._read_attribute(fk) { |n| owner.send(:missing_attribute, n, caller) }
+              owner.read_attribute(fk) { |n| owner.send(:missing_attribute, n, caller) }
             end
             attributes if attributes.any?
           else
-            owner._read_attribute(foreign_key) { |n| owner.send(:missing_attribute, n, caller) }
+            owner.read_attribute(foreign_key) { |n| owner.send(:missing_attribute, n, caller) }
           end
         end
     end

--- a/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     # = Active Record Belongs To Polymorphic Association
     class BelongsToPolymorphicAssociation < BelongsToAssociation # :nodoc:
       def klass
-        type = owner[reflection.foreign_type]
+        type = owner.read_attribute(reflection.foreign_type)
         type.presence && owner.class.polymorphic_class_for(type)
       end
 
@@ -28,7 +28,7 @@ module ActiveRecord
           target_type = record ? record.class.polymorphic_name : nil
 
           if force || owner.read_attribute(reflection.foreign_type) != target_type
-            owner[reflection.foreign_type] = target_type
+            owner.write_attribute(reflection.foreign_type, target_type)
           end
         end
 
@@ -42,7 +42,7 @@ module ActiveRecord
 
         def stale_state
           if foreign_key = super
-            [foreign_key, owner[reflection.foreign_type]]
+            [foreign_key, owner.read_attribute(reflection.foreign_type)]
           end
         end
     end

--- a/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
@@ -27,7 +27,7 @@ module ActiveRecord
 
           target_type = record ? record.class.polymorphic_name : nil
 
-          if force || owner._read_attribute(reflection.foreign_type) != target_type
+          if force || owner.read_attribute(reflection.foreign_type) != target_type
             owner[reflection.foreign_type] = target_type
           end
         end

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -332,7 +332,7 @@ module ActiveRecord
             if mem_record = memory.delete(record)
 
               ((record.attribute_names & mem_record.attribute_names) - mem_record.changed_attribute_names_to_save - mem_record.class._attr_readonly).each do |name|
-                mem_record._write_attribute(name, record[name])
+                mem_record._write_attribute(name, record.read_attribute(name))
               end
 
               mem_record

--- a/activerecord/lib/active_record/associations/disable_joins_association_scope.rb
+++ b/activerecord/lib/active_record/associations/disable_joins_association_scope.rb
@@ -17,7 +17,7 @@ module ActiveRecord
       private
         def last_scope_chain(reverse_chain, owner)
           first_item = reverse_chain.shift
-          first_scope = [first_item, false, [owner._read_attribute(first_item.join_foreign_key)]]
+          first_scope = [first_item, false, [owner.read_attribute(first_item.join_foreign_key)]]
 
           reverse_chain.inject(first_scope) do |(reflection, ordered, join_ids), next_reflection|
             key = reflection.join_primary_key

--- a/activerecord/lib/active_record/associations/foreign_association.rb
+++ b/activerecord/lib/active_record/associations/foreign_association.rb
@@ -30,12 +30,12 @@ module ActiveRecord::Associations
         primary_key_foreign_key_pairs = primary_key_attribute_names.zip(foreign_key_attribute_names)
 
         primary_key_foreign_key_pairs.each do |primary_key, foreign_key|
-          value = owner._read_attribute(foreign_key)
-          record._write_attribute(primary_key, value)
+          value = owner.read_attribute(foreign_key)
+          record.write_attribute(primary_key, value)
         end
 
         if reflection.type
-          record._write_attribute(reflection.type, owner.class.polymorphic_name)
+          record.write_attribute(reflection.type, owner.class.polymorphic_name)
         end
       end
   end

--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -130,7 +130,7 @@ module ActiveRecord
             update_counter(-records.length) unless reflection.inverse_updates_counter_cache?
           else
             query_constraints = reflection.klass.composite_query_constraints_list
-            values = records.map { |r| query_constraints.map { |col| r._read_attribute(col) } }
+            values = records.map { |r| query_constraints.map { |col| r.read_attribute(col) } }
             scope = self.scope.where(query_constraints => values)
             update_counter(-delete_count(method, scope))
           end

--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -119,7 +119,7 @@ module ActiveRecord
         end
 
         def target_reflection_has_associated_record?
-          !(through_reflection.belongs_to? && Array(through_reflection.foreign_key).all? { |foreign_key_column| owner[foreign_key_column].blank? })
+          !(through_reflection.belongs_to? && Array(through_reflection.foreign_key).all? { |foreign_key_column| owner.read_attribute(foreign_key_column).blank? })
         end
 
         def update_through_counter?(method)

--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -118,9 +118,9 @@ module ActiveRecord
 
         def nullify_owner_attributes(record)
           Array(reflection.foreign_key).each do |foreign_key_column|
-            record[foreign_key_column] = nil unless foreign_key_column.in?(Array(record.class.primary_key))
+            record.write_attribute(foreign_key_column, nil) unless foreign_key_column.in?(Array(record.class.primary_key))
           end
-          record[reflection.type] = nil if reflection.type.present?
+          record.write_attribute(reflection.type, nil) if reflection.type.present?
         end
 
         def transaction_if(value, &block)

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -265,9 +265,9 @@ module ActiveRecord
 
           def derive_key(owner, key)
             if key.is_a?(Array)
-              key.map { |k| convert_key(owner._read_attribute(k)) }
+              key.map { |k| convert_key(owner.read_attribute(k)) }
             else
-              convert_key(owner._read_attribute(key))
+              convert_key(owner.read_attribute(key))
             end
           end
 

--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -20,7 +20,7 @@ module ActiveRecord
             if owners.first.association(through_reflection.name).loaded?
               if source_type = reflection.options[:source_type]
                 through_records = through_records.select do |record|
-                  record[reflection.foreign_type] == source_type
+                  record.read_attribute(reflection.foreign_type) == source_type
                 end
               end
             end

--- a/activerecord/lib/active_record/associations/through_association.rb
+++ b/activerecord/lib/active_record/associations/through_association.rb
@@ -82,14 +82,14 @@ module ActiveRecord
         def stale_state
           if through_reflection.belongs_to?
             Array(through_reflection.foreign_key).filter_map do |foreign_key_column|
-              owner[foreign_key_column]
+              owner.read_attribute(foreign_key_column)
             end.presence
           end
         end
 
         def foreign_key_present?
           through_reflection.belongs_to? && Array(through_reflection.foreign_key).all? do |foreign_key_column|
-            !owner[foreign_key_column].nil?
+            !owner.read_attribute(foreign_key_column).nil?
           end
         end
 

--- a/activerecord/lib/active_record/associations/through_association.rb
+++ b/activerecord/lib/active_record/associations/through_association.rb
@@ -62,7 +62,7 @@ module ActiveRecord
           if Array(association_primary_key) == reflection.klass.composite_query_constraints_list && !options[:source_type]
             join_attributes = { source_reflection.name => records }
           else
-            assoc_pk_values = records.map { |record| record._read_attribute(association_primary_key) }
+            assoc_pk_values = records.map { |record| record.read_attribute(association_primary_key) }
             join_attributes = { source_reflection.foreign_key => assoc_pk_values }
           end
 

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -497,7 +497,7 @@ module ActiveRecord
 
             primary_key_foreign_key_pairs.each do |primary_key, foreign_key|
               association_id = read_attribute(primary_key)
-              record[foreign_key] = association_id unless record[foreign_key] == association_id
+              record.write_attribute(foreign_key, association_id) unless record.read_attribute(foreign_key) == association_id
             end
             association.set_inverse_instance(record)
           end
@@ -552,7 +552,7 @@ module ActiveRecord
 
           if autosave && record.marked_for_destruction?
             foreign_key = Array(reflection.foreign_key)
-            foreign_key.each { |key| self[key] = nil }
+            foreign_key.each { |key| write_attribute(key, nil) }
             record.destroy
           elsif autosave != false
             saved = if record.new_record? || (autosave && record.changed_for_autosave?)
@@ -572,7 +572,7 @@ module ActiveRecord
               primary_key_foreign_key_pairs = primary_key.zip(foreign_key)
               primary_key_foreign_key_pairs.each do |primary_key, foreign_key|
                 association_id = record.read_attribute(primary_key)
-                self[foreign_key] = association_id unless self[foreign_key] == association_id
+                write_attribute(foreign_key, association_id) unless read_attribute(foreign_key) == association_id
               end
               association.loaded!
             end

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -488,7 +488,7 @@ module ActiveRecord
           record.destroy
         elsif autosave != false
           primary_key = Array(reflection.active_record_primary_key).map(&:to_s)
-          primary_key_value = primary_key.map { |key| _read_attribute(key) }
+          primary_key_value = primary_key.map { |key| read_attribute(key) }
           return unless (autosave && record.changed_for_autosave?) || _record_changed?(reflection, record, primary_key_value)
 
           unless reflection.through_reflection
@@ -496,7 +496,7 @@ module ActiveRecord
             primary_key_foreign_key_pairs = primary_key.zip(foreign_key)
 
             primary_key_foreign_key_pairs.each do |primary_key, foreign_key|
-              association_id = _read_attribute(primary_key)
+              association_id = read_attribute(primary_key)
               record[foreign_key] = association_id unless record[foreign_key] == association_id
             end
             association.set_inverse_instance(record)
@@ -523,15 +523,15 @@ module ActiveRecord
         return false if reflection.through_reflection?
 
         foreign_key = Array(reflection.foreign_key)
-        return false unless foreign_key.all? { |key| record._has_attribute?(key) }
+        return false unless foreign_key.all? { |key| record.has_attribute?(key) }
 
-        foreign_key.map { |key| record._read_attribute(key) } != Array(key)
+        foreign_key.map { |key| record.read_attribute(key) } != Array(key)
       end
 
       def inverse_polymorphic_association_changed?(reflection, record)
         return false unless reflection.inverse_of&.polymorphic?
 
-        class_name = record._read_attribute(reflection.inverse_of.foreign_type)
+        class_name = record.read_attribute(reflection.inverse_of.foreign_type)
         reflection.active_record.polymorphic_name != class_name
       end
 
@@ -571,7 +571,7 @@ module ActiveRecord
 
               primary_key_foreign_key_pairs = primary_key.zip(foreign_key)
               primary_key_foreign_key_pairs.each do |primary_key, foreign_key|
-                association_id = record._read_attribute(primary_key)
+                association_id = record.read_attribute(primary_key)
                 self[foreign_key] = association_id unless self[foreign_key] == association_id
               end
               association.loaded!

--- a/activerecord/lib/active_record/key.rb
+++ b/activerecord/lib/active_record/key.rb
@@ -102,7 +102,7 @@ module ActiveRecord
       end
 
       def value_of(record)
-        record._read_attribute(@name)
+        record.read_attribute(@name)
       end
 
       def expects_multiple_ids?(value)
@@ -142,7 +142,7 @@ module ActiveRecord
       end
 
       def value_of(record)
-        @columns.map { |column| record._read_attribute(column) }
+        @columns.map { |column| record.read_attribute(column) }
       end
 
       # A single composite id is itself an Array, so several ids are an Array of

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -548,7 +548,7 @@ module ActiveRecord
       def association_scope_cache(klass, owner, &block)
         key = self
         if polymorphic?
-          key = [key, owner._read_attribute(@foreign_type)]
+          key = [key, owner.read_attribute(@foreign_type)]
         end
         klass.with_connection do |connection|
           klass.cached_find_by_statement(connection, key, &block)
@@ -633,7 +633,7 @@ module ActiveRecord
       end
 
       def join_id_for(owner) # :nodoc:
-        Array(join_foreign_key).map { |key| owner._read_attribute(key) }
+        Array(join_foreign_key).map { |key| owner.read_attribute(key) }
       end
 
       def through_reflection

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -109,6 +109,11 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal companies(:first_firm).name, client.firm_with_primary_key.name
   end
 
+  def test_belongs_to_with_alias_attribute_foreign_key
+    post = PostWithAliasedAuthorId.find(posts(:welcome).id)
+    assert_equal authors(:david), post.author
+  end
+
   def test_belongs_to_with_primary_key_joins_on_correct_column
     sql = Client.joins(:firm_with_primary_key).to_sql
     if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -178,6 +178,20 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_not_equal queries, capture_sql_and_binds { post.comments.to_a }
   end
 
+  def test_has_many_writes_foreign_key_through_alias_attribute
+    author = authors(:david)
+    post = author.posts_with_aliased_author_id.create!(title: "New Post", body: "Body")
+    assert_equal author.id, post.writer_id
+    assert_equal author.id, post.author_id
+  end
+
+  def test_has_many_sets_inverse_instance_through_alias_attribute_foreign_key
+    author = authors(:david)
+    author.posts_with_aliased_author_id.create!(title: "New Post", body: "Body")
+    post = author.posts_with_aliased_author_id.reload.first
+    assert_same author, post.author
+  end
+
   def test_has_many_build_with_options
     college = College.create(name: "UFMT")
     Student.create(active: true, college_id: college.id, name: "Sarah")

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -14,6 +14,7 @@ class Author < ActiveRecord::Base
   has_many :posts_with_categories, -> { includes(:categories) }, class_name: "Post"
   has_many :posts_with_comments_and_categories, -> { includes(:comments, :categories).order("posts.id") }, class_name: "Post"
   has_many :posts_with_special_categorizations, class_name: "PostWithSpecialCategorization"
+  has_many :posts_with_aliased_author_id, class_name: "PostWithAliasedAuthorId", foreign_key: :writer_id, inverse_of: :author
   has_one  :post_about_thinking, -> { where("posts.title like '%thinking%'") }, class_name: "Post"
   has_one  :post_about_thinking_with_last_comment, -> { where("posts.title like '%thinking%'").includes(:last_comment) }, class_name: "Post"
 

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -443,3 +443,10 @@ class PostRecord < ActiveRecord::Base
     end
   end
 end
+
+class PostWithAliasedAuthorId < ActiveRecord::Base
+  self.table_name = "posts"
+  self.inheritance_column = nil
+  alias_attribute :writer_id, :author_id
+  belongs_to :author, foreign_key: :writer_id, inverse_of: :posts_with_aliased_author_id
+end


### PR DESCRIPTION
be2b98b4ae switched belongs_to association reads from `ActiveRecord::Base#[]` (which resolves `alias_attribute` via the public `read_attribute`) to `_read_attribute`, an internal fast path that skips the alias / primary-key check. At the time this was for performance — `Base#[]` had non-trivial overhead introduced in Rails 4.2.

Since then, an `alias_attribute` on the owner's foreign key or on the target's primary key has been silently ignored in associations. Production apps worked around it by overriding `_read_attribute` itself (see #57795 background).

`read_attribute` / `write_attribute` have since been optimized enough that the extra alias lookup no longer justifies the bypass:

* #36052     — cache `@primary_key` as an ivar (+20% pk access)
* 5575bd7b22 — drop redundant `attribute_alias?` (+40% alias resolution)
* 27a1ca2bfe — inline delegation to `_read_attribute` (+15%)

Undo the fast-path adoption in associations so `alias_attribute` declarations are honored again:

```ruby
class Post < ActiveRecord::Base
  alias_attribute :writer_id, :author_id
  belongs_to :author, foreign_key: :writer_id
end

post.author               # reads FK via alias
author.posts.create!(...) # writes FK via alias
```
