### PR TITLE
Fix test class name collision in Active Storage railties tests

### DIFF
--- a/railties/test/application/active_storage/analyzers_integration_test.rb
+++ b/railties/test/application/active_storage/analyzers_integration_test.rb
@@ -3,7 +3,7 @@
 require "isolation/abstract_unit"
 
 module ApplicationTests
-  class ActiveStorageEngineTest < ActiveSupport::TestCase
+  class AnalyzersIntegrationTest < ActiveSupport::TestCase
     include ActiveSupport::Testing::Isolation
 
     include ActiveJob::TestHelper


### PR DESCRIPTION
### Motivation / Background

The test class `ApplicationTests::ActiveStorageEngineTest` is defined by two files:

- railties/test/application/active_storage/analyzers_integration_test.rb
- railties/test/application/active_storage/engine_integration_test.rb

Three tests fail as a result, reporting a leaked environment variable:

```
Environment leak detected:
  - Changed variables:
    - BUNDLE_GEMFILE from "<rails>/Gemfile" to "<rails>/tmp/d20260802-463299-f70uer/app/Gemfile"
```

This is not a problem in CI which runs process-isolated tests with `test:isolated`. The collision only shows up when running the tests locally, e.g. with `bin/test`.


### Detail

The class in `analyzers_integration_test.rb` is renamed to `ApplicationTests::AnalyzersIntegrationTest`, so each file keeps its own test class along with its own `setup` and `teardown`. The new name matches the other files in the directory, which name their test class after the file: `DirectUploadsIntegrationTest`, `UploadsIntegrationTest`, and `ValidatingServiceTest`.

### Additional information

This is not a problem in CI. `railties`'s default Rake test task is `test:isolated`, which loads each test file in its own forked process. The collision only shows up when running the tests locally, where `bin/test` given a directory loads more than one file into a single process.

Both files were added in [`367445d0`](https://github.com/rails/rails/commit/367445d037b8f0d0baea684d14c0343ee29e8da1) with the same class name.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] ~~Tests are added or updated if you fix a bug or add a feature.~~
* [ ] ~~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~~
