### PR TITLE
Append `TRADITIONAL` instead of `STRICT_ALL_TABLES` to MySQL's `sql_mode` by default

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Append `TRADITIONAL` instead of `STRICT_ALL_TABLES` to MySQL's `sql_mode`
+    by default.
+
+    On environments whose global `sql_mode` is empty — most notably Amazon
+    RDS and Aurora MySQL default parameter groups — appending only
+    `STRICT_ALL_TABLES` leaves out `NO_ZERO_IN_DATE`, `NO_ZERO_DATE`, and
+    `ERROR_FOR_DIVISION_BY_ZERO`, which MySQL 5.7+ has otherwise made part
+    of its own default. Appending `TRADITIONAL` closes the gap.
+
+    Reproducing the previous behavior is possible via
+    `variables: { sql_mode: "STRICT_ALL_TABLES" }` in `database.yml`.
+
+    *Ryuta Kamizono*
+
 *   Restore `alias_attribute` support in associations.
 
     Since Rails 4.2, association reads have bypassed the public

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Append `TRADITIONAL` instead of `STRICT_ALL_TABLES` to MySQL's `sql_mode`
+    by default.
+
+    On environments whose global `sql_mode` is empty — most notably Amazon
+    RDS and Aurora MySQL default parameter groups — appending only
+    `STRICT_ALL_TABLES` leaves out `NO_ZERO_IN_DATE`, `NO_ZERO_DATE`, and
+    `ERROR_FOR_DIVISION_BY_ZERO`, which MySQL 5.7+ has otherwise made part
+    of its own default. Appending `TRADITIONAL` closes the gap.
+
+    Reproducing the previous behavior is possible via
+    `variables: { sql_mode: "STRICT_ALL_TABLES" }` in `database.yml`.
+
+    *Ryuta Kamizono*
+
 *   Change the shape of `ActiveRecord::Migration::CommandRecorder#commands`.
 
     Each recorded migration command is now stored as

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -963,7 +963,7 @@ module ActiveRecord
           defaults = [":default", :default].to_set
 
           # Make MySQL reject illegal values rather than truncating or blanking them, see
-          # https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_strict_all_tables
+          # https://dev.mysql.com/doc/refman/en/sql-mode.html#sqlmode_traditional
           # If the user has provided another value for sql_mode, don't replace it.
           # Set sql_mode to false or :default in variables to skip.
           if variables.key?("sql_mode")
@@ -973,7 +973,7 @@ module ActiveRecord
             end
           elsif !defaults.include?(strict_mode?)
             if strict_mode?
-              sql_mode = "CONCAT(@@sql_mode, ',STRICT_ALL_TABLES')"
+              sql_mode = "CONCAT(@@sql_mode, ',TRADITIONAL')"
             else
               sql_mode = "REPLACE(@@sql_mode, 'STRICT_TRANS_TABLES', '')"
               sql_mode = "REPLACE(#{sql_mode}, 'STRICT_ALL_TABLES', '')"

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/connection_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/connection_test.rb
@@ -114,6 +114,9 @@ class ConnectionTest < ActiveRecord::AbstractMysqlTestCase
   def test_mysql_default_in_strict_mode
     result = @connection.select_value("SELECT @@SESSION.sql_mode")
     assert_match %r(STRICT_ALL_TABLES), result
+    assert_match %r(NO_ZERO_IN_DATE), result
+    assert_match %r(NO_ZERO_DATE), result
+    assert_match %r(ERROR_FOR_DIVISION_BY_ZERO), result
   end
 
   def test_mysql_strict_mode_disabled
@@ -122,6 +125,8 @@ class ConnectionTest < ActiveRecord::AbstractMysqlTestCase
         ActiveRecord::Base.establish_connection(orig_connection.merge(strict: false))
         result = ActiveRecord::Base.lease_connection.select_value("SELECT @@SESSION.sql_mode")
         assert_no_match %r(STRICT_ALL_TABLES), result
+        assert_no_match %r(STRICT_TRANS_TABLES), result
+        assert_no_match %r(TRADITIONAL), result
       end
     end
   end


### PR DESCRIPTION
On environments whose global `sql_mode` is empty — most notably Amazon RDS and Aurora MySQL default parameter groups — appending only `STRICT_ALL_TABLES` leaves out `NO_ZERO_IN_DATE`, `NO_ZERO_DATE`, and `ERROR_FOR_DIVISION_BY_ZERO`, which MySQL 5.7+ has otherwise made part of its own default. Empty-`sql_mode` environments were expected to fade with MySQL 5.7+ adoption, but they haven't.

As #57077 noted when deprecating the `strict: false` option, silently accepting invalid values is not a recommended default for modern applications. Appending `TRADITIONAL` closes the gap so the recommended behavior holds regardless of what `sql_mode` the server happens to default to.

Reproducing the previous behavior is possible via `variables: { sql_mode: "STRICT_ALL_TABLES" }` in `database.yml`.
