### PR TITLE
Validate attribute names in ActiveModel::Attributes

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Raise an `ArgumentError` when `ActiveModel::Attributes` receives a name that
+    cannot generate usable readers, writers, or dirty tracking methods.
+
+    Attribute names are now restricted to letters, digits, and underscores, so
+    names such as `wat?`, `oof!`, or `oh:my:gaw` are rejected instead of
+    defining methods that can only be reached through `public_send` or that
+    raise a `SyntaxError` when used with `ActiveModel::Dirty`.
+
+    Fixes #57962.
+
 *   Fix `normalizes` re-applying normalizations on every validation of an
     unpersisted record, and speed up validation of normalized attributes.
 

--- a/activemodel/lib/active_model/attributes.rb
+++ b/activemodel/lib/active_model/attributes.rb
@@ -32,6 +32,12 @@ module ActiveModel
 
     autoload :Normalization
 
+    # Attribute names are restricted to letters, digits, and underscores so that
+    # every generated method, including the ones added by ActiveModel::Dirty, can
+    # be called with regular Ruby syntax. This is stricter than Ruby itself, which
+    # also accepts symbols such as emoji in method names.
+    VALID_ATTRIBUTE_NAME_REGEXP = /\A(?:\p{L}|_)(?:\p{L}|\p{M}|\p{N}|_)*\z/u
+
     extend ActiveSupport::Concern
     include ActiveModel::AttributeRegistration
     include ActiveModel::AttributeMethods
@@ -61,6 +67,9 @@ module ActiveModel
       #   person.name   # => "Volmer"
       #   person.active # => true
       def attribute(name, ...)
+        name = name.to_s
+        validate_attribute_name!(name)
+
         super
         define_attribute_method(name)
       end
@@ -93,6 +102,16 @@ module ActiveModel
 
       ##
       private
+        def validate_attribute_name!(name)
+          unless VALID_ATTRIBUTE_NAME_REGEXP.match?(name)
+            raise_invalid_attribute_name(name)
+          end
+        end
+
+        def raise_invalid_attribute_name(name)
+          raise ArgumentError, "#{name.inspect} is not a valid attribute name for ActiveModel::Attributes"
+        end
+
         def define_method_attribute=(canonical_name, owner:, as: canonical_name)
           ActiveModel::AttributeMethods::AttrNames.define_attribute_accessor_method(
             owner, canonical_name, writer: true,

--- a/activemodel/test/cases/attributes_test.rb
+++ b/activemodel/test/cases/attributes_test.rb
@@ -176,6 +176,93 @@ module ActiveModel
       end
     end
 
+    test "attribute names must generate usable readers, writers, and dirty tracking methods" do
+      invalid_names = [
+        :"wat?", :"oof!", :"oh:my:gaw", # names from the original report
+        :"foo bar", :"with-dash", :"with/slash", :"foo=", :"1abc", :"", :"🤔"
+      ]
+
+      invalid_names.each do |name|
+        error = assert_raises(ArgumentError, "expected #{name.inspect} to be rejected") do
+          Class.new do
+            include ActiveModel::Model
+            include ActiveModel::Attributes
+            include ActiveModel::Dirty
+
+            attribute name, :string
+          end
+        end
+
+        assert_equal "#{name.to_s.inspect} is not a valid attribute name for ActiveModel::Attributes", error.message
+      end
+    end
+
+    test "attribute names are validated when given as strings" do
+      error = assert_raises(ArgumentError) do
+        Class.new do
+          include ActiveModel::Model
+          include ActiveModel::Attributes
+
+          attribute "wat?", :string
+        end
+      end
+
+      assert_equal "\"wat?\" is not a valid attribute name for ActiveModel::Attributes", error.message
+    end
+
+    test "attribute names that are valid Ruby identifiers are accepted" do
+      model = Class.new do
+        include ActiveModel::Model
+        include ActiveModel::Attributes
+        include ActiveModel::Dirty
+
+        attribute :café, :string
+        attribute :def, :string
+        attribute :_private, :string
+        attribute :Name, :string
+        attribute :name123, :string
+      end
+
+      assert_equal ["café", "def", "_private", "Name", "name123"], model.attribute_names
+    end
+
+    test "valid attribute names generate dirty tracking methods callable with regular syntax" do
+      model = Class.new do
+        include ActiveModel::Model
+        include ActiveModel::Attributes
+        include ActiveModel::Dirty
+
+        attribute :café, :string
+        attribute :def, :string
+      end
+
+      record = model.new
+      record.café = "before"
+      record.def = "before"
+      record.changes_applied
+      record.café = "after"
+      record.def = "after"
+
+      assert_equal "after", record.café
+      assert_equal "after", record.def
+      assert_equal "before", record.café_was
+      assert_equal "before", record.def_was
+      assert_equal({ "café" => ["before", "after"], "def" => ["before", "after"] }, record.changes)
+    end
+
+    test "attributes can be redefined within the same class" do
+      model = Class.new do
+        include ActiveModel::Model
+        include ActiveModel::Attributes
+
+        attribute :redefined_field, :string
+        attribute :redefined_field, :integer
+      end
+
+      assert_instance_of Type::Integer, model.attribute_types["redefined_field"]
+      assert_equal 4, model.new(redefined_field: "4.4").redefined_field
+    end
+
     test ".type_for_attribute supports attribute aliases" do
       with_alias = Class.new(ModelForAttributesTest) do
         alias_attribute :integer_field, :x


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `ActiveModel::Attributes` accepts any
name that Ruby allows in a symbol, including names containing interpunctuation
such as `wat?`, `oof!` or `oh:my:gaw`. The attribute gets registered and its
accessors defined, so the declaration looks like it worked — but the generated
methods cannot be called with regular Ruby syntax:

```ruby
class User
  include ActiveModel::Model
  include ActiveModel::Attributes
  include ActiveModel::Dirty

  attribute :wat?, :boolean, default: false
  attribute :oof!, :string, default: "Oof"
  attribute :"oh:my:gaw", :string, default: "OMG"
end

user = User.new(wat?: true)
user.wat? = false             # SyntaxError
user.wat?_was                 # SyntaxError
user.public_send(:"wat?_was") # => works
```

The writer (`name=`) and every method generated by `ActiveModel::Dirty`
(`name_was`, `name_changed?`, `name_previously_was`, …) can only be reached
through `public_send`. The failure happens at the call site, far away from the
`attribute` declaration that caused it, which makes it hard to diagnose. It also
affects downstream code generators: tools such as `rbs_activerecord` introspect
`attribute_names` and emit method signatures from them, producing files that do
not parse.

Failing early with a clear `ArgumentError` at declaration time — as suggested in
the issue — points directly at the offending line and fixes the problem for every
consumer at once.

Fixes #57962.

### Detail

This Pull Request changes `ActiveModel::Attributes::ClassMethods#attribute` to
validate the attribute name before registering it.

* Adds `ActiveModel::Attributes::VALID_ATTRIBUTE_NAME_REGEXP`
  (`/\A(?:\p{L}|_)(?:\p{L}|\p{M}|\p{N}|_)*\z/u`): a name must start with a
  Unicode letter or an underscore, and may then contain Unicode letters, marks,
  digits and underscores.
* `#attribute` now casts the name to a `String` and validates it *before*
  delegating to `super`, so an invalid attribute is never registered nor
  partially defined.
* Invalid names raise
  `ArgumentError: "wat?" is not a valid attribute name for ActiveModel::Attributes`.

Names now rejected include the ones from the report (`:"wat?"`, `:"oof!"`,
`:"oh:my:gaw"`) as well as `:"foo bar"`, `:"with-dash"`, `:"with/slash"`,
`:"foo="`, `:"1abc"`, `:""` and emoji such as `:"🤔"`.

Names that are valid Ruby identifiers keep working, including non-ASCII ones:
`:café`, `:_private`, `:Name`, `:name123`, and keywords like `:def` (callable
with an explicit receiver).

Tests cover the rejected names, names passed as strings, the accepted names, and
that dirty tracking methods (`_was`, `changes`) are callable with regular Ruby
syntax for accepted names.

### Additional information

The regexp is intentionally stricter than Ruby itself: Ruby accepts emoji and
other symbols in dynamically defined method names, but those cannot be called
with regular syntax either, so they are rejected for the same reason.

**Scope** — this only affects `ActiveModel::Attributes` and its consumers
(`ActiveJob::Attributes`). Active Record is unaffected: `ActiveRecord::Attributes`
includes `ActiveModel::AttributeRegistration` and
`ActiveModel::Attributes::Normalization` directly, not `ActiveModel::Attributes`,
so database columns with unusual names still work and
`ActiveRecord::Base.attribute` does not go through this code path.

**Compatibility** — this is a behaviour change. Applications currently declaring
an attribute with a non-identifier name will now raise at class definition time
instead of failing later at the call site. Such attributes are only usable via
`public_send` today, so the practical impact is expected to be very small — but
I'm happy to put this behind a deprecation cycle or a `load_defaults` flag if the
team prefers a softer transition.

Alternatives considered:

* Emitting a deprecation warning instead of raising — keeps working code working,
  but leaves the broken generated methods in place and does not help downstream
  generators.
* Sanitizing the name (e.g. mangling `wat?` into `wat`) — surprising, and would
  silently make `attribute_names` disagree with what the user wrote.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
