### PR TITLE
Allow to access the type of an attribute inside a ractor

### DIFF
--- a/activemodel/lib/active_model/attribute_registration.rb
+++ b/activemodel/lib/active_model/attribute_registration.rb
@@ -42,6 +42,7 @@ module ActiveModel
       def attribute_types # :nodoc:
         @attribute_types ||= _default_attributes.cast_types.tap do |hash|
           hash.default = Type.default_value
+          ActiveSupport::Ractors.try_make_shareable(hash)
         end
       end
 

--- a/activemodel/test/cases/attribute_registration_test.rb
+++ b/activemodel/test/cases/attribute_registration_test.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
+require "active_support/testing/ractors_assertions"
 require "cases/helper"
 
 module ActiveModel
   class AttributeRegistrationTest < ActiveModel::TestCase
+    include ActiveSupport::Testing::RactorsAssertions
+
     MyType = Class.new(Type::Value)
     Type.register(MyType.name.to_sym, MyType)
 
@@ -95,6 +98,29 @@ module ActiveModel
       assert_includes klass._default_attributes, "bar"
       assert_same TYPE_1, klass.attribute_types["foo"]
       assert_same TYPE_2, klass.attribute_types["bar"]
+    end
+
+    if RUBY_VERSION >= "4.0"
+      test "attribute_types can be accessed in a Ractor" do
+        previous = ActiveSupport::Ractors.unshareable_proc_action
+        ActiveSupport::Ractors.unshareable_proc_action = :raise
+
+        klass = class_with do
+          attribute :foo, TYPE_1
+          attribute :bar, TYPE_2
+        end
+
+        klass.attribute_types["foo"]
+
+        foo_type, bar_type = on_ractor do
+          [klass.attribute_types["foo"], klass.attribute_types["bar"]]
+        end
+
+        assert_same TYPE_1, foo_type
+        assert_same TYPE_2, bar_type
+      ensure
+        ActiveSupport::Ractors.unshareable_proc_action = previous
+      end
     end
 
     test "attributes are inherited" do

--- a/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
+++ b/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
@@ -54,12 +54,24 @@ module ActiveRecord
       end
 
       def previous_types # :nodoc:
-        @previous_types ||= {} # Memoizing on support_unencrypted_data so that we can tweak it during tests
-        @previous_types[support_unencrypted_data?] ||= build_previous_types_for(previous_schemes_including_clean_text)
+        @previous_types ||= {
+          support_unencrypted_data? => build_previous_types_for(previous_schemes_including_clean_text),
+        }
+
+        @previous_types[support_unencrypted_data?] || build_previous_types_for(previous_schemes_including_clean_text)
       end
 
       def support_unencrypted_data?
         scheme.support_unencrypted_data? && !previous_type?
+      end
+
+      def freeze
+        serialize_with_oldest?
+        previous_types_without_clean_text
+        previous_types
+        clean_text_scheme
+
+        super
       end
 
       private
@@ -120,7 +132,9 @@ module ActiveRecord
         end
 
         def serialize_with_oldest?
-          @serialize_with_oldest ||= fixed? && previous_types_without_clean_text.present?
+          return @serialize_with_oldest if defined?(@serialize_with_oldest)
+
+          @serialize_with_oldest = fixed? && previous_types_without_clean_text.present?
         end
 
         def serialize_with_oldest(value)

--- a/activerecord/lib/active_record/encryption/key_provider.rb
+++ b/activerecord/lib/active_record/encryption/key_provider.rb
@@ -25,6 +25,13 @@ module ActiveRecord
         @encryption_key
       end
 
+      def freeze
+        encryption_key
+        keys_grouped_by_id
+
+        super
+      end
+
       # Returns the list of decryption keys
       #
       # When the message holds a reference to its encryption key, it will return an array

--- a/activerecord/lib/active_record/encryption/scheme.rb
+++ b/activerecord/lib/active_record/encryption/scheme.rb
@@ -33,6 +33,14 @@ module ActiveRecord
         @context_properties[:encryptor] = Encryptor.new(compressor: compressor) if compressor
       end
 
+      def freeze
+        fixed?
+        key_provider_from_key
+        deterministic_key_provider
+
+        super
+      end
+
       def ignore_case?
         @ignore_case
       end
@@ -50,8 +58,10 @@ module ActiveRecord
       end
 
       def fixed?
+        return @fixed if defined?(@fixed)
+
         # by default deterministic encryption is fixed
-        @fixed ||= @deterministic && (!@deterministic.is_a?(Hash) || @deterministic[:fixed])
+        @fixed = @deterministic && (!@deterministic.is_a?(Hash) || @deterministic[:fixed])
       end
 
       def key_provider
@@ -88,13 +98,17 @@ module ActiveRecord
         end
 
         def key_provider_from_key
-          @key_provider_from_key ||= if @key.present?
+          return @key_provider_from_key if defined?(@key_provider_from_key)
+
+          @key_provider_from_key = if @key.present?
             DerivedSecretKeyProvider.new(@key)
           end
         end
 
         def deterministic_key_provider
-          @deterministic_key_provider ||= if @deterministic
+          return @deterministic_key_provider if defined?(@deterministic_key_provider)
+
+          @deterministic_key_provider = if @deterministic
             DeterministicKeyProvider.new(ActiveRecord::Encryption.config.deterministic_key)
           end
         end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because Active Model's attribue_types memoizes a hash that's not ractor safe. Any code attemptying to load the type of an attribute inside a ractor would fail with an isolation error.

### Detail

Simply freezing the attribute types hash isn't enough and we need to deep freeze all Types object as well. Most AM and AR types can be frozen without any code changes.

This patch freeze the attribute types object graph and eagerly set memoized values.

Worth to note that some memoization related to encryption would set a falsy value, making the memoization to always be evaluated. I modified those with early return instead.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
