### PR TITLE
Fix Single Table Inheritance doc example for the type column change

### DIFF
--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -25,7 +25,7 @@ module ActiveRecord
   #
   #   Company.new.changed? # => false
   #   Firm.new.changed?    # => true
-  #   Firm.new.changes     # => {"type"=>["","Firm"]}
+  #   Firm.new.changes     # => {"type"=>[nil, "Firm"]}
   #
   # If you don't have a type column defined in your table, single-table inheritance won't
   # be triggered. In that case, it'll work just like normal subclasses with no special magic


### PR DESCRIPTION
The STI overview example shows `""` as the old value of the type column, but `ensure_proper_type` writes into a `nil` default, not an empty String:

```ruby
Firm.new.changes # => {"type"=>[nil, "Firm"]}
```

Corrects the documented old value from `""` to `nil`. The pre-3.4 `Hash#inspect` style is kept to match the surrounding examples and the gem's minimum Ruby (≥ 3.3.1).

Documentation-only; no behavior change.