### PR TITLE
Resolve attribute aliases in belongs_to change tracking

### DIFF
--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -66,13 +66,13 @@ module ActiveRecord
 
       def decrement_counters_before_last_save
         if reflection.polymorphic?
-          model_type_was = owner.attribute_before_last_save(reflection.foreign_type)
+          model_type_was = owner.attribute_before_last_save(resolve_attribute_alias(reflection.foreign_type))
           model_was = owner.class.polymorphic_class_for(model_type_was) if model_type_was
         else
           model_was = klass
         end
 
-        foreign_key_was = owner.attribute_before_last_save(reflection.foreign_key)
+        foreign_key_was = owner.attribute_before_last_save(resolve_attribute_alias(reflection.foreign_key))
 
         if foreign_key_was && model_was < ActiveRecord::Base
           update_counters_via_scope(model_was, foreign_key_was, -1)
@@ -80,15 +80,15 @@ module ActiveRecord
       end
 
       def target_changed?
-        Array(reflection.foreign_key).any? { |fk| owner.attribute_changed?(fk) } || (!foreign_key_present? && target&.new_record?)
+        Array(reflection.foreign_key).any? { |fk| owner.attribute_changed?(resolve_attribute_alias(fk)) } || (!foreign_key_present? && target&.new_record?)
       end
 
       def target_previously_changed?
-        Array(reflection.foreign_key).any? { |fk| owner.attribute_previously_changed?(fk) }
+        Array(reflection.foreign_key).any? { |fk| owner.attribute_previously_changed?(resolve_attribute_alias(fk)) }
       end
 
       def saved_change_to_target?
-        owner.saved_change_to_attribute?(reflection.foreign_key)
+        owner.saved_change_to_attribute?(resolve_attribute_alias(reflection.foreign_key))
       end
 
       private
@@ -172,6 +172,17 @@ module ActiveRecord
             attributes if attributes.any?
           else
             owner.read_attribute(foreign_key) { |n| owner.send(:missing_attribute, n, caller) }
+          end
+        end
+
+        # The reflection's foreign key (or foreign type) may be declared with an
+        # +alias_attribute+ name, while change tracking is keyed by the real
+        # attribute name, so aliases must be resolved before querying it.
+        def resolve_attribute_alias(name)
+          if name.is_a?(Array)
+            name.map { |n| owner.class.attribute_aliases[n] || n }
+          else
+            owner.class.attribute_aliases[name] || name
           end
         end
     end

--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -4,6 +4,19 @@ module ActiveRecord
   module Associations
     # = Active Record Belongs To Association
     class BelongsToAssociation < SingularAssociation # :nodoc:
+      attr_reader :foreign_key, :foreign_type
+
+      def initialize(owner, reflection)
+        super
+        aliases = owner.class.attribute_aliases
+        fk = reflection.foreign_key
+        @foreign_key = fk.is_a?(Array) ? fk.map { |k| aliases[k] || k }.freeze : (aliases[fk] || fk)
+        if reflection.polymorphic?
+          ft = reflection.foreign_type
+          @foreign_type = aliases[ft] || ft
+        end
+      end
+
       def handle_dependency
         return unless load_target
 
@@ -11,16 +24,15 @@ module ActiveRecord
         when :destroy
           raise ActiveRecord::Rollback unless target.destroy
         when :destroy_async
-          if reflection.foreign_key.is_a?(Array)
-            primary_key_column = reflection.active_record_primary_key
-            id = reflection.foreign_key.map { |col| owner.public_send(col) }
+          primary_key_column = reflection.active_record_primary_key
+          id = if @foreign_key.is_a?(Array)
+            @foreign_key.map { |col| owner.public_send(col) }
           else
-            primary_key_column = reflection.active_record_primary_key
-            id = owner.public_send(reflection.foreign_key)
+            owner.public_send(@foreign_key)
           end
 
           association_class = if reflection.polymorphic?
-            owner.public_send(reflection.foreign_type)
+            owner.public_send(@foreign_type)
           else
             reflection.klass
           end
@@ -66,13 +78,13 @@ module ActiveRecord
 
       def decrement_counters_before_last_save
         if reflection.polymorphic?
-          model_type_was = owner.attribute_before_last_save(resolve_attribute_alias(reflection.foreign_type))
+          model_type_was = owner.attribute_before_last_save(@foreign_type)
           model_was = owner.class.polymorphic_class_for(model_type_was) if model_type_was
         else
           model_was = klass
         end
 
-        foreign_key_was = owner.attribute_before_last_save(resolve_attribute_alias(reflection.foreign_key))
+        foreign_key_was = owner.attribute_before_last_save(@foreign_key)
 
         if foreign_key_was && model_was < ActiveRecord::Base
           update_counters_via_scope(model_was, foreign_key_was, -1)
@@ -80,15 +92,15 @@ module ActiveRecord
       end
 
       def target_changed?
-        Array(reflection.foreign_key).any? { |fk| owner.attribute_changed?(resolve_attribute_alias(fk)) } || (!foreign_key_present? && target&.new_record?)
+        Array(@foreign_key).any? { |fk| owner.attribute_changed?(fk) } || (!foreign_key_present? && target&.new_record?)
       end
 
       def target_previously_changed?
-        Array(reflection.foreign_key).any? { |fk| owner.attribute_previously_changed?(resolve_attribute_alias(fk)) }
+        Array(@foreign_key).any? { |fk| owner.attribute_previously_changed?(fk) }
       end
 
       def saved_change_to_target?
-        owner.saved_change_to_attribute?(resolve_attribute_alias(reflection.foreign_key))
+        owner.saved_change_to_attribute?(@foreign_key)
       end
 
       private
@@ -111,7 +123,7 @@ module ActiveRecord
             if target && !stale_target?
               target.increment!(reflection.counter_cache_column, by, touch: reflection.options[:touch])
             else
-              update_counters_via_scope(klass, owner.read_attribute(reflection.foreign_key), by)
+              update_counters_via_scope(klass, owner.read_attribute(@foreign_key), by)
             end
           end
         end
@@ -130,13 +142,12 @@ module ActiveRecord
         end
 
         def replace_keys(record, force: false)
-          reflection_fk = reflection.foreign_key
-          if reflection_fk.is_a?(Array)
+          if @foreign_key.is_a?(Array)
             target_key_values = record ? Array(primary_key(record.class)).map { |key| record.read_attribute(key) } : []
 
-            if force || reflection_fk.map { |fk| owner.read_attribute(fk) } != target_key_values
+            if force || @foreign_key.map { |fk| owner.read_attribute(fk) } != target_key_values
               owner_pk = Array(owner.class.primary_key)
-              reflection_fk.each_with_index do |key, index|
+              @foreign_key.each_with_index do |key, index|
                 next if record.nil? && owner_pk.include?(key)
                 owner.write_attribute(key, target_key_values[index])
               end
@@ -144,8 +155,8 @@ module ActiveRecord
           else
             target_key_value = record ? record.read_attribute(primary_key(record.class)) : nil
 
-            if force || owner.read_attribute(reflection_fk) != target_key_value
-              owner.write_attribute(reflection_fk, target_key_value)
+            if force || owner.read_attribute(@foreign_key) != target_key_value
+              owner.write_attribute(@foreign_key, target_key_value)
             end
           end
         end
@@ -155,7 +166,7 @@ module ActiveRecord
         end
 
         def foreign_key_present?
-          Array(reflection.foreign_key).all? { |fk| owner.read_attribute(fk) }
+          Array(@foreign_key).all? { |fk| owner.read_attribute(fk) }
         end
 
         def invertible_for?(record)
@@ -164,25 +175,13 @@ module ActiveRecord
         end
 
         def stale_state
-          foreign_key = reflection.foreign_key
-          if foreign_key.is_a?(Array)
-            attributes = foreign_key.map do |fk|
+          if @foreign_key.is_a?(Array)
+            attributes = @foreign_key.map do |fk|
               owner.read_attribute(fk) { |n| owner.send(:missing_attribute, n, caller) }
             end
             attributes if attributes.any?
           else
-            owner.read_attribute(foreign_key) { |n| owner.send(:missing_attribute, n, caller) }
-          end
-        end
-
-        # The reflection's foreign key (or foreign type) may be declared with an
-        # +alias_attribute+ name, while change tracking is keyed by the real
-        # attribute name, so aliases must be resolved before querying it.
-        def resolve_attribute_alias(name)
-          if name.is_a?(Array)
-            name.map { |n| owner.class.attribute_aliases[n] || n }
-          else
-            owner.class.attribute_aliases[name] || name
+            owner.read_attribute(@foreign_key) { |n| owner.send(:missing_attribute, n, caller) }
           end
         end
     end

--- a/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
@@ -10,15 +10,15 @@ module ActiveRecord
       end
 
       def target_changed?
-        super || owner.attribute_changed?(reflection.foreign_type)
+        super || owner.attribute_changed?(resolve_attribute_alias(reflection.foreign_type))
       end
 
       def target_previously_changed?
-        super || owner.attribute_previously_changed?(reflection.foreign_type)
+        super || owner.attribute_previously_changed?(resolve_attribute_alias(reflection.foreign_type))
       end
 
       def saved_change_to_target?
-        super || owner.saved_change_to_attribute?(reflection.foreign_type)
+        super || owner.saved_change_to_attribute?(resolve_attribute_alias(reflection.foreign_type))
       end
 
       private

--- a/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
@@ -5,20 +5,20 @@ module ActiveRecord
     # = Active Record Belongs To Polymorphic Association
     class BelongsToPolymorphicAssociation < BelongsToAssociation # :nodoc:
       def klass
-        type = owner.read_attribute(reflection.foreign_type)
+        type = owner.read_attribute(@foreign_type)
         type.presence && owner.class.polymorphic_class_for(type)
       end
 
       def target_changed?
-        super || owner.attribute_changed?(resolve_attribute_alias(reflection.foreign_type))
+        super || owner.attribute_changed?(@foreign_type)
       end
 
       def target_previously_changed?
-        super || owner.attribute_previously_changed?(resolve_attribute_alias(reflection.foreign_type))
+        super || owner.attribute_previously_changed?(@foreign_type)
       end
 
       def saved_change_to_target?
-        super || owner.saved_change_to_attribute?(resolve_attribute_alias(reflection.foreign_type))
+        super || owner.saved_change_to_attribute?(@foreign_type)
       end
 
       private
@@ -27,8 +27,8 @@ module ActiveRecord
 
           target_type = record ? record.class.polymorphic_name : nil
 
-          if force || owner.read_attribute(reflection.foreign_type) != target_type
-            owner.write_attribute(reflection.foreign_type, target_type)
+          if force || owner.read_attribute(@foreign_type) != target_type
+            owner.write_attribute(@foreign_type, target_type)
           end
         end
 
@@ -42,7 +42,7 @@ module ActiveRecord
 
         def stale_state
           if foreign_key = super
-            [foreign_key, owner.read_attribute(reflection.foreign_type)]
+            [foreign_key, owner.read_attribute(@foreign_type)]
           end
         end
     end

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -42,33 +42,28 @@ module ActiveRecord::Associations::Builder # :nodoc:
       model.counter_cached_association_names = (model.counter_cached_association_names | [reflection.name]).freeze
     end
 
-    def self.touch_record(o, changes, foreign_key, name, touch) # :nodoc:
-      # +changes+ is keyed by real attribute names, so any +alias_attribute+
-      # name in the reflection must be resolved before looking it up.
-      aliases = o.class.attribute_aliases
-      foreign_key = if foreign_key.is_a?(Array)
-        foreign_key.map { |fk| aliases[fk] || fk }
-      else
-        aliases[foreign_key] || foreign_key
-      end
+    def self.touch_record(o, change_method, name, touch) # :nodoc:
+      association = o.association(name)
+      foreign_key = association.foreign_key
 
       old_foreign_id =
         if foreign_key.is_a?(Array)
-          if foreign_key.any? { |fk| changes[fk] }
+          if foreign_key.any? { |fk| o.public_send(change_method, fk) }
             foreign_key.map do |fk|
-              changes[fk] ? changes[fk].first : o.read_attribute(fk)
+              change = o.public_send(change_method, fk)
+              change ? change.first : o.read_attribute(fk)
             end
           end
-        elsif changes[foreign_key]
-          changes[foreign_key].first
+        elsif change = o.public_send(change_method, foreign_key)
+          change.first
         end
 
       if old_foreign_id
-        association = o.association(name)
         reflection = association.reflection
         if reflection.polymorphic?
-          foreign_type = aliases[reflection.foreign_type] || reflection.foreign_type
-          klass = changes[foreign_type] && changes[foreign_type].first || o.public_send(foreign_type)
+          foreign_type = association.foreign_type
+          change = o.public_send(change_method, foreign_type)
+          klass = (change && change.first) || o.public_send(foreign_type)
           klass = o.class.polymorphic_class_for(klass)
         else
           klass = association.klass
@@ -96,27 +91,26 @@ module ActiveRecord::Associations::Builder # :nodoc:
     end
 
     def self.add_touch_callbacks(model, reflection)
-      foreign_key = reflection.foreign_key
-      name        = reflection.name
-      touch       = reflection.options[:touch]
+      name  = reflection.name
+      touch = reflection.options[:touch]
 
-      callback = lambda { |changes_method| lambda { |record|
-        BelongsTo.touch_record(record, record.send(changes_method), foreign_key, name, touch)
+      callback = lambda { |change_method| lambda { |record|
+        BelongsTo.touch_record(record, change_method, name, touch)
       }}
 
       if reflection.counter_cache_column
-        touch_callback = callback.(:saved_changes)
+        touch_callback = callback.(:saved_change_to_attribute)
         update_callback = lambda { |record|
           instance_exec(record, &touch_callback) unless association(reflection.name).saved_change_to_target?
         }
         model.after_update update_callback, if: :saved_changes?
       else
-        model.after_create callback.(:saved_changes), if: :saved_changes?
-        model.after_update callback.(:saved_changes), if: :saved_changes?
-        model.after_destroy callback.(:changes_to_save)
+        model.after_create callback.(:saved_change_to_attribute), if: :saved_changes?
+        model.after_update callback.(:saved_change_to_attribute), if: :saved_changes?
+        model.after_destroy callback.(:attribute_change_to_be_saved)
       end
 
-      model.after_touch callback.(:changes_to_save)
+      model.after_touch callback.(:attribute_change_to_be_saved)
     end
 
     def self.add_default_callbacks(model, reflection)
@@ -155,16 +149,15 @@ module ActiveRecord::Associations::Builder # :nodoc:
           model.validates_presence_of reflection.name, message: :required
         else
           condition = lambda { |record|
-            aliases = record.class.attribute_aliases
-            foreign_key = Array(reflection.foreign_key).map { |fk| aliases[fk] || fk }
-            foreign_type = aliases[reflection.foreign_type] || reflection.foreign_type
+            association = record.association(reflection.name)
+            foreign_key = Array(association.foreign_key)
 
             fk_missing_or_changed = foreign_key.any? do |fk|
               record.read_attribute(fk).nil? || record.attribute_changed?(fk)
             end
 
             fk_missing_or_changed ||
-              (reflection.polymorphic? && (record.read_attribute(foreign_type).nil? || record.attribute_changed?(foreign_type)))
+              (reflection.polymorphic? && (record.read_attribute(association.foreign_type).nil? || record.attribute_changed?(association.foreign_type)))
           }
 
           model.validates_presence_of reflection.name, message: :required, if: condition

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -43,6 +43,15 @@ module ActiveRecord::Associations::Builder # :nodoc:
     end
 
     def self.touch_record(o, changes, foreign_key, name, touch) # :nodoc:
+      # +changes+ is keyed by real attribute names, so any +alias_attribute+
+      # name in the reflection must be resolved before looking it up.
+      aliases = o.class.attribute_aliases
+      foreign_key = if foreign_key.is_a?(Array)
+        foreign_key.map { |fk| aliases[fk] || fk }
+      else
+        aliases[foreign_key] || foreign_key
+      end
+
       old_foreign_id =
         if foreign_key.is_a?(Array)
           if foreign_key.any? { |fk| changes[fk] }
@@ -58,7 +67,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
         association = o.association(name)
         reflection = association.reflection
         if reflection.polymorphic?
-          foreign_type = reflection.foreign_type
+          foreign_type = aliases[reflection.foreign_type] || reflection.foreign_type
           klass = changes[foreign_type] && changes[foreign_type].first || o.public_send(foreign_type)
           klass = o.class.polymorphic_class_for(klass)
         else
@@ -146,10 +155,11 @@ module ActiveRecord::Associations::Builder # :nodoc:
           model.validates_presence_of reflection.name, message: :required
         else
           condition = lambda { |record|
-            foreign_key = reflection.foreign_key
-            foreign_type = reflection.foreign_type
+            aliases = record.class.attribute_aliases
+            foreign_key = Array(reflection.foreign_key).map { |fk| aliases[fk] || fk }
+            foreign_type = aliases[reflection.foreign_type] || reflection.foreign_type
 
-            fk_missing_or_changed = Array(foreign_key).any? do |fk|
+            fk_missing_or_changed = foreign_key.any? do |fk|
               record.read_attribute(fk).nil? || record.attribute_changed?(fk)
             end
 

--- a/activerecord/lib/active_record/touch_later.rb
+++ b/activerecord/lib/active_record/touch_later.rb
@@ -27,7 +27,7 @@ module ActiveRecord
       self.class.reflect_on_all_associations.each do |r|
         if touch = r.options[:touch]
           if r.macro == :belongs_to
-            ActiveRecord::Associations::Builder::BelongsTo.touch_record(self, changes_to_save, r.foreign_key, r.name, touch)
+            ActiveRecord::Associations::Builder::BelongsTo.touch_record(self, :attribute_change_to_be_saved, r.name, touch)
           elsif r.macro == :has_one
             ActiveRecord::Associations::Builder::HasOne.touch_record(self, r.name, touch)
           end

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -114,6 +114,83 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal authors(:david), post.author
   end
 
+  def test_belongs_to_with_alias_attribute_foreign_key_change_tracking
+    post = PostWithAliasedAuthorId.find(posts(:welcome).id)
+    post.writer_id = authors(:mary).id
+
+    assert_predicate post, :author_changed?
+
+    post.save!
+
+    assert_not_predicate post, :author_changed?
+    assert_predicate post, :author_previously_changed?
+  end
+
+  def test_belongs_to_counter_with_alias_attribute_foreign_key
+    debate = Topic.create!(title: "debate")
+    debate2 = Topic.create!(title: "debate2")
+    reply = ReplyWithAliasedParentId.create!(title: "blah!", content: "world around!", topic: debate)
+
+    assert_equal 1, debate.reload.replies_count
+    assert_equal 0, debate2.reload.replies_count
+
+    reply.update!(topic: debate2)
+
+    assert_equal 0, debate.reload.replies_count
+    assert_equal 1, debate2.reload.replies_count
+
+    reply.destroy!
+
+    assert_equal 0, debate.reload.replies_count
+    assert_equal 0, debate2.reload.replies_count
+  end
+
+  def test_belongs_to_touch_with_alias_attribute_foreign_key
+    debate = Topic.create!(title: "debate")
+    debate2 = Topic.create!(title: "debate2")
+    reply = ReplyWithAliasedTouchParentId.create!(title: "blah!", content: "world around!", topic: debate)
+
+    time = 1.day.ago
+    debate.touch(time: time)
+    debate2.touch(time: time)
+
+    reply.update!(topic: debate2)
+
+    assert_operator debate.reload.updated_at, :>, time
+    assert_operator debate2.reload.updated_at, :>, time
+  end
+
+  def test_belongs_to_required_validation_with_alias_attribute_foreign_key
+    original_value = ActiveRecord.belongs_to_required_validates_foreign_key
+    ActiveRecord.belongs_to_required_validates_foreign_key = false
+
+    model = Class.new(ActiveRecord::Base) do
+      self.table_name = "posts"
+      self.inheritance_column = nil
+
+      def self.name; "TempPost"; end
+
+      alias_attribute :writer_id, :author_id
+
+      belongs_to :author, foreign_key: :writer_id, required: true
+    end
+
+    post = model.create!(title: "Title", body: "Body", author: authors(:david))
+    post.reload
+
+    post.writer_id = 987_654_321
+    assert_not_predicate post, :valid?
+    assert_includes post.errors.full_messages, "Author must exist"
+
+    post.reload
+
+    post.author_id = 987_654_321
+    assert_not_predicate post, :valid?
+    assert_includes post.errors.full_messages, "Author must exist"
+  ensure
+    ActiveRecord.belongs_to_required_validates_foreign_key = original_value
+  end
+
   def test_belongs_to_with_primary_key_joins_on_correct_column
     sql = Client.joins(:firm_with_primary_key).to_sql
     if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)

--- a/activerecord/test/models/reply.rb
+++ b/activerecord/test/models/reply.rb
@@ -77,3 +77,21 @@ module Web
     belongs_to :topic, foreign_key: "parent_id", counter_cache: true, class_name: "Web::Topic"
   end
 end
+
+class ReplyWithAliasedParentId < ActiveRecord::Base
+  self.table_name = "topics"
+  self.inheritance_column = nil
+
+  alias_attribute :discussion_id, :parent_id
+
+  belongs_to :topic, foreign_key: :discussion_id, counter_cache: :replies_count
+end
+
+class ReplyWithAliasedTouchParentId < ActiveRecord::Base
+  self.table_name = "topics"
+  self.inheritance_column = nil
+
+  alias_attribute :discussion_id, :parent_id
+
+  belongs_to :topic, foreign_key: :discussion_id, touch: true
+end


### PR DESCRIPTION
Follow-up to #58348.

`alias_attribute` on a `belongs_to` foreign key is honored for reads and writes, but change tracking is keyed by the real column name. Querying it under the alias never reported a change, so re-pointing the association broke `counter_cache` (counters went negative on destroy), `touch: true` (previous parent not touched), and required validation with `belongs_to_required_validates_foreign_key = false` (dangling FK saved without error).

Aliases are now resolved to their column names wherever `belongs_to` consults the Dirty API, matching how the attribute itself is read and written.