### PR TITLE
Fix Ractor logger level lookup to not rely on Fiber keyed overrides

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Don't rely on `::Logger`'s Fiber keyed level overrides in `ActiveSupport::Ractors::Logger`.
+
+    `::Logger#level` looks up a hash keyed by `Fiber.current`, which can't be used from a
+    non-main Ractor and crashed a shareable logger used inside one. The Ractor logger now
+    resolves its level through `ActiveSupport::LoggerThreadSafeLevel` only.
+
+    Fixes #57954.
+
+    *Nicolas Vandenbogaerde*
+
 *   Deprecate `ActiveSupport::Cache::RedisCacheStore::DEFAULT_REDIS_OPTIONS`.
 
     The `redis-client` implementation no longer reads this constant. Pass

--- a/activesupport/lib/active_support/ractors/logger.rb
+++ b/activesupport/lib/active_support/ractors/logger.rb
@@ -16,9 +16,36 @@ module ActiveSupport
 
       delegate :flush, to: :@logdev
 
+      # ::Logger keeps per-Fiber level overrides in a hash keyed by ::Logger#level_key, which returns
+      # +Fiber.current+. That key can't be computed from a non-main Ractor, and the hash is shared
+      # mutable state. Active Support already provides Ractor-safe per-execution-context levels through
+      # ActiveSupport::LoggerThreadSafeLevel, so bypass the ::Logger implementation entirely.
+      def level
+        local_level || @level
+      end
+
+      def with_level(severity, &block)
+        log_at(coerce_level(severity), &block)
+      end
+
       extend ActiveSupport::Autoload
       autoload :DeviceProxy
       autoload :Writer
+
+      private
+        def coerce_level(severity)
+          return severity if severity.is_a?(Integer)
+
+          case severity.to_s.downcase
+          when "debug" then ::Logger::DEBUG
+          when "info" then ::Logger::INFO
+          when "warn" then ::Logger::WARN
+          when "error" then ::Logger::ERROR
+          when "fatal" then ::Logger::FATAL
+          when "unknown" then ::Logger::UNKNOWN
+          else raise ArgumentError, "invalid log level: #{severity}"
+          end
+        end
     end
   end
 end

--- a/activesupport/test/ractor_logger_test.rb
+++ b/activesupport/test/ractor_logger_test.rb
@@ -192,6 +192,27 @@ class RactorLoggerTest < ActiveSupport::TestCase
       logger&.close
     end
 
+    test "log level is honored from a non-main Ractor" do
+      path = log_path("ractor_level.log")
+      logger = ActiveSupport::TaggedLogging.ractor_logger(path)
+      logger.level = ::Logger::WARN
+      Ractor.make_shareable(logger)
+
+      Ractor.new(logger) do |lg|
+        lg.info("below-threshold")
+        lg.warn("above-threshold")
+        :done
+      end.value
+
+      logger.flush
+
+      contents = File.read(path)
+      assert_includes contents, "above-threshold"
+      assert_not_includes contents, "below-threshold"
+    ensure
+      logger&.close
+    end
+
     test "a failing log device does not kill the consumer or raise in the caller" do
       device = FailingDevice.new(fail_writes: true, fail_flush: true)
       logger = ActiveSupport::TaggedLogging.ractor_logger(device)
@@ -224,6 +245,77 @@ class RactorLoggerTest < ActiveSupport::TestCase
     end
   end
 
+  # ActiveSupport::Ractors::Logger#initialize builds a Writer, which requires Ractor::Port. Only the
+  # level resolution is exercised below, so build the logger without its Ractor backed device to keep
+  # the test running on every supported Ruby.
+  class LevelOnlyLogger < ActiveSupport::Ractors::Logger
+    def initialize
+      ActiveSupport::Logger.instance_method(:initialize).bind_call(self, IO::NULL)
+    end
+  end
+
+  test "level reads the base level without ::Logger's Fiber keyed overrides" do
+    logger = level_only_logger
+    assert_equal ::Logger::DEBUG, logger.level
+
+    logger.level = ::Logger::INFO
+    assert_equal ::Logger::INFO, logger.level
+  ensure
+    logger&.close
+  end
+
+  test "log_at uses local level storage without ::Logger's Fiber keyed overrides" do
+    logger = level_only_logger
+    logger.level = ::Logger::INFO
+
+    logger.log_at(::Logger::WARN) do
+      assert_equal ::Logger::WARN, logger.level
+    end
+
+    assert_equal ::Logger::INFO, logger.level
+  ensure
+    logger&.close
+  end
+
+  test "with_level coerces severity like ::Logger without using Fiber keyed overrides" do
+    logger = level_only_logger
+    logger.level = ::Logger::INFO
+
+    logger.with_level(::Logger::ERROR) { assert_equal ::Logger::ERROR, logger.level }
+    logger.with_level(:debug) { assert_equal ::Logger::DEBUG, logger.level }
+    logger.with_level("fatal") { assert_equal ::Logger::FATAL, logger.level }
+
+    assert_equal ::Logger::INFO, logger.level
+  ensure
+    logger&.close
+  end
+
+  test "with_level restores nested local levels" do
+    logger = level_only_logger
+    logger.level = ::Logger::INFO
+
+    logger.with_level(:warn) do
+      assert_equal ::Logger::WARN, logger.level
+      logger.with_level(:error) { assert_equal ::Logger::ERROR, logger.level }
+      assert_equal ::Logger::WARN, logger.level
+    end
+
+    assert_equal ::Logger::INFO, logger.level
+  ensure
+    logger&.close
+  end
+
+  test "with_level rejects invalid severities" do
+    logger = level_only_logger
+
+    error = assert_raises(ArgumentError) do
+      logger.with_level("invalid") { true }
+    end
+    assert_equal "invalid log level: invalid", error.message
+  ensure
+    logger&.close
+  end
+
   class FailingDevice
     attr_reader :written
 
@@ -251,6 +343,16 @@ class RactorLoggerTest < ActiveSupport::TestCase
   end
 
   private
+    def level_only_logger
+      LevelOnlyLogger.new.tap do |logger|
+        # ::Logger#level reads level_override[level_key], and level_key is Fiber.current, which can't be
+        # used from a non-main Ractor. See https://bugs.ruby-lang.org/issues/22173.
+        logger.define_singleton_method(:level_key) do
+          raise "::Logger#level_key relies on Fiber.current and must not be used"
+        end
+      end
+    end
+
     def log_path(name)
       tmp_dir = File.join(__dir__, "tmp", "ractor_logger_test")
       FileUtils.mkdir_p(tmp_dir)


### PR DESCRIPTION
### Motivation / Background

Fixes #57954.

When a shareable `ActiveSupport::Ractors::Logger` is used from a non-main Ractor, `::Logger#level` accesses Fiber-keyed level overrides. On a Ruby debug build, this can raise `rb_ractor_confirm_belonging` because the `Fiber.current` key belongs to another Ractor.

### Detail

`ActiveSupport::Ractors::Logger` now resolves its level through `ActiveSupport::LoggerThreadSafeLevel` instead of relying on the Fiber-keyed level storage used by `::Logger`. `with_level` also performs the same severity coercion as `::Logger` while keeping the level override Ractor-safe.

Regression tests cover logging from a shareable logger in a non-main Ractor, base and nested local levels, severity coercion, and invalid severities.

### Additional information

The underlying Ruby issue is tracked in https://bugs.ruby-lang.org/issues/22173.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
