### PR TITLE
Define DateTimeSelector datetime readers with shareable lambdas

### DIFF
--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -890,14 +890,16 @@ module ActionView
 
       private
         %w( sec min hour day month year ).each do |method|
-          define_method(method) do
+          name = method.to_sym
+          reader = ActiveSupport::Ractors.shareable_lambda do
             case @datetime
-            when Hash then @datetime[method.to_sym]
+            when Hash then @datetime[name]
             when Numeric then @datetime
             when nil then nil
-            else @datetime.send(method)
+            else @datetime.send(name)
             end
           end
+          define_method(method, reader)
         end
 
         def prompt_text(prompt, type)

--- a/actionview/test/template/date_helper_ractor_test.rb
+++ b/actionview/test/template/date_helper_ractor_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+class DateHelperRactorTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::Isolation
+
+  if defined?(Ractor) && RUBY_VERSION >= "4.0"
+    test "select_datetime renders inside a non-main Ractor" do
+      datetime = Time.utc(2004, 6, 4, 15, 16, 35)
+      options = { order: [:year, :month, :day], use_month_names: Date::MONTHNAMES }
+
+      rendered_in_ractor = Ractor.new(datetime, options) do |time, opts|
+        Object.new.extend(ActionView::Helpers::DateHelper).select_datetime(time, opts)
+      end
+
+      rendered = Object.new.extend(ActionView::Helpers::DateHelper).select_datetime(datetime, options)
+
+      assert_equal rendered, rendered_in_ractor.value
+    end
+
+    test "DateTimeSelector datetime readers are callable from a non-main Ractor" do
+      values = Ractor.new do
+        time = ActionView::Helpers::DateTimeSelector.new(Time.utc(2004, 6, 4, 15, 16, 35), {})
+        hash = ActionView::Helpers::DateTimeSelector.new({ year: 2004, month: 6, day: 4 }, {})
+        [
+          %i(sec min hour day month year).map { |reader| time.send(reader) },
+          %i(day month year).map { |reader| hash.send(reader) },
+        ]
+      end.value
+
+      assert_equal [[35, 16, 15, 4, 6, 2004], [4, 6, 2004]], values
+    end
+  end
+end


### PR DESCRIPTION
To be able to render date time `<select>` fields, we need to be able to call `sec` `min` `hour` `day` `month` `year` on the `DateTimeSelector` instance, but since they're defined using `define_method` and a proc, they can't be called from a Ractor.

We could also use `module_eval` and a string of Ruby code.