### PR TITLE
Fix incorrect documentation

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -274,7 +274,7 @@ module ActiveRecord
     #   ActiveRecord::Base.connected_to(role: :reading, shard: :shard_one) do
     #     ActiveRecord::Base.connected_to?(role: :reading, shard: :shard_one) #=> true
     #     ActiveRecord::Base.connected_to?(role: :reading, shard: :default) #=> false
-    #     ActiveRecord::Base.connected_to?(role: :writing, shard: :shard_one) #=> true
+    #     ActiveRecord::Base.connected_to?(role: :writing, shard: :shard_one) #=> false
     #   end
     def connected_to?(role:, shard: ActiveRecord::Base.default_shard)
       current_role == role.to_sym && current_shard == shard.to_sym

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1371,7 +1371,7 @@ module ActiveRecord
     #
     # To make a readonly relation writable, pass +false+.
     #
-    #   users.readonly(false)
+    #   users = users.readonly(false)
     #   users.first.save
     #   # => true
     def readonly(value = true)

--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -608,8 +608,8 @@ When you assign an object to a `has_one` association, that object is
 automatically saved to update its foreign key. Additionally, any object being
 replaced is also automatically saved, as its foreign key will change too.
 
-If either of these saves fails due to validation errors, the assignment
-statement returns `false`, and the assignment itself is canceled.
+If either of these saves fails due to validation errors,
+`ActiveRecord::RecordNotSaved` is raised and the assignment is canceled.
 
 If the parent object (the one declaring the `has_one` association) is unsaved
 (that is, `new_record?` returns `true`) then the child objects are not saved
@@ -937,8 +937,8 @@ When you assign an object to a `has_many` association, that object is
 automatically saved (in order to update its foreign key). If you assign multiple
 objects in one statement, then they are all saved.
 
-If any of these saves fails due to validation errors, then the assignment
-statement returns `false` and the assignment itself is cancelled.
+If any of these saves fails due to validation errors, then
+`ActiveRecord::RecordNotSaved` is raised and the assignment is cancelled.
 
 If the parent object (the one declaring the `has_many` association) is unsaved
 (that is, `new_record?` returns `true`) then the child objects are not saved
@@ -1427,8 +1427,8 @@ When you assign an object to a `has_and_belongs_to_many` association, that
 object is automatically saved (in order to update the join table). If you assign
 multiple objects in one statement, then they are all saved.
 
-If any of these saves fails due to validation errors, then the assignment
-statement returns `false` and the assignment itself is cancelled.
+If any of these saves fails due to validation errors, then
+`ActiveRecord::RecordInvalid` is raised and the assignment is cancelled.
 
 If the parent object (the one declaring the `has_and_belongs_to_many`
 association) is unsaved (that is, `new_record?` returns `true`) then the child


### PR DESCRIPTION
This PR bundles documentation-only fixes across Active Record.

### Fix incorrect RDoc examples in Active Record

Two RDoc examples in Active Record show values the code cannot produce.

#### `connected_to?` (`activerecord/lib/active_record/connection_handling.rb`)

`connected_to?` returns `true` only when both the role and the shard match the current connection context, so the example inside the `connected_to(role: :reading, shard: :shard_one)` block cannot return `true` for `role: :writing`. `connection_handlers_sharding_db_test.rb` asserts this exact scenario with `assert_not`.

#### `#readonly` (`activerecord/lib/active_record/relation/query_methods.rb`)

`#readonly` spawns a new relation, so the example discards the writable relation and `users.first.save` raises `ActiveRecord::ReadOnlyRecord` instead of returning `true`. Assign the result back, like the `#create_with` example below does.

### Fix associations guide on failed assignment saves

The Associations guide states in three places (`has_one`, `has_many`, and `has_and_belongs_to_many`) that when saving an assigned record fails, "the assignment statement returns `false`". Assignment expressions in Ruby always evaluate to the right-hand side — what actually happens is that `ActiveRecord::RecordNotSaved` (or `RecordInvalid` for HABTM) is raised and the assignment is cancelled. This brings the guide in line with the API docs and the actual behavior since 2011.

> [!NOTE]
> Documentation-only changes