### PR TITLE
Allow to configure ERB options through `ActionView::Base`

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Configuring ERB options is now to be made on the ActionView::Base class.
+
+    The `ActionView::Template::Handlers::ERB` class is now private API. Applications
+    that used to configure ERB options such as `escape_ignore_list` now need
+    to do this on the `ActionView::Base` class or on the railtie `config.action_view`
+    configuration.
+
+    ```ruby
+    ActionView::Base.erb_trim_mode = nil
+    ActionView::Base.erb_implementation = ERB
+    ActionView::Base.escape_ignore_list = ["text/csv"]
+    ActionView::Base.strip_trailing_newlines = false
+    ```
+
+    *Edouard Chin*
+
 *   Fix `search_field` raising `NameError` when passed `autosave: true`.
 
     *Hammad Khan*

--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -187,7 +187,27 @@ module ActionView # :nodoc:
     cattr_accessor :remove_hidden_field_autocomplete, default: false
 
     class << self
-      delegate :erb_trim_mode=, to: "ActionView::Template::Handlers::ERB"
+      ##
+      # :singleton-method: erb_trim_mode=
+      #
+      # Controls if certain ERB syntax should trim. It defaults to <tt>'-'</tt>, which turns on trimming of trailing spaces and
+      # newline when using <tt><%= -%></tt> or <tt><%= =%></tt>. Setting this to anything else will turn off trimming support.
+
+      ##
+      # :singleton-method: erb_implementation=
+      #
+      # Default ERB implementation to use. Defaults to Erubi.
+
+      ##
+      # :singleton-method: escape_ignore_list=
+      #
+      # Do not escape templates of these mime types. Defaults to ["text/plain"]
+
+      ##
+      # :singleton-method: strip_trailing_newlines=
+      #
+      # Strip trailing newlines from rendered output. Defaults to <tt>false</tt>.
+      delegate :erb_trim_mode=, :erb_implementation=, :escape_ignore_list=, :strip_trailing_newlines=, to: "ActionView::Template::Handlers::ERB"
 
       def cache_template_loading
         ActionView::Resolver.caching?

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -67,7 +67,7 @@ module ActionView
     end
 
     config.after_initialize do
-      ActionView::Template::Handlers::ERB.escape_ignore_list.freeze
+      ActiveSupport::Ractors.make_shareable(ActionView::Template::Handlers::ERB.escape_ignore_list)
     end
 
     config.after_initialize do |app|

--- a/actionview/test/actionpack/abstract/abstract_controller_test.rb
+++ b/actionview/test/actionpack/abstract/abstract_controller_test.rb
@@ -55,6 +55,23 @@ module AbstractController
         render "with_final_newline.erb"
       end
 
+      def erb_implementation
+        render(inline: "")
+      end
+
+      def capture_and_multiline
+        render(inline: <<~ERB)
+          <% @a = 1 %>
+          Foo
+        ERB
+      end
+
+      def escape
+        sentence = %q(friends "or" families's)
+
+        render(inline: "<%= sentence %>", formats: :csv, locals: { sentence: sentence })
+      end
+
       def index_to_string
         self.response_body = render_to_string "index"
       end
@@ -78,6 +95,15 @@ module AbstractController
     end
 
     class TestRenderingController < ActiveSupport::TestCase
+      class FakeErubi
+        def initialize(...)
+        end
+
+        def src
+          "'It works!'"
+        end
+      end
+
       def setup
         @controller = Me2.new
       end
@@ -93,6 +119,36 @@ module AbstractController
         assert_equal "Hello from with_final_newline.erb", @controller.response_body
       ensure
         ActionView::Template::Handlers::ERB.strip_trailing_newlines = false
+      end
+
+      test "erb_implementation is respected" do
+        prev = ActionView::Template::Handlers::ERB.erb_implementation
+        ActionView::Base.erb_implementation = FakeErubi
+
+        @controller.process(:erb_implementation)
+        assert_equal "It works!", @controller.response_body
+      ensure
+        ActionView::Base.erb_implementation = prev
+      end
+
+      test "erb_trim_mode is respected" do
+        prev = ActionView::Template::Handlers::ERB.erb_trim_mode
+        ActionView::Base.erb_trim_mode = nil
+
+        @controller.process(:capture_and_multiline)
+        assert_equal "\nFoo\n", @controller.response_body
+      ensure
+        ActionView::Base.erb_trim_mode = prev
+      end
+
+      test "escape_ignore_list is respected" do
+        prev = ActionView::Template::Handlers::ERB.escape_ignore_list
+        ActionView::Base.escape_ignore_list = ["text/csv"]
+
+        @controller.process(:escape)
+        assert_equal %q(friends "or" families's), @controller.response_body
+      ensure
+        ActionView::Base.escape_ignore_list = prev
       end
 
       test "render_to_string works with a String as an argument" do

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2642,6 +2642,18 @@ Accepts a logger conforming to the interface of Log4r or the default Ruby Logger
 
 Controls if certain ERB syntax should trim. It defaults to `'-'`, which turns on trimming of tail spaces and newline when using `<%= -%>` or `<%= =%>`. Setting this to anything else will turn off trimming support.
 
+#### `config.action_view.erb_implementation`
+
+Controls the default ERB implementation to use. It defaults to `Erubi`.
+
+#### `config.action_view.escape_ignore_list`
+
+Control whether template should be escaped based on the mime type. Defaults to `["text/plain"]`.
+
+#### `config.action_view.strip_trailing_newlines`
+
+Strip trailing newlines from rendered output. Defaults to `false`.
+
 #### `config.action_view.frozen_string_literal`
 
 Compiles the ERB template with the `# frozen_string_literal: true` magic comment, making all string literals frozen and saving allocations. Set to `true` to enable it for all views.

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3575,15 +3575,17 @@ module ApplicationTests
       assert_equal true, ActionView::Helpers::FormTagHelper.default_enforce_utf8
     end
 
-    test "ActionView::Template::Handlers::ERB.escape_ignore_list is frozen after boot" do
-      app "development"
+    if RUBY_VERSION >= "4.0"
+      test "ActionView::Template::Handlers::ERB.escape_ignore_list is frozen after boot" do
+        app "development"
 
-      escape_ignore_list = on_ractor do
-        ActionView::Template::Handlers::ERB.escape_ignore_list
+        escape_ignore_list = on_ractor do
+          ActionView::Template::Handlers::ERB.escape_ignore_list
+        end
+
+        assert_equal(["text/plain"], escape_ignore_list)
+        assert_predicate(escape_ignore_list, :frozen?)
       end
-
-      assert_equal(["text/plain"], escape_ignore_list)
-      assert_predicate(escape_ignore_list, :frozen?)
     end
 
     test "ActionView::Helpers::NavigationHelper.button_to_generates_button_tag is true by default" do


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because in 970bf380fe8 we added a :nodoc: to officialy not document AV::Template::Handlers::ERB, but some applications were legitimatelly referecing that class to store documented configuration.

### Additional information

This patch allows to configure all options from the ERB handlers inside ActionView::Base (or `config.action_view.<setting>`). This was already possible for `erb_trim_mode`.

Also added new tests to ensure the behaviour since none existed.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
