### PR TITLE
Fix TimeWithZone#to_s raising in a non-main Ractor

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -187,7 +187,7 @@ module ActiveSupport
     }
 
     UTC_OFFSET_WITH_COLON = "%s%02d:%02d" # :nodoc:
-    UTC_OFFSET_WITHOUT_COLON = UTC_OFFSET_WITH_COLON.tr(":", "") # :nodoc:
+    UTC_OFFSET_WITHOUT_COLON = UTC_OFFSET_WITH_COLON.tr(":", "").freeze # :nodoc:
     private_constant :UTC_OFFSET_WITH_COLON, :UTC_OFFSET_WITHOUT_COLON
 
     @lazy_zones_map = Concurrent::Map.new

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -889,6 +889,12 @@ class TimeZoneTest < ActiveSupport::TestCase
     assert_ractor_shareable(ActiveSupport::TimeZone["Central Time (US & Canada)"])
   end
 
+  def test_formatted_offset_in_ractor
+    twz = ActiveSupport::TimeZone["Eastern Time (US & Canada)"].local(2000, 1, 1)
+
+    assert_equal ["2000-01-01 00:00:00 -0500", "Sat, 01 Jan 2000 00:00:00 -0500"], on_ractor(twz) { |t| [t.to_s, t.rfc2822] }
+  end
+
   def test_us_zones
     assert_includes ActiveSupport::TimeZone.us_zones, ActiveSupport::TimeZone["Hawaii"]
     assert_not_includes ActiveSupport::TimeZone.us_zones, ActiveSupport::TimeZone["Kuala Lumpur"]


### PR DESCRIPTION
26e78a20db made `ActiveSupport::TimeZone` instances Ractor-shareable, but `#to_s`, `#rfc2822`, `to_fs(:rfc822)` still raised `Ractor::IsolationError` on non-main Ractors — `UTC_OFFSET_WITHOUT_COLON` was a mutable string (`String#tr` is not covered by `frozen_string_literal`). Freezing it fixes the issue.

```ruby
Time.zone = "Eastern Time (US & Canada)"
Ractor.new(Time.zone.local(2000, 1, 1)) { |t| t.to_s }.value
# => Ractor::IsolationError (before) / "2000-01-01 00:00:00 -0500" (after)
```