### PR TITLE
Freeze ActionView::Template::Handlers::ERB.escape_ignore_list

### DIFF
--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -66,6 +66,10 @@ module ActionView
       ActionView::Template.frozen_string_literal = frozen_string_literal
     end
 
+    config.after_initialize do
+      ActionView::Template::Handlers::ERB.escape_ignore_list.freeze
+    end
+
     config.after_initialize do |app|
       ActionView::Helpers::AssetTagHelper.image_loading = app.config.action_view.delete(:image_loading)
       ActionView::Helpers::AssetTagHelper.image_decoding = app.config.action_view.delete(:image_decoding)

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_support/testing/ractors_assertions"
 require "isolation/abstract_unit"
 require "rack/test"
 require "env_helpers"
@@ -40,6 +41,7 @@ class ::MyOldKeyProvider; end
 module ApplicationTests
   class ConfigurationTest < ActiveSupport::TestCase
     include ActiveSupport::Testing::Isolation
+    include ActiveSupport::Testing::RactorsAssertions
     include Rack::Test::Methods
     include EnvHelpers
 
@@ -3571,6 +3573,17 @@ module ApplicationTests
       app "development"
 
       assert_equal true, ActionView::Helpers::FormTagHelper.default_enforce_utf8
+    end
+
+    test "ActionView::Template::Handlers::ERB.escape_ignore_list is frozen after boot" do
+      app "development"
+
+      escape_ignore_list = on_ractor do
+        ActionView::Template::Handlers::ERB.escape_ignore_list
+      end
+
+      assert_equal(["text/plain"], escape_ignore_list)
+      assert_predicate(escape_ignore_list, :frozen?)
     end
 
     test "ActionView::Helpers::NavigationHelper.button_to_generates_button_tag is true by default" do


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I'd like to access this array inside a Ractor. It's not possible now because the array isn't frozen.

### Detail

This configuration is Public API (even though the surrounding class was recently changed to be nodoc, but the doc is being re-introduced in #58359)

While it's possible that this array gets mutated at runtime, it's really unlikely, and it would be inconsistent. A quick GitHub codesearch confirms that the few libraries/app that modifies this config does that at boot time.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
