### PR TITLE
Make Proc layouts shareable

### DIFF
--- a/actionview/lib/action_view/layouts.rb
+++ b/actionview/lib/action_view/layouts.rb
@@ -308,10 +308,11 @@ module ActionView
               end
             RUBY
           when Proc
-            define_method :_layout_from_proc, &_layout
+            layout_proc = ActiveSupport::Ractors.try_shareable_proc(_layout)
+            define_method :_layout_from_proc, layout_proc
             private :_layout_from_proc
             <<-RUBY
-              result = _layout_from_proc(#{_layout.arity == 0 ? '' : 'self'})
+              result = _layout_from_proc(#{layout_proc.arity == 0 ? '' : 'self'})
               return #{default_behavior} if result.nil?
               result
             RUBY

--- a/actionview/test/actionpack/abstract/layouts_ractor_test.rb
+++ b/actionview/test/actionpack/abstract/layouts_ractor_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "active_support/testing/ractors_assertions"
+require "active_support/core_ext/object/with"
+
+class LayoutsRactorTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::RactorsAssertions
+
+  def controller_class_with_proc_layout(layout_proc)
+    Class.new(AbstractController::Base) do
+      include AbstractController::Rendering
+      include ActionView::Rendering
+      include ActionView::Layouts
+
+      layout layout_proc
+    end
+  end
+
+  test "an unshareable proc layout works without Ractors" do
+    words = []
+    klass = controller_class_with_proc_layout(proc { (words << "layout").join })
+
+    assert_equal "layout", klass.new.send(:_layout_from_proc)
+    assert_equal ["layout"], words
+  end
+
+  test "a proc layout is callable from a non-main Ractor when made shareable" do
+    klass = ActiveSupport::Ractors.with(unshareable_proc_action: :raise) do
+      controller_class_with_proc_layout(proc { "overwritten" })
+    end
+
+    assert_equal "overwritten", on_ractor(klass) { |k| k.new.send(:_layout_from_proc) }
+  end
+
+  test "a lambda layout keeps its arity and receives the controller when made shareable" do
+    klass = ActiveSupport::Ractors.with(unshareable_proc_action: :raise) do
+      controller_class_with_proc_layout(->(controller) { controller.is_a?(AbstractController::Base) ? "lambda" : "wrong" })
+    end
+
+    assert_equal "lambda", on_ractor(klass) { |k|
+      controller = k.new
+      controller.send(:_layout_from_proc, controller)
+    }
+  end
+end


### PR DESCRIPTION
At first I thought that could stay strictly a problem for applications running Ractor, but turbo-rails provides a [proc layout for turbo frames](https://github.com/hotwired/turbo-rails/blob/v2.0.23/app/controllers/turbo/frames/frame_request.rb#L24) so I reconsidered.

Given we have `ActiveSupport::Ractors.try_shareable_proc` it's pretty straightforward without adding incompatibility issues. And if an application owner wants to try the ractor support, this will show the issue directly instead of indirectly at request time.

I will also push a PR to turbo-rails to turn the proc in a method. Actually there's already a PR: https://github.com/hotwired/turbo-rails/pull/786.