### PR TITLE
Honor composite / aliased FKs in belongs_to counter cache, autosave, and has_many :through nullify

### DIFF
--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -84,7 +84,13 @@ module ActiveRecord
           model_was = klass
         end
 
-        foreign_key_was = owner.attribute_before_last_save(@foreign_key)
+        foreign_key_was =
+          if @foreign_key.is_a?(Array)
+            values = @foreign_key.map { |fk| owner.attribute_before_last_save(fk) }
+            values if values.all?
+          else
+            owner.attribute_before_last_save(@foreign_key)
+          end
 
         if foreign_key_was && model_was < ActiveRecord::Base
           update_counters_via_scope(model_was, foreign_key_was, -1)
@@ -100,7 +106,7 @@ module ActiveRecord
       end
 
       def saved_change_to_target?
-        owner.saved_change_to_attribute?(@foreign_key)
+        Array(@foreign_key).any? { |fk| owner.saved_change_to_attribute?(fk) }
       end
 
       private
@@ -123,13 +129,20 @@ module ActiveRecord
             if target && !stale_target?
               target.increment!(reflection.counter_cache_column, by, touch: reflection.options[:touch])
             else
-              update_counters_via_scope(klass, owner.read_attribute(@foreign_key), by)
+              foreign_key_value =
+                if @foreign_key.is_a?(Array)
+                  @foreign_key.map { |fk| owner.read_attribute(fk) }
+                else
+                  owner.read_attribute(@foreign_key)
+                end
+              update_counters_via_scope(klass, foreign_key_value, by)
             end
           end
         end
 
         def update_counters_via_scope(klass, foreign_key, by)
-          scope = klass.unscoped.where!(primary_key(klass) => foreign_key)
+          primary_key = ActiveRecord::Key.for(reflection.association_primary_key(klass))
+          scope = klass.unscoped.where!(primary_key.where_hash(foreign_key))
           scope.update_counters(reflection.counter_cache_column => by, touch: reflection.options[:touch])
         end
 

--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -153,7 +153,7 @@ module ActiveRecord
               count = scope.delete_all
             end
           when :nullify
-            count = scope.update_all(source_reflection.foreign_key => nil)
+            count = scope.update_all(Array(source_reflection.foreign_key).index_with(nil))
           else
             count = scope.delete_all
           end

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -516,7 +516,7 @@ module ActiveRecord
         record.new_record? ||
           (association_foreign_key_changed?(reflection, record, key) ||
           inverse_polymorphic_association_changed?(reflection, record)) ||
-          record.will_save_change_to_attribute?(reflection.foreign_key)
+          Array(reflection.foreign_key).any? { |fk| record.will_save_change_to_attribute?(record.class.attribute_aliases[fk] || fk) }
       end
 
       def association_foreign_key_changed?(reflection, record, key)

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1727,6 +1727,20 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal(chapter.book, book)
   end
 
+  def test_delete_all_nullify_on_through_with_composite_source_foreign_key
+    author = Cpk::Author.create!(name: "author")
+    order = Cpk::Order.create!(id: [9999, 30001], status: "open")
+    book = Cpk::Book.create!(id: [author.id, 30001], title: "Book", order: order)
+
+    assert_equal 1, author.orders.count
+
+    author.orders.delete_all(:nullify)
+
+    book.reload
+    assert_nil book.shop_id
+    assert_nil book.order_id
+  end
+
   def test_ids_reader_with_composite_primary_key_on_source
     blog = Sharded::Blog.create!
     post = Sharded::BlogPost.create!(blog_id: blog.id)

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -1304,6 +1304,22 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
     assert_nil Cpk::Order.find_by(id: 4, shop_id: 3)
   end
 
+  def test_autosave_has_one_cpk_association_when_composite_foreign_key_is_manually_set
+    author = Cpk::Author.create!(name: "author")
+    book = Cpk::Book.create!(id: [author.id, 9999], title: "Book")
+    assert_nil book.shop_id
+    assert_nil book.order_id
+
+    order = Cpk::Order.new(id: [1, 100], status: "open")
+    order.book = book
+
+    order.save!
+
+    book.reload
+    assert_equal 1, book.shop_id
+    assert_equal 100, book.order_id
+  end
+
   def test_should_skip_validation_on_a_parent_association_if_marked_for_destruction
     @ship.pirate.catchphrase = ""
     assert_not_predicate @ship, :valid?

--- a/activerecord/test/cases/counter_cache_test.rb
+++ b/activerecord/test/cases/counter_cache_test.rb
@@ -203,6 +203,40 @@ class CounterCacheTest < ActiveRecord::TestCase
     end
   end
 
+  test "belongs_to counter cache is maintained on create/update/destroy for cpk model" do
+    order1 = Cpk::Order.create!(id: [9999, 10001], status: "open")
+    order2 = Cpk::Order.create!(id: [9999, 10002], status: "open")
+
+    book = nil
+    assert_difference -> { order1.reload.books_count }, 1 do
+      book = Cpk::Book.create!(id: [9999, 10001], title: "Book", order: order1)
+    end
+
+    assert_difference(
+      { -> { order1.reload.books_count } => -1,
+        -> { order2.reload.books_count } => 1 }
+    ) do
+      book.update!(order: order2)
+    end
+
+    assert_difference -> { order2.reload.books_count }, -1 do
+      book.destroy!
+    end
+  end
+
+  test "belongs_to counter cache is maintained when composite foreign key is manually set" do
+    author = Cpk::Author.create!(name: "author")
+    book = Cpk::Book.create!(id: [author.id, 9999], title: "Book")
+    assert_nil book.shop_id
+    assert_nil book.order_id
+
+    order = Cpk::Order.create!(id: [1, 200], status: "open")
+
+    assert_difference -> { order.reload.books_count }, 1 do
+      book.update!(order: order)
+    end
+  end
+
   test "reset counters for cpk model with string ids" do
     order = cpk_orders(:cpk_book_order_1)
     assert order.books_count > 0, "Must have books"


### PR DESCRIPTION
`reflection.foreign_key` was passed directly to code that didn't handle composite (Array coerced via `to_s`) or aliased (mutation tracker keys by real column) FKs:

* `BelongsToAssociation` counter cache — no-op'd. Iterate per FK; use `ActiveRecord::Key#where_hash` for the composite WHERE. (Aliased FKs handled via the init-time `@foreign_key` cache.)

* `AutosaveAssociation#_record_changed?` — the `will_save_change_to_attribute?` fallback silently returned false. Iterate per FK and resolve aliases inline.

* `HasManyThroughAssociation#delete_records` `:nullify` — produced `UPDATE ... SET "[\"col1\", \"col2\"]" = NULL` / `SET "aliased" = NULL`. Expand the composite FK to a multi-column update Hash (`Arel::Table#[]` resolves aliases for each scalar key).
