### PR TITLE
Prevent ActiveSupport::Notifications::Fanout lock-order deadlock

### DIFF
--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -201,9 +201,12 @@ module ActiveSupport
       end
 
       def groups_for(name) # :nodoc:
-        silenceable_groups, groups = @groups_for.compute_if_absent(name) do
-          listeners = all_listeners_for(name)
-          listeners.partition(&:silenceable).map { |l| group_listeners(l) }
+        # Acquire @mutex before Concurrent::Map's write lock to prevent lock-order deadlocks.
+        silenceable_groups, groups = @groups_for[name] || @mutex.synchronize do
+          @groups_for.compute_if_absent(name) do
+            listeners = all_listeners_for_locked(name)
+            listeners.partition(&:silenceable).map { |l| group_listeners(l) }
+          end
         end
 
         unless silenceable_groups.empty?
@@ -326,9 +329,7 @@ module ActiveSupport
       def all_listeners_for(name)
         # this is correctly done double-checked locking (Concurrent::Map's lookups have volatile semantics)
         @all_listeners_for[name] || @mutex.synchronize do
-          # use synchronisation when accessing @subscribers
-          @all_listeners_for[name] ||=
-            @string_subscribers[name] + @other_subscribers.select { |s| s.subscribed_to?(name) }
+          all_listeners_for_locked(name)
         end
       end
 
@@ -469,6 +470,12 @@ module ActiveSupport
           end
         end
       end
+
+      private
+        def all_listeners_for_locked(name)
+          @all_listeners_for[name] ||=
+            @string_subscribers[name] + @other_subscribers.select { |s| s.subscribed_to?(name) }
+        end
     end
   end
 end

--- a/activesupport/test/notifications_test.rb
+++ b/activesupport/test/notifications_test.rb
@@ -320,6 +320,68 @@ module Notifications
   end
 
   class UnsubscribeTest < TestCase
+    def test_subscribed_cleanup_does_not_deadlock_with_concurrent_instrumentation
+      cache_clear_started = Queue.new
+      continue_cache_clear = Queue.new
+      mutex_acquisition_started = Queue.new
+      subscribed_block_started = Queue.new
+      finish_subscribed_block = Queue.new
+      instrumenter = ActiveSupport::Notifications.instrumenter
+
+      signaling_mutex = Class.new do
+        def initialize(mutex_acquisition_started)
+          @mutex = Mutex.new
+          @mutex_acquisition_started = mutex_acquisition_started
+        end
+
+        def synchronize(&block)
+          @mutex_acquisition_started << true if Thread.current[:report_mutex_acquisition]
+          @mutex.synchronize(&block)
+        end
+      end.new(mutex_acquisition_started)
+
+      cache_clear_barrier = Module.new do
+        define_method(:clear_cache) do |key = nil|
+          if Thread.current[:pause_cache_clear]
+            cache_clear_started << true
+            continue_cache_clear.pop
+          end
+          super(key)
+        end
+      end
+
+      @notifier.instance_variable_set(:@mutex, signaling_mutex)
+      @notifier.singleton_class.prepend(cache_clear_barrier)
+
+      unsubscribe_thread = Thread.new do
+        ActiveSupport::Notifications.subscribed(->(*) { }, "concurrent") do
+          subscribed_block_started << true
+          finish_subscribed_block.pop
+        ensure
+          Thread.current[:pause_cache_clear] = true
+        end
+      end
+      subscribed_block_started.pop
+      finish_subscribed_block << true
+      cache_clear_started.pop
+
+      instrument_thread = Thread.new do
+        Thread.current[:report_mutex_acquisition] = true
+        instrumenter.instrument("uncached") { }
+      end
+      mutex_acquisition_started.pop
+
+      continue_cache_clear << true
+
+      assert unsubscribe_thread.join(1), "unsubscribe thread did not finish"
+      assert instrument_thread.join(1), "instrument thread did not finish"
+    ensure
+      finish_subscribed_block&.push(true)
+      continue_cache_clear&.push(true)
+      [unsubscribe_thread, instrument_thread].compact.each(&:kill)
+      [unsubscribe_thread, instrument_thread].compact.each(&:join)
+    end
+
     def test_unsubscribing_removes_a_subscription
       @notifier.publish :foo
       @notifier.wait


### PR DESCRIPTION
### Motivation / Background

Fixes #58365.

`ActiveSupport::Notifications::Fanout` can deadlock when instrumentation
populates the groups cache concurrently with a subscription change. The two
paths acquire the Fanout mutex and the `Concurrent::Map` write lock in opposite
orders.

### Detail

This Pull Request makes cache population use the same lock order as cache
invalidation: the Fanout mutex is acquired before the groups map write lock.
`all_listeners_for_locked` lets the groups-cache path reuse listener-cache
population without reacquiring the non-reentrant mutex.

The regression test coordinates the standard
`ActiveSupport::Notifications.subscribed` cleanup path with concurrent
`Instrumenter#instrument` using queues. It deterministically deadlocks on the
previous implementation and completes with the fix.

### Additional information

Verification:

* Regression test fails on `origin/main` with `unsubscribe thread did not finish`.
* `activesupport/test/notifications_test.rb`: 39 runs, 91 assertions, 0 failures.
* Full Active Support suite: 6,715 runs, 19,335 assertions, 0 failures.
* RuboCop passes for both changed files.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

