### PR TITLE
Allow ZJIT to be used instead of YJIT

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -661,7 +661,6 @@ If YJIT is enabled, ZJIT will not be enabled.
 | Starting with version | The default value is                 |
 | --------------------- | ------------------------------------ |
 | (original)            | `false`                              |
-| TBD                   | `!Rails.env.local? && !config.yjit`  |
 
 ### Configuring Assets
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -652,6 +652,17 @@ Additionally, you can pass a hash to configure YJIT options such as `{ stats: tr
 | 7.2                   | `true`               |
 | 8.1                   | `!Rails.env.local?`  |
 
+#### `config.zjit`
+
+Enables ZJIT as of Ruby 4.0, to bring sizeable performance improvements. If you are
+deploying to a memory constrained environment you may want to set this to `false`.
+If YJIT is enabled, ZJIT will not be enabled.
+
+| Starting with version | The default value is                 |
+| --------------------- | ------------------------------------ |
+| (original)            | `false`                              |
+| TBD                   | `!Rails.env.local? && !config.yjit`  |
+
 ### Configuring Assets
 
 #### `config.assets.css_compressor`

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -25,7 +25,7 @@ module Rails
                     :content_security_policy_nonce_auto,
                     :require_master_key, :credentials, :disable_sandbox, :sandbox_by_default,
                     :add_autoload_paths_to_load_path, :rake_eager_load, :server_timing, :log_file_size,
-                    :dom_testing_default_html_version, :yjit, :action_on_early_load_hook
+                    :dom_testing_default_html_version, :yjit, :zjit, :action_on_early_load_hook
 
       attr_reader :encoding, :api_only, :loaded_config_version, :log_level
 
@@ -86,6 +86,7 @@ module Rails
         @server_timing                           = false
         @dom_testing_default_html_version        = :html4
         @yjit                                    = false
+        @zjit                                    = false
         @action_on_early_load_hook               = :log
       end
 

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -234,6 +234,13 @@ module Rails
           RubyVM::YJIT.enable(**options)
         end
       end
+
+      initializer :enable_zjit do
+        if config.zjit && defined?(RubyVM::ZJIT.enable)
+          # If YJIT is already enabled, this will print a warning but is safe to run.
+          RubyVM::ZJIT.enable
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This is in preparation for ZJIT to purportedly be Production-ready by Ruby 4.1, which should be released end of 2026. This copied the YJIT enabler in all the relevant places, and is kept simple by not depending on `config.yjit` (Ruby will print if ZJIT enable was successful for us).

If the configuration guide changes aren't necessary yet, I'll happily remove them =)

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because ZJIT is available in Ruby 4.0 and Rails can offer the ability to enable it at the right point in the application initialisation/boot process.

### Detail

This Pull Request adds an `enable_zjit` initialiser and `config.zjit` config just like the existing YJIT initialiser and config. Options cannot be passed to `RubyVM::ZJIT.enable` so it differs in that respect, but is otherwise identical.

### Additional information

This doesn't force ZJIT on consumers, and it doesn't change how YJIT is enabled or used. It's just an additional option for those who want to run ZJIT in the right place.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

Is the `railties/CHANGELOG.md` file auto-generated from commits?