### PR TITLE
Pluck from the target when the owner is a new record

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,23 @@
+*   Fix `pluck` ignoring records assigned to a new record's association.
+
+    ```ruby
+    # Before
+    post = Post.new
+    post.tags = [Tag.create!(name: "ruby")]
+
+    post.tags.pluck(:name) # => []
+    post.save!
+    post.tags.pluck(:name) # => ["ruby"]
+
+    # After
+    post = Post.new
+    post.tags = [Tag.create!(name: "ruby")]
+
+    post.tags.pluck(:name) # => ["ruby"]
+    ```
+
+    *Donal McBreen*
+
 *   Restore `alias_attribute` support in associations.
 
     Since Rails 4.2, association reads have bypassed the public

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -730,7 +730,7 @@ module ActiveRecord
           Base.strict_loading_violation!(owner: proxy_association.owner.class, reflection: proxy_association.reflection)
         end
 
-        null_scope? ? scope.pluck(*column_names) : super
+        null_scope? ? records.pluck(*column_names) : super
       end
 
       ##

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -754,6 +754,21 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     assert_not_predicate developer.projects, :loaded?
   end
 
+  def test_ids_reader_on_loaded_association_of_new_record
+    developer = Developer.new("name" => "Joe")
+    developer.projects = [projects(:active_record)]
+
+    assert_predicate developer.projects, :loaded?
+    assert_equal [projects(:active_record).id], developer.projects.ids
+  end
+
+  def test_pluck_on_loaded_association_of_new_record
+    developer = Developer.new("name" => "Joe")
+    developer.projects = [projects(:active_record)]
+
+    assert_equal [projects(:active_record).name], developer.projects.pluck(:name)
+  end
+
   def test_assign_ids
     developer = Developer.new("name" => "Joe")
     developer.project_ids = projects(:active_record, :action_controller).map(&:id)

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2223,6 +2223,30 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal 1, firm.clients.size
   end
 
+  def test_ids_reader_on_loaded_association_of_new_record
+    client = Client.create!(name: "Client")
+    firm = Firm.new(name: "Startup")
+    firm.clients = [client]
+
+    assert_predicate firm.clients, :loaded?
+    assert_equal [client.id], firm.clients.ids
+  end
+
+  def test_pluck_on_loaded_association_of_new_record
+    client = Client.create!(name: "Client")
+    firm = Firm.new(name: "Startup")
+    firm.clients = [client]
+
+    assert_equal ["Client"], firm.clients.pluck(:name)
+  end
+
+  def test_pluck_on_unloaded_association_of_new_record
+    Client.create!(name: "Client")
+    firm = Firm.new(name: "Startup")
+
+    assert_equal [], firm.clients.pluck(:name)
+  end
+
   def test_ids_reader_cache_should_be_cleared_when_collection_is_deleted
     firm = companies(:first_firm)
     assert_equal [2, 3, 11], firm.client_ids


### PR DESCRIPTION
Since rails/rails@56c95aee, `Relation#ids` delegates to `pluck`, which for an association is `CollectionProxy#pluck`. For a new record that reads the null scope, not the target, so `ids` changed:

    post = Post.new
    post.tags = [tag]

    # before 56c95aee
    post.tags.ids          # => [1]
    post.tags.pluck(:name) # => []

    # after
    post.tags.ids          # => []
    post.tags.pluck(:name) # => []

Read the target instead:

    post.tags.ids          # => [1]
    post.tags.pluck(:name) # => ["ruby"]

This seems like a better result, but we have swapped one breaking change for another. The alternative would be to special case `ids`.