### PR TITLE
Honour `prepared_statements` on rails main

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -81,7 +81,7 @@ module ActiveRecord
           arel: arel,
           name: name,
           binds: binds,
-          prepare: preparable,
+          prepare: prepared_statements && preparable,
           allow_async: async,
           allow_retry: allow_retry
         )

--- a/activerecord/test/cases/adapters/postgresql/prepared_statements_disabled_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/prepared_statements_disabled_test.rb
@@ -24,4 +24,29 @@ class PreparedStatementsDisabledTest < ActiveRecord::PostgreSQLTestCase
     assert_equal david, Developer.where(name: "David").last # With Binds
     assert_operator Developer.count, :>, 0 # Without Binds
   end
+
+  def test_statement_cache_queries_do_not_prepare_when_prepared_statements_are_disabled
+    assert_not Developer.lease_connection.prepared_statements
+
+    david = developers(:david)
+
+    statement_names = capture_statement_names do
+      assert_equal david, Developer.find(david.id)
+      assert_equal david, Developer.find_by(name: "David")
+    end
+
+    assert_empty statement_names
+  end
+
+  private
+    def capture_statement_names
+      names = []
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+        names << payload[:statement_name] if payload[:statement_name]
+      end
+      yield
+      names
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber)
+    end
 end


### PR DESCRIPTION
Fixes #58371

`select_all` passed the caller's `preparable:` straight through as `prepare:`, so the adapter prepared whenever the caller asked, whether or not prepared statements were enabled. `StatementCache#execute` always passes `preparable: true` and `to_sql_and_binds` leaves it untouched for a String query, so `Model.find` and `Model.find_by` always prepared with PostgreSQL issuing a named PREPARE per query. This breaks behind a transaction-pooling proxy where the name doesn't survive a backend swap.

Restore the `prepared_statements &&` dropped in 1277a8f09c. Since `prepared_statements` is aliased to the dynamic `prepared_statements?`, this covers both ways preparation gets turned off: 
1. the `prepared_statements: false` connection option
2. and `unprepared_statement` blocks, which work by making that predicate return false for their duration.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
