### PR TITLE
Ractor safe Active Record primary key

### DIFF
--- a/activerecord/lib/active_record/key.rb
+++ b/activerecord/lib/active_record/key.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     include Enumerable
 
     def self.for(name)
-      case name
+      key = case name
       when Array
         Composite.new(name)
       when nil, false
@@ -13,6 +13,8 @@ module ActiveRecord
       else
         Single.new(name)
       end
+
+      key.freeze
     end
 
     attr_reader :name, :columns

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_support/testing/ractors_assertions"
 require "cases/helper"
 require "support/schema_dumping_helper"
 require "models/topic"
@@ -13,7 +14,24 @@ require "models/non_primary_key"
 require "models/cpk"
 
 class PrimaryKeysTest < ActiveRecord::TestCase
+  include ActiveSupport::Testing::RactorsAssertions
+
   fixtures :topics, :subscribers, :movies, :mixed_case_monkeys
+
+  def test_primary_key_can_be_read_from_a_ractor_when_single
+    Topic.primary_key
+    assert_equal "id", on_ractor { Topic.primary_key }
+  end
+
+  def test_primary_key_can_be_read_from_a_ractor_when_composite
+    Cpk::Order.primary_key
+    assert_equal ["shop_id", "id"], on_ractor { Cpk::Order.primary_key }
+  end
+
+  def test_primary_key_can_be_read_from_a_ractor_when_absent
+    NonPrimaryKey.primary_key
+    assert_nil on_ractor { NonPrimaryKey.primary_key }
+  end
 
   def test_to_key_with_default_primary_key
     topic = Topic.new


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I want to be able to access a record primary key inside a Ractor.

### Detail

This is another object that we have to freeze in order to access it inside a Ractor.

All 3 type of PK (Single, Composite, None) are safe to freeze and are never mutated after being computed.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
