### PR TITLE
Add `NUL` (`\0`) to the list of unsafe characters for storage

### DIFF
--- a/activestorage/app/models/active_storage/filename.rb
+++ b/activestorage/app/models/active_storage/filename.rb
@@ -55,9 +55,10 @@ class ActiveStorage::Filename
   #   ActiveStorage::Filename.new("foo:bar.jpg").sanitized # => "foo-bar.jpg"
   #   ActiveStorage::Filename.new("foo/bar.jpg").sanitized # => "foo-bar.jpg"
   #
-  # Characters considered unsafe for storage (e.g. \, $, and the RTL override character) are replaced with a dash.
+  # Characters considered unsafe for storage (e.g. \, $, the null character, and the RTL override character) are
+  # replaced with a dash.
   def sanitized
-    @filename.encode(Encoding::UTF_8, invalid: :replace, undef: :replace, replace: "�").strip.tr("\u{202E}%$|:;/<>?*\"\t\r\n\\", "-")
+    @filename.encode(Encoding::UTF_8, invalid: :replace, undef: :replace, replace: "�").strip.tr("\u{202E}\u{0000}%$|:;/<>?*\"\t\r\n\\", "-")
   end
 
   # Returns the sanitized version of the filename.

--- a/activestorage/test/models/filename_test.rb
+++ b/activestorage/test/models/filename_test.rb
@@ -22,7 +22,7 @@ class ActiveStorage::FilenameTest < ActiveSupport::TestCase
   end
 
   test "sanitize" do
-    "%$|:;/<>?*\"\t\r\n\\".each_char do |character|
+    "%$|:;/<>?*\"\t\r\n\\\u{0000}".each_char do |character|
       filename = ActiveStorage::Filename.new("foo#{character}bar.pdf")
       assert_equal "foo-bar.pdf", filename.sanitized
       assert_equal "foo-bar.pdf", filename.to_s


### PR DESCRIPTION
### Motivation / Background

From time to time, we get an `ArgumentError: string contains null byte` when we're using an Active Storage blob's filename with `File.join` or other methods. The reason is that sometimes null characters end up being part of a user-provided upload's name. 

### Detail

By chance, Active Storage already removed null characters at the beginning or at the end of the filename because it used `strip` in `Filename#sanitized` , but those in the middle of the name survived the sanitization. Since the null character is not valid in filenames in most (all?) filesystems, this PR includes it in the list of characters that are removed during sanitization.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
