### PR TITLE
Load every matching command/generator file per resolved lookup path, not just the first found

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Load every matching command/generator file found across `$LOAD_PATH`, not just the first.
+
+    *Ben Sheldon*
+
 *   Don't filter nonexistent i18n paths on initialize. This negatively impacts
     applications with lots of translation files.
 

--- a/railties/lib/rails/command/behavior.rb
+++ b/railties/lib/rails/command/behavior.rb
@@ -31,32 +31,41 @@ module Rails
             puts
           end
 
-          # Receives namespaces in an array and tries to find matching generators
-          # in the load path.
+          # Receives namespaces in an array and tries to find matching files
+          # in the load path. Once a namespace/lookup-path combination resolves,
+          # all files across all load paths matching that combination are loaded. 
+          # Lower-priority combinations are skipped once a higher-priority 
+          # combination has resolved.
           def lookup(namespaces)
             paths = namespaces_to_paths(namespaces)
 
             paths.each do |raw_path|
               lookup_paths.each do |base|
-                path = "#{base}/#{raw_path}_#{command_type}"
+                relative_path = "#{base}/#{raw_path}_#{command_type}.rb"
+                found = false
 
-                begin
-                  require path
-                  return
-                rescue LoadError => e
-                  raise unless /#{Regexp.escape(path)}$/.match?(e.message)
-                rescue Exception => e
-                  warn "[WARNING] Could not load #{command_type} #{path.inspect}. Error: #{e.message}.\n#{e.backtrace.join("\n")}"
+                $LOAD_PATH.each do |load_path|
+                  full_path = File.join(load_path, relative_path)
+                  next unless File.file?(full_path)
+
+                  found = true
+
+                  begin
+                    require full_path
+                  rescue Exception => e
+                    warn "[WARNING] Could not load #{command_type} #{full_path.inspect}. Error: #{e.message}.\n#{e.backtrace.join("\n")}"
+                  end
                 end
+
+                return if found
               end
             end
           end
 
-          # This will try to load any command in the load path to show in help.
+          # This will try to load every file in the load path to show in help.
           def lookup!
             $LOAD_PATH.each do |base|
               Dir[File.join(base, *file_lookup_paths)].each do |path|
-                path = path.delete_prefix("#{base}/")
                 require path
               rescue Exception
                 # No problem

--- a/railties/test/command/help_integration_test.rb
+++ b/railties/test/command/help_integration_test.rb
@@ -30,6 +30,38 @@ class Rails::Command::HelpIntegrationTest < ActiveSupport::TestCase
     assert_no_match "MY_TASK already defined? => true", output
   end
 
+  test "loads every matching command file even if names collide across load paths" do
+    app_file "vendor/plugin_a/lib/commands/custom_command.rb", <<~RUBY
+      puts "PLUGIN_A_COMMAND_LOADED"
+      class Rails::Command::CustomCommand < Rails::Command::Base
+        desc "custom", "Plugin A's custom command"
+        def perform
+          puts "Performed plugin A's custom command"
+        end
+      end
+    RUBY
+
+    app_file "vendor/plugin_b/lib/commands/custom_command.rb", <<~RUBY
+      puts "PLUGIN_B_COMMAND_LOADED"
+      class Rails::Command::CustomCommand < Rails::Command::Base
+        desc "custom", "Plugin B's custom command"
+        def perform
+          puts "Performed plugin B's custom command"
+        end
+      end
+    RUBY
+
+    app_file "config/boot.rb", <<~RUBY, "a"
+      $LOAD_PATH.unshift(File.expand_path("../vendor/plugin_a/lib", __dir__))
+      $LOAD_PATH.unshift(File.expand_path("../vendor/plugin_b/lib", __dir__))
+    RUBY
+
+    command_output = rails "custom", allow_failure: true
+
+    assert_match "PLUGIN_A_COMMAND_LOADED", command_output
+    assert_match "PLUGIN_B_COMMAND_LOADED", command_output
+  end
+
   test "prints help via `X:help` command when running `X` and `X:X` command is not defined" do
     help = rails "dev:help"
     output = rails "dev", allow_failure: true


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This was extracted from #50218.

**Before:** `Behavior#lookup` would stop at the first matching `require`. So if two gems (or a gem and the host app) shipped a command/generator file at the same relative path (e.g. both defining `commands/custom_command.rb`) only the first one encountered on the load path was ever loaded. 

**After:** once a namespace/lookup-path combination resolves (i.e., a match is found), the code scans the entire $LOAD_PATH itself and requires every file matching that combination. Priority ordering between different lookup-path combinations is preserved (e.g. `rails:model` is still tried before `model`). Once a higher-priority combination resolves, lower-priority ones are never attempted. 

A related `delete_prefix` in lookup! was also removed. When I spoke to @matthewd several years ago (😓) he believed this was a legacy of Ruby 1.8 resolution.


### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
