### PR TITLE
Add test coverage for `CombinedConfiguration` option defaults, keys, and reload

### DIFF
--- a/activesupport/test/combined_configuration_test.rb
+++ b/activesupport/test/combined_configuration_test.rb
@@ -123,6 +123,44 @@ class CombinedConfigurationTest < ActiveSupport::TestCase
     assert_equal false, @combined.option(:false)
   end
 
+  test "optional missing key returns nil" do
+    assert_nil @combined.option(:gone)
+  end
+
+  test "optional missing key with default value returns default" do
+    assert_equal "there", @combined.option(:gone, default: "there")
+  end
+
+  test "optional missing key with default block returns default" do
+    assert_equal "there", @combined.option(:gone, default: -> { "there" })
+  end
+
+  test "optional present key with default block returns value without triggering default" do
+    called = false
+    assert_equal "cred", @combined.option(:only_in_credentials, default: -> { called = true; "there" })
+    assert_equal false, called
+  end
+
+  test "keys returns the symbolized keys of every backend" do
+    keys = @combined.keys
+
+    assert_includes keys, :only_in_env
+    assert_includes keys, :only_in_dotenv
+    assert_includes keys, :only_in_credentials
+    assert_equal keys, keys.uniq
+  end
+
+  test "cached reads can be reloaded" do
+    assert_nil @combined.option(:added_later)
+
+    ENV["ADDED_LATER"] = "env"
+    @combined.reload
+
+    assert_equal "env", @combined.require(:added_later)
+  ensure
+    ENV.delete("ADDED_LATER")
+  end
+
   test "require with missing key raises key error" do
     assert_raise(KeyError, match: "Missing key: [:gone]") do
       @combined.require(:gone)


### PR DESCRIPTION
### Summary

`ActiveSupport::CombinedConfiguration` composes the configuration backends and applies its own fallback when none of them holds a key, but that fallback had no tests.

All three backends cover `option`'s `default:` keyword:

- `env_configuration_test.rb` — static default, callable default, `false`/`nil` from the block, present key not triggering the default
- `dot_env_configuration_test.rb` — same set
- `encrypted_configuration_test.rb` — same set

`combined_configuration_test.rb` had none of them. It also never called `#keys` directly (only indirectly through the `#inspect` assertion), and never called `#reload`.

### What this adds

Six tests, named to match the existing backend tests:

- `option` with a missing key returns `nil`
- `option` with a missing key returns a static `default:`
- `option` with a missing key calls a callable `default:`
- `option` with a present key returns the value without invoking the `default:` block
- `keys` returns symbolized, de-duplicated keys drawn from every backend, not just the first
- `reload` picks up a value added at runtime

No behavior changes — `lib/` is untouched, so no CHANGELOG entry.

### Verification

```
23 runs, 42 assertions, 0 failures, 0 errors, 0 skips
```

I checked the tests actually fail when the behavior regresses, by temporarily mutating `combined_configuration.rb`:

| Mutation | Result |
| --- | --- |
| `option` ignores `default:` | 2 failures |
| `keys` returns only the first backend's keys | 1 failure |
| `reload` becomes a no-op | 1 error |

`rubocop` is clean.