### PR TITLE
Add 7-day cooldown to bin/brakeman --ensure-latest

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Add a 7-day cooldown to the generated `bin/brakeman` binstub.
+
+    Brakeman 8.0.3 added an age parameter to `--ensure-latest` so the check
+    only fails when the most recent release is at least the given number of
+    days old. This protects against supply chain attacks in case the
+    Brakeman gems are compromised.
+
+    *Rene van Lieshout*
+
 *   Don't filter nonexistent i18n paths on initialize. This negatively impacts
     applications with lots of translation files.
 

--- a/railties/lib/rails/generators/rails/app/templates/bin/brakeman.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/brakeman.tt
@@ -1,6 +1,6 @@
 require "rubygems"
 require "bundler/setup"
 
-ARGV.unshift("--ensure-latest")
+ARGV.unshift("--ensure-latest", "7")
 
 load Gem.bin_path("brakeman", "brakeman")

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -672,6 +672,11 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_gem "brakeman"
   end
 
+  def test_brakeman_binstub_passes_ensure_latest_cooldown
+    run_generator
+    assert_file "bin/brakeman", /ARGV\.unshift\("--ensure-latest", "7"\)/
+  end
+
   def test_brakeman_is_skipped_if_required
     run_generator [destination_root, "--skip-brakeman"]
 


### PR DESCRIPTION
### Motivation / Background

Brakeman 8.0.3 added an age parameter to `--ensure-latest`: the check
now only returns a non-zero exit code when the most recent release is
at least the given number of days old. The Brakeman team introduced
this to protect against supply chain attacks in case the Brakeman gems
are compromised. Without a cooldown, a fresh malicious release would
immediately start failing CI in every generated Rails app and pressure
users into upgrading before the release has had time to be vetted.

Ref: https://brakemanscanner.org/blog/2026/02/26/brakeman-8-dot-0-dot-3-released

This replaces #57779, which was closed automatically when I deleted the
head repository. Same change, rebased onto current `main`.

### Detail

This Pull Request changes the generated `bin/brakeman` binstub to pass
`--ensure-latest 7`, giving newly generated apps a one-week grace
period after each new Brakeman release before the binstub fails CI.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
