### PR TITLE
undefined method 'to_i' for true in ActiveRecord 8.1+

### DIFF
--- a/activemodel/lib/active_model/attribute.rb
+++ b/activemodel/lib/active_model/attribute.rb
@@ -9,6 +9,10 @@ module ActiveModel
         FromDatabase.new(name, value_before_type_cast, type, nil, value)
       end
 
+      def from_database_default(name, value_before_type_cast, type) # :nodoc:
+        FromDatabaseDefault.new(name, value_before_type_cast, type)
+      end
+
       def from_user(name, value_before_type_cast, type, original_attribute = nil)
         FromUser.new(name, value_before_type_cast, type, original_attribute)
       end
@@ -202,6 +206,78 @@ module ActiveModel
           end
       end
 
+      # Column defaults are read from the schema as raw database values, and are
+      # deserialized so that +*_before_type_cast+ returns the same thing as
+      # reading the column back from the database.
+      #
+      # The raw value is kept around because a model can override the type of a
+      # column with ActiveModel::AttributeRegistration::ClassMethods#attribute.
+      # When that happens the default has to be deserialized again, with the
+      # overridden type rather than with the type of the column.
+      class FromDatabaseDefault < FromDatabase # :nodoc:
+        def value
+          @value = type_cast(raw_value_before_type_cast) unless defined?(@value)
+          @value
+        end
+
+        def value_before_type_cast
+          # A mutable type is left serialized, otherwise mutations of the shared
+          # default would leak from one record to the next.
+          if raw_value_before_type_cast.nil? || type.nil? || type.mutable?
+            raw_value_before_type_cast
+          else
+            value
+          end
+        end
+
+        def original_value
+          if assigned?
+            original_attribute.original_value
+          else
+            # Deserialize again rather than reuse +value+, so that in place
+            # mutations of +value+ aren't reflected here.
+            type_cast(raw_value_before_type_cast)
+          end
+        end
+
+        def with_type(type)
+          if changed_in_place?
+            with_value_from_user(value).with_type(type)
+          else
+            self.class.new(name, raw_value_before_type_cast, type, original_attribute)
+          end
+        end
+
+        def forgetting_assignment
+          if !defined?(@value_for_database) && !changed_in_place?
+            with_value_from_database(raw_value_before_type_cast)
+          else
+            super
+          end
+        end
+
+        def init_with(coder)
+          super
+          @value_before_type_cast = coder["raw_value_before_type_cast"]
+        end
+
+        def encode_with(coder)
+          super
+          unless raw_value_before_type_cast.nil?
+            coder["raw_value_before_type_cast"] = raw_value_before_type_cast
+          end
+        end
+
+        def raw_value_before_type_cast # :nodoc:
+          @value_before_type_cast
+        end
+
+        private
+          def _original_value_for_database
+            raw_value_before_type_cast
+          end
+      end
+
       class FromUser < Attribute # :nodoc:
         def type_cast(value)
           type.cast(value)
@@ -280,6 +356,6 @@ module ActiveModel
         end
       end
 
-      private_constant :FromDatabase, :FromUser, :Null, :Uninitialized, :WithCastValue
+      private_constant :FromDatabase, :FromDatabaseDefault, :FromUser, :Null, :Uninitialized, :WithCastValue
   end
 end

--- a/activemodel/test/cases/attribute_test.rb
+++ b/activemodel/test/cases/attribute_test.rb
@@ -328,5 +328,41 @@ module ActiveModel
 
       assert_equal 1, attribute.with_type(Type::Integer.new).value
     end
+
+    test "from_database_default type casts from the raw value" do
+      attribute = Attribute.from_database_default(:foo, "1", Type::Boolean.new)
+
+      assert_equal true, attribute.value
+      assert_equal true, attribute.value_before_type_cast
+    end
+
+    test "from_database_default keeps mutable values serialized" do
+      attribute = Attribute.from_database_default(:foo, "[]", Type::Value.new)
+
+      assert_equal "[]", attribute.value_before_type_cast
+    end
+
+    test "with_type re-casts from_database_default from the raw value" do
+      attribute = Attribute.from_database_default(:foo, "1", Type::Boolean.new)
+
+      assert_equal true, attribute.value
+      assert_equal 1, attribute.with_type(Type::Integer.new).value
+    end
+
+    test "with_type preserves from_database_default mutations" do
+      attribute = Attribute.from_database_default(:foo, +"", Type::Value.new)
+      attribute.value << "1"
+
+      assert_equal 1, attribute.with_type(Type::Integer.new).value
+    end
+
+    test "from_database_default round trips through YAML" do
+      attribute = Attribute.from_database_default(:foo, "1", Type::Boolean.new)
+      permitted = [Symbol, ActiveModel::Type::Boolean, attribute.class]
+      attribute = YAML.load(YAML.dump(attribute), permitted_classes: permitted)
+
+      assert_equal true, attribute.value
+      assert_equal 1, attribute.with_type(Type::Integer.new).value
+    end
   end
 end

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,29 @@
+*   Fix overriding the type of a column that has a default value.
+
+    Column defaults are deserialized when the schema is loaded, so overriding
+    the type of such a column with `attribute` would type cast the already
+    deserialized default a second time, with the wrong type. On a boolean
+    column redefined as an integer this raised
+    `NoMethodError: undefined method 'to_i' for true`:
+
+    ```ruby
+    # A tinyint(1) column with `DEFAULT '1'`, mapped to :boolean.
+    class Post < ActiveRecord::Base
+      attribute :status, :integer
+    end
+
+    Post.new.status # => NoMethodError: undefined method 'to_i' for true
+    ```
+
+    Columns now also keep the default as the database reported it, in
+    `Column#default_before_type_cast`, and an overriding type (including the
+    one `enum` installs) deserializes that value instead. Defaults of columns
+    whose type is not overridden are unaffected.
+
+    Fixes #58292.
+
+    *Jokūbas Lekevičius*, *Nicolas Vandenbogaerde*
+
 *   Restore `alias_attribute` support in associations.
 
     Since Rails 4.2, association reads have bypassed the public

--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -253,7 +253,7 @@ module ActiveRecord
       def _default_attributes # :nodoc:
         @default_attributes ||= begin
           attributes_hash = columns_hash.transform_values do |column|
-            ActiveModel::Attribute.from_database(column.name, column.default, type_for_column(column))
+            ActiveModel::Attribute.from_database_default(column.name, column.default_before_type_cast, type_for_column(column))
           end
 
           attribute_set = ActiveModel::AttributeSet.new(attributes_hash)

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
@@ -86,7 +86,7 @@ module ActiveRecord
         def schema_default(column)
           return unless column.has_default?
           type = column.cast_type
-          default = type.deserialize(column.default)
+          default = type.deserialize(column.default_before_type_cast)
           if default.nil?
             schema_expression(column)
           else

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -14,7 +14,9 @@ module ActiveRecord
       # Instantiates a new column in the table.
       #
       # +name+ is the column's name, such as <tt>supplier_id</tt> in <tt>supplier_id bigint</tt>.
-      # +default+ is the type-casted default value, such as +new+ in <tt>sales_stage varchar(20) default 'new'</tt>.
+      # +default+ is the default value as the database reported it, such as <tt>"new"</tt> in
+      # <tt>sales_stage varchar(20) default 'new'</tt>. It is kept as is in
+      # #default_before_type_cast, and exposed deserialized by #default.
       # +sql_type_metadata+ is various information about the type of the column
       # +null+ determines if this column allows +NULL+ values.
       def initialize(name, cast_type, default, sql_type_metadata = nil, null = true, default_function = nil, collation: nil, comment: nil, **)
@@ -22,6 +24,7 @@ module ActiveRecord
         @cast_type = cast_type
         @sql_type_metadata = sql_type_metadata
         @null = null
+        @default_before_type_cast = default
         @default = default.nil? || cast_type.mutable? ? default : cast_type.deserialize(default)
         @default_function = default_function
         @collation = collation
@@ -30,6 +33,19 @@ module ActiveRecord
 
       def has_default?
         !default.nil? || default_function
+      end
+
+      # The default exactly as the database reported it. Callers that deserialize
+      # the default themselves, in particular with another type, must use this
+      # rather than #default, which may already be deserialized.
+      def default_before_type_cast
+        if !defined?(@default_before_type_cast) || @default_before_type_cast.nil?
+          # Columns restored from a schema cache dumped before this attribute
+          # existed only have the (possibly deserialized) default.
+          @default
+        else
+          @default_before_type_cast
+        end
       end
 
       def bigint?
@@ -50,6 +66,7 @@ module ActiveRecord
         @sql_type_metadata = coder["sql_type_metadata"]
         @null = coder["null"]
         @default = coder["default"]
+        @default_before_type_cast = coder["default_before_type_cast"]
         @default_function = coder["default_function"]
         @collation = coder["collation"]
         @comment = coder["comment"]
@@ -61,6 +78,7 @@ module ActiveRecord
         coder["sql_type_metadata"] = @sql_type_metadata
         coder["null"] = @null
         coder["default"] = @default
+        coder["default_before_type_cast"] = @default_before_type_cast
         coder["default_function"] = @default_function
         coder["collation"] = @collation
         coder["comment"] = @comment
@@ -89,6 +107,7 @@ module ActiveRecord
           name == other.name &&
           cast_type == other.cast_type &&
           default == other.default &&
+          default_before_type_cast == other.default_before_type_cast &&
           sql_type_metadata == other.sql_type_metadata &&
           null == other.null &&
           default_function == other.default_function &&
@@ -104,6 +123,7 @@ module ActiveRecord
           @name.encoding,
           @cast_type,
           @default,
+          @default_before_type_cast,
           @sql_type_metadata,
           @null,
           @default_function,
@@ -121,6 +141,7 @@ module ActiveRecord
           @name = -name
           @sql_type_metadata = sql_type_metadata.deduplicate if sql_type_metadata
           @default = -default if String === default
+          @default_before_type_cast = -default_before_type_cast if String === default_before_type_cast
           @default_function = -default_function if default_function
           @collation = -collation if collation
           @comment = -comment if comment

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
@@ -140,6 +140,7 @@ module ActiveRecord
 
             type_metadata = fetch_type_metadata(field["type"])
             default_value = extract_value_from_default(default)
+            default_value = normalize_boolean_default(default_value) if type_metadata.type == :boolean
             generated_type = extract_generated_type(field)
 
             if generated_type.present?

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -602,6 +602,14 @@ module ActiveRecord
           end
         end
 
+        def normalize_boolean_default(default)
+          case default
+          when "TRUE" then "1"
+          when "FALSE" then "0"
+          else default
+          end
+        end
+
         def extract_default_function(default_value, default)
           default if has_default_function?(default_value, default)
         end
@@ -694,7 +702,7 @@ module ActiveRecord
                 column_options[:stored] = column.virtual_stored?
                 column_options[:type] = column.type
               elsif column.has_default?
-                default = column.cast_type.deserialize(column.default)
+                default = column.cast_type.deserialize(column.default_before_type_cast)
                 default = -> { column.default_function } if default.nil?
 
                 unless column.auto_increment?

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -58,6 +58,176 @@ class DefaultNumbersTest < ActiveRecord::TestCase
   end
 end
 
+class DefaultsWithOverriddenAttributeTypeTest < ActiveRecord::TestCase
+  # A custom type is expected to receive the raw value from the database, so it
+  # can be used to assert what the default is deserialized from.
+  class RawValueType < ActiveModel::Type::Value
+    def deserialize(value)
+      value.class.name
+    end
+  end
+
+  class StringNumber < ActiveRecord::Base
+    self.table_name = "overridden_defaults"
+    attribute :number, :string
+  end
+
+  class RawNumber < ActiveRecord::Base
+    self.table_name = "overridden_defaults"
+    attribute :number, RawValueType.new
+  end
+
+  class DatetimePublishedOn < ActiveRecord::Base
+    self.table_name = "overridden_defaults"
+    attribute :published_on, :datetime
+  end
+
+  class RawPrice < ActiveRecord::Base
+    self.table_name = "overridden_defaults"
+    attribute :price, RawValueType.new
+  end
+
+  class IntegerFlag < ActiveRecord::Base
+    self.table_name = "overridden_defaults"
+    attribute :flag, :integer
+  end
+
+  class StringFlag < ActiveRecord::Base
+    self.table_name = "overridden_defaults"
+    attribute :flag, :string
+  end
+
+  class IntegerFlagWithDefault < ActiveRecord::Base
+    self.table_name = "overridden_defaults"
+    attribute :flag, :integer, default: 3
+  end
+
+  class NumberEnum < ActiveRecord::Base
+    self.table_name = "overridden_defaults"
+    enum :number, { seven: 7, eight: 8 }
+  end
+
+  class PlainDefaults < ActiveRecord::Base
+    self.table_name = "overridden_defaults"
+  end
+
+  MODELS = [StringNumber, RawNumber, DatetimePublishedOn, RawPrice, IntegerFlag,
+            StringFlag, IntegerFlagWithDefault, NumberEnum, PlainDefaults].freeze
+
+  setup do
+    @connection = ActiveRecord::Base.lease_connection
+    @connection.create_table :overridden_defaults, force: true do |t|
+      t.integer :number, default: 7
+      t.boolean :flag, default: true
+      t.date :published_on, default: "2020-01-02"
+      t.decimal :price, default: 1.5, precision: 8, scale: 2
+    end
+    MODELS.each(&:reset_column_information)
+  end
+
+  teardown do
+    @connection.drop_table :overridden_defaults, if_exists: true
+  end
+
+  def test_default_is_deserialized_with_the_overridden_type
+    record = StringNumber.new
+    assert_equal "7", record.number
+    assert_equal "7", record.number_before_type_cast
+  end
+
+  def test_overridden_type_receives_the_raw_default
+    assert_equal "String", RawNumber.new.number
+    assert_equal "String", RawPrice.new.price
+  end
+
+  def test_mutable_overridden_type_deserializes_the_raw_default
+    published_on = DatetimePublishedOn.new.published_on
+    assert_kind_of Time, published_on
+    assert_equal [2020, 1, 2], [published_on.year, published_on.month, published_on.day]
+  end
+
+  # Deserializing the default with the overridden type must not change anything
+  # for the columns whose type is not overridden.
+  def test_defaults_of_columns_that_are_not_overridden_are_unaffected
+    record = PlainDefaults.new
+
+    assert_equal 7, record.number
+    assert_equal 7, record.number_before_type_cast
+    assert_equal Date.new(2020, 1, 2), record.published_on
+    assert_equal BigDecimal("1.5"), record.price
+    assert_equal BigDecimal("1.5"), record.price_before_type_cast
+  end
+
+  # The column type deserializes the default into `true`, which an integer type
+  # cannot deserialize. The overridden type has to be given the raw default.
+  def test_overriding_the_type_of_a_column_the_default_is_not_valid_for
+    assert_kind_of Integer, IntegerFlag.new.flag
+  end
+
+  if current_adapter?(:SQLite3Adapter)
+    def test_sqlite_boolean_default_is_deserialized_with_the_overridden_type
+      assert_equal 1, IntegerFlag.new.flag
+      assert_equal "1", StringFlag.new.flag
+    end
+  end
+
+  def test_overridden_type_is_used_to_round_trip_values
+    record = StringNumber.create!(number: "9")
+    assert_equal "9", record.reload.number
+  end
+
+  def test_partial_inserts_with_an_overridden_type
+    original_partial_inserts = IntegerFlag.partial_inserts?
+    IntegerFlag.partial_inserts = true
+
+    record = IntegerFlag.create!(flag: 2)
+    assert_equal 2, record.reload.flag
+  ensure
+    IntegerFlag.partial_inserts = original_partial_inserts
+  end
+
+  def test_overridden_type_with_a_user_provided_default
+    assert_equal 3, IntegerFlagWithDefault.new.flag
+    assert_equal 3, IntegerFlagWithDefault.create!.reload.flag
+  end
+
+  # `enum` overrides the type of the column it is declared on, so a column with
+  # a default reaches the same code path as an explicit `attribute` override.
+  def test_enum_on_a_column_with_a_default
+    assert_equal "seven", NumberEnum.new.number
+    assert_equal "seven", NumberEnum.create!.reload.number
+  end
+
+  def test_column_keeps_the_default_before_type_cast
+    column = PlainDefaults.columns_hash["number"]
+
+    assert_equal 7, column.default
+    assert_equal "7", column.default_before_type_cast
+  end
+
+  def test_column_default_before_type_cast_survives_serialization
+    column = YAML.unsafe_load(YAML.dump(StringNumber.columns_hash["number"]))
+
+    assert_equal 7, column.default
+    assert_equal "7", column.default_before_type_cast
+  end
+
+  def test_column_default_before_type_cast_falls_back_for_an_older_schema_cache
+    column = ActiveRecord::ConnectionAdapters::Column.allocate
+    column.init_with("name" => "number", "cast_type" => ActiveRecord::Type::Integer.new, "default" => 7)
+
+    assert_equal 7, column.default_before_type_cast
+  end
+
+  def test_column_default_before_type_cast_falls_back_for_an_older_marshal_schema_cache
+    column = StringNumber.columns_hash["number"].dup
+    column.remove_instance_variable(:@default_before_type_cast)
+    column = Marshal.load(Marshal.dump(column))
+
+    assert_equal column.default, column.default_before_type_cast
+  end
+end
+
 class DefaultStringsTest < ActiveRecord::TestCase
   class DefaultString < ActiveRecord::Base; end
 


### PR DESCRIPTION
Fixes #58292

### Motivation / Background

Since Rails 8.1, overriding the type of a column that has a default value can raise or silently return the wrong value:

```ruby
create_table :posts do |t|
  t.boolean :status, default: true # tinyint(1) + emulate_booleans on MySQL
end

class Post < ActiveRecord::Base
  attribute :status, :integer
end

Post.new.status # => NoMethodError: undefined method 'to_i' for true
```

I bisected this to 13bc31ef4fa35d70e8cf17e82ac0c25f43a0404c ("Deserialize column defaults", #54556), which made `_default_attributes` deserialize the default *before* any `attribute` override is applied:

```ruby
 columns_hash.transform_values do |column|
-  ActiveModel::Attribute.from_database(column.name, column.default, type_for_column(connection, column))
+  type = type_for_column(connection, column)
+  default = column.default
+  default = type.deserialize(default) unless default.nil?
+  ActiveModel::Attribute.from_database(column.name, default, type)
 end
```

On current `main` the eager deserialization has moved one step further upstream, into `Column#initialize`, so `column.default` itself is already `true`.

`attribute :status, :integer` then swaps the type through `ActiveModel::Attribute#with_type`, which keeps `value_before_type_cast` as is and only replaces the type. The attribute therefore ends up calling `ActiveModel::Type::Integer#deserialize(true)` → `true.to_i` → `NoMethodError`. Before the regression `value_before_type_cast` was still the raw `"1"`, and `Integer#deserialize("1")` returned `1`.

| Revision | `column.default` | `_default_attributes["status"].value_before_type_cast` |
| --- | --- | --- |
| `13bc31ef~1` | `"1"` | `"1"` |
| `13bc31ef` | `"1"` | `true` |
| `main` | `true` | `true` |

This is not MySQL or boolean specific, as the reporter noted: any column whose column type deserializes the default into something the overriding type cannot handle is affected. Some combinations do not even raise, they silently change the default (`attribute :status, :string` returns `"true"` instead of `"1"`), and a custom type no longer receives the raw database value in `#deserialize`, which breaks its documented contract.

### Detail

The fix keeps the deserialized default (it is what made #54556 fast) but also keeps the value the database reported, so that an overriding type can deserialize it again from the raw value.

**`ActiveRecord::ConnectionAdapters::Column`**

* Keeps the raw default in a new `#default_before_type_cast`. `#default` is unchanged and still returns the deserialized default.
* `#default_before_type_cast` falls back to `@default` when the ivar is missing or `nil`, so columns restored from a schema cache dumped by an older version (YAML `init_with` or Marshal) keep working.
* The raw default is included in `==`, `hash`, `deduplicated`, `init_with` and `encode_with`.

**`ActiveModel::Attribute::FromDatabaseDefault`** (new, private, built via `Attribute.from_database_default`)

* Holds the *raw* default and deserializes lazily, so `#with_type` can re-deserialize from the raw value instead of type casting an already deserialized value.
* `#value_before_type_cast` returns the deserialized value, so `*_before_type_cast` keeps returning what reading the column back from the database returns — except for mutable types, which stay serialized so mutations of the shared default cannot leak from one record to the next.
* `#original_value` deserializes again rather than reusing `#value`, so in place mutations are not reflected in the original value.
* `#with_type` falls back to `with_value_from_user(value)` when the value was mutated in place, so mutations survive an override.
* `#forgetting_assignment` restores the raw default, and `init_with`/`encode_with` round trip it through YAML.

**`ActiveRecord::Attributes#_default_attributes`**

* Builds defaults with `Attribute.from_database_default(column.name, column.default_before_type_cast, type_for_column(column))`. This covers `enum` too, since it overrides the type of the column it is declared on.

**Callers that deserialize the default themselves** now use `#default_before_type_cast` instead of `#default`, which was being deserialized twice: `SchemaDumper#schema_default` and the SQLite3 `copy_table`.

**SQLite3 adapter**

* SQLite reports boolean defaults as the literals `TRUE`/`FALSE`. `Type::Boolean` deserializes both fine, but an overriding type would receive `"TRUE"`, which is not a value any other type can make sense of. `new_column_from_field` now normalizes them to `"1"`/`"0"` for boolean columns, which is what the other adapters report and what the column type already deserializes identically.

### Additional information

Tests:

* `activemodel/test/cases/attribute_test.rb` covers `FromDatabaseDefault` directly: casting from the raw value, mutable values staying serialized, `with_type` re-casting from the raw value, in place mutations surviving `with_type`, and the YAML round trip.
* `activerecord/test/cases/defaults_test.rb` adds `DefaultsWithOverriddenAttributeTypeTest`, which covers the reported case and the variants raised in the issue thread: `:integer`, `:string`, `:datetime` and custom type overrides, a custom type receiving the raw default, `enum` on a column with a default, `attribute ... default:` still winning, partial inserts, round tripping written values, columns whose type is *not* overridden being unaffected, and the schema cache fallbacks.

Alternatives considered:

* #58293 only normalizes booleans, and the issue is not boolean specific (a `:date` column overridden as `:datetime` is affected too, while `:datetime` is not, because `Type::DateTime` is `mutable?`).
* Reverting the eager deserialization would reintroduce the slowdown #54556 fixed, and would no longer be enough on `main` since `Column#default` is now deserialized on construction.
* Deserializing the default lazily with the final type only, without keeping the raw value, would break `Column#default`, which is public API and is expected to return a deserialized value.

Ping @joklek-vinted, who reported the issue and had a patch in the works, and @Edilbek.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
