### PR TITLE
Remove collector methods of unregistered Mime types

### DIFF
--- a/actionpack/lib/abstract_controller/collector.rb
+++ b/actionpack/lib/abstract_controller/collector.rb
@@ -20,8 +20,11 @@ module AbstractController
     end
 
     Mime::Type.on_change do |mime, registered|
-      next unless registered
-      generate_method_for_mime(mime) unless instance_methods.include?(mime.to_sym)
+      if registered
+        generate_method_for_mime(mime) unless instance_methods.include?(mime.to_sym)
+      elsif instance_methods.include?(mime.to_sym)
+        remove_method(mime.to_sym)
+      end
     end
 
   private

--- a/actionpack/test/abstract/collector_test.rb
+++ b/actionpack/test/abstract/collector_test.rb
@@ -43,6 +43,38 @@ module AbstractController
         end
       end
 
+      test "removes the generated method when a mime type is unregistered" do
+        Mime::Type.register "text/foobar", :foobar
+        collector = MyCollector.new
+        assert_respond_to collector, :foobar
+
+        Mime::Type.unregister :foobar
+        assert_not_respond_to collector, :foobar
+
+        error = assert_raise(NoMethodError) { collector.foobar }
+        assert_match(/register it as a MIME type first/, error.message)
+      ensure
+        Mime::Type.unregister(:foobar) if Mime[:foobar]
+        if AbstractController::Collector.method_defined?(:foobar)
+          AbstractController::Collector.remove_method(:foobar)
+        end
+      end
+
+      test "re-registering a mime type restores the collector method" do
+        Mime::Type.register "text/foobar", :foobar
+        Mime::Type.unregister :foobar
+        Mime::Type.register "text/foobar", :foobar
+
+        collector = MyCollector.new
+        collector.foobar
+        assert_equal [Mime[:foobar], [], {}, nil], collector.responses[0]
+      ensure
+        Mime::Type.unregister(:foobar) if Mime[:foobar]
+        if AbstractController::Collector.method_defined?(:foobar)
+          AbstractController::Collector.remove_method(:foobar)
+        end
+      end
+
       test "does not register unknown mime types" do
         collector = MyCollector.new
         assert_raise NoMethodError do


### PR DESCRIPTION
Follow-up to https://github.com/rails/rails/pull/57994#discussion_r3702780181

The collector's on_change handler only added methods, so unregistering a Mime type left a stale Collector method silently dispatching custom(Mime[:sym], ...) with a nil mime. Redefine the method to emit a deprecation warning instead.
The collector's `Mime::Type.on_change` handler (previously `Mime.register_callback`) only added methods, so `Mime::Type.unregister` left a stale collector method behind. Calling it dispatched custom(Mime[:sym], ...) with a nil mime, which ActionController's Collector#custom turns into `Type.new(nil)` and a confusing `Mime::Type::InvalidMimeType (nil is not a valid MIME type)` exception.

Removing the method routes the call through Collector#method_missing instead, which raises a NoMethodError explaining the format must be registered as a MIME type first. No deprecation cycle: the stale method already raised, only the error message improves. Re-registering the type regenerates the method.
