### PR TITLE
Delete leaked Cpk::Author in the autosave teardown

### DIFF
--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -1203,6 +1203,7 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
     @pirate.delete
     Cpk::Book.delete_all
     Cpk::Order.delete_all
+    Cpk::Author.delete_all
   end
 
   # reload


### PR DESCRIPTION
`TestDestroyAsPartOfAutosaveAssociation#test_autosave_has_one_cpk_association_when_composite_foreign_key_is_manually_set` runs without transactional tests, creates a Cpk::Author that the teardown doesn't delete.
`WhereChainTest#test_missing_with_composite_primary_key` then creates Cpk::Book(id: [1, 2]), whose author_id matches the leaked author, so `where.missing(:author)` is legitimately empty and the assertion fails whenever the autosave test run first.

	ARCONN=sqlite3 bundle exec ruby -Ilib:test -e 'load "test/cases/autosave_association_test.rb"; load "test/cases/relation/where_chain_test.rb"' -- --seed=35972

The test flaked in https://buildkite.com/rails/rails/builds/132057.