### PR TITLE
Allow `config.active_storage.variant_processor` to be set to a class

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   Allow `config.active_storage.variant_processor` to be set to a transformer class.
+
+    `config.active_storage.variant_processor` now accepts a class, in addition to `:vips`,
+    `:mini_magick`, and `:disabled`. The class must implement the interface defined by
+    `ActiveStorage::Transformers::Transformer`. Active Storage then uses it for variant processing.
+
+    ```ruby
+    config.active_storage.variant_processor = CustomTransformer
+    ```
+
+    Note that the built-in image analyzers accept a blob only when `variant_processor` is `:vips` or
+    `:mini_magick`, so setting this configuration to a custom class requires adding a custom
+    analyzer to `config.active_storage.analyzers` as well.
+
+    An unrecognized value now raises `ArgumentError` while booting, instead of failing later with
+    `NoMethodError` when a variant is generated.
+
+    *Mike Dalessio*
+
 *   Disable libvips's unfuzzed image loaders and savers.
 
     libvips flags some of its loaders and savers as "unfuzzed" or "untrusted", meaning they are only

--- a/activestorage/app/models/active_storage/variant.rb
+++ b/activestorage/app/models/active_storage/variant.rb
@@ -6,9 +6,9 @@
 # These variants are used to create thumbnails, fixed-size avatars, or any other derivative image from the
 # original.
 #
-# Variants rely on {ImageProcessing}[https://github.com/janko/image_processing] gem for the actual transformations
-# of the file, so you must add <tt>gem "image_processing"</tt> to your Gemfile if you wish to use variants. By
-# default, images will be processed with {libvips}[http://libvips.github.io/libvips/] using the
+# The built-in transformers rely on the {ImageProcessing}[https://github.com/janko/image_processing] gem for
+# the actual transformations of the file, so you must add <tt>gem "image_processing"</tt> to your Gemfile to use
+# them. By default, images will be processed with {libvips}[http://libvips.github.io/libvips/] using the
 # {ruby-vips}[https://github.com/libvips/ruby-vips] gem, but you can also switch to the
 # {ImageMagick}[http://imagemagick.org] processor operated by the {MiniMagick}[https://github.com/minimagick/minimagick]
 # gem). You'll need to add either <tt>gem "ruby-vips"</tt> or <tt>gem "mini_magick"</tt> to your Gemfile.
@@ -19,10 +19,22 @@
 #   Rails.application.config.active_storage.variant_processor = :mini_magick
 #   # => :mini_magick
 #
-# Note that to create a variant it's necessary to download the entire blob file from the service. Because of this process,
-# you also want to be considerate about when the variant is actually processed. You shouldn't be processing variants inline
-# in a template, for example. Delay the processing to an on-demand controller, like the one provided in
-# ActiveStorage::Representations::ProxyController and ActiveStorage::Representations::RedirectController.
+# You can also set +variant_processor+ to a class. The class must implement the interface defined by
+# ActiveStorage::Transformers::Transformer. Active Storage then uses it for variant processing.
+#
+#   Rails.application.config.active_storage.variant_processor = CustomTransformer
+#
+# Note that the built-in image analyzers accept a blob only when +variant_processor+ is
+# <tt>:vips</tt> or <tt>:mini_magick</tt>, so setting this configuration to a custom class requires
+# adding a custom analyzer to +config.active_storage.analyzers+ as well. See
+# ActiveStorage::Blob::Analyzable#analyze.
+#
+# Also note that to create a variant it's necessary to download the entire blob file from the
+# service. Because of this process, you also want to be considerate about when the variant is
+# actually processed. You shouldn't be processing variants inline in a template, for example. Delay
+# the processing to an on-demand controller, like the one provided in
+# ActiveStorage::Representations::ProxyController and
+# ActiveStorage::Representations::RedirectController.
 #
 # To refer to such a delayed on-demand variant, simply link to the variant through the resolved route provided
 # by Active Storage like so:

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -103,6 +103,14 @@ module ActiveStorage
               ActiveStorage::Transformers::Vips
             when :mini_magick
               ActiveStorage::Transformers::ImageMagick
+            when Class
+              ActiveStorage.variant_processor
+            else
+              raise ArgumentError, <<~ERROR.squish
+                Unknown variant processor #{ActiveStorage.variant_processor.inspect}.
+                Set `config.active_storage.variant_processor` to :vips, :mini_magick, :disabled,
+                or to a transformer class. See ActiveStorage::Transformers::Transformer.
+              ERROR
             end
         rescue LoadError => error
           case error.message

--- a/activestorage/lib/active_storage/transformers/transformer.rb
+++ b/activestorage/lib/active_storage/transformers/transformer.rb
@@ -10,6 +10,10 @@ module ActiveStorage
     #
     # * ActiveStorage::Transformers::ImageProcessingTransformer:
     #   backed by ImageProcessing, a common interface for MiniMagick and ruby-vips
+    #
+    # An application can set +config.active_storage.variant_processor+ to a class. The class must
+    # implement the interface defined by Transformer. Active Storage then uses it for variant
+    # processing.
     class Transformer
       attr_reader :transformations
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -3504,7 +3504,19 @@ The default value is `/https?:\/\/localhost:\d+/` in the `development` environme
 
 #### `config.active_storage.variant_processor`
 
-Accepts a symbol `:mini_magick`, `:vips`, or `:disabled` specifying whether or not variant transformations and blob analysis will be performed with MiniMagick or ruby-vips.
+Accepts a symbol `:mini_magick`, `:vips`, or `:disabled` specifying whether or not variant
+processing and blob analysis will be performed with MiniMagick or ruby-vips.
+
+It also accepts a class. The class must implement the interface defined by
+`ActiveStorage::Transformers::Transformer`. Active Storage then uses it for variant processing:
+
+```ruby
+config.active_storage.variant_processor = CustomTransformer
+```
+
+Note that the built-in image analyzers accept a blob only when `variant_processor` is `:vips` or
+`:mini_magick`, so setting this configuration to a custom class requires adding a custom analyzer to
+[`config.active_storage.analyzers`](#config-active-storage-analyzers) as well.
 
 The default value depends on the `config.load_defaults` target version:
 

--- a/railties/test/application/active_storage/custom_processors_integration_test.rb
+++ b/railties/test/application/active_storage/custom_processors_integration_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+
+module ApplicationTests
+  class ActiveStorageCustomProcessorsTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+
+    self.file_fixture_path = "#{RAILS_FRAMEWORK_ROOT}/activestorage/test/fixtures/files"
+
+    def setup
+      build_app
+
+      rails "active_storage:install"
+
+      rails "generate", "model", "user", "name:string", "avatar:attachment"
+      rails "db:migrate"
+
+      app_file "config/initializers/custom_media_processing.rb", <<~RUBY
+        require "tempfile"
+
+        class CustomAnalyzer < ActiveStorage::Analyzer
+          def self.accept?(blob)
+            blob.image?
+          end
+
+          def metadata
+            { analyzed_by: "CustomAnalyzer" }
+          end
+        end
+
+        class CustomTransformer < ActiveStorage::Transformers::Transformer
+          private
+            def process(file, format:)
+              Tempfile.new([ "custom", ".\#{format}" ], binmode: true).tap do |output|
+                output.write("\#{transformations.inspect} as \#{format}")
+                output.rewind
+              end
+            end
+        end
+
+        Rails.application.config.active_storage.analyzers = [ CustomAnalyzer ]
+        Rails.application.config.active_storage.variant_processor = CustomTransformer
+      RUBY
+    end
+
+    def teardown
+      teardown_app
+    end
+
+    def test_custom_analyzer_extracts_metadata
+      app("development")
+
+      user = User.create!(name: "Test User", avatar: file_fixture("racecar.jpg"))
+
+      assert_equal "CustomAnalyzer", user.avatar.blob.reload.metadata["analyzed_by"]
+    end
+
+    def test_custom_transformer_produces_the_variant
+      app("development")
+
+      user = User.create!(name: "Test User", avatar: file_fixture("racecar.jpg"))
+      variant = user.avatar.variant(resize_to_limit: [ 100, 100 ]).processed
+
+      assert_equal "#{{ resize_to_limit: [ 100, 100 ] }.inspect} as jpg", variant.image.download
+    end
+  end
+end

--- a/railties/test/application/active_storage/engine_integration_test.rb
+++ b/railties/test/application/active_storage/engine_integration_test.rb
@@ -63,6 +63,30 @@ module ApplicationTests
       assert_includes(output, "ActiveStorage::Transformers::NullTransformer")
     end
 
+    def test_custom_transformer_without_image_gems_no_warning
+      app_file "config/initializers/custom_transformer.rb", <<~RUBY
+        class CustomTransformer < ActiveStorage::Transformers::Transformer
+        end
+
+        Rails.application.config.active_storage.variant_processor = CustomTransformer
+      RUBY
+
+      output = run_command("puts ActiveStorage.variant_transformer")
+
+      assert_not_includes(output, 'Generating image variants require the image_processing gem. Please add `gem "image_processing", "~> 2.0"` to your Gemfile')
+      assert_includes(output, "CustomTransformer")
+    end
+
+    def test_unknown_transformer_raises
+      add_to_config "config.active_storage.variant_processor = :nope"
+
+      output = run_command("puts ActiveStorage.variant_transformer")
+
+      assert_not_predicate $?, :success?
+      assert_includes(output, "ArgumentError")
+      assert_includes(output, "Unknown variant processor :nope")
+    end
+
     private
       def run_command(cmd)
         Dir.chdir(app_path) do


### PR DESCRIPTION
### Motivation / Background

Active Storage passes attachment bytes to a media library in three operations: analysis, preview generation, and variant processing. An application can replace the code for two of them: `config.active_storage.analyzers` and `config.active_storage.previewers` each accept an array of classes. 

Variant processing has no equivalent. `config.active_storage.variant_processor` accepts only `:vips`, `:mini_magick`, and `:disabled` (though, note that `ActiveStorage::Engine` maps those symbols to a class):

```ruby
ActiveStorage.variant_transformer =
  case ActiveStorage.variant_processor
  when :disabled
    ActiveStorage::Transformers::NullTransformer
  when :vips
    ActiveStorage::Transformers::Vips
  when :mini_magick
    ActiveStorage::Transformers::ImageMagick
  end
```

`ActiveStorage.variant_transformer` is an undocumented `mattr_accessor`, so an application cannot use it directly.

This gap makes it challenging to experiment with variant processors, for example to play around with sandboxing image transformations.

### Detail

`config.active_storage.variant_processor` now accepts a class, in addition to `:vips`, `:mini_magick`, and `:disabled`. The class must implement the interface defined by `ActiveStorage::Transformers::Transformer` in order to behave properly, though that is not explicitly checked. Active Storage then uses it for variant processing.

```ruby
config.active_storage.variant_processor = CustomTransformer
```

Note that the built-in image analyzers accept a blob only when `variant_processor` is `:vips` or `:mini_magick`, so setting this configuration to a custom class requires adding a custom analyzer to `config.active_storage.analyzers` as well (for now).

One notable change: an unrecognized value now raises `ArgumentError` while booting, instead of failing later with `NoMethodError` when a variant is generated. I think this is a good thing.

### Additional information

This change only adds the abstraction layer. It does not add any custom or additional transformers.

Active Storage does not check the type of the configured class. The class does not have to subclass `ActiveStorage::Transformers::Transformer`. It only has to implement the same interface.

The allowlist for transformation names and arguments is in `ActiveStorage::Transformers::ImageMagick`, and `ActiveStorage::Transformers::Vips` does not apply it. I think that it's worth moving that validation to the analyzer/transformer/previewer classes, but should be done in a separate PR.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
