### PR TITLE
Require rack/ractorize in ractorize!

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -678,6 +678,12 @@ module Rails
       Ractor.make_shareable(Rails.error)
       Ractor.make_shareable(Rails.backtrace_cleaner)
       ActionView::DependencyTracker.share_registry if defined?(ActionView)
+
+      begin
+        require "rack/ractorize"
+      rescue LoadError
+        raise "rack/ractorize not available, but required for Ractor support."
+      end
     end
 
   protected

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -685,6 +685,12 @@ module Rails
       Ractor.make_shareable(Rails.error)
       Ractor.make_shareable(Rails.backtrace_cleaner)
       ActionView::DependencyTracker.share_registry if defined?(ActionView)
+
+      begin
+        require "rack/ractorize"
+      rescue LoadError
+        raise "rack/ractorize not available, but required for Ractor support."
+      end
     end
 
   protected

--- a/railties/test/application/ractors_test.rb
+++ b/railties/test/application/ractors_test.rb
@@ -3,7 +3,7 @@
 require "isolation/abstract_unit"
 require "active_support/testing/ractors_assertions"
 
-if RUBY_VERSION >= "4.0"
+if RUBY_VERSION >= "4.0" && ENV["RACK"] == "head"
   module ApplicationTests
     class RactorsTest < ActiveSupport::TestCase
       include ActiveSupport::Testing::Isolation


### PR DESCRIPTION
rack/ractorize freezes public Rack constants which can't yet be made frozen due to backwards compatibility. However, they will need to be frozen to serve requests inside non-main Ractors.