### PR TITLE
Make Relation::FromClause.empty Ractor safe

### DIFF
--- a/activerecord/lib/active_record/relation/from_clause.rb
+++ b/activerecord/lib/active_record/relation/from_clause.rb
@@ -23,8 +23,11 @@ module ActiveRecord
       end
 
       def self.empty
-        @empty ||= new(nil, nil).freeze
+        EMPTY
       end
+
+      EMPTY = new(nil, nil).freeze
+      private_constant :EMPTY
     end
   end
 end


### PR DESCRIPTION
This follows the same change to [`WhereClause`][1]

[1]: https://github.com/rails/rails/commit/d8c7523c016a59e425a8c930d792fd937bbe8ccf