### PR TITLE
Cleanup duplicate/unneeded requires

### DIFF
--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -3,7 +3,6 @@
 # :markup: markdown
 
 require "active_support/ractors"
-require "active_support/core_ext/module/delegation"
 require "action_dispatch/middleware/stack"
 
 module ActionController

--- a/actionpack/lib/action_controller/metal/renderers.rb
+++ b/actionpack/lib/action_controller/metal/renderers.rb
@@ -2,8 +2,6 @@
 
 # :markup: markdown
 
-require "active_support/deprecation"
-
 module ActionController
   # See Renderers.add
   def self.add_renderer(key, &block)

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -3,7 +3,6 @@
 # :markup: markdown
 
 require "singleton"
-require "active_support/deprecation"
 require "action_dispatch/deprecator"
 require "active_support/core_ext/string/filters"
 

--- a/actionview/lib/action_view/helpers/navigation_helper.rb
+++ b/actionview/lib/action_view/helpers/navigation_helper.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/concern"
 require "action_view/helpers/content_exfiltration_prevention_helper"
 require "action_view/helpers/tag_helper"
 require "action_view/helpers/url_helper"


### PR DESCRIPTION
```
$ ./tools/railspect requires .
actionpack/lib/action_controller/metal/renderers.rb
  - active_support/deprecation (active_support/rails)
actionpack/lib/action_controller/metal.rb
  - active_support/core_ext/module/delegation (active_support/rails)
actionpack/lib/action_dispatch/http/mime_type.rb
  - active_support/deprecation (active_support/rails)
actionview/lib/action_view/helpers/navigation_helper.rb
  - active_support/concern (active_support/rails)
```