### PR TITLE
Update the `.node-version` file conditionally generated for new applications to 24.19.0

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -222,7 +222,7 @@
 
     *Trevor Turk*
 
-*   Update the `.node-version` file conditionally generated for new applications to 22.21.1
+*   Update the `.node-version` file conditionally generated for new applications to 24.19.0
 
     *Taketo Takashima*
 

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -15,7 +15,7 @@ module Rails
       include AppName
       include BundleHelper
 
-      NODE_LTS_VERSION = "22.21.1"
+      NODE_LTS_VERSION = "24.19.0"
       BUN_VERSION = "1.0.1"
 
       JAVASCRIPT_OPTIONS = %w( importmap bun webpack esbuild rollup ).freeze


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

When running `rails new`, the `.node-version` file that is generated specifies the Node.js version based on the version installed on the system.
If no Node.js installation is found, the version defined by the constant `NODE_LTS_VERSION` is used instead.
- #47461

Currently, the value of `NODE_LTS_VERSION` is `22.21.1`.
Since Node.js v22 will reach its End-of-Life (EoL) on 2027-04-30, this Pull Request updates the version.

- Node.js Release & EoL schedule
  - https://github.com/nodejs/release#release-schedule

### Detail

This Pull Request updates the value of `NODE_LTS_VERSION` from `22.21.1` to `24.19.0`, which is the current Active LTS release.
Node.js version `24.19.0` is the latest v24 release as of August 6, 2026.

- Node.js v24.19.0
  - https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V24.md#24.19.0

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

The previous update intentionally did not switch to Node.js v24 because using Node.js v24 with Yarn v1 produced the following deprecation warning.

Since Node.js 24.15.0, this warning has been addressed on the Node.js side and is no longer expected to occur in normal usage.
- https://github.com/yarnpkg/yarn/issues/9210#issuecomment-4262573676

> However, using Node.js v24 with Yarn v1 currently triggers the following warning:
> 
> ```
> (node:63926) [DEP0169] DeprecationWarning: `url.parse()` behavior is not standardized and prone to errors that have security implications. Use the WHATWG URL API instead. CVEs are not issued for `url.parse()` vulnerabilities.
> (Use `node --trace-deprecation ...` to show where the warning was created)
> ```
> 
> Until this warning is resolved, I believe it's better to avoid using Node.js v24.
> 
> * [Use userland `url` module to resolve `url.parse` deprecation warning yarnpkg/yarn#9211](https://github.com/yarnpkg/yarn/pull/9211)
> * [`DeprecationWarning` for `url.parse` in Node.js 24 yarnpkg/yarn#9210](https://github.com/yarnpkg/yarn/issues/9210)

- https://github.com/rails/rails/pull/56106

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
