### PR TITLE
Make template lookup ractor-safe

### DIFF
--- a/actionview/lib/action_view/digestor.rb
+++ b/actionview/lib/action_view/digestor.rb
@@ -4,9 +4,6 @@ require "action_view/dependency_tracker"
 
 module ActionView
   class Digestor
-    MUTEX = Mutex.new
-    private_constant :MUTEX
-
     class << self
       # Supported options:
       #
@@ -24,7 +21,7 @@ module ActionView
 
         # this is a correctly done double-checked locking idiom
         # (Concurrent::Map's lookups have volatile semantics)
-        finder.digest_cache[cache_key] || MUTEX.synchronize do
+        finder.digest_cache[cache_key] || digest_mutex.synchronize do
           finder.digest_cache.fetch(cache_key) do # re-check under lock
             path = TemplatePath.parse(name)
             root = tree(path.to_s, finder, path.partial?)
@@ -69,6 +66,11 @@ module ActionView
       end
 
       private
+        # Digest caches are per-Ractor, so the mutex is too.
+        def digest_mutex
+          ActiveSupport::Ractors.store_if_absent(:action_view_digest_mutex) { Mutex.new }
+        end
+
         def find_template(finder, name, prefixes, partial, keys)
           finder.disable_cache do
             finder.find(name, prefixes, partial, keys)

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -23,6 +23,7 @@ module ActionView
     end
 
     def self.register_detail(name, &block)
+      block = ActiveSupport::Ractors.shareable_proc(&block)
       self.default_procs = self.default_procs.merge(name => block).freeze
 
       Accessors.define_method(:"default_#{name}", &block)

--- a/actionview/test/template/digestor_test.rb
+++ b/actionview/test/template/digestor_test.rb
@@ -3,6 +3,7 @@
 require "abstract_unit"
 require "fileutils"
 require "action_view/dependency_tracker"
+require "active_support/testing/ractors_assertions"
 
 class FixtureFinder < ActionView::LookupContext
   FIXTURES_DIR = File.expand_path("../fixtures/digestor", __dir__)
@@ -404,4 +405,47 @@ class TemplateDigestorTest < ActionView::TestCase
     def remove_template(template_name)
       File.delete("digestor/#{template_name}.html.erb")
     end
+end
+
+class DigestorRactorTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::Isolation
+  include ActiveSupport::Testing::RactorsAssertions
+
+  TEMPLATES = {
+    "messages/show.html.erb" => %(<%= render "messages/message" %>),
+    "messages/_message.html.erb" => "Message",
+  }.freeze
+
+  setup do
+    Mime.eager_load!
+    # OpenSSL::Digest per-algorithm class methods are defined with
+    # unshareable closures until a Ruby ships with ruby/openssl@502bc6c
+    require "digest"
+    ActiveSupport::Digest.hash_digest_class = ::Digest::MD5
+    ActionView::DependencyTracker.eager_load!
+    ActionView::DependencyTracker.share_registry
+
+    # The i18n gem keeps its configuration in class variables.
+    I18n::Config.prepend(Module.new do
+      def available_locales = [:en].freeze
+    end)
+  end
+
+  test "digests are computed inside a non-main Ractor" do
+    digest_in_ractor = on_ractor do
+      finder = ActionView::LookupContext.new(
+        [ActionView::FixtureResolver.new(TEMPLATES.dup)],
+        { locale: [:en], formats: [:html], variants: [], handlers: [:erb] }
+      )
+      ActionView::Digestor.digest(name: "messages/show", format: :html, finder: finder)
+    end
+
+    finder = ActionView::LookupContext.new(
+      [ActionView::FixtureResolver.new(TEMPLATES.dup)],
+      { locale: [:en], formats: [:html], variants: [], handlers: [:erb] }
+    )
+    digest = ActionView::Digestor.digest(name: "messages/show", format: :html, finder: finder)
+
+    assert_equal digest, digest_in_ractor
+  end
 end

--- a/actionview/test/template/lookup_context_test.rb
+++ b/actionview/test/template/lookup_context_test.rb
@@ -211,6 +211,30 @@ if RUBY_VERSION >= "4.0"
         on_ractor { ActionView::LookupContext.view_context_class }
     end
 
+    if RUBY_VERSION >= "4.0"
+      test "builds lookup contexts and interns their details keys inside a non-main Ractor" do
+        Mime.eager_load!
+
+        same_key, worker_key_id, defaulted_variants = on_ractor do
+          details = { locale: [:en], formats: [:html], variants: [], handlers: [:erb] }
+          a = ActionView::LookupContext.new([], details)
+          b = ActionView::LookupContext.new([], details.dup)
+          interned_same = a.details_key.equal?(b.details_key)
+          key_id = a.details_key.object_id
+          # check default_ methods can be called (defaulted_variants in this case)
+          a.variants = nil
+          [interned_same, key_id, a.variants]
+        end
+
+        assert same_key
+        assert_equal [], defaulted_variants
+
+        details = { locale: [:en], formats: [:html], variants: [], handlers: [:erb] }
+        main_key_id = ActionView::LookupContext.new([], details).details_key.object_id
+        assert_not_equal main_key_id, worker_key_id
+      end
+    end
+
     test "interns details keys and builds digest caches inside a non-main Ractor" do
       interned, digest_cache = on_ractor do
         details = { locale: [:en], formats: nil, variants: [], handlers: [:erb] }


### PR DESCRIPTION
Follow-up to #58281.

The first commit makes the details default procs Ractor-shareable, so a non-main Ractor can build a LookupContext. The second commit moves the Digestor mutex to Ractor-local storage, matching the digest caches it guards since #58281.

A non-main Ractor can now build a lookup context, intern its details keys, and compute template digests.