### PR TITLE
Define shareable compiled_method_container readers

### DIFF
--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -203,16 +203,17 @@ module ActionView # :nodoc:
 
       def with_empty_template_cache # :nodoc:
         subclass = Class.new(self) {
-          # We can't implement these as self.class because subclasses will
-          # share the same template cache as superclasses, so "changed?" won't work
-          # correctly.
-          define_method(:compiled_method_container)           { subclass }
-          define_singleton_method(:compiled_method_container) { subclass }
-
           def inspect
             "#<ActionView::Base:#{'%#016x' % (object_id << 1)}>"
           end
         }
+
+        # We can't implement these as self.class because subclasses will share the same
+        # template cache as superclasses, so "changed?" won't work correctly.
+        reader = ActiveSupport::Ractors.shareable_lambda { subclass }
+        subclass.define_method(:compiled_method_container, reader)
+        subclass.define_singleton_method(:compiled_method_container, reader)
+        subclass
       end
 
       def changed?(other) # :nodoc:

--- a/actionview/test/template/lookup_context_test.rb
+++ b/actionview/test/template/lookup_context_test.rb
@@ -205,6 +205,17 @@ if RUBY_VERSION >= "4.0"
     include ActiveSupport::Testing::Isolation
     include ActiveSupport::Testing::RactorsAssertions
 
+    test "view_context_class's compiled method container is readable from a non-main Ractor" do
+      klass = ActionView::LookupContext.view_context_class
+
+      singleton_container, instance_container = on_ractor(klass) do |k|
+        [k.compiled_method_container, k.allocate.compiled_method_container]
+      end
+
+      assert_same klass, singleton_container
+      assert_same klass, instance_container
+    end
+
     test "view_context_class is Ractor-shareable" do
       ActionView::LookupContext.view_context_class # needs to be eager-loaded to be ractor-shareable
       assert_same ActionView::LookupContext.view_context_class,


### PR DESCRIPTION
This is another bit of template compilation/rendering that does not work with Ractors.

The lambda captures only the subclass, created after the assignment completes, so it can be made shareable.