### PR TITLE
Move duplicated execute_batch up to MySQL::DatabaseStatements

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -54,6 +54,24 @@ module ActiveRecord
           super unless column.auto_increment?
         end
 
+        def execute_batch(statements, name = nil, **kwargs) # :nodoc:
+          combine_multi_statements(statements).each do |statement|
+            intent = QueryIntent.new(
+              adapter: self,
+              processed_sql: statement,
+              name: name,
+              batch: true,
+              binds: kwargs[:binds] || [],
+              prepare: kwargs[:prepare] || false,
+              allow_async: kwargs[:async] || false,
+              allow_retry: kwargs[:allow_retry] || false,
+              materialize_transactions: kwargs[:materialize_transactions] != false
+            )
+            intent.execute!
+            intent.finish
+          end
+        end
+
         private
           # https://mariadb.com/kb/en/analyze-statement/
           def analyze_without_explain?

--- a/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
@@ -13,24 +13,6 @@ module ActiveRecord
           end
         end
 
-        def execute_batch(statements, name = nil, **kwargs) # :nodoc:
-          combine_multi_statements(statements).each do |statement|
-            intent = QueryIntent.new(
-              adapter: self,
-              processed_sql: statement,
-              name: name,
-              batch: true,
-              binds: kwargs[:binds] || [],
-              prepare: kwargs[:prepare] || false,
-              allow_async: kwargs[:async] || false,
-              allow_retry: kwargs[:allow_retry] || false,
-              materialize_transactions: kwargs[:materialize_transactions] != false
-            )
-            intent.execute!
-            intent.finish
-          end
-        end
-
         private
           def last_inserted_id(result)
             if supports_insert_returning?

--- a/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
@@ -13,24 +13,6 @@ module ActiveRecord
           intent.raw_result
         end
 
-        def execute_batch(statements, name = nil, **kwargs) # :nodoc:
-          combine_multi_statements(statements).each do |statement|
-            intent = QueryIntent.new(
-              adapter: self,
-              processed_sql: statement,
-              name: name,
-              batch: true,
-              binds: kwargs[:binds] || [],
-              prepare: kwargs[:prepare] || false,
-              allow_async: kwargs[:async] || false,
-              allow_retry: kwargs[:allow_retry] || false,
-              materialize_transactions: kwargs[:materialize_transactions] != false
-            )
-            intent.execute!
-            intent.finish
-          end
-        end
-
         private
           def multi_statements_enabled?
             @config[:multi_statement]


### PR DESCRIPTION
Moved duplicate execute_batch to a common place.