### PR TITLE
Eager load templates

### DIFF
--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -460,7 +460,15 @@ module ActionView
       # Compile a template. This method ensures a template is compiled
       # just once and removes the source after it is compiled.
       def compile!(view)
-        return if @compiled
+        if @compiled
+          if @compiled_method_container && view.compiled_method_container != @compiled_method_container
+            raise ArgumentError, "Template #{short_identifier.inspect} was compiled to render with " \
+              "#{@compiled_method_container.inspect} but is being rendered with a view whose compiled " \
+              "method container is #{view.compiled_method_container.inspect}. A template compiles into " \
+              "a single container; render it with the view class it was compiled with."
+          end
+          return
+        end
 
         # Templates can be used concurrently in threaded environments
         # so compilation and any instance variable modification must
@@ -477,6 +485,7 @@ module ActionView
             compile(mod)
           end
 
+          @compiled_method_container = mod
           @compiled = true
         end
       end

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -408,6 +408,23 @@ module ActionView
       strict_locals!
     end
 
+    def freeze # :nodoc:
+      unless @compiled
+        raise ArgumentError, "Cannot freeze #{short_identifier.inspect}: the template must be compiled first. " \
+          "Frozen templates cannot compile, so an uncompiled one could never render."
+      end
+      strict_locals!
+      method_name.freeze
+      @source.freeze
+      @identifier.freeze
+      @virtual_path&.freeze
+      @locals&.freeze
+      @strict_locals.freeze if @strict_locals.is_a?(String)
+      @variant.freeze if @variant.is_a?(String)
+      @compile_mutex = nil
+      super
+    end
+
     # Exceptions are marshalled when using the parallel test runner with DRb, so we need
     # to ensure that references to the template object can be marshalled as well. This means forgoing
     # the marshalling of the compiler mutex and instantiating that again on unmarshalling.

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -102,6 +102,14 @@ module ActionView
       super
     end
 
+    def eager_load_templates(view = nil)
+      template_glob("**/*").each do |file|
+        unbound = build_unbound_template(file)
+        (@unbound_templates[unbound.virtual_path] ||= []) << unbound
+        unbound.bind_locals([]).send(:compile!, view) if view
+      end
+    end
+
     def to_s
       @path.to_s
     end

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -33,9 +33,12 @@ module ActionView
         }x
       end
 
-      def parse(path)
+      def path_regex
         @regex ||= build_path_regex
-        match = @regex.match(path)
+      end
+
+      def parse(path)
+        match = path_regex.match(path)
         path = TemplatePath.build(match[:action], match[:prefix] || "", !!match[:partial])
         details = TemplateDetails.new(
           match[:locale]&.to_sym,
@@ -44,6 +47,11 @@ module ActionView
           match[:variant]&.to_sym
         )
         ParsedPath.new(path, details)
+      end
+
+      def freeze
+        path_regex
+        super
       end
     end
 
@@ -110,6 +118,18 @@ module ActionView
       end
     end
 
+    def freeze
+      @path.freeze
+      @path_parser.freeze
+      @unbound_templates = @unbound_templates.each_pair.to_h unless @unbound_templates.is_a?(::Hash)
+      @unbound_templates.each_value do |unbound_templates|
+        unbound_templates.each(&:freeze)
+        unbound_templates.freeze
+      end
+      @unbound_templates.freeze
+      super
+    end
+
     def to_s
       @path.to_s
     end
@@ -153,6 +173,7 @@ module ActionView
 
     private
       def unbound_templates_for(name, prefix, partial, cached)
+        return @unbound_templates[TemplatePath.virtual(name, prefix, partial)] || [].freeze if frozen?
         return unbound_templates_from_path(TemplatePath.build(name, prefix, partial)) unless cached
 
         @unbound_templates.compute_if_absent(TemplatePath.virtual(name, prefix, partial)) do

--- a/actionview/lib/action_view/template/sources.rb
+++ b/actionview/lib/action_view/template/sources.rb
@@ -11,6 +11,11 @@ module ActionView
         def to_s
           ::File.binread @filename
         end
+
+        def freeze
+          @filename.freeze
+          super
+        end
       end
     end
   end

--- a/actionview/lib/action_view/unbound_template.rb
+++ b/actionview/lib/action_view/unbound_template.rb
@@ -13,13 +13,37 @@ module ActionView
       @details = details
       @virtual_path = virtual_path
 
+      @strict_locals_template = nil
       @templates = Concurrent::Map.new(initial_capacity: 2)
       @write_lock = Mutex.new
     end
 
     def bind_locals(locals)
-      unless template = @templates[locals]
+      @strict_locals_template || @templates[locals] || build_bound_template(locals)
+    end
+
+    def built_templates # :nodoc:
+      @strict_locals_template ? [@strict_locals_template] : @templates.values
+    end
+
+    def freeze # :nodoc:
+      unless bind_locals([]).strict_locals?
+        raise ArgumentError, "Cannot freeze #{@virtual_path.inspect}: templates must declare strict locals (e.g. `<%# locals: () %>`) to be frozen."
+      end
+      @source.freeze
+      @identifier.freeze
+      @virtual_path.freeze
+      @details.freeze
+      @strict_locals_template.freeze
+      @templates = nil
+      @write_lock = nil
+      super
+    end
+
+    private
+      def build_bound_template(locals)
         @write_lock.synchronize do
+          return @strict_locals_template if @strict_locals_template
           normalized_locals = normalize_locals(locals)
 
           # We need ||=, both to dedup on the normalized locals and to check
@@ -27,25 +51,17 @@ module ActionView
           template = (@templates[normalized_locals] ||= build_template(normalized_locals))
 
           if template.strict_locals?
-            # Under strict locals, we only need one template.
-            # This replaces the @templates Concurrent::Map with a hash which
-            # returns this template for every key.
-            @templates = Hash.new(template).freeze
+            @strict_locals_template = template
           else
             # This may have already been assigned, but we've already de-dup'd so
             # reassignment is fine.
             @templates[locals.dup] = template
           end
+
+          template
         end
       end
-      template
-    end
 
-    def built_templates # :nodoc:
-      @templates.values
-    end
-
-    private
       def build_template(locals)
         Template.new(
           @source,

--- a/actionview/test/template/file_system_resolver_test.rb
+++ b/actionview/test/template/file_system_resolver_test.rb
@@ -9,4 +9,43 @@ class FileSystemResolverTest < ActiveSupport::TestCase
   def resolver
     ActionView::FileSystemResolver.new(tmpdir)
   end
+
+  DETAILS = { locale: [:en], formats: [:html], variants: [], handlers: [:erb] }.freeze
+
+  def find_all(resolver, name = "hello_world", prefix = "test", partial = false, locals = [])
+    resolver.find_all(name, prefix, partial, DETAILS, nil, locals)
+  end
+
+  def test_eager_load_templates_populates_cache_without_freezing
+    with_file "test/hello_world.html.erb", "Hello!"
+    resolver = ActionView::FileSystemResolver.new(tmpdir)
+    resolver.eager_load_templates
+
+    assert_not resolver.frozen?
+    templates = find_all(resolver)
+    assert_equal 1, templates.size
+    assert_equal "Hello!", templates[0].source
+  end
+
+  def test_eager_load_templates_compiles_templates_when_given_a_view
+    with_file "test/hello_world.html.erb", "Hello!"
+    view = ActionView::Base.with_empty_template_cache.empty
+    resolver = ActionView::FileSystemResolver.new(tmpdir)
+
+    assert_difference -> { view.compiled_method_container.instance_methods.size }, 1 do
+      resolver.eager_load_templates(view)
+    end
+  end
+
+  def test_eager_loaded_resolver_still_binds_new_locals
+    with_file "test/hello_world.html.erb", "<%= message %>"
+    resolver = ActionView::FileSystemResolver.new(tmpdir)
+    resolver.eager_load_templates
+
+    a = find_all(resolver, "hello_world", "test", false, [:message])[0]
+    b = find_all(resolver, "hello_world", "test", false, [:message, :other])[0]
+
+    assert_not_same a, b
+    assert_not resolver.frozen?
+  end
 end

--- a/actionview/test/template/file_system_resolver_test.rb
+++ b/actionview/test/template/file_system_resolver_test.rb
@@ -2,9 +2,11 @@
 
 require "abstract_unit"
 require "template/resolver_shared_tests"
+require "active_support/testing/ractors_assertions"
 
 class FileSystemResolverTest < ActiveSupport::TestCase
   include ResolverSharedTests
+  include ActiveSupport::Testing::RactorsAssertions
 
   def resolver
     ActionView::FileSystemResolver.new(tmpdir)
@@ -14,6 +16,19 @@ class FileSystemResolverTest < ActiveSupport::TestCase
 
   def find_all(resolver, name = "hello_world", prefix = "test", partial = false, locals = [])
     resolver.find_all(name, prefix, partial, DETAILS, nil, locals)
+  end
+
+  def compile_view
+    ActionView::Base.with_empty_template_cache.empty
+  end
+
+  def test_freeze_raises_for_uncompiled_template
+    with_file "test/hello_world.html.erb", "<%# locals: () %>Hi"
+    resolver = ActionView::FileSystemResolver.new(tmpdir)
+    resolver.eager_load_templates
+
+    error = assert_raises(ArgumentError) { resolver.freeze }
+    assert_match "must be compiled first", error.message
   end
 
   def test_eager_load_templates_populates_cache_without_freezing
@@ -47,5 +62,49 @@ class FileSystemResolverTest < ActiveSupport::TestCase
 
     assert_not_same a, b
     assert_not resolver.frozen?
+  end
+
+  def test_freeze_after_eager_load_makes_resolver_shareable
+    with_file "test/hello_world.html.erb", "<%# locals: () %>Hi"
+    ActiveSupport::Ractors.make_shareable(Mime[:html])
+    resolver = ActionView::FileSystemResolver.new(tmpdir)
+    resolver.eager_load_templates(compile_view)
+    resolver.freeze
+
+    assert_predicate resolver, :frozen?
+    assert_ractor_shareable resolver
+
+    templates = find_all(resolver)
+    assert_equal 1, templates.size
+    assert_predicate templates[0], :frozen?
+  end
+
+  def test_freeze_raises_for_non_strict_partial
+    with_file "test/_card.html.erb", "<%= post %>"
+    resolver = ActionView::FileSystemResolver.new(tmpdir)
+    resolver.eager_load_templates
+
+    error = assert_raises(ArgumentError) { resolver.freeze }
+    assert_match "test/_card", error.message
+    assert_match "strict locals", error.message
+  end
+
+  def test_freeze_raises_for_non_strict_template
+    with_file "test/hello_world.html.erb", "no locals here"
+    resolver = ActionView::FileSystemResolver.new(tmpdir)
+    resolver.eager_load_templates
+
+    error = assert_raises(ArgumentError) { resolver.freeze }
+    assert_match "test/hello_world", error.message
+    assert_match "strict locals", error.message
+  end
+
+  def test_frozen_resolver_returns_empty_for_missing_template
+    with_file "test/hello_world.html.erb", "<%# locals: () %>Hi"
+    resolver = ActionView::FileSystemResolver.new(tmpdir)
+    resolver.eager_load_templates(compile_view)
+    resolver.freeze
+
+    assert_empty find_all(resolver, "nonexistent")
   end
 end

--- a/actionview/test/template/template_test.rb
+++ b/actionview/test/template/template_test.rb
@@ -87,6 +87,18 @@ class TestERBTemplate < ActiveSupport::TestCase
     assert_equal "Hello", render
   end
 
+  def test_render_with_a_different_compiled_method_container_raises
+    @template = new_template
+    assert_equal "Hello", render
+
+    other_context = Context.with_empty_template_cache.empty
+    error = assert_raises(ActionView::Template::Error) do
+      @template.render(other_context, {})
+    end
+    assert_kind_of ArgumentError, error.cause
+    assert_match "compiled to render with", error.message
+  end
+
   def test_basic_template_does_html_escape
     @template = new_template("<%= apostrophe %>")
     assert_equal "l&#39;apostrophe", render

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -673,6 +673,13 @@ module Rails
 
       @autoloaders, @reloaders, @routes_reloader = nil, nil, nil
 
+      if defined?(ActionView::PathRegistry)
+        view = ActionView::LookupContext.view_context_class.new(ActionView::LookupContext.new([]), {}, nil)
+        ActionView::PathRegistry.all_file_system_resolvers.each do |resolver|
+          resolver.eager_load_templates(view)
+        end
+      end
+
       Ractor.make_shareable(self)
       Ractor.make_shareable(Rails.event)
       Ractor.make_shareable(Rails.error)

--- a/railties/test/application/ractors_test.rb
+++ b/railties/test/application/ractors_test.rb
@@ -36,6 +36,15 @@ if RUBY_VERSION >= "4.0"
         assert_ractor_shareable Rails.backtrace_cleaner
       end
 
+      test "ractorize! eager loads and compiles view templates" do
+        app "production"
+
+        ractorize!
+
+        templates = ActionView::PathRegistry.all_file_system_resolvers.flat_map(&:built_templates)
+        assert_not_empty templates
+      end
+
       test "error reporting works after the application is ractorized" do
         app "production"
 


### PR DESCRIPTION
This gives a way to load templates at boot time and make them shareable.
For now only strict locals templates are supported, since they allow folding the `UnboundTemplate.@templates` cache into a single Template object. I have a follow-up that also compiles non-strict templates into a Ractor-local cache ([Shopify/rails@actionview-frozen-non-strict-templates](https://github.com/Shopify/rails/tree/actionview-frozen-non-strict-templates))

I've added a safety check that didn't exist before, about the container into which the template is compiled. A template is compiled into the method container of the view it was first rendered with. If it is later rendered with a view whose container differs, the compiled method is missing and the render fails with an unexplained `NoMethodError`, this now raises explicitly.

Typically it is not the case, since `ApplicationController.view_context_class.compiled_method_container.equal?(ApplicationMailer.view_context_class.compiled_method_container)` but with `ractorize!` compiling methods, that could happen if a controller overrides `view_context_class` with a context class that has a different method container.