### PR TITLE
Extract duplicated UPDATE self-join preparation into Arel::Visitors::…

### DIFF
--- a/activerecord/lib/arel/visitors/postgresql.rb
+++ b/activerecord/lib/arel/visitors/postgresql.rb
@@ -44,17 +44,7 @@ module Arel # :nodoc: all
         # these, we must use a subquery.
         def prepare_update_statement(o)
           if o.key && has_join_sources?(o) && !has_group_by_and_having?(o) && !has_limit_or_offset_or_orders?(o)
-            # Join clauses cannot reference the target table, so alias the
-            # updated table, place the entire relation in the FROM clause, and
-            # add a self-join (which requires the primary key)
-            stmt = o.clone
-            stmt.relation, stmt.wheres = o.relation.clone, o.wheres.clone
-            stmt.relation.right = [stmt.relation.left, *stmt.relation.right]
-            stmt.relation.left = stmt.relation.left.alias("__active_record_update_alias")
-            Array.wrap(o.key).each do |key|
-              stmt.wheres << key.eq(stmt.relation.left[key.name])
-            end
-            stmt
+            prepare_update_statement_with_self_join(o)
           else
             super
           end

--- a/activerecord/lib/arel/visitors/sqlite.rb
+++ b/activerecord/lib/arel/visitors/sqlite.rb
@@ -36,17 +36,7 @@ module Arel # :nodoc: all
           # Sqlite need to be built with the SQLITE_ENABLE_UPDATE_DELETE_LIMIT compile-time option
           # to support LIMIT/OFFSET/ORDER in UPDATE and DELETE statements.
           if o.key && has_join_sources?(o) && !has_group_by_and_having?(o) && !has_limit_or_offset_or_orders?(o)
-            # Join clauses cannot reference the target table, so alias the
-            # updated table, place the entire relation in the FROM clause, and
-            # add a self-join (which requires the primary key)
-            stmt = o.clone
-            stmt.relation, stmt.wheres = o.relation.clone, o.wheres.clone
-            stmt.relation.right = [stmt.relation.left, *stmt.relation.right]
-            stmt.relation.left = stmt.relation.left.alias("__active_record_update_alias")
-            Array.wrap(o.key).each do |key|
-              stmt.wheres << key.eq(stmt.relation.left[key.name])
-            end
-            stmt
+            prepare_update_statement_with_self_join(o)
           else
             super
           end

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -956,6 +956,21 @@ module Arel # :nodoc: all
         end
         alias :prepare_delete_statement :prepare_update_statement
 
+        # Used by dialects that support `UPDATE ... FROM` (PostgreSQL, SQLite).
+        # Join clauses cannot reference the target table, so alias the updated
+        # table, place the entire relation in the FROM clause, and add a
+        # self-join (which requires the primary key).
+        def prepare_update_statement_with_self_join(o)
+          stmt = o.clone
+          stmt.relation, stmt.wheres = o.relation.clone, o.wheres.clone
+          stmt.relation.right = [stmt.relation.left, *stmt.relation.right]
+          stmt.relation.left = stmt.relation.left.alias("__active_record_update_alias")
+          Array.wrap(o.key).each do |key|
+            stmt.wheres << key.eq(stmt.relation.left[key.name])
+          end
+          stmt
+        end
+
         # FIXME: we should probably have a 2-pass visitor for this
         def build_subselect(key, o)
           stmt             = Nodes::SelectStatement.new


### PR DESCRIPTION
The PostgreSQL and SQLite Arel visitors had identical bodies in prepare_update_statement. 

This extracts that body into a shared ToSql#prepare_update_statement_with_self_join  helper, each visitor keeps its own guard. 

The MySQL visitor overrides prepare_update_statement is unaffected.                                                                                                                    

No behavior change.                                                                                                                                     