### PR TITLE
Activestorage transformers for custom media types

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,27 @@
+*   Allow variants of blobs the image processor cannot transform.
+
+    Transformers registered in `ActiveStorage.transformers` are asked whether they accept a blob,
+    the way previewers already are. A blob accepted by one is variable, so `variant` and
+    `representation` work for media types that are not images.
+
+        class AudioTransformer < ActiveStorage::Transformers::Transformer
+          def self.accept?(blob)
+            blob.content_type.start_with?("audio/")
+          end
+
+          private
+            def process(file, format:)
+              # ...
+            end
+        end
+
+        ActiveStorage.transformers += [ AudioTransformer ]
+
+    Images are unaffected: they remain governed by `ActiveStorage.variable_content_types` and the
+    transformer configured by `config.active_storage.variant_processor`.
+
+    *Julian Rubisch*
+
 *   Marcel 2 for content type detection
 
     Broader and more precise MIME type detection, security hardening, and uses canonical types

--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,8 +1,9 @@
 *   Allow variants of blobs the image processor cannot transform.
 
-    Transformers registered in `ActiveStorage.transformers` are asked whether they accept a blob,
-    the way previewers already are. A blob accepted by one is variable, so `variant` and
-    `representation` work for media types that are not images.
+    Transformers registered in `config.active_storage.transformers` are asked whether they accept
+    a blob, the way previewers already are. A blob accepted by one is variable, so `variant` and
+    `representation` work for media types that are not images. Such a variant defaults to the
+    blob's own format rather than to PNG.
 
         class AudioTransformer < ActiveStorage::Transformers::Transformer
           def self.accept?(blob)
@@ -15,10 +16,11 @@
             end
         end
 
-        ActiveStorage.transformers += [ AudioTransformer ]
+        config.active_storage.transformers = [ AudioTransformer ]
 
     Images are unaffected: they remain governed by `ActiveStorage.variable_content_types` and the
-    transformer configured by `config.active_storage.variant_processor`.
+    transformer configured by `config.active_storage.variant_processor`, which also stays in use
+    for any blob the registered transformers do not accept.
 
     *Julian Rubisch*
 

--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,27 @@
+*   Allow variants of blobs the image processor cannot transform.
+
+    Transformers registered in `ActiveStorage.transformers` are asked whether they accept a blob,
+    the way previewers already are. A blob accepted by one is variable, so `variant` and
+    `representation` work for media types that are not images.
+
+        class AudioTransformer < ActiveStorage::Transformers::Transformer
+          def self.accept?(blob)
+            blob.content_type.start_with?("audio/")
+          end
+
+          private
+            def process(file, format:)
+              # ...
+            end
+        end
+
+        ActiveStorage.transformers += [ AudioTransformer ]
+
+    Images are unaffected: they remain governed by `ActiveStorage.variable_content_types` and the
+    transformer configured by `config.active_storage.variant_processor`.
+
+    *Julian Rubisch*
+
 *   Disable libvips's unfuzzed image loaders and savers.
 
     libvips flags some of its loaders and savers as "unfuzzed" or "untrusted", meaning they are only

--- a/activestorage/app/models/active_storage/blob/representable.rb
+++ b/activestorage/app/models/active_storage/blob/representable.rb
@@ -106,9 +106,11 @@ module ActiveStorage::Blob::Representable
   end
 
   # Returns true if the variant processor can transform the blob (its content
-  # type is in +ActiveStorage.variable_content_types+).
+  # type is in +ActiveStorage.variable_content_types+), or if a transformer
+  # registered in +ActiveStorage.transformers+ accepts it.
   def variable?
-    ActiveStorage.variable_content_types.include?(content_type)
+    ActiveStorage.variable_content_types.include?(content_type) ||
+      ActiveStorage.transformers.any? { |transformer| transformer.accept?(self) }
   end
 
 

--- a/activestorage/app/models/active_storage/blob/representable.rb
+++ b/activestorage/app/models/active_storage/blob/representable.rb
@@ -174,8 +174,13 @@ module ActiveStorage::Blob::Representable
     def default_variant_format
       if web_image?
         format || :png
-      else
+      elsif ActiveStorage.variable_content_types.include?(content_type)
+        # An image the variant processor can transform, but which browsers may not display.
         :png
+      else
+        # Variable only because a transformer accepted it. The blob is not an image, so default
+        # to its own format instead of converting it to one.
+        format || :png
       end
     end
 

--- a/activestorage/app/models/active_storage/variant.rb
+++ b/activestorage/app/models/active_storage/variant.rb
@@ -126,7 +126,7 @@ class ActiveStorage::Variant
   def process_from_io(io) # :nodoc:
     return if processed?
 
-    variation.transform(io) do |output|
+    variation.transform(io, blob: blob) do |output|
       service.upload(key, output, content_type: content_type)
     end
   end
@@ -134,7 +134,7 @@ class ActiveStorage::Variant
   private
     def process
       blob.open do |input|
-        variation.transform(input) do |output|
+        variation.transform(input, blob: blob) do |output|
           service.upload(key, output, content_type: content_type)
         end
       end

--- a/activestorage/app/models/active_storage/variant.rb
+++ b/activestorage/app/models/active_storage/variant.rb
@@ -114,7 +114,7 @@ class ActiveStorage::Variant
   def process_from_io(io) # :nodoc:
     return if processed?
 
-    variation.transform(io) do |output|
+    variation.transform(io, blob: blob) do |output|
       service.upload(key, output, content_type: content_type)
     end
   end
@@ -122,7 +122,7 @@ class ActiveStorage::Variant
   private
     def process
       blob.open do |input|
-        variation.transform(input) do |output|
+        variation.transform(input, blob: blob) do |output|
           service.upload(key, output, content_type: content_type)
         end
       end

--- a/activestorage/app/models/active_storage/variant_with_record.rb
+++ b/activestorage/app/models/active_storage/variant_with_record.rb
@@ -46,7 +46,7 @@ class ActiveStorage::VariantWithRecord
   def process_from_io(io) # :nodoc:
     return if processed?
 
-    variation.transform(io) do |output|
+    variation.transform(io, blob: blob) do |output|
       create_or_find_record(image: {
         io: output,
         filename: "#{blob.filename.base}.#{variation.format.downcase}",
@@ -63,7 +63,7 @@ class ActiveStorage::VariantWithRecord
 
     def transform_blob
       blob.open do |input|
-        variation.transform(input) do |output|
+        variation.transform(input, blob: blob) do |output|
           yield io: output, filename: "#{blob.filename.base}.#{variation.format.downcase}",
             content_type: variation.content_type, service_name: blob.service.name
         end

--- a/activestorage/app/models/active_storage/variation.rb
+++ b/activestorage/app/models/active_storage/variation.rb
@@ -53,9 +53,9 @@ class ActiveStorage::Variation
 
   # Accepts a File object, performs the +transformations+ against it, and
   # saves the transformed image into a temporary file.
-  def transform(file, &block)
+  def transform(file, blob: nil, &block)
     ActiveSupport::Notifications.instrument("transform.active_storage") do
-      transformer.transform(file, format: format, &block)
+      transformer(blob).transform(file, format: format, &block)
     end
   end
 
@@ -81,7 +81,12 @@ class ActiveStorage::Variation
   end
 
   private
-    def transformer
-      ActiveStorage.variant_transformer.new(transformations.except(:format))
+    def transformer(blob)
+      transformer_class(blob).new(transformations.except(:format))
+    end
+
+    def transformer_class(blob)
+      blob && ActiveStorage.transformers.find { |transformer| transformer.accept?(blob) } ||
+        ActiveStorage.variant_transformer
     end
 end

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -52,6 +52,7 @@ module ActiveStorage
   mattr_accessor :variant_processor, default: :mini_magick
 
   mattr_accessor :variant_transformer
+  mattr_accessor :transformers, default: []
 
   mattr_accessor :queues, default: {}
 

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -26,6 +26,7 @@ module ActiveStorage
     config.active_storage = ActiveSupport::OrderedOptions.new
     config.active_storage.previewers = [ ActiveStorage::Previewer::PopplerPDFPreviewer, ActiveStorage::Previewer::MuPDFPreviewer, ActiveStorage::Previewer::VideoPreviewer ]
     config.active_storage.analyzers = [ ActiveStorage::Analyzer::ImageAnalyzer::Vips, ActiveStorage::Analyzer::ImageAnalyzer::ImageMagick, ActiveStorage::Analyzer::VideoAnalyzer, ActiveStorage::Analyzer::AudioAnalyzer ]
+    config.active_storage.transformers = []
     config.active_storage.paths = ActiveSupport::OrderedOptions.new
     config.active_storage.queues = ActiveSupport::InheritableOptions.new
     config.active_storage.precompile_assets = true
@@ -93,6 +94,7 @@ module ActiveStorage
         ActiveStorage.variant_processor = app.config.active_storage.variant_processor || :mini_magick
         ActiveStorage.previewers        = app.config.active_storage.previewers || []
         ActiveStorage.analyzers         = app.config.active_storage.analyzers || []
+        ActiveStorage.transformers      = app.config.active_storage.transformers || []
 
         begin
           ActiveStorage.variant_transformer =

--- a/activestorage/lib/active_storage/transformers/transformer.rb
+++ b/activestorage/lib/active_storage/transformers/transformer.rb
@@ -11,14 +11,27 @@ module ActiveStorage
     # * ActiveStorage::Transformers::ImageProcessingTransformer:
     #   backed by ImageProcessing, a common interface for MiniMagick and ruby-vips
     #
-    # An application can set +config.active_storage.variant_processor+ to a class. The class must
-    # implement the interface defined by Transformer. Active Storage then uses it for variant
-    # processing.
+    # An application can supply a transformer of its own in either of two ways. Both take a class
+    # implementing the interface defined by Transformer.
+    #
+    # Setting +config.active_storage.variant_processor+ replaces the transformer used for every
+    # variant:
+    #
+    #   config.active_storage.variant_processor = CustomTransformer
+    #
+    # Adding to +config.active_storage.transformers+ instead registers a transformer alongside the
+    # variant processor, which goes on handling everything the registered ones do not claim. Each
+    # is asked whether it accepts a blob, the way previewers already are, and a blob accepted by
+    # one is variable even when its media type is not an image:
+    #
+    #   config.active_storage.transformers = [ AudioTransformer ]
     class Transformer
       attr_reader :transformations
 
-      # Implement this method in a transformer registered in +ActiveStorage.transformers+. Have it
-      # return true when given a blob the transformer can transform.
+      # Implement this method in a transformer registered in
+      # +config.active_storage.transformers+. Have it return true when given a blob the transformer
+      # can transform. The variant processor is never asked, so a transformer installed only
+      # through +config.active_storage.variant_processor+ does not need to implement it.
       def self.accept?(blob)
         false
       end

--- a/activestorage/lib/active_storage/transformers/transformer.rb
+++ b/activestorage/lib/active_storage/transformers/transformer.rb
@@ -17,6 +17,12 @@ module ActiveStorage
     class Transformer
       attr_reader :transformations
 
+      # Implement this method in a transformer registered in +ActiveStorage.transformers+. Have it
+      # return true when given a blob the transformer can transform.
+      def self.accept?(blob)
+        false
+      end
+
       def initialize(transformations)
         @transformations = transformations
       end

--- a/activestorage/lib/active_storage/transformers/transformer.rb
+++ b/activestorage/lib/active_storage/transformers/transformer.rb
@@ -13,6 +13,12 @@ module ActiveStorage
     class Transformer
       attr_reader :transformations
 
+      # Implement this method in a transformer registered in +ActiveStorage.transformers+. Have it
+      # return true when given a blob the transformer can transform.
+      def self.accept?(blob)
+        false
+      end
+
       def initialize(transformations)
         @transformations = transformations
       end

--- a/activestorage/test/models/custom_transformer_test.rb
+++ b/activestorage/test/models/custom_transformer_test.rb
@@ -85,6 +85,34 @@ class ActiveStorage::CustomTransformerTest < ActiveSupport::TestCase
     assert_equal "audio/mpeg", blob.variant(format: :mp3).content_type
   end
 
+  test "variant of a custom media type defaults to the blob's own format" do
+    ActiveStorage.transformers += [ AudioTransformer ]
+    blob = create_file_blob(filename: "audio.mp3", content_type: "audio/mpeg")
+
+    variant = blob.variant(sample_rate: 44100)
+
+    assert_equal "mp3", variant.variation.format
+    assert_equal "audio/mpeg", variant.content_type
+  end
+
+  test "recorded variant of a custom media type is filed under the blob's own format" do
+    ActiveStorage.track_variants = true
+    ActiveStorage.transformers += [ AudioTransformer ]
+    blob = create_file_blob(filename: "audio.mp3", content_type: "audio/mpeg")
+
+    variant = blob.variant(sample_rate: 44100).processed
+
+    assert_equal "audio.mp3", variant.image.filename.to_s
+    assert_equal "audio/mpeg", variant.image.content_type
+  end
+
+  test "a non-web image is still converted to PNG" do
+    ActiveStorage.transformers += [ AudioTransformer ]
+    blob = create_file_blob(filename: "racecar.tif", content_type: "image/tiff")
+
+    assert_equal :png, blob.variant(resize_to_limit: [ 100, 100 ]).variation.format
+  end
+
   test "representable? and representation follow variable?" do
     blob = create_file_blob(filename: "audio.mp3", content_type: "audio/mpeg")
     assert_not blob.representable?

--- a/activestorage/test/models/custom_transformer_test.rb
+++ b/activestorage/test/models/custom_transformer_test.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "database/setup"
+
+class ActiveStorage::CustomTransformerTest < ActiveSupport::TestCase
+  class AudioTransformer < ActiveStorage::Transformers::Transformer
+    class << self
+      attr_accessor :calls
+
+      def accept?(blob)
+        blob.content_type.to_s.start_with?("audio/")
+      end
+    end
+
+    private
+      def process(file, format:)
+        self.class.calls = (self.class.calls || []) << { transformations: transformations, format: format }
+        file
+      end
+  end
+
+  class RejectingTransformer < ActiveStorage::Transformers::Transformer
+    def self.accept?(blob)
+      false
+    end
+
+    private
+      def process(file, format:)
+        raise "should not be called"
+      end
+  end
+
+  setup do
+    @was_transformers = ActiveStorage.transformers
+    @was_tracking, ActiveStorage.track_variants = ActiveStorage.track_variants, false
+    AudioTransformer.calls = []
+  end
+
+  teardown do
+    ActiveStorage.transformers = @was_transformers
+    ActiveStorage.track_variants = @was_tracking
+  end
+
+  test "blob is not variable when no registered transformer accepts it" do
+    blob = create_file_blob(filename: "audio.mp3", content_type: "audio/mpeg")
+
+    assert_not blob.variable?
+    assert_raises ActiveStorage::InvariableError, match: /content_type=audio\/mpeg/ do
+      blob.variant(format: :mp3)
+    end
+  end
+
+  test "blob is variable when a registered transformer accepts it" do
+    ActiveStorage.transformers += [ AudioTransformer ]
+    blob = create_file_blob(filename: "audio.mp3", content_type: "audio/mpeg")
+
+    assert blob.variable?
+    assert_kind_of ActiveStorage::Variant, blob.variant(format: :mp3)
+  end
+
+  test "blob is not variable when the registered transformer rejects it" do
+    ActiveStorage.transformers += [ RejectingTransformer ]
+    blob = create_file_blob(filename: "audio.mp3", content_type: "audio/mpeg")
+
+    assert_not blob.variable?
+  end
+
+  test "processing a variant uses the transformer that accepts the blob" do
+    ActiveStorage.transformers += [ RejectingTransformer, AudioTransformer ]
+    blob = create_file_blob(filename: "audio.mp3", content_type: "audio/mpeg")
+
+    variant = blob.variant(format: :mp3, sample_rate: 44100).processed
+
+    assert_equal 1, AudioTransformer.calls.size
+    assert_equal({ sample_rate: 44100 }, AudioTransformer.calls.first[:transformations])
+    assert_equal :mp3, AudioTransformer.calls.first[:format]
+    assert_equal blob.download, variant.download
+  end
+
+  test "variant of a custom media type carries that type's content type" do
+    ActiveStorage.transformers += [ AudioTransformer ]
+    blob = create_file_blob(filename: "audio.mp3", content_type: "audio/mpeg")
+
+    assert_equal "audio/mpeg", blob.variant(format: :mp3).content_type
+  end
+
+  test "representable? and representation follow variable?" do
+    blob = create_file_blob(filename: "audio.mp3", content_type: "audio/mpeg")
+    assert_not blob.representable?
+    assert_raises ActiveStorage::UnrepresentableError do
+      blob.representation(format: :mp3)
+    end
+
+    ActiveStorage.transformers += [ AudioTransformer ]
+
+    assert blob.representable?
+    assert_kind_of ActiveStorage::Variant, blob.representation(format: :mp3)
+  end
+
+  test "a previewable blob is still represented by its preview" do
+    ActiveStorage.transformers += [ AudioTransformer ]
+    blob = create_file_blob(filename: "video.mp4", content_type: "video/mp4")
+
+    assert_kind_of ActiveStorage::Preview, blob.representation(resize_to_limit: [ 100, 100 ])
+  end
+
+  test "images remain variable through the default transformers" do
+    blob = create_file_blob(filename: "racecar.jpg")
+
+    assert blob.variable?
+
+    variant = blob.variant(resize_to_limit: [ 100, 100 ]).processed
+    image = read_image(variant)
+    assert_equal 100, image.width
+    assert_equal 67, image.height
+  end
+
+  test "images remain governed by variable_content_types" do
+    was = ActiveStorage.variable_content_types
+    ActiveStorage.variable_content_types = was - [ "image/jpeg" ]
+
+    assert_not create_file_blob(filename: "racecar.jpg").variable?
+  ensure
+    ActiveStorage.variable_content_types = was
+  end
+
+  test "registering a transformer does not make unrelated types variable" do
+    ActiveStorage.transformers += [ AudioTransformer ]
+
+    assert_not create_blob(filename: "hello.txt", content_type: "text/plain").variable?
+  end
+end

--- a/railties/test/application/active_storage/transformers_integration_test.rb
+++ b/railties/test/application/active_storage/transformers_integration_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+
+module ApplicationTests
+  class ActiveStorageTransformersTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+
+    self.file_fixture_path = "#{RAILS_FRAMEWORK_ROOT}/activestorage/test/fixtures/files"
+
+    def setup
+      build_app
+
+      rails "active_storage:install"
+
+      rails "generate", "model", "user", "name:string", "recording:attachment"
+      rails "db:migrate"
+
+      app_file "config/initializers/custom_transformers.rb", <<~RUBY
+        require "tempfile"
+
+        class AudioTransformer < ActiveStorage::Transformers::Transformer
+          def self.accept?(blob)
+            blob.content_type.to_s.start_with?("audio/")
+          end
+
+          private
+            def process(file, format:)
+              Tempfile.new([ "audio", ".\#{format}" ], binmode: true).tap do |output|
+                output.write("\#{transformations.inspect} as \#{format}")
+                output.rewind
+              end
+            end
+        end
+
+        Rails.application.config.active_storage.transformers = [ AudioTransformer ]
+      RUBY
+    end
+
+    def teardown
+      teardown_app
+    end
+
+    def test_registered_transformer_makes_a_non_image_blob_variable
+      app("development")
+
+      user = User.create!(name: "Test User", recording: file_fixture("audio.mp3"))
+
+      assert user.recording.variable?
+    end
+
+    def test_registered_transformer_produces_the_variant
+      app("development")
+
+      user = User.create!(name: "Test User", recording: file_fixture("audio.mp3"))
+      variant = user.recording.variant(sample_rate: 44100).processed
+
+      assert_equal "#{{ sample_rate: 44100 }.inspect} as mp3", variant.image.download
+      assert_equal "audio/mpeg", variant.image.content_type
+    end
+
+    def test_images_still_go_through_the_variant_processor
+      app("development")
+
+      user = User.create!(name: "Test User", recording: file_fixture("racecar.jpg"))
+      variant = user.recording.variant(resize_to_limit: [ 100, 100 ]).processed
+
+      assert_equal "image/jpeg", variant.image.content_type
+    end
+  end
+end


### PR DESCRIPTION
### Motivation / Background

This Pull Request allows developers to inject custom transformers into the Active Storage variant pipeline. The need arose in an application managing and publishing long form audio, when I realized that an MP3 couldn't be transformed in the same lazily processed, URL-addressable way that Active Storage has always given images.

With this change, you can register your own transformers to be able to e.g. do `audio_tag episode.file.variant(format: :opus, bitrate: 96)` instead of a hand-rolled transcode job plus a second attachment to hold its output.

This might look like this:

```rb
# app/models/audio_transformer.rb
class AudioTransformer < ActiveStorage::Transformers::Transformer
  def self.accept?(blob)
    blob.content_type.start_with?("audio/")
  end

  private
    def process(file, format:)
      Tempfile.new([ "audio", ".#{format}" ], binmode: true).tap do |output|
        system "ffmpeg", "-i", file.path, *flags, "-y", output.path, exception: true
      end
    end

    def flags
      transformations.flat_map { |name, value| [ "-#{name}", value.to_s ] }
    end
end

# config/application.rb
config.active_storage.transformers = [ AudioTransformer ]
```


### Detail

This Pull Request changes `Blob#variable?` and the transformer lookup so both consult a new transformer registry:

a transformer answers `.accept?(blob)` the way previewers already do, a blob accepted by one is variable, and `Variation` picks that transformer when processing it, so variant and representation work for media types the image processor can't handle.

Registration goes through `config.active_storage.transformers`, alongside the existing `previewers` and `analyzers`, so an application never has to reference an autoloadable class from an initializer.

A variant of a blob that only a registered transformer accepts defaults to that blob's own format. The previous default of PNG is right for a variable image that browsers may not display, but for an MP3 it produced a variant served as `image/png`, and recorded under a `.png` filename, without raising.

**Images are untouched**, still governed by `variable_content_types` and the configured `variant_processor`. Revives the approach proposed in #39283.


### Relationship to #58384

#58384 landed while this was open, and the two are complementary rather than competing.

`config.active_storage.variant_processor = CustomTransformer` *replaces* the single transformer used for every variant, and it does not change `variable?`. Set it to an audio transformer and an audio blob still raises `InvariableError`, because nothing has said that blob is transformable.

`config.active_storage.transformers` is additive and per blob. Registered transformers are asked whether they accept a blob, that answer is what makes the blob variable, and the variant processor goes on handling everything they do not claim. So the two compose: the registry is consulted first, and whatever `variant_processor` resolves to remains the fallback.

Rebased on top of #58384, and the `Transformers::Transformer` docs now describe both routes in one place.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
