### PR TITLE
Active Record ivar ractor safety

### DIFF
--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -464,12 +464,14 @@ module ActiveRecord
       end
 
       def _returning_columns_for_insert(connection) # :nodoc:
-        @_returning_columns_for_insert ||= begin
-          auto_populated_columns = columns.filter_map do |c|
-            c.name if connection.return_value_after_insert?(c)
-          end
+        @_returning_columns_for_insert || ActiveSupport::Ractors.on_main(self) do
+          @_returning_columns_for_insert ||= begin
+            auto_populated_columns = columns.filter_map do |c|
+              -c.name if connection.return_value_after_insert?(c)
+            end
 
-          auto_populated_columns.empty? ? Array(primary_key) : auto_populated_columns
+            (auto_populated_columns.empty? ? Array(primary_key) : auto_populated_columns).freeze
+          end
         end
       end
 

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -269,7 +269,7 @@ module ActiveRecord
       #     self.table_name = "project"
       #   end
       def table_name=(value)
-        value = value && value.to_s
+        value = (value && value.to_s).freeze
 
         if defined?(@table_name)
           return if value == @table_name
@@ -289,14 +289,16 @@ module ActiveRecord
 
       # Computes the table name, (re)sets it internally, and returns it.
       def reset_table_name # :nodoc:
-        self.table_name = if self == Base
-          nil
-        elsif abstract_class?
-          superclass.table_name
-        elsif superclass.abstract_class?
-          superclass.table_name || compute_table_name
-        else
-          compute_table_name
+        ActiveSupport::Ractors.on_main(self) do
+          self.table_name = if self == Base
+            nil
+          elsif abstract_class?
+            superclass.table_name
+          elsif superclass.abstract_class?
+            superclass.table_name || compute_table_name
+          else
+            compute_table_name
+          end
         end
       end
 
@@ -645,7 +647,7 @@ module ActiveRecord
               contained += "_"
             end
 
-            "#{full_table_name_prefix}#{contained}#{undecorated_table_name(model_name)}#{full_table_name_suffix}"
+            "#{full_table_name_prefix}#{contained}#{undecorated_table_name(model_name)}#{full_table_name_suffix}".freeze
           else
             # STI subclasses always use their superclass's table.
             base_class.table_name

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -512,7 +512,9 @@ module ActiveRecord
       end
 
       def symbol_column_to_string(name_symbol) # :nodoc:
-        @symbol_column_to_string_name_hash ||= column_names.index_by(&:to_sym)
+        @symbol_column_to_string_name_hash || ActiveSupport::Ractors.on_main(self) do
+          @symbol_column_to_string_name_hash ||= column_names.index_by(&:to_sym).freeze
+        end
         @symbol_column_to_string_name_hash[name_symbol]
       end
 

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -212,7 +212,7 @@ module ActiveRecord
       def query_constraints(*columns_list)
         raise ArgumentError, "You must specify at least one column to be used in querying" if columns_list.empty?
 
-        @query_constraints_list = columns_list.map(&:to_s)
+        @query_constraints_list = columns_list.map { |column| -column.to_s }.freeze
         @has_query_constraints = @query_constraints_list
       end
 
@@ -221,7 +221,9 @@ module ActiveRecord
       end
 
       def query_constraints_list # :nodoc:
-        @query_constraints_list ||= if base_class? || primary_key != base_class.primary_key
+        return @query_constraints_list if @query_constraints_list
+
+        if base_class? || primary_key != base_class.primary_key
           primary_key if primary_key.is_a?(Array)
         else
           base_class.query_constraints_list

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -13,11 +13,9 @@ module ActiveRecord
       @table = table
       @handlers = []
 
-      register_handler(BasicObject, BasicObjectHandler.new(self))
-      register_handler(Range, RangeHandler.new(self))
-      register_handler(Relation, RelationHandler.new)
-      register_handler(Array, ArrayHandler.new(self))
-      register_handler(Set, ArrayHandler.new(self))
+      register_handlers
+
+      ActiveSupport::Ractors.make_shareable(self)
     end
 
     def build_from_hash(attributes, &block)
@@ -114,6 +112,14 @@ module ActiveRecord
 
     protected
       attr_writer :table
+
+      def register_handlers
+        register_handler(BasicObject, BasicObjectHandler.new(self))
+        register_handler(Range, RangeHandler.new(self))
+        register_handler(Relation, RelationHandler.new)
+        register_handler(Array, ArrayHandler.new(self))
+        register_handler(Set, ArrayHandler.new(self))
+      end
 
       def expand_from_hash(attributes, &block)
         return [Arel.sql("1=0", retryable: true)] if attributes.empty?

--- a/activerecord/lib/arel/table.rb
+++ b/activerecord/lib/arel/table.rb
@@ -26,6 +26,8 @@ module Arel # :nodoc: all
         as = nil
       end
       @table_alias = as
+
+      ActiveSupport::Ractors.make_shareable(self)
     end
 
     def name

--- a/activerecord/test/cases/arel/helper.rb
+++ b/activerecord/test/cases/arel/helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support"
+require "active_support/testing/ractors_assertions"
 require "minitest/autorun"
 require "arel"
 
@@ -23,6 +24,7 @@ end
 module Arel
   class Test < ActiveSupport::TestCase
     include Assertions
+    include ActiveSupport::Testing::RactorsAssertions
 
     setup do
       @arel_engine = Arel::Table.engine

--- a/activerecord/test/cases/arel/table_test.rb
+++ b/activerecord/test/cases/arel/table_test.rb
@@ -187,5 +187,9 @@ module Arel
         Table.new
       end
     end
+
+    test "is ractor shareable" do
+      assert_ractor_shareable Table.new(name: :users)
+    end
   end
 end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -890,6 +890,10 @@ class BasicsTest < ActiveRecord::TestCase
     assert_ractor_shareable ReadonlyAuthorPost._attr_readonly
   end
 
+  def test_table_name_is_ractor_safe
+    assert_ractor_shareable Topic.table_name
+  end
+
   def test_unicode_column_name
     Weird.reset_column_information
     weird = Weird.create(なまえ: "たこ焼き仮面")

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -41,6 +41,11 @@ class PrimaryKeysTest < ActiveRecord::TestCase
     assert_ractor_shareable Cpk::Order.query_constraints_list
   end
 
+  def test_returning_columns_for_insert_is_ractor_shareable
+    columns = Topic._returning_columns_for_insert(ActiveRecord::Base.lease_connection)
+    assert_ractor_shareable columns
+  end
+
   def test_to_key_with_default_primary_key
     topic = Topic.new
     assert_nil topic.to_key

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -33,6 +33,14 @@ class PrimaryKeysTest < ActiveRecord::TestCase
     assert_nil on_ractor { NonPrimaryKey.primary_key }
   end
 
+  def test_query_constraints_list_is_ractor_shareable
+    assert_ractor_shareable Topic.query_constraints_list
+  end
+
+  def test_cpk_query_constraints_list_is_ractor_shareable
+    assert_ractor_shareable Cpk::Order.query_constraints_list
+  end
+
   def test_to_key_with_default_primary_key
     topic = Topic.new
     assert_nil topic.to_key

--- a/activerecord/test/cases/relation/predicate_builder_test.rb
+++ b/activerecord/test/cases/relation/predicate_builder_test.rb
@@ -2,9 +2,13 @@
 
 require "cases/helper"
 require "models/reply"
+require "active_support/testing/ractors_assertions"
+require "active_support/core_ext/object/with"
 
 module ActiveRecord
   class PredicateBuilderTest < ActiveRecord::TestCase
+    include ActiveSupport::Testing::RactorsAssertions
+
     class UnaccentedString < ActiveRecord::Type::String
       def transforms_query_predicates?
         true
@@ -40,10 +44,19 @@ module ActiveRecord
       end
     end
 
+    class RegexpPredicateBuilder < PredicateBuilder
+      def register_handlers
+        super
+
+        register_handler(Regexp, ActiveSupport::Ractors.shareable_proc do |column, value, _type|
+          Arel::Nodes::InfixOperation.new("~", column, Arel::Nodes.build_quoted(value.source))
+        end)
+      end
+    end
+
     def setup
-      Topic.predicate_builder.register_handler(Regexp, proc do |column, value, _type|
-        Arel::Nodes::InfixOperation.new("~", column, Arel::Nodes.build_quoted(value.source))
-      end)
+      builder = RegexpPredicateBuilder.new(TableMetadata.new(Topic, Topic.arel_table))
+      Topic.class_eval { @predicate_builder = builder }
     end
 
     def teardown
@@ -76,6 +89,10 @@ module ActiveRecord
       defaults = { topics: { title: "rails" }, "topics.approved" => true }
       Topic.where(defaults).to_sql
       assert_equal({ topics: { title: "rails" }, "topics.approved" => true }, defaults)
+    end
+
+    def test_is_ractor_shareable
+      assert_ractor_shareable Topic.predicate_builder
     end
 
     def test_attribute_type_can_transform_query_attribute_and_value


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because some model instance variables cannot be referenced on non-main Ractors due to the values not being frozen (but should be). Memoization patterns also need to be made lazily, so for those cases, I added a dispatch call to the main Ractor.

### Detail

This Pull Request changes Active Record to freeze the value of, and dispatch on assignment of `@symbol_column_to_string_name_hash`, `@_returning_columns_for_insert`, `@query_constraints_list`, and `@table_name`

We also needed to freeze eagerly assigned ivars of type `Arel::Table` and `ActiveRecord::PredicateBuilder` for `@predicate_builder` and `@arel_table`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
*  [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
