### PR TITLE
Return a UTC time from `Time.rfc3339` for "Z" inputs

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,24 @@
+*   Return a UTC time from `Time.rfc3339` for strings with the "Z" UTC designator.
+
+    ```ruby
+    Time.rfc3339("2026-08-07T10:00:00Z")
+    # Before: 2026-08-07 10:00:00 +0000 (utc? => false)
+    # After:  2026-08-07 10:00:00 UTC   (utc? => true)
+    ```
+
+    This matches Ruby's `Time.rfc3339`, which is expected to be included in
+    Ruby 4.1.
+    The resulting time value is unchanged, but serialized forms such as
+    `as_json` now end in "Z" instead of "+00:00". Call `getlocal("+00:00")`
+    to keep the previous representation:
+
+    ```ruby
+    Time.rfc3339("2026-08-07T10:00:00Z").getlocal("+00:00")
+    # => 2026-08-07 10:00:00 +0000 (utc? => false)
+    ```
+
+    *Yasuo Honda*
+
 *   Fix `Range#sum` with a falsey initial value.
 
     Summing an integer range with a falsey starting value (such as nil or false)

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -1,6 +1,8 @@
 # :markup: markdown
 # frozen_string_literal: true
 
+require "time"
+
 require "active_support/duration"
 require "active_support/core_ext/time/conversions"
 require "active_support/time_with_zone"
@@ -58,31 +60,43 @@ class Time
     alias_method :at_without_coercion, :at
     alias_method :at, :at_with_coercion
 
-    # Creates a `Time` instance from an RFC 3339 string.
-    #
-    # ```
-    # Time.rfc3339('1999-12-31T14:00:00-10:00') # => 2000-01-01 00:00:00 -1000
-    # ```
-    #
-    # If the time or offset components are missing then an `ArgumentError` will be raised.
-    #
-    # ```
-    # Time.rfc3339('1999-12-31') # => ArgumentError: invalid date
-    # ```
-    def rfc3339(str)
-      parts = Date._rfc3339(str)
+    unless ::Time.respond_to?(:rfc3339)
+      # Creates a `Time` instance from an RFC 3339 string.
+      #
+      # ```
+      # Time.rfc3339('1999-12-31T14:00:00-10:00') # => 2000-01-01 00:00:00 -1000
+      # ```
+      #
+      # If the time or offset components are missing then an `ArgumentError` will be raised.
+      #
+      # ```
+      # Time.rfc3339('1999-12-31') # => ArgumentError: invalid date
+      # ```
+      #
+      # Strings with the "Z" UTC designator return a UTC time, matching Ruby's
+      # `Time.rfc3339`.
+      #
+      # ```
+      # Time.rfc3339('1999-12-31T14:00:00Z').utc? # => true
+      # ```
+      def rfc3339(str)
+        parts = Date._rfc3339(str)
 
-      raise ArgumentError, "invalid date" if parts.empty?
+        raise ArgumentError, "invalid date" if parts.empty?
 
-      Time.new(
-        parts.fetch(:year),
-        parts.fetch(:mon),
-        parts.fetch(:mday),
-        parts.fetch(:hour),
-        parts.fetch(:min),
-        parts.fetch(:sec) + parts.fetch(:sec_fraction, 0),
-        parts.fetch(:offset)
-      )
+        time = Time.new(
+          parts.fetch(:year),
+          parts.fetch(:mon),
+          parts.fetch(:mday),
+          parts.fetch(:hour),
+          parts.fetch(:min),
+          parts.fetch(:sec) + parts.fetch(:sec_fraction, 0),
+          parts.fetch(:offset)
+        )
+
+        # "Z" denotes UTC, which the integer offset alone cannot represent.
+        parts[:zone].casecmp?("Z") ? time.utc : time
+      end
     end
   end
 

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "time"
+
 require "active_support/duration"
 require "active_support/core_ext/time/conversions"
 require "active_support/time_with_zone"
@@ -57,27 +59,37 @@ class Time
     alias_method :at_without_coercion, :at
     alias_method :at, :at_with_coercion
 
-    # Creates a +Time+ instance from an RFC 3339 string.
-    #
-    #   Time.rfc3339('1999-12-31T14:00:00-10:00') # => 2000-01-01 00:00:00 -1000
-    #
-    # If the time or offset components are missing then an +ArgumentError+ will be raised.
-    #
-    #   Time.rfc3339('1999-12-31') # => ArgumentError: invalid date
-    def rfc3339(str)
-      parts = Date._rfc3339(str)
+    unless ::Time.respond_to?(:rfc3339)
+      # Creates a +Time+ instance from an RFC 3339 string.
+      #
+      #   Time.rfc3339('1999-12-31T14:00:00-10:00') # => 2000-01-01 00:00:00 -1000
+      #
+      # If the time or offset components are missing then an +ArgumentError+ will be raised.
+      #
+      #   Time.rfc3339('1999-12-31') # => ArgumentError: invalid date
+      #
+      # Strings with the "Z" UTC designator return a UTC time, matching Ruby's
+      # Time.rfc3339.
+      #
+      #   Time.rfc3339('1999-12-31T14:00:00Z').utc? # => true
+      def rfc3339(str)
+        parts = Date._rfc3339(str)
 
-      raise ArgumentError, "invalid date" if parts.empty?
+        raise ArgumentError, "invalid date" if parts.empty?
 
-      Time.new(
-        parts.fetch(:year),
-        parts.fetch(:mon),
-        parts.fetch(:mday),
-        parts.fetch(:hour),
-        parts.fetch(:min),
-        parts.fetch(:sec) + parts.fetch(:sec_fraction, 0),
-        parts.fetch(:offset)
-      )
+        time = Time.new(
+          parts.fetch(:year),
+          parts.fetch(:mon),
+          parts.fetch(:mday),
+          parts.fetch(:hour),
+          parts.fetch(:min),
+          parts.fetch(:sec) + parts.fetch(:sec_fraction, 0),
+          parts.fetch(:offset)
+        )
+
+        # "Z" denotes UTC, which the integer offset alone cannot represent.
+        parts[:zone].casecmp?("Z") ? time.utc : time
+      end
     end
   end
 

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -1331,19 +1331,33 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
       Time.rfc3339("1999-12-31")
     end
 
-    assert_equal "invalid date", exception.message
+    assert_match(/\Ainvalid (date|rfc3339 format)/, exception.message)
 
     exception = assert_raises(ArgumentError) do
       Time.rfc3339("1999-12-31T19:00:00")
     end
 
-    assert_equal "invalid date", exception.message
+    assert_match(/\Ainvalid (date|rfc3339 format)/, exception.message)
 
     exception = assert_raises(ArgumentError) do
       Time.rfc3339("foobar")
     end
 
-    assert_equal "invalid date", exception.message
+    assert_match(/\Ainvalid (date|rfc3339 format)/, exception.message)
+  end
+
+  def test_rfc3339_parse_with_utc_designator
+    time = Time.rfc3339("1999-12-31T19:00:00Z")
+
+    assert_predicate time, :utc?
+    assert_equal Time.utc(1999, 12, 31, 19, 0, 0), time
+  end
+
+  def test_rfc3339_parse_with_numeric_zero_offset
+    time = Time.rfc3339("1999-12-31T19:00:00+00:00")
+
+    assert_not_predicate time, :utc?
+    assert_equal 0, time.utc_offset
   end
 
   def test_prev_day


### PR DESCRIPTION
### Motivation / Background

Ruby 4.1 is expected to include `Time.rfc3339` via time as a default gem. For the "Z" UTC designator it returns a UTC time — a deliberate upstream decision, for consistency with `Time.iso8601` and `Time.xmlschema` (https://github.com/ruby/time/issues/73#issuecomment-5156124363). Active Support's `Time.rfc3339` has returned a +00:00 fixed offset since Rails 5.1 (08e05d4a49): the same time value, in a representation no test or documentation ever asserted.

After the reports in ruby/time#73, ruby/time#77, and ruby/time#80, the time gem's master branch (with ruby/time#72, #74, #75, #77, and #79) now accepts and rejects the same strings as Active Support's implementation on every input the Active Support unit tests assert. The remaining differences are the "Z" representation and the exception message wording.

The direction was discussed in #58172: converge on Ruby's implementation, and document the "Z" change in the CHANGELOG rather than deliver it behind a framework default (https://github.com/rails/rails/pull/58172#issuecomment-5203093611).

### Detail

* Define `Time.rfc3339` only when Ruby does not provide it, following the `Range#overlap?` precedent (1d76d45411). `require "time"` runs first so the feature check does not depend on load order.
* The Active Support definition now returns a UTC time for the "Z" designator, matching Ruby's implementation.
* The exception message still differs between the two implementations (`invalid date` vs `invalid rfc3339 format`), so the message assertions use `assert_match`.

Behavior:

```ruby
Time.rfc3339("2026-08-07T10:00:00Z")
# Before: 2026-08-07 10:00:00 +0000 (utc? => false)
# After:  2026-08-07 10:00:00 UTC   (utc? => true)

Time.rfc3339("2026-08-07T10:00:00Z").getlocal("+00:00")
# => 2026-08-07 10:00:00 +0000 (utc? => false), the previous representation
```

The resulting time value is unchanged, but serialized forms such as `as_json` now end in "Z" instead of "+00:00". Equality, arithmetic, `in_time_zone`, `Time.zone.rfc3339`, and times persisted through Active Record are unaffected.

| Environment | `Time.rfc3339` definition | Result for "Z" |
|---|---|---|
| time gem without `Time.rfc3339` (all released Rubies) | Active Support | UTC time (`utc?` is true) |
| time gem with `Time.rfc3339` (expected from Ruby 4.1) | Ruby | UTC time (`utc?` is true), with no redefinition |

### Additional information

Supersedes #58172.

Running the full Rails suite with Active Support delegating to the time gem's master branch left only the three exception message assertions failing (https://buildkite.com/rails/rails/builds/132098); this pull request relaxes those assertions.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
