### PR TITLE
Fix the `Request#media_type` documentation example

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -282,7 +282,7 @@ module ActionDispatch
 
     # The `String` MIME type of the request.
     #
-    #     # get "/articles"
+    #     # post "/articles", params: { title: "Rails" }
     #     request.media_type # => "application/x-www-form-urlencoded"
     def media_type
       content_mime_type&.to_s


### PR DESCRIPTION
The example documents a GET, which carries no body and therefore no `Content-Type`, so `media_type` returns `nil`:

```ruby
# get "/articles"
request.media_type # => "application/x-www-form-urlencoded"   # actually nil
```

`test/dispatch/request_test.rb:1109` already pins this (`assert_nil(request.media_type)` for a request with no content type).

The example was accurate when it was written — integration requests set that `Content-Type` unconditionally back then. 86754a8f7b made the default request encoder report no content type, and the example was left behind.

This documents a request that actually carries a form-encoded body, so the documented value is the one produced:

```ruby
# post "/articles", params: { title: "Rails" }
request.media_type # => "application/x-www-form-urlencoded"   # verified
```

>[!NOTE]
> Documentation-only; no behavior change.