### PR TITLE
Load ruby-vips only when using the Vips analyzer

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Avoid loading ruby-vips when the `:mini_magick` Active Storage variant
+    processor is selected.
+
+    This prevents an installed but unsupported ruby-vips version from raising during
+    application boot when Vips processing is not configured.
+
+    Fixes #58394.
+
+    *tianrking*
+
 *   Allow `config.active_storage.variant_processor` to be set to a transformer class.
 
     `config.active_storage.variant_processor` now accepts a class, in addition to `:vips`,

--- a/activestorage/lib/active_storage/analyzer/image_analyzer/vips.rb
+++ b/activestorage/lib/active_storage/analyzer/image_analyzer/vips.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_storage/vips"
-
 module ActiveStorage
   # This analyzer relies on the third-party {ruby-vips}[https://github.com/libvips/ruby-vips] gem. Ruby-vips requires
   # the {libvips}[https://libvips.github.io/libvips/] system library.
@@ -12,6 +10,8 @@ module ActiveStorage
 
     private
       def read_image
+        require "active_storage/vips"
+
         unless VIPS_AVAILABLE
           logger.error "Skipping image analysis because the ruby-vips gem isn't installed"
           return {}

--- a/railties/test/application/active_storage/engine_integration_test.rb
+++ b/railties/test/application/active_storage/engine_integration_test.rb
@@ -87,7 +87,50 @@ module ApplicationTests
       assert_includes(output, "Unknown variant processor :nope")
     end
 
+    def test_mini_magick_transformer_does_not_load_vips
+      add_to_config "config.active_storage.variant_processor = :mini_magick"
+      add_ruby_vips_without_block_untrusted
+
+      output = run_command('puts "booted"')
+
+      assert_includes(output, "booted")
+      assert_not_includes(output, "Active Storage cannot disable them")
+    end
+
+    def test_vips_transformer_requires_block_untrusted
+      add_to_config "config.active_storage.variant_processor = :vips"
+      add_ruby_vips_without_block_untrusted
+
+      output = run_command('puts "booted"')
+
+      assert_not_includes(output, "booted")
+      assert_includes(output, "Active Storage cannot disable them")
+    end
+
     private
+      def add_ruby_vips_without_block_untrusted
+        FileUtils.mkdir_p app_path("ruby-vips", "lib")
+
+        File.write app_path("ruby-vips", "ruby-vips.gemspec"), <<~RUBY
+          Gem::Specification.new do |spec|
+            spec.name = "ruby-vips"
+            spec.version = "2.3.0"
+            spec.summary = "ruby-vips without block_untrusted"
+            spec.authors = [ "Rails test" ]
+            spec.files = [ "lib/ruby-vips.rb" ]
+          end
+        RUBY
+
+        File.write app_path("ruby-vips", "lib", "ruby-vips.rb"), <<~RUBY
+          module Vips
+          end
+        RUBY
+
+        File.open app_path("Gemfile"), "a" do |f|
+          f.puts %(gem "ruby-vips", path: "#{app_path("ruby-vips")}")
+        end
+      end
+
       def run_command(cmd)
         Dir.chdir(app_path) do
           Bundler.with_original_env do


### PR DESCRIPTION
### Motivation / Background

Active Storage loads all default analyzer classes during application boot.
The Vips analyzer currently requires `active_storage/vips` as soon as its class is
loaded. As a result, an app configured with `:mini_magick` can fail to boot when
an installed ruby-vips/libvips combination cannot block untrusted operations, even
though that app does not use Vips for processing.

Fixes #58394.

### Detail

Move the `active_storage/vips` require into the Vips analyzer's `read_image`
path. The configured Vips transformer still loads it during boot, so applications
that actually use Vips continue to fail fast when the installed versions cannot
disable unsafe operations.

Add integration coverage with a local ruby-vips stub that lacks
`Vips.block_untrusted`. The tests verify that MiniMagick applications boot without
loading Vips, while Vips applications retain the existing safety check.

### Additional information

Tested with:

* `railties/test/application/active_storage/engine_integration_test.rb`
* `activestorage/test/analyzer/image_analyzer/vips_test.rb`
* `railties/test/application/active_storage/analyzers_integration_test.rb`
* RuboCop on the two changed Ruby files

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.