### PR TITLE
Apply query predicate transforms to NULL checks

### DIFF
--- a/activemodel/lib/active_model/type/value.rb
+++ b/activemodel/lib/active_model/type/value.rb
@@ -118,11 +118,13 @@ module ActiveModel
       # rendered in hash-based +where+ predicates. When this method returns
       # true, equality, array (+IN+), and range (+BETWEEN+) predicates are
       # built by passing the attribute through Value#query_attribute and each
-      # value through Value#query_value. Returns +false+ by default. Types
-      # whose read-side SQL differs from what +cast+ and +serialize+ produce
-      # (e.g. a UUID stored as binary comparing as
-      # <tt>id = UUID_TO_BIN(?)</tt>) should override this method to return
-      # +true+.
+      # value through Value#query_value. +NULL+ checks compare the transformed
+      # attribute (<tt>f(column) IS NULL</tt>), so they can keep using an index
+      # on the transformed expression; +nil+ values are not passed to
+      # Value#query_value. Returns +false+ by default. Types whose read-side
+      # SQL differs from what +cast+ and +serialize+ produce (e.g. a UUID
+      # stored as binary comparing as <tt>id = UUID_TO_BIN(?)</tt>) should
+      # override this method to return +true+.
       def transforms_query_predicates?
         false
       end
@@ -140,9 +142,9 @@ module ActiveModel
 
       # Returns the Arel node used for the value side of a +where+
       # predicate. Only called when Value#transforms_query_predicates?
-      # returns +true+. The default implementation returns a bind parameter
-      # for +value+. Override this method to wrap the bind parameter, for
-      # example in a SQL function call.
+      # returns +true+ and +value+ is not +nil+. The default implementation
+      # returns a bind parameter for +value+. Override this method to wrap
+      # the bind parameter, for example in a SQL function call.
       #
       # +attribute+ The Arel attribute for the column being compared.
       #

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -64,7 +64,7 @@ module ActiveRecord
       if operator ||= type.force_equality?(value) && :eq
         if type.transforms_query_predicates?
           right = query_value(attribute, value, type)
-          left = right.nil? ? attribute : type.query_attribute(attribute)
+          left = type.query_attribute(attribute)
         else
           right = build_bind_attribute(attribute.name, value, type)
           left = attribute

--- a/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
@@ -25,7 +25,8 @@ module ActiveRecord
           end
 
         if nils
-          values_predicate = values_predicate.or(attribute.eq(nil))
+          null_attribute = transformable ? type.query_attribute(attribute) : attribute
+          values_predicate = values_predicate.or(null_attribute.eq(nil))
         end
 
         if ranges.empty?

--- a/activerecord/test/cases/relation/predicate_builder_test.rb
+++ b/activerecord/test/cases/relation/predicate_builder_test.rb
@@ -132,8 +132,35 @@ module ActiveRecord
       assert_equal expected_sql, sql
     end
 
-    def test_attribute_type_query_transform_keeps_nil_predicates_unwrapped
+    def test_attribute_type_query_transform_applies_to_nil_predicates
       topic = topic_model_with_title_type(UnaccentedString.new)
+      sql = topic.where(title: nil).to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "WHERE #{normalized_title} IS NULL"
+
+      assert_equal expected_sql, sql
+    end
+
+    def test_attribute_type_query_transform_applies_to_negated_nil_predicates
+      topic = topic_model_with_title_type(UnaccentedString.new)
+      sql = topic.where.not(title: nil).to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "WHERE #{normalized_title} IS NOT NULL"
+
+      assert_equal expected_sql, sql
+    end
+
+    def test_attribute_type_query_transform_applies_to_nil_values_in_arrays
+      topic = topic_model_with_title_type(UnaccentedString.new)
+      sql = topic.where(title: ["CAFE", nil]).to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "WHERE (#{normalized_title} = #{normalized_value("CAFE")} OR #{normalized_title} IS NULL)"
+
+      assert_equal expected_sql, sql
+    end
+
+    def test_attribute_type_query_transform_with_default_query_attribute_keeps_nil_predicates_unwrapped
+      topic = topic_model_with_title_type(UuidToBinString.new)
       sql = topic.where(title: nil).to_sql
       expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
         "WHERE #{quote_table_name("topics.title")} IS NULL"


### PR DESCRIPTION
Follow-up to #58135.

For a type that transforms query predicates, nil values skipped `query_attribute` entirely: `where(title: nil)` rendered `title IS NULL` while every other predicate on the column compared through the transformed expression, e.g. `lower(title) = lower(?)`. A NULL check on the raw column cannot use an index built on the transformed expression, so these queries degraded to filtering.

Any reasonable transform in this context is strict (`f(NULL)` is `NULL`) and never maps a non-NULL value to NULL, so both forms match the same rows and it is safe to compare the transformed attribute.

Nil predicates now use `query_attribute` for the attribute side, in both the equality path and the nil branch of the array handler, rendering `lower(title) IS NULL`. Nil values are still not passed to `query_value`; types that only override `query_value` (e.g. the UUID_TO_BIN example) keep the unwrapped `title IS NULL`.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
