### PR TITLE
Fix incorrect RDoc examples in Active Record

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -274,7 +274,7 @@ module ActiveRecord
     #   ActiveRecord::Base.connected_to(role: :reading, shard: :shard_one) do
     #     ActiveRecord::Base.connected_to?(role: :reading, shard: :shard_one) #=> true
     #     ActiveRecord::Base.connected_to?(role: :reading, shard: :default) #=> false
-    #     ActiveRecord::Base.connected_to?(role: :writing, shard: :shard_one) #=> true
+    #     ActiveRecord::Base.connected_to?(role: :writing, shard: :shard_one) #=> false
     #   end
     def connected_to?(role:, shard: ActiveRecord::Base.default_shard)
       current_role == role.to_sym && current_shard == shard.to_sym

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1371,7 +1371,7 @@ module ActiveRecord
     #
     # To make a readonly relation writable, pass +false+.
     #
-    #   users.readonly(false)
+    #   users = users.readonly(false)
     #   users.first.save
     #   # => true
     def readonly(value = true)


### PR DESCRIPTION
Two RDoc examples in Active Record show values the code cannot produce.

### `connected_to?` (`activerecord/lib/active_record/connection_handling.rb`)

```ruby
ActiveRecord::Base.connected_to(role: :reading, shard: :shard_one) do
  ActiveRecord::Base.connected_to?(role: :reading, shard: :shard_one) #=> true
  ActiveRecord::Base.connected_to?(role: :reading, shard: :default) #=> false
  ActiveRecord::Base.connected_to?(role: :writing, shard: :shard_one) #=> true
end
```

`connected_to?` returns `true` only when both the role and the shard match the current connection context, so the last line returns `false`, not `true` — as the preceding line in the same example already illustrates for a mismatched shard. `activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb` asserts this exact scenario:

```ruby
ActiveRecord::Base.connected_to(role: :reading, shard: :shard_one) do
  assert_equal :reading, ActiveRecord::Base.current_role
  assert ActiveRecord::Base.connected_to?(role: :reading, shard: :shard_one)
  assert_not ActiveRecord::Base.connected_to?(role: :writing, shard: :shard_one)
```

### `#readonly` (`activerecord/lib/active_record/relation/query_methods.rb`)

```ruby
users = User.readonly
users.first.save
# => ActiveRecord::ReadOnlyRecord: User is marked as readonly

# To make a readonly relation writable, pass +false+.

users.readonly(false)
users.first.save
# => true
```

`#readonly` returns a new relation, so the second example discards the writable relation and `users.first.save` still raises `ActiveRecord::ReadOnlyRecord` instead of returning `true`:

```ruby
users = Topic.readonly
users.readonly(false)
users.first.save # raises ActiveRecord::ReadOnlyRecord

users = Topic.readonly
users = users.readonly(false)
users.first.save # => true
```

>[!NOTE]
>Documentation-only change