### PR TITLE
Honor `group`/`having` alone in `update_all` and `delete_all`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,23 @@
+*   Honor `group` and `having` in `update_all` and `delete_all` when either one
+    is used on its own.
+
+    The clause was previously dropped from the generated statement unless both
+    `group` and `having` were present, so every row of the table was updated or
+    deleted:
+
+        Post.group(:author_id).delete_all
+        # => DELETE FROM "posts"
+
+    The statement is now scoped by a primary key subquery, the same way it
+    already was for `group` combined with `having`, `joins`, `limit` or `order`:
+
+        Post.group(:author_id).delete_all
+        # => DELETE FROM "posts" WHERE "posts"."id" IN (SELECT "posts"."id" FROM "posts" GROUP BY "posts"."author_id")
+
+    Fixes #54177.
+
+    *Juan Vásquez*
+
 *   Add query predicate hooks for Active Model types.
 
     Types can override `transforms_query_predicates?`, `query_attribute`, and

--- a/activerecord/lib/arel/visitors/mysql.rb
+++ b/activerecord/lib/arel/visitors/mysql.rb
@@ -79,7 +79,7 @@ module Arel # :nodoc: all
         # query. However, this does not allow for LIMIT, OFFSET and ORDER. To support
         # these, we must use a subquery.
         def prepare_update_statement(o)
-          if o.offset || has_group_by_and_having?(o) ||
+          if o.offset || has_group_by_or_having?(o) ||
             has_join_sources?(o) && has_limit_or_offset_or_orders?(o)
             super
           else

--- a/activerecord/lib/arel/visitors/postgresql.rb
+++ b/activerecord/lib/arel/visitors/postgresql.rb
@@ -43,7 +43,7 @@ module Arel # :nodoc: all
         # query. However, this does not allow for LIMIT, OFFSET and ORDER. To support
         # these, we must use a subquery.
         def prepare_update_statement(o)
-          if o.key && has_join_sources?(o) && !has_group_by_and_having?(o) && !has_limit_or_offset_or_orders?(o)
+          if o.key && has_join_sources?(o) && !has_group_by_or_having?(o) && !has_limit_or_offset_or_orders?(o)
             prepare_update_statement_with_self_join(o)
           else
             super

--- a/activerecord/lib/arel/visitors/sqlite.rb
+++ b/activerecord/lib/arel/visitors/sqlite.rb
@@ -35,7 +35,7 @@ module Arel # :nodoc: all
         def prepare_update_statement(o)
           # Sqlite need to be built with the SQLITE_ENABLE_UPDATE_DELETE_LIMIT compile-time option
           # to support LIMIT/OFFSET/ORDER in UPDATE and DELETE statements.
-          if o.key && has_join_sources?(o) && !has_group_by_and_having?(o) && !has_limit_or_offset_or_orders?(o)
+          if o.key && has_join_sources?(o) && !has_group_by_or_having?(o) && !has_limit_or_offset_or_orders?(o)
             prepare_update_statement_with_self_join(o)
           else
             super

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -931,15 +931,15 @@ module Arel # :nodoc: all
           o.limit || o.offset || !o.orders.empty?
         end
 
-        def has_group_by_and_having?(o)
-          !o.groups.empty? && !o.havings.empty?
+        def has_group_by_or_having?(o)
+          !o.groups.empty? || !o.havings.empty?
         end
 
         # The default strategy for an UPDATE with joins is to use a subquery. This doesn't work
         # on MySQL (even when aliasing the tables), but MySQL allows using JOIN directly in
         # an UPDATE statement, so in the MySQL visitor we redefine this to do that.
         def prepare_update_statement(o)
-          if o.key && (has_limit_or_offset_or_orders?(o) || has_join_sources?(o) || has_group_by_and_having?(o))
+          if o.key && (has_limit_or_offset_or_orders?(o) || has_join_sources?(o) || has_group_by_or_having?(o))
             stmt = o.clone
             stmt.limit = nil
             stmt.offset = nil

--- a/activerecord/test/cases/relation/delete_all_test.rb
+++ b/activerecord/test/cases/relation/delete_all_test.rb
@@ -96,6 +96,24 @@ class DeleteAllTest < ActiveRecord::TestCase
     assert_not Post.exists?(posts[2].id)
   end
 
+  def test_delete_all_with_group_by_without_having_is_scoped_by_a_subquery
+    posts = [
+      Post.create!(title: "one", body: "x", legacy_comments_count: 0),
+      Post.create!(title: "two", body: "x", legacy_comments_count: 0),
+    ]
+    relation = Post.where(id: posts).group("posts.id")
+
+    sqls = capture_sql do
+      # The GROUP BY must be honored instead of being dropped from the query,
+      # which would delete every row of the table.
+      assert_equal 2, relation.delete_all
+    end
+
+    assert_match(/IN \(SELECT/i, sqls.last)
+    assert_match(/GROUP BY/i, sqls.last)
+    assert_not_predicate Post, :none?
+  end
+
   def test_delete_all_with_unpermitted_relation_raises_error
     assert_raises(ActiveRecord::ActiveRecordError) { Author.distinct.delete_all }
     assert_raises(ActiveRecord::ActiveRecordError) { Author.with(limited: Author.limit(2)).delete_all }

--- a/activerecord/test/cases/relation/update_all_test.rb
+++ b/activerecord/test/cases/relation/update_all_test.rb
@@ -83,6 +83,25 @@ class UpdateAllTest < ActiveRecord::TestCase
     assert_equal "updated", posts[2].reload.title
   end
 
+  def test_update_all_with_group_by_without_having_is_scoped_by_a_subquery
+    posts = [
+      Post.create!(title: "one", body: "x", legacy_comments_count: 0),
+      Post.create!(title: "two", body: "x", legacy_comments_count: 0),
+    ]
+    relation = Post.where(id: posts).group("posts.id")
+
+    sqls = capture_sql do
+      # The GROUP BY must be honored instead of being dropped from the query,
+      # which would update every row of the table.
+      assert_equal 2, relation.update_all(title: "updated")
+    end
+
+    assert_match(/IN \(SELECT/i, sqls.last)
+    assert_match(/GROUP BY/i, sqls.last)
+    assert_equal ["updated", "updated"], posts.map { |post| post.reload.title }
+    assert_not_equal "updated", Post.where.not(id: posts).first.title
+  end
+
   def test_update_all_with_joins_and_limit
     pets = Pet.joins(:toys).where(toys: { name: "Bone" }).limit(2)
 


### PR DESCRIPTION
### Motivation / Background

`update_all` / `delete_all` silently drop `group` (or `having`) when either is used on its own, and affect every row of the table:

```ruby
Post.group(:author_id).delete_all
# => DELETE FROM "posts"
```

Fixes #54177. The `group` + `having` half of that issue was fixed in #57601; this is the remaining half.

### Detail

`Arel::Visitors::ToSql#prepare_update_statement` wrapped the statement in a primary key subquery only when `group` **and** `having` were both present, so a relation carrying just one of them fell through and lost it. The predicate now matches either clause, and the PostgreSQL/SQLite/MySQL shortcuts that cannot carry a `GROUP BY` are skipped accordingly.

```ruby
Post.group(:author_id).delete_all
# => DELETE FROM "posts" WHERE "posts"."id" IN (SELECT "posts"."id" FROM "posts" GROUP BY "posts"."author_id")
```

### Additional information

`group` is already honored when combined with `joins`, `limit`, `order` or `having`. These two shapes were the only ones dropping it.

Grouping by a non-primary-key column now raises on PostgreSQL and MySQL instead of deleting the table. That is not new behavior: `Post.joins(:comments).group(:author_id).delete_all` already raises the same `PG::GroupingError` on main, since that path already routes through the subquery.

I went with a fix rather than a deprecation cycle because `group`/`having` can be honored and already are in most shapes, unlike `distinct` / `with` / `with_recursive`, which can never be translated into an UPDATE/DELETE and were deprecated in 1585064d71. Happy to switch if you prefer.

<details>
<summary>Reproduction script (fails on main, passes on this branch)</summary>

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails", github: "rails/rails", branch: "main"
  gem "sqlite3"
end

require "active_record/railtie"
require "minitest/autorun"

ENV["DATABASE_URL"] = "sqlite3::memory:"

class TestApp < Rails::Application
  config.load_defaults Rails::VERSION::STRING.to_f
  config.eager_load = false
  config.logger = Logger.new($stdout)
  config.secret_key_base = "secret_key_base"
end
Rails.application.initialize!

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.integer :author_id
  end

  create_table :comments, force: true do |t|
    t.integer :post_id
  end
end

class Post < ActiveRecord::Base
  has_many :comments
end

class Comment < ActiveRecord::Base
  belongs_to :post
end

class GroupWithoutHavingTest < ActiveSupport::TestCase
  setup do
    3.times { Post.create!(author_id: 1) }
    2.times { Post.create!(author_id: 2) }
  end

  # `group` combined with `having` is honored (fixed in #57601).
  def test_group_with_having_is_honored
    assert_match(/GROUP BY/, capture_delete_sql { Post.group(:author_id).having("COUNT(*) > 2").delete_all })
  end

  # `group` combined with `joins`, `limit` or `order` is honored too.
  def test_group_with_joins_limit_or_order_is_honored
    assert_match(/GROUP BY/, capture_delete_sql { Post.joins(:comments).group(:author_id).delete_all })
    assert_match(/GROUP BY/, capture_delete_sql { Post.group(:author_id).limit(2).delete_all })
    assert_match(/GROUP BY/, capture_delete_sql { Post.group(:author_id).order(:id).delete_all })
  end

  # BUG: `group` on its own is dropped and every row is deleted.
  def test_group_alone_is_dropped_and_deletes_every_row
    sql = capture_delete_sql { Post.group(:author_id).delete_all }

    assert_match(/GROUP BY/, sql)
    assert_operator Post.count, :>, 0
  end

  # BUG: same for `having` on its own.
  def test_having_alone_is_dropped_and_deletes_every_row
    assert_match(/HAVING/, capture_delete_sql { Post.having("COUNT(*) > 2").delete_all rescue nil })
  end

  private
    def capture_delete_sql(&block)
      sql = nil
      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
        sql = payload[:sql] if payload[:sql].start_with?("DELETE")
      end
      block.call
      sql.to_s
    ensure
      ActiveSupport::Notifications.unsubscribe(subscriber)
    end
end
```

</details>

Full Active Record suite passes locally via `rake test:<adapter>` on `sqlite3`, `sqlite3_mem`, `postgresql`, `mysql2` and `trilogy`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
