### PR TITLE
Let unscope and rewhere see through transformed query predicates

### DIFF
--- a/activerecord/lib/arel/nodes/binary.rb
+++ b/activerecord/lib/arel/nodes/binary.rb
@@ -30,11 +30,15 @@ module Arel # :nodoc: all
     end
 
     module FetchAttribute
-      def fetch_attribute(&)
+      def fetch_attribute(&block)
         if left.is_a?(Arel::Attributes::Attribute)
           yield left
         elsif right.is_a?(Arel::Attributes::Attribute)
           yield right
+        elsif left.is_a?(Arel::Nodes::Function)
+          left.fetch_attribute(&block)
+        elsif right.is_a?(Arel::Nodes::Function)
+          right.fetch_attribute(&block)
         end
       end
     end

--- a/activerecord/lib/arel/nodes/function.rb
+++ b/activerecord/lib/arel/nodes/function.rb
@@ -14,6 +14,17 @@ module Arel # :nodoc: all
         @distinct    = false
       end
 
+      def fetch_attribute(&block)
+        return unless expressions.size == 1
+
+        expression = expressions.first
+        if expression.is_a?(Arel::Attributes::Attribute)
+          yield expression
+        elsif expression.is_a?(Arel::Nodes::Node)
+          expression.fetch_attribute(&block)
+        end
+      end
+
       def hash
         [@expressions, @distinct].hash
       end

--- a/activerecord/test/cases/relation/predicate_builder_test.rb
+++ b/activerecord/test/cases/relation/predicate_builder_test.rb
@@ -141,6 +141,39 @@ module ActiveRecord
       assert_equal expected_sql, sql
     end
 
+    def test_attribute_type_query_transform_predicates_can_be_unscoped
+      topic = topic_model_with_title_type(UnaccentedString.new)
+      sql = topic.where(title: "CAFE").unscope(where: :title).to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics}"
+
+      assert_equal expected_sql, sql
+    end
+
+    def test_attribute_type_query_transform_array_predicates_can_be_unscoped
+      topic = topic_model_with_title_type(UnaccentedString.new)
+      sql = topic.where(title: ["CAFE", "BAR"]).unscope(where: :title).to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics}"
+
+      assert_equal expected_sql, sql
+    end
+
+    def test_attribute_type_query_transform_negated_predicates_can_be_unscoped
+      topic = topic_model_with_title_type(UnaccentedString.new)
+      sql = topic.where.not(title: "CAFE").unscope(where: :title).to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics}"
+
+      assert_equal expected_sql, sql
+    end
+
+    def test_attribute_type_query_transform_predicates_can_be_replaced_by_rewhere
+      topic = topic_model_with_title_type(UnaccentedString.new)
+      sql = topic.where(title: "CAFE").rewhere(title: "BAR").to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "WHERE #{normalized_title} = #{normalized_value("BAR")}"
+
+      assert_equal expected_sql, sql
+    end
+
     private
       def quoted_topics
         quote_table_name("topics")


### PR DESCRIPTION
Follow-up to #58135

When a type transforms query predicates through `query_attribute`, the predicate's attribute side is a function node wrapping the column, e.g. `lower(title) = lower(?)`. `Arel::Nodes::Binary::FetchAttribute` only recognizes a bare attribute on either side, so `unscope(where: :title)`, `rewhere(title: ...)`, and where-clause merges silently left the transformed predicate in place, and the two conditions stacked.

`Arel::Nodes::Function` now yields the attribute wrapped by its single expression (recursing through nested functions such as `lower(unaccent(title))`), and binary predicate nodes fall back to fetching the attribute from a function side when neither side is a bare attribute. Where-clause introspection can then match the underlying column, so unscoping and rewhereing transformed predicates behaves the same as for untransformed ones.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
