### PR TITLE
Omit optional route segments given empty strings

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Fix `url_for` to leave out an optional part of a route when its value is an
+    empty string, the same way it already does for `nil`.
+
+    Before, the empty string ended up in the path, producing a URL the route
+    itself cannot match:
+
+    ```ruby
+    get "(/locale/:locale)/products(/:id)", to: "products#show"
+
+    url_for(controller: "products", action: "show", locale: "", id: 123)
+    # Before: "/locale//products/123"
+    # After:  "/products/123"
+    ```
+
+    Empty strings for required parameters behave as before.
+
+    *Carl Dawson*
+
 *   Deprecate registering and unregistering MIME types after application initialization.
 
     `Mime::Type.register`, `Mime::Type.register_alias`, and `Mime::Type.unregister` will raise

--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -90,6 +90,11 @@ module ActionDispatch
           defaults       = route.defaults
           required_parts = route.required_parts
 
+          # After query param extraction, so empty values are consumed as path parts.
+          parameterized_parts.delete_if do |key, value|
+            value == "" && !required_parts.include?(key)
+          end
+
           route.parts.reverse_each do |key|
             break if defaults[key].nil? && parameterized_parts[key].present?
             next if parameterized_parts[key].to_s != defaults[key].to_s

--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -90,6 +90,11 @@ module ActionDispatch
           defaults       = route.defaults
           required_parts = route.required_parts
 
+          # After query param extraction, so empty values are consumed as path parts.
+          parameterized_parts.delete_if do |key, value|
+            value.blank? && !required_parts.include?(key)
+          end
+
           route.parts.reverse_each do |key|
             break if defaults[key].nil? && parameterized_parts[key].present?
             next if parameterized_parts[key].to_s != defaults[key].to_s

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -2713,6 +2713,71 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
       url_for(controller: "photos", action: "index", username: nil)
   end
 
+  def test_url_generator_treats_empty_strings_like_nil_for_optional_segments
+    draw do
+      get "(/locale/:locale)(/currency/:currency)/products(/:id)" => "products#show"
+    end
+
+    assert_equal "http://www.example.com/currency/USD/products/123",
+      url_for(controller: "products", action: "show", locale: "", currency: "USD", id: 123)
+    assert_equal "http://www.example.com/currency/USD/products/123",
+      url_for(controller: "products", action: "show", locale: nil, currency: "USD", id: 123)
+
+    assert_equal "http://www.example.com/locale/en/products/123",
+      url_for(controller: "products", action: "show", locale: "en", currency: "", id: 123)
+    assert_equal "http://www.example.com/locale/en/products/123",
+      url_for(controller: "products", action: "show", locale: "en", currency: nil, id: 123)
+
+    assert_equal "http://www.example.com/locale/en/currency/USD/products",
+      url_for(controller: "products", action: "show", locale: "en", currency: "USD", id: "")
+    assert_equal "http://www.example.com/locale/en/currency/USD/products",
+      url_for(controller: "products", action: "show", locale: "en", currency: "USD", id: nil)
+
+    assert_equal "http://www.example.com/locale/false/currency/USD/products/123",
+      url_for(controller: "products", action: "show", locale: false, currency: "USD", id: 123)
+
+    assert_equal "http://www.example.com/currency/USD/products/123?filter=",
+      url_for(controller: "products", action: "show", locale: "", currency: "USD", id: 123, filter: "")
+  end
+
+  def test_url_generator_preserves_empty_strings_for_required_segments
+    draw do
+      get "/products/:id" => "products#show"
+    end
+
+    assert_equal "http://www.example.com/products/",
+      url_for(controller: "products", action: "show", id: "")
+  end
+
+  def test_url_generator_omits_nested_optional_groups_for_empty_strings
+    draw do
+      get "(/locale/:locale(/currency/:currency))/products" => "products#index"
+    end
+
+    assert_equal "http://www.example.com/products",
+      url_for(controller: "products", action: "index", locale: "", currency: "USD")
+    assert_equal "http://www.example.com/locale/en/products",
+      url_for(controller: "products", action: "index", locale: "en", currency: "")
+  end
+
+  def test_url_generator_omits_whole_optional_group_when_one_part_is_empty
+    draw do
+      get "(/a/:a_id/:b_id)/products" => "products#index"
+    end
+
+    assert_equal "http://www.example.com/products",
+      url_for(controller: "products", action: "index", a_id: "", b_id: "2")
+  end
+
+  def test_url_generator_keeps_whitespace_only_optional_segments
+    draw do
+      get "(/locale/:locale)/products" => "products#index"
+    end
+
+    assert_equal "http://www.example.com/locale/%20/products",
+      url_for(controller: "products", action: "index", locale: " ")
+  end
+
   def test_url_recognition_for_optional_static_segments
     draw do
       scope "(groups)" do


### PR DESCRIPTION
### Motivation / Background

Fixes #55845. Replaces #55846.

When `url_for` gets an empty string for an optional part of a route, the empty string ends up in the path:

```ruby
get "(/locale/:locale)/products(/:id)", to: "products#show"

url_for(controller: "products", action: "show", locale: nil, id: 123) # => "/products/123"
url_for(controller: "products", action: "show", locale: "", id: 123)  # => "/locale//products/123"
```

The second URL is broken: the route that generated it cannot match it. This comes up in practice when the value arrives from a form, where a blank field is `""` rather than `nil`.

Rails does leave the segment out when the empty string is in trailing position — but that turns out to be an accident of how trailing default values are trimmed in `Journey::Formatter#generate` (`"".present?` is false and `"".to_s == nil.to_s`), not designed behavior. That accident is why the two positions disagree today.

### Detail

An empty string for an optional part now means the same as `nil`: the part is left out of the generated URL.

The empty values are removed from the path parameters in `Journey::Formatter#generate`, after query parameters have been split off, so an empty value is still used up by the path rather than turning into a stray `?locale=` query parameter. Empty strings for required parts, `false` values, and empty query parameters keep their current behavior, and the tests pin each of these down.

This replaces #55846, which changed the shared options hash while candidate routes were still being tried, so one candidate's normalization could leak into the next.

### Checklist

- [x] This Pull Request is related to one change.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.