### PR TITLE
[8-1-stable] Warn when image_processing 2.x is missing ruby-vips or mini_magick

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Warn instead of aborting boot when `image_processing` 2.x is installed without `ruby-vips`
+    or `mini_magick`.
+
+    Both gems became soft dependencies in `image_processing` 2.0, and the `LoadError` raised for
+    a missing one names that gem instead of `image_processing`. Active Storage did not recognize
+    the message, so it re-raised rather than logging its usual warning.
+
+    Fixes #58413.
+
+    *Janko Marohnić*
+
 *   Fix `MirrorService#mirror` losing blob metadata when copying to mirrors.
 
     Mirrored copies on S3, Azure, and GCS were served as `application/octet-stream`

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -115,6 +115,16 @@ module ActiveStorage
               Please add `gem "image_processing", "~> 1.2"` to your Gemfile
               or set `config.active_storage.variant_processor = :disabled`.
             WARNING
+          when /ruby-vips/
+            ActiveStorage.logger.warn <<~WARNING.squish
+              Generating image variants with libvips requires the ruby-vips gem.
+              Please add `gem "ruby-vips", "~> 2.3"` to your Gemfile.
+            WARNING
+          when /mini_magick/
+            ActiveStorage.logger.warn <<~WARNING.squish
+              Generating image variants with ImageMagick requires the mini_magick gem.
+              Please add `gem "mini_magick", "~> 5.0"` to your Gemfile.
+            WARNING
           else
             raise
           end


### PR DESCRIPTION
### Motivation / Background

On `8-1-stable`, an application with `image_processing` 2.x and no `ruby-vips` aborts during `run_initializers`:

```
LoadError: ImageProcessing::Vips requires the ruby-vips gem. Please add `gem "ruby-vips", "~> 2.0"` to your Gemfile. (LoadError)
  image_processing-2.0.2/lib/image_processing/vips.rb:5
  activestorage-8.1.3.1/lib/active_storage/transformers/vips.rb:10
  activestorage-8.1.3.1/lib/active_storage/engine.rb:101
```

The engine already rescues that `LoadError` and logs a warning instead, but its `case` matches only `/libvips/` and `/image_processing/`. ImageProcessing 2.0 made `ruby-vips` and `mini_magick` soft dependencies, and the message it raises for a missing one names that gem rather than `image_processing`, so nothing matches and the engine re-raises. The eager `require "image_processing/vips"` that 8.1.3.1 added to `transformers/vips.rb` is what turns this from dormant into a boot failure.

Fixes #58413.

### Detail

Backports the `/ruby-vips/` and `/mini_magick/` branches added in 244549b36b (#57403), which merged to `main` before 8.1.3.1 shipped but never reached `8-1-stable`. The Gemfile and app generator changes from that PR are left out, since an application already on 8.1 has its own Gemfile. The CHANGELOG entry is worded differently from the one on `main` for the same reason: that one describes the Gemfile and generator work too.

### Additional information

I could not find a way to cover this in the suite: the branches only fire when `image_processing` 2.x is installed without `ruby-vips`, and the Gemfile on this branch ships `image_processing` 1.x with `ruby-vips`. #57403 did not add a test for them either. To reproduce by hand, boot an app on 8.1.3.1 with `gem "image_processing", "~> 2.0"` and no `ruby-vips`.

Verified the two messages `image_processing` 2.0.2 raises:

```
ImageProcessing::Vips requires the ruby-vips gem. Please add `gem "ruby-vips", "~> 2.0"` to your Gemfile.
ImageProcessing::MiniMagick requires the mini_magick gem. Please add `gem "mini_magick", "~> 5.0"` to your Gemfile.
```

Neither matches the two branches on `8-1-stable`; both match the ones added here.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.