### PR TITLE
Remove `symbol_column_to_string` in favor of `columns_hash` + `Symbol#name`

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -294,9 +294,8 @@ module ActiveRecord
       # If the result is true then check for the select case.
       # For queries selecting a subset of columns, return false for unselected columns.
       if @attributes
-        if name = self.class.symbol_column_to_string(name.to_sym)
-          return _has_attribute?(name)
-        end
+        name = name.name if name.is_a?(Symbol)
+        return _has_attribute?(name) if self.class.columns_hash.key?(name)
       end
 
       true

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -513,13 +513,6 @@ module ActiveRecord
         columns.map(&:name).freeze
       end
 
-      def symbol_column_to_string(name_symbol) # :nodoc:
-        @symbol_column_to_string_name_hash || ActiveSupport::Ractors.on_main(self) do
-          @symbol_column_to_string_name_hash ||= column_names.index_by(&:to_sym).freeze
-        end
-        @symbol_column_to_string_name_hash[name_symbol]
-      end
-
       # Returns an array of column objects where the primary id, all columns ending in "_id" or "_count",
       # and columns used for single table inheritance have been removed.
       def content_columns
@@ -590,7 +583,6 @@ module ActiveRecord
           @_returning_columns_for_insert = nil
           @_returning_columns_for_update = nil
           @arel_table = Arel::Table.new(klass: self)
-          @symbol_column_to_string_name_hash = nil
           @content_columns = nil
           @column_defaults = nil
           @columns = nil


### PR DESCRIPTION
Added in #34197 to make `respond_to?` allocation-free for symbol inputs by memoizing a `{sym => str}` hash keyed by column names. `columns_hash` is already a frozen `{str => Column}` hash memoized on the class, providing the same O(1) column lookup, and `Symbol#name` (Ruby 3.0+) yields the interned string without allocating a new `String`. Use those directly and drop the now-redundant helper and its cache slot.
