### PR TITLE
Use `ActiveRecord::Key.for` in remaining `Array(reflection.*_key)` sites

### DIFF
--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -370,8 +370,7 @@ module ActiveRecord
 
         # Returns true if record contains the foreign_key
         def foreign_key_for?(record)
-          foreign_key = Array(reflection.foreign_key)
-          foreign_key.all? { |key| record.has_attribute?(key) }
+          ActiveRecord::Key.for(reflection.foreign_key).all? { |key| record.has_attribute?(key) }
         end
 
         # This should be implemented to return the values of the relevant key(s) on the owner,
@@ -424,15 +423,15 @@ module ActiveRecord
         end
 
         def foreign_key_values(record)
-          Array(reflection.foreign_key).map { |key| record.read_attribute(key) }
+          ActiveRecord::Key.for(reflection.foreign_key).map { |key| record.read_attribute(key) }
         end
 
         def active_record_primary_key_values(record)
-          Array(reflection.active_record_primary_key).map { |key| record.read_attribute(key) }
+          ActiveRecord::Key.for(reflection.active_record_primary_key).map { |key| record.read_attribute(key) }
         end
 
         def association_primary_key_values(record)
-          Array(reflection.association_primary_key(record.class)).map { |key| record.read_attribute(key) }
+          ActiveRecord::Key.for(reflection.association_primary_key(record.class)).map { |key| record.read_attribute(key) }
         end
     end
   end

--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -57,8 +57,8 @@ module ActiveRecord
         end
 
         def last_chain_scope(scope, reflection, owner)
-          primary_key = Array(reflection.join_primary_key)
-          foreign_key = Array(reflection.join_foreign_key)
+          primary_key = ActiveRecord::Key.for(reflection.join_primary_key)
+          foreign_key = ActiveRecord::Key.for(reflection.join_foreign_key)
 
           table = reflection.aliased_table
           primary_key_foreign_key_pairs = primary_key.zip(foreign_key)
@@ -80,8 +80,8 @@ module ActiveRecord
         end
 
         def next_chain_scope(scope, reflection, next_reflection)
-          primary_key = Array(reflection.join_primary_key)
-          foreign_key = Array(reflection.join_foreign_key)
+          primary_key = ActiveRecord::Key.for(reflection.join_primary_key)
+          foreign_key = ActiveRecord::Key.for(reflection.join_foreign_key)
 
           table = reflection.aliased_table
           foreign_table = next_reflection.aliased_table

--- a/activerecord/lib/active_record/associations/foreign_association.rb
+++ b/activerecord/lib/active_record/associations/foreign_association.rb
@@ -4,7 +4,7 @@ module ActiveRecord::Associations
   module ForeignAssociation # :nodoc:
     def foreign_key_present?
       if reflection.klass.primary_key
-        Array(reflection.active_record_primary_key).all? do |key|
+        ActiveRecord::Key.for(reflection.active_record_primary_key).all? do |key|
           owner.attribute_present?(key)
         end
       else
@@ -14,7 +14,7 @@ module ActiveRecord::Associations
 
     def nullified_owner_attributes
       Hash.new.tap do |attrs|
-        Array(reflection.foreign_key).each { |foreign_key| attrs[foreign_key] = nil }
+        ActiveRecord::Key.for(reflection.foreign_key).each { |foreign_key| attrs[foreign_key] = nil }
         attrs[reflection.type] = nil if reflection.type.present?
       end
     end
@@ -24,8 +24,8 @@ module ActiveRecord::Associations
       def set_owner_attributes(record)
         return if options[:through]
 
-        primary_key_attribute_names = Array(reflection.join_primary_key)
-        foreign_key_attribute_names = Array(reflection.join_foreign_key)
+        primary_key_attribute_names = ActiveRecord::Key.for(reflection.join_primary_key)
+        foreign_key_attribute_names = ActiveRecord::Key.for(reflection.join_foreign_key)
 
         primary_key_foreign_key_pairs = primary_key_attribute_names.zip(foreign_key_attribute_names)
 

--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -117,8 +117,9 @@ module ActiveRecord
         end
 
         def nullify_owner_attributes(record)
-          Array(reflection.foreign_key).each do |foreign_key_column|
-            record.write_attribute(foreign_key_column, nil) unless foreign_key_column.in?(Array(record.class.primary_key))
+          primary_key = ActiveRecord::Key.for(record.class.primary_key)
+          ActiveRecord::Key.for(reflection.foreign_key).each do |foreign_key_column|
+            record.write_attribute(foreign_key_column, nil) unless primary_key.include?(foreign_key_column)
           end
           record.write_attribute(reflection.type, nil) if reflection.type.present?
         end

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -487,12 +487,12 @@ module ActiveRecord
         if autosave && record.marked_for_destruction?
           record.destroy
         elsif autosave != false
-          primary_key = Array(reflection.active_record_primary_key).map(&:to_s)
+          primary_key = ActiveRecord::Key.for(reflection.active_record_primary_key)
           primary_key_value = primary_key.map { |key| read_attribute(key) }
           return unless (autosave && record.changed_for_autosave?) || _record_changed?(reflection, record, primary_key_value)
 
           unless reflection.through_reflection
-            foreign_key = Array(reflection.foreign_key)
+            foreign_key = ActiveRecord::Key.for(reflection.foreign_key)
             primary_key_foreign_key_pairs = primary_key.zip(foreign_key)
 
             primary_key_foreign_key_pairs.each do |primary_key, foreign_key|
@@ -516,13 +516,13 @@ module ActiveRecord
         record.new_record? ||
           (association_foreign_key_changed?(reflection, record, key) ||
           inverse_polymorphic_association_changed?(reflection, record)) ||
-          Array(reflection.foreign_key).any? { |fk| record.will_save_change_to_attribute?(record.class.attribute_aliases[fk] || fk) }
+          ActiveRecord::Key.for(reflection.foreign_key).any? { |fk| record.will_save_change_to_attribute?(record.class.attribute_aliases[fk] || fk) }
       end
 
       def association_foreign_key_changed?(reflection, record, key)
         return false if reflection.through_reflection?
 
-        foreign_key = Array(reflection.foreign_key)
+        foreign_key = ActiveRecord::Key.for(reflection.foreign_key)
         return false unless foreign_key.all? { |key| record.has_attribute?(key) }
 
         foreign_key.map { |key| record.read_attribute(key) } != Array(key)
@@ -551,7 +551,7 @@ module ActiveRecord
           autosave = reflection.options[:autosave]
 
           if autosave && record.marked_for_destruction?
-            foreign_key = Array(reflection.foreign_key)
+            foreign_key = ActiveRecord::Key.for(reflection.foreign_key)
             foreign_key.each { |key| write_attribute(key, nil) }
             record.destroy
           elsif autosave != false
@@ -566,8 +566,8 @@ module ActiveRecord
             end
 
             if association.updated?
-              primary_key = Array(reflection.association_primary_key(record.class)).map(&:to_s)
-              foreign_key = Array(reflection.foreign_key)
+              primary_key = ActiveRecord::Key.for(reflection.association_primary_key(record.class))
+              foreign_key = ActiveRecord::Key.for(reflection.foreign_key)
 
               primary_key_foreign_key_pairs = primary_key.zip(foreign_key)
               primary_key_foreign_key_pairs.each do |primary_key, foreign_key|

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -92,7 +92,7 @@ module ActiveRecord
             @scope.joins!(association)
           end
 
-          association_conditions = Array(reflection.association_primary_key).index_with(nil)
+          association_conditions = ActiveRecord::Key.for(reflection.association_primary_key).index_with(nil)
           if reflection.options[:class_name]
             self.not(association => association_conditions)
           else
@@ -125,7 +125,7 @@ module ActiveRecord
         associations.each do |association|
           reflection = scope_association_reflection(association)
           @scope.left_outer_joins!(association)
-          association_conditions = Array(reflection.association_primary_key).index_with(nil)
+          association_conditions = ActiveRecord::Key.for(reflection.association_primary_key).index_with(nil)
           if reflection.options[:class_name]
             @scope.where!(association => association_conditions)
           else


### PR DESCRIPTION
Follow-up to #58368.

The rest of the codebase still coerced reflection key names with `Array(...)` before iterating; replace those call sites with `ActiveRecord::Key.for(...)` so single / composite key handling flows through the same `Enumerable` API.
