### PR TITLE
Fix LoadError crash when image_processing 2.0 is missing ruby-vips or…

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Warn instead of raising when `image_processing` 2.0's `ruby-vips` or `mini_magick`
+    dependency is missing.
+
+    `image_processing` 2.0 dropped `ruby-vips` and `mini_magick` as runtime
+    dependencies. Booting with `variant_processor` set to `:vips` or `:mini_magick`
+    without the corresponding gem installed raised a `LoadError` that Active Storage's
+    engine didn't recognize, crashing the application instead of logging the same kind
+    of actionable warning already given for a missing `libvips` or `image_processing`.
+
+    Fixes #58413.
+
+    *Ankita Advitot*
+
 *   Fix `MirrorService#mirror` losing blob metadata when copying to mirrors.
 
     Mirrored copies on S3, Azure, and GCS were served as `application/octet-stream`

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -115,6 +115,16 @@ module ActiveStorage
               Please add `gem "image_processing", "~> 1.2"` to your Gemfile
               or set `config.active_storage.variant_processor = :disabled`.
             WARNING
+          when /ruby-vips/
+            ActiveStorage.logger.warn <<~WARNING.squish
+              Generating image variants with libvips requires the ruby-vips gem.
+              Please add `gem "ruby-vips", "~> 2.0"` to your Gemfile.
+            WARNING
+          when /mini_magick/
+            ActiveStorage.logger.warn <<~WARNING.squish
+              Generating image variants with ImageMagick requires the mini_magick gem.
+              Please add `gem "mini_magick"` to your Gemfile.
+            WARNING
           else
             raise
           end

--- a/railties/test/application/active_storage/engine_integration_test.rb
+++ b/railties/test/application/active_storage/engine_integration_test.rb
@@ -53,6 +53,28 @@ module ApplicationTests
       assert_includes(output, "ActiveStorage::Transformers::Vips")
     end
 
+    def test_vips_transformer_missing_ruby_vips_gem_warning
+      add_to_config "config.active_storage.variant_processor = :vips"
+      File.open("#{app_path}/Gemfile", "a") do |f|
+        f.puts <<~GEMFILE
+          gem "image_processing", "~> 2.0"
+        GEMFILE
+      end
+      output = run_command("puts ActiveStorage.variant_transformer")
+      assert_includes(output, 'Generating image variants with libvips requires the ruby-vips gem. Please add `gem "ruby-vips", "~> 2.0"` to your Gemfile')
+    end
+
+    def test_mini_magick_transformer_missing_mini_magick_gem_warning
+      add_to_config "config.active_storage.variant_processor = :mini_magick"
+      File.open("#{app_path}/Gemfile", "a") do |f|
+        f.puts <<~GEMFILE
+          gem "image_processing", "~> 2.0"
+        GEMFILE
+      end
+      output = run_command("puts ActiveStorage.variant_transformer")
+      assert_includes(output, 'Generating image variants with ImageMagick requires the mini_magick gem. Please add `gem "mini_magick"` to your Gemfile')
+    end
+
     def test_disabled_transformer_missing_gem_no_warning
       add_to_config "config.active_storage.variant_processor = :disabled"
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because Rails 8.1.3.1 crashes on boot for
applications using `image_processing ~> 2.0` with `variant_processor` set to
`:vips` or `:mini_magick` but without `ruby-vips` or `mini_magick` in the
Gemfile:
LoadError: ImageProcessing::Vips requires the ruby-vips gem. Please add
gem "ruby-vips", "~> 2.0" to your Gemfile. (LoadError)
image_processing-2.0.2/lib/image_processing/vips.rb:5
activestorage-8.1.3.1/lib/active_storage/transformers/vips.rb:10
activestorage-8.1.3.1/lib/active_storage/engine.rb:101

`image_processing` 2.0 dropped `ruby-vips` and `mini_magick` as runtime
dependencies. `ActiveStorage::Engine` already rescues `LoadError` here and
turns it into a warning, but on `8-1-stable` the `case error.message` only
matches `/libvips/` and `/image_processing/`. The message `image_processing`
2.x actually raises ("... requires the ruby-vips gem ...") matches neither
branch, so it falls through to `else raise` and re-raises what was meant to
be an actionable warning, aborting boot instead.

The eager `require "image_processing/vips"` added to `transformers/vips.rb`
in 8.1.3.1 is what turns this from dormant into a boot failure — before
that, the constant was only referenced lazily inside the processor, so a
missing `ruby-vips` went unnoticed.

Fixes #58413.

### Detail

This Pull Request changes `ActiveStorage::Engine`'s `LoadError` rescue in
`activestorage/lib/active_storage/engine.rb` to add `/ruby-vips/` and
`/mini_magick/` branches, alongside the existing `/libvips/` and
`/image_processing/` ones. This is the same fix already merged to `main`
via #57403 for this same error, backported here as just the two rescue
branches — that PR also updated the app generator's Gemfile template,
which is out of scope for a stable-branch backport since an application
already on Rails 8.1 has its own Gemfile.

### Additional information

#58394 and #58313 are also 8.1.3.1 Active Storage boot regressions,
addressed by #58406 — those come from the analyzer loading vips rather
than the transformer, a different path than this one.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
