### PR TITLE
Add a backwards-compatibility alias for ActionCable::Connection::TaggedLoggerProxy

### DIFF
--- a/actioncable/lib/action_cable/connection/tagged_logger_proxy.rb
+++ b/actioncable/lib/action_cable/connection/tagged_logger_proxy.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# :markup: markdown
+
+module ActionCable
+  module Connection
+    TaggedLoggerProxy = ActionCable::Server::TaggedLoggerProxy
+  end
+end


### PR DESCRIPTION
### Motivation / Background

ActionCable::Connection::TaggedLoggerProxy was renamed to ActionCable::Server::TaggedLoggerProxy in edge-rails at https://github.com/rails/rails/commit/983502497098a1ed569962836709b68743a16f89.

This breaks apps & gems that were using ActionCable::Connection::TaggedLoggerProxy, which appears to be public API (at least, it isn't marked with nodoc)

In the same PR, ActionCable::Server::Configuration was aliased to ActionCable::Configuration presumably for backwards compatibility - should ActionCable::Connection::TaggedLoggerProxy be treated the same?

### Detail

This Pull Request re-adds ActionCable::Connection::TaggedLoggerProxy, as an alias of ActionCable::Server::TaggedLoggerProxy

### Additional information

[rails_semantic_logger already added a fix](https://github.com/reidmorrison/rails_semantic_logger/issues/326) to work around it, but a [casual search on Github](https://github.com/search?type=code&q=ActionCable%3A%3AConnection%3A%3ATaggedLoggerProxy+NOT+%22Allows+the+use+of+per-connection+tags+against+the+server+logger%22) shows they might not be the only ones affected.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
