### PR TITLE
Fix ERB syntax error line numbers

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Report the original ERB line for template syntax errors instead of the
+    corresponding line in the generated Ruby source.
+
+    *aouxwoux*
+
 *   Configuring ERB options is now to be made on the ActionView::Base class.
 
     The `ActionView::Template::Handlers::ERB` class is now private API. Applications

--- a/actionview/lib/action_view/template/error.rb
+++ b/actionview/lib/action_view/template/error.rb
@@ -269,6 +269,14 @@ module ActionView
       end
     end
 
+    def line_number
+      if template.handler.respond_to?(:syntax_error_line)
+        template.handler.syntax_error_line(@offending_code_string)&.to_s || super
+      else
+        super
+      end
+    end
+
     def annotated_source_code
       @offending_code_string.split("\n").map.with_index(1) { |line, index|
         indentation = " " * 4

--- a/actionview/lib/action_view/template/handlers/erb.rb
+++ b/actionview/lib/action_view/template/handlers/erb.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "strscan"
+require "ripper"
 require "active_support/core_ext/erb/util"
 
 module ActionView
@@ -26,8 +27,20 @@ module ActionView
 
         LocationParsingError = Class.new(StandardError) # :nodoc:
 
+        class SyntaxErrorParser < Ripper # :nodoc:
+          attr_reader :line_number
+
+          def on_parse_error(*)
+            @line_number ||= lineno
+          end
+        end
+
         def self.call(template, source)
           new.call(template, source)
+        end
+
+        def self.syntax_error_line(source)
+          new.syntax_error_line(source)
         end
 
         def supports_streaming?
@@ -91,6 +104,31 @@ module ActionView
           end
 
           self.class.erb_implementation.new(erb, options).src
+        end
+
+        def syntax_error_line(source)
+          code = +""
+          code.force_encoding(source.encoding)
+          executable = false
+
+          ::ERB::Util.tokenize(source).each do |type, value|
+            case type
+            when :OPEN
+              executable = !value.start_with?("<%#", "<%%")
+              code << value.gsub(/[^\r\n]/, " ")
+            when :CODE
+              code << (executable ? value : value.gsub(/[^\r\n]/, " "))
+            else
+              code << value.gsub(/[^\r\n]/, " ")
+              executable = false if type == :CLOSE
+            end
+          end
+
+          parser = SyntaxErrorParser.new(code)
+          parser.parse
+          parser.line_number
+        rescue NotImplementedError
+          nil
         end
 
       private

--- a/actionview/test/fixtures/test/syntax_error_on_later_line.html.erb
+++ b/actionview/test/fixtures/test/syntax_error_on_later_line.html.erb
@@ -1,0 +1,8 @@
+<h1>Posts</h1>
+
+<div id="posts">
+  <%# @posts.each do |post| %>
+    <%#= render post %>
+    <p>post</p>
+  <% end %>
+</div>

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -215,6 +215,15 @@ module RenderTestCases
     assert_equal "1:    <%= foo(", e.annotated_source_code[0].strip
   end
 
+  def test_render_template_with_syntax_error_on_later_line
+    e = assert_raises(ActionView::Template::Error) do
+      silence_warnings { @view.render(template: "test/syntax_error_on_later_line") }
+    end
+
+    assert_equal "7", e.line_number
+    assert_includes e.annotated_source_code.map(&:strip), "7:      <% end %>"
+  end
+
   def test_render_runtime_error
     ex = assert_raises(ActionView::Template::Error) {
       @view.render(template: "test/runtime_error")


### PR DESCRIPTION
syntax errors in erb templates currently derive their line number from the generated ruby source. when an extra `end` closes the generated method early, ruby reports the later wrapper `end`, so an error on template line 7 can be shown as line 11.

this change rebuilds the executable ruby fragments from the original erb while preserving line breaks, then uses `Ripper` to locate the parse error. html, erb comments, and escaped erb tags are blanked before parsing. non-erb handlers keep the existing fallback.

the regression fixture includes commented-out ruby before the invalid `end`, which verifies that comments do not affect the result.

checks:
- `bundle exec ruby -Itest test/template/render_test.rb -i /syntax_error/`
- `bundle exec ruby -Itest test/template/template_test.rb -i /translate_location/`
- `bundle exec rubocop --force-exclusion actionview/lib/action_view/template/error.rb actionview/lib/action_view/template/handlers/erb.rb actionview/test/template/render_test.rb`