### PR TITLE
Refactor `MiddlewareStack::Middleware` off `Hash.ruby2_keywords_hash`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Split keyword arguments off `#args` on `Rails.application.middleware` entries.
+
+    Middleware entries now expose keyword arguments through a new `#kwargs`
+    accessor. `#args` previously bundled kwargs as a trailing hash inside the
+    positional array (via `Hash.ruby2_keywords_hash`); it now returns
+    positional arguments only. Code that inspects `middleware.args` directly
+    needs to also read `middleware.kwargs`.
+
+    *Ryuta Kamizono*
+
 *   Deprecate registering and unregistering MIME types after application initialization.
 
     `Mime::Type.register`, `Mime::Type.register_alias`, and `Mime::Type.unregister` will raise

--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -37,10 +37,10 @@ module ActionController
     end
 
     class Middleware < ActionDispatch::MiddlewareStack::Middleware # :nodoc:
-      def initialize(klass, args, actions, strategy, block)
+      def initialize(klass, args, kwargs, actions, strategy, block)
         @actions = actions
         @strategy = strategy
-        super(klass, args, block)
+        super(klass, args, kwargs, block)
       end
 
       def valid?(action)
@@ -64,7 +64,6 @@ module ActionController
       def build_middleware(klass, args, kwargs, block)
         only   = Array(kwargs.delete(:only)).map(&:to_s)
         except = Array(kwargs.delete(:except)).map(&:to_s)
-        args << Hash.ruby2_keywords_hash(kwargs) unless kwargs.empty?
 
         strategy = NULL
         list     = nil
@@ -77,7 +76,7 @@ module ActionController
           list     = except
         end
 
-        Middleware.new(klass, args, list, strategy, block)
+        Middleware.new(klass, args, kwargs, list, strategy, block)
       end
   end
 

--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -12,13 +12,14 @@ module ActionDispatch
   # stack](https://guides.rubyonrails.org/rails_on_rack.html#action-dispatcher-middleware-stack)
   # in the guides.
   class MiddlewareStack
-    class Middleware
-      attr_reader :args, :block, :klass
+    class Middleware # :nodoc:
+      attr_reader :args, :kwargs, :block, :klass
 
-      def initialize(klass, args, block)
-        @klass = klass
-        @args  = args
-        @block = block
+      def initialize(klass, args, kwargs, block)
+        @klass  = klass
+        @args   = args
+        @kwargs = kwargs
+        @block  = block
       end
 
       def name; klass.name; end
@@ -41,7 +42,7 @@ module ActionDispatch
       end
 
       def build(app)
-        klass.new(app, *args, &block)
+        klass.new(app, *args, **kwargs, &block)
       end
 
       def build_instrumented(app)
@@ -51,7 +52,7 @@ module ActionDispatch
 
     # This class is used to instrument the execution of a single middleware. It
     # proxies the `call` method transparently and instruments the method call.
-    class InstrumentationProxy
+    class InstrumentationProxy # :nodoc:
       EVENT_NAME = "process_middleware.action_dispatch"
 
       def initialize(middleware, class_name)
@@ -177,8 +178,7 @@ module ActionDispatch
       end
 
       def build_middleware(klass, args, kwargs, block)
-        args << Hash.ruby2_keywords_hash(kwargs) unless kwargs.empty?
-        Middleware.new(klass, args, block)
+        Middleware.new(klass, args, kwargs, block)
       end
 
       def index_of(klass)

--- a/actionpack/test/dispatch/middleware_stack_test.rb
+++ b/actionpack/test/dispatch/middleware_stack_test.rb
@@ -67,7 +67,8 @@ class MiddlewareStackTest < ActiveSupport::TestCase
       @stack.use BazMiddleware, true, foo: "bar"
     end
     assert_equal BazMiddleware, @stack.last.klass
-    assert_equal([true, { foo: "bar" }], @stack.last.args)
+    assert_equal [true], @stack.last.args
+    assert_equal({ foo: "bar" }, @stack.last.kwargs)
   end
 
   test "use should push middleware class with block arguments onto the stack" do
@@ -127,7 +128,8 @@ class MiddlewareStackTest < ActiveSupport::TestCase
     @stack.use BazMiddleware, true, foo: "bar"
     @stack.move_before(FooMiddleware, BazMiddleware)
 
-    assert_equal [true, foo: "bar"], @stack.first.args
+    assert_equal [true], @stack.first.args
+    assert_equal({ foo: "bar" }, @stack.first.kwargs)
   end
 
   test "move_before moves middleware before another middleware class" do
@@ -162,7 +164,8 @@ class MiddlewareStackTest < ActiveSupport::TestCase
     @stack.use BazMiddleware, true, foo: "bar"
     @stack.move_after(FooMiddleware, BazMiddleware)
 
-    assert_equal [true, foo: "bar"], @stack[1].args
+    assert_equal [true], @stack[1].args
+    assert_equal({ foo: "bar" }, @stack[1].kwargs)
   end
 
   test "unshift adds a new middleware at the beginning of the stack" do
@@ -212,6 +215,6 @@ class MiddlewareStackTest < ActiveSupport::TestCase
   end
 
   test "includes a middleware" do
-    assert_equal true, @stack.include?(ActionDispatch::MiddlewareStack::Middleware.new(BarMiddleware, nil, nil))
+    assert_equal true, @stack.include?(ActionDispatch::MiddlewareStack::Middleware.new(BarMiddleware, nil, nil, nil))
   end
 end

--- a/railties/test/commands/middleware_test.rb
+++ b/railties/test/commands/middleware_test.rb
@@ -211,7 +211,7 @@ class Rails::Command::MiddlewareTest < ActiveSupport::TestCase
     add_to_config "config.ssl_options = { redirect: { host: 'example.com' } }"
     boot!
 
-    assert_equal [{ redirect: { host: "example.com" }, ssl_default_redirect_status: 308 }], Rails.application.middleware[1].args
+    assert_equal({ redirect: { host: "example.com" }, ssl_default_redirect_status: 308 }, Rails.application.middleware[1].kwargs)
   end
 
   test "ActionDispatch::PermissionsPolicy::MiddlewareStack is included if permissions_policy set" do


### PR DESCRIPTION
Follow-up to #58239. `Hash.ruby2_keywords_hash` is scheduled for deprecation (https://bugs.ruby-lang.org/issues/22205); libraries that only support Ruby 3.0+ shouldn't depend on it.

`Middleware` (and its `ActionController` subclass) now store positional args and keyword args separately (`@args` / `@kwargs`) instead of bundling `Hash.ruby2_keywords_hash(kwargs)` into `@args`, and `#build` dispatches with `klass.new(app, *args, **kwargs, &block)`.

`Middleware` and `InstrumentationProxy` are also marked `:nodoc:`. Users interact with the stack through `use` / `insert` / etc. and, for instrumentation, subscribe to `process_middleware.action_dispatch` (documented in the Active Support Instrumentation guide). Neither class is intended to be constructed directly, so their internal structure doesn't belong in the API docs even though iterating `Rails.application.middleware` still exposes `Middleware#args` / `#kwargs` for debugging.
