### PR TITLE
Let the schema readers answer for many tables at once

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,38 @@
+*   Let the schema readers answer for many tables at once.
+
+    `indexes`, `primary_keys`, `foreign_keys`, `check_constraints`,
+    `exclusion_constraints` and `unique_constraints` now accept a list of tables and
+    answer for all of them at once:
+
+    ```ruby
+    connection.indexes(:users)            # => [IndexDefinition, ...]
+    connection.indexes([:users, :posts])  # => { "users" => [...], "posts" => [...] }
+    ```
+
+    Adapters that can read a kind of metadata for many tables in one query do so, a
+    schema at a time; SQLite, which has no catalog to read them from, reads table by
+    table, so every adapter answers.
+
+    Schema dumping asked about each table separately, which meant the number of
+    round trips grew with the size of the schema: primary keys, indexes, foreign
+    keys and constraints each cost one statement per table, and MySQL spent another
+    `SHOW TABLE STATUS` per table just to read a collation. It now reads each kind
+    in one query for the tables it is about to dump. On a schema with a few thousand
+    tables that removes about 70% of the statements a dump issues, and the output is
+    unchanged.
+
+    An empty list reads nothing, without querying. A blank table name no longer
+    raises `ArgumentError`: MySQL was the only adapter that did, and only from
+    `foreign_keys` and `primary_keys`. On PostgreSQL, `primary_keys` for a table
+    that does not exist now returns `[]` instead of raising
+    `ActiveRecord::StatementInvalid`.
+
+    Reading collations from `information_schema` also fixes MySQL looking them up
+    with a `LIKE` pattern, where a table name containing `_` or `%` could match a
+    different table.
+
+    *Ngan Pham*
+
 *   The database selector middleware treats HTTP QUERY requests
     ([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008)) as reads, routing
     them to the replica like GET and HEAD, subject to the same

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -7,6 +7,8 @@ require "openssl"
 module ActiveRecord
   module ConnectionAdapters # :nodoc:
     module SchemaStatements
+      EMPTY_METADATA = [].freeze # :nodoc:
+
       # Returns a hash of mappings from the abstract data types to the native
       # database types. See TableDefinition#column for details on the recognized
       # abstract data types.
@@ -76,7 +78,8 @@ module ActiveRecord
         views.include?(view_name.to_s)
       end
 
-      # Returns an array of indexes for the given table.
+      # Returns an array of indexes for the given table, or a Hash of them keyed by
+      # table name when given an Array of tables.
       def indexes(table_name)
         raise NotImplementedError, "#indexes is not implemented"
       end
@@ -1185,7 +1188,8 @@ module ActiveRecord
       end
       alias :remove_belongs_to :remove_reference
 
-      # Returns an array of foreign keys for the given table.
+      # Returns an array of foreign keys for the given table, or a Hash of them keyed
+      # by table name when given an Array of tables.
       # The foreign keys are represented as ForeignKeyDefinition objects.
       def foreign_keys(table_name)
         raise NotImplementedError, "foreign_keys is not implemented"
@@ -1377,7 +1381,8 @@ module ActiveRecord
         options
       end
 
-      # Returns an array of check constraints for the given table.
+      # Returns an array of check constraints for the given table, or a Hash of them
+      # keyed by table name when given an Array of tables.
       # The check constraints are represented as CheckConstraintDefinition objects.
       def check_constraints(table_name)
         raise NotImplementedError
@@ -1715,6 +1720,21 @@ module ActiveRecord
       end
 
       private
+        def quoted_table_names(table_names)
+          table_names.map { |name| quoted_scope(name)[:name] }.join(", ")
+        end
+
+        # One read filters by one schema, so tables naming different schemas are read
+        # a schema at a time.
+        def fetch_by_schema(tables)
+          tables.group_by { |table| quoted_scope(table)[:schema] }
+            .each_with_object({}) { |(schema, group), result| result.merge!(yield(schema, group)) }
+        end
+
+        def rows_for(rows_by_name, table)
+          rows_by_name.fetch(bare_table_name(table), EMPTY_METADATA)
+        end
+
         def generate_index_name(table_name, column)
           name = "index_#{table_name}_on_#{Array(column) * '_and_'}"
           return name if name.bytesize <= max_index_name_size

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -350,6 +350,11 @@ module ActiveRecord
         show_variable "collation_database"
       end
 
+      def table_collation(table_name) # :nodoc:
+        result = fetch_table_collations(Array(table_name).map(&:to_s))
+        table_name.is_a?(Array) ? result : result[table_name.to_s]
+      end
+
       def table_comment(table_name) # :nodoc:
         scope = quoted_scope(table_name)
 
@@ -506,87 +511,13 @@ module ActiveRecord
       end
 
       def foreign_keys(table_name)
-        raise ArgumentError unless table_name.present?
-
-        scope = quoted_scope(table_name)
-
-        # MySQL returns 1 row for each column of composite foreign keys.
-        fk_info = query_all(<<~SQL)
-          SELECT fk.referenced_table_name AS 'to_table',
-                 fk.referenced_column_name AS 'primary_key',
-                 fk.column_name AS 'column',
-                 fk.constraint_name AS 'name',
-                 fk.ordinal_position AS 'position',
-                 rc.update_rule AS 'on_update',
-                 rc.delete_rule AS 'on_delete'
-          FROM information_schema.referential_constraints rc
-          JOIN information_schema.key_column_usage fk
-          USING (constraint_schema, constraint_name)
-          WHERE fk.referenced_column_name IS NOT NULL
-            AND fk.table_schema = #{scope[:schema]}
-            AND fk.table_name = #{scope[:name]}
-            AND rc.constraint_schema = #{scope[:schema]}
-            AND rc.table_name = #{scope[:name]}
-        SQL
-
-        grouped_fk = fk_info.group_by { |row| row["name"] }.values.each { |group| group.sort_by! { |row| row["position"] } }
-        grouped_fk.map do |group|
-          row = group.first
-          options = {
-            name: row["name"],
-            on_update: extract_foreign_key_action(row["on_update"]),
-            on_delete: extract_foreign_key_action(row["on_delete"])
-          }
-
-          if group.one?
-            options[:column] = unquote_identifier(row["column"])
-            options[:primary_key] = row["primary_key"]
-          else
-            options[:column] = group.map { |row| unquote_identifier(row["column"]) }
-            options[:primary_key] = group.map { |row| row["primary_key"] }
-          end
-
-          ForeignKeyDefinition.new(table_name, unquote_identifier(row["to_table"]), options)
-        end
+        result = fetch_foreign_keys(Array(table_name).map(&:to_s))
+        table_name.is_a?(Array) ? result : result[table_name.to_s]
       end
 
       def check_constraints(table_name)
-        if supports_check_constraints?
-          scope = quoted_scope(table_name)
-
-          sql = <<~SQL
-            SELECT cc.constraint_name AS 'name',
-                  cc.check_clause AS 'expression'
-            FROM information_schema.check_constraints cc
-            JOIN information_schema.table_constraints tc
-            USING (constraint_schema, constraint_name)
-            WHERE tc.table_schema = #{scope[:schema]}
-              AND tc.table_name = #{scope[:name]}
-              AND cc.constraint_schema = #{scope[:schema]}
-          SQL
-          sql += " AND cc.table_name = #{scope[:name]}" if mariadb?
-
-          chk_info = query_all(sql)
-
-          chk_info.map do |row|
-            options = {
-              name: row["name"]
-            }
-            expression = row["expression"]
-            expression = expression[1..-2] if expression.start_with?("(") && expression.end_with?(")")
-            expression = strip_whitespace_characters(expression)
-
-            unless mariadb?
-              # MySQL returns check constraints expression in an already escaped form.
-              # This leads to duplicate escaping later (e.g. when the expression is used in the SchemaDumper).
-              expression = expression.gsub("\\'", "'")
-            end
-
-            CheckConstraintDefinition.new(table_name, expression, options)
-          end
-        else
-          raise NotImplementedError
-        end
+        result = fetch_check_constraints(Array(table_name).map(&:to_s))
+        table_name.is_a?(Array) ? result : result[table_name.to_s]
       end
 
       def table_options(table_name) # :nodoc:
@@ -626,18 +557,8 @@ module ActiveRecord
       end
 
       def primary_keys(table_name) # :nodoc:
-        raise ArgumentError unless table_name.present?
-
-        scope = quoted_scope(table_name)
-
-        query_values(<<~SQL)
-          SELECT column_name
-          FROM information_schema.statistics
-          WHERE index_name = 'PRIMARY'
-            AND table_schema = #{scope[:schema]}
-            AND table_name = #{scope[:name]}
-          ORDER BY seq_in_index
-        SQL
+        result = fetch_primary_keys(Array(table_name).map(&:to_s))
+        table_name.is_a?(Array) ? result : result[table_name.to_s]
       end
 
       def case_sensitive_comparison(attribute, value) # :nodoc:
@@ -823,6 +744,125 @@ module ActiveRecord
       EMULATE_BOOLEANS_TRUE = { emulate_booleans: true }.freeze
 
       private
+        def fetch_table_collations(tables)
+          fetch_by_schema(tables) do |schema, group|
+            by_name = query_all(<<~SQL).to_h { |row| [row["table"], row["collation"]] }
+              SELECT table_name AS 'table', table_collation AS 'collation'
+              FROM information_schema.tables
+              WHERE table_schema = #{schema}
+                AND table_name IN (#{quoted_table_names(group)})
+            SQL
+
+            group.index_with { |table| by_name[bare_table_name(table)] }
+          end
+        end
+
+        def fetch_foreign_keys(tables)
+          fetch_by_schema(tables) do |schema, group|
+            names = quoted_table_names(group)
+
+            # MySQL returns 1 row for each column of composite foreign keys.
+            by_name = query_all(<<~SQL).group_by { |row| row["from_table"] }
+              SELECT fk.table_name AS 'from_table',
+                     fk.referenced_table_name AS 'to_table',
+                     fk.referenced_column_name AS 'primary_key',
+                     fk.column_name AS 'column',
+                     fk.constraint_name AS 'name',
+                     fk.ordinal_position AS 'position',
+                     rc.update_rule AS 'on_update',
+                     rc.delete_rule AS 'on_delete'
+              FROM information_schema.referential_constraints rc
+              JOIN information_schema.key_column_usage fk
+              USING (constraint_schema, constraint_name)
+              WHERE fk.referenced_column_name IS NOT NULL
+                AND fk.table_schema = #{schema}
+                AND rc.constraint_schema = #{schema}
+                AND fk.table_name IN (#{names}) AND rc.table_name IN (#{names})
+            SQL
+
+            group.index_with { |table| build_foreign_keys(table, rows_for(by_name, table)) }
+          end
+        end
+
+        def fetch_check_constraints(tables)
+          raise NotImplementedError unless supports_check_constraints?
+
+          fetch_by_schema(tables) do |schema, group|
+            names = quoted_table_names(group)
+
+            sql = +<<~SQL
+              SELECT tc.table_name AS 'table',
+                     cc.constraint_name AS 'name',
+                     cc.check_clause AS 'expression'
+              FROM information_schema.check_constraints cc
+              JOIN information_schema.table_constraints tc
+              USING (constraint_schema, constraint_name)
+              WHERE tc.table_schema = #{schema}
+                AND tc.table_name IN (#{names})
+                AND cc.constraint_schema = #{schema}
+            SQL
+            sql << " AND cc.table_name IN (#{names})" if mariadb?
+
+            by_name = query_all(sql).group_by { |row| row["table"] }
+
+            group.index_with { |table| build_check_constraints(table, rows_for(by_name, table)) }
+          end
+        end
+
+        def fetch_primary_keys(tables)
+          fetch_by_schema(tables) do |schema, group|
+            by_name = query_all(<<~SQL).group_by { |row| row["table"] }
+              SELECT table_name AS 'table', column_name AS 'column'
+              FROM information_schema.statistics
+              WHERE index_name = 'PRIMARY'
+                AND table_schema = #{schema}
+                AND table_name IN (#{quoted_table_names(group)})
+              ORDER BY table_name, seq_in_index
+            SQL
+
+            group.index_with { |table| rows_for(by_name, table).map { |row| row["column"] } }
+          end
+        end
+
+        def build_foreign_keys(table_name, fk_info)
+          grouped_fk = fk_info.group_by { |row| row["name"] }.values.each { |group| group.sort_by! { |row| row["position"] } }
+          grouped_fk.map do |group|
+            row = group.first
+            options = {
+              name: row["name"],
+              on_update: extract_foreign_key_action(row["on_update"]),
+              on_delete: extract_foreign_key_action(row["on_delete"])
+            }
+
+            if group.one?
+              options[:column] = unquote_identifier(row["column"])
+              options[:primary_key] = row["primary_key"]
+            else
+              options[:column] = group.map { |row| unquote_identifier(row["column"]) }
+              options[:primary_key] = group.map { |row| row["primary_key"] }
+            end
+
+            ForeignKeyDefinition.new(table_name, unquote_identifier(row["to_table"]), options)
+          end
+        end
+
+        def build_check_constraints(table_name, chk_info)
+          chk_info.map do |row|
+            options = { name: row["name"] }
+            expression = row["expression"]
+            expression = expression[1..-2] if expression.start_with?("(") && expression.end_with?(")")
+            expression = strip_whitespace_characters(expression)
+
+            unless mariadb?
+              # MySQL returns check constraints expression in an already escaped form.
+              # This leads to duplicate escaping later (e.g. when the expression is used in the SchemaDumper).
+              expression = expression.gsub("\\'", "'")
+            end
+
+            CheckConstraintDefinition.new(table_name, expression, options)
+          end
+        end
+
         def strip_whitespace_characters(expression)
           expression.gsub('\\\n', "").gsub("x0A", "").squish
         end

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
@@ -5,6 +5,11 @@ module ActiveRecord
     module MySQL
       class SchemaDumper < ConnectionAdapters::SchemaDumper # :nodoc:
         private
+          def read_schema_metadata(tables)
+            super
+            @table_collations = @connection.table_collation(tables)
+          end
+
           def prepare_column_options(column)
             spec = super
             spec[:unsigned] = "true" if column.unsigned?
@@ -63,12 +68,9 @@ module ActiveRecord
           end
 
           def schema_collation(column)
-            if column.collation
-              @table_collation_cache ||= {}
-              @table_collation_cache[table_name] ||=
-                @connection.query_one("SHOW TABLE STATUS LIKE #{@connection.quote(table_name)}")["Collation"]
-              column.collation.inspect if column.collation != @table_collation_cache[table_name]
-            end
+            return unless column.collation
+
+            column.collation.inspect if column.collation != @table_collations[table_name]
           end
 
           def extract_expression_for_virtual_column(column)

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -6,77 +6,8 @@ module ActiveRecord
       module SchemaStatements # :nodoc:
         # Returns an array of indexes for the given table.
         def indexes(table_name)
-          indexes = []
-          current_index = nil
-          query_all("SHOW KEYS FROM #{quote_table_name(table_name)}").each do |row|
-            if current_index != row["Key_name"]
-              next if row["Key_name"] == "PRIMARY" # skip the primary key
-              current_index = row["Key_name"]
-
-              mysql_index_type = row["Index_type"].downcase.to_sym
-              case mysql_index_type
-              when :fulltext, :spatial
-                index_type = mysql_index_type
-              when :btree, :hash
-                index_using = mysql_index_type
-              end
-
-              index = [
-                row["Table"],
-                row["Key_name"],
-                row["Non_unique"].to_i == 0,
-                [],
-                lengths: {},
-                orders: {},
-                type: index_type,
-                using: index_using,
-                comment: row["Index_comment"].presence,
-              ]
-
-              if supports_disabling_indexes?
-                index[-1][:enabled] = mariadb? ? row["Ignored"] == "NO" : row["Visible"] == "YES"
-              end
-
-              indexes << index
-            end
-
-            if expression = row["Expression"]
-              expression = expression.gsub("\\'", "'")
-              expression = +"(#{expression})" unless expression.start_with?("(")
-              indexes.last[-2] << expression
-              indexes.last[-1][:expressions] ||= {}
-              indexes.last[-1][:expressions][expression] = expression
-              indexes.last[-1][:orders][expression] = :desc if row["Collation"] == "D"
-            else
-              indexes.last[-2] << row["Column_name"]
-              indexes.last[-1][:lengths][row["Column_name"]] = row["Sub_part"].to_i if row["Sub_part"]
-              indexes.last[-1][:orders][row["Column_name"]] = :desc if row["Collation"] == "D"
-            end
-          end
-
-          indexes.map do |index|
-            options = index.pop
-
-            if expressions = options.delete(:expressions)
-              orders = options.delete(:orders)
-              lengths = options.delete(:lengths)
-
-              columns = index[-1].to_h { |name|
-                [ name.to_sym, expressions[name] || +quote_column_name(name) ]
-              }
-
-              index[-1] = add_options_for_index_columns(
-                columns, order: orders, length: lengths
-              ).values.join(", ")
-            end
-            MySQL::IndexDefinition.new(*index, **options)
-          end
-        rescue StatementInvalid => e
-          if e.message.match?(/Table '.+' doesn't exist/)
-            []
-          else
-            raise
-          end
+          result = fetch_indexes(Array(table_name).map(&:to_s))
+          table_name.is_a?(Array) ? result : result[table_name.to_s]
         end
 
         def create_index_definition(table_name, name, unique, columns, **options)
@@ -149,6 +80,104 @@ module ActiveRecord
         end
 
         private
+          def fetch_indexes(tables)
+            # MariaDB has no EXPRESSION column, and neither it nor MySQL before
+            # 8.0.13 reports index visibility the same way, so ask for what the
+            # server has.
+            optional_columns = +""
+            optional_columns << ", expression AS 'Expression'" if supports_expression_index?
+            if supports_disabling_indexes?
+              optional_columns << (mariadb? ? ", IF(ignored = 'NO', 'YES', 'NO') AS 'Enabled'" : ", is_visible AS 'Enabled'")
+            end
+
+            fetch_by_schema(tables) do |schema, group|
+              by_name = query_all(<<~SQL).group_by { |row| row["Table"] }
+                SELECT table_name AS 'Table',
+                       index_name AS 'Key_name',
+                       non_unique AS 'Non_unique',
+                       column_name AS 'Column_name',
+                       collation AS 'Collation',
+                       sub_part AS 'Sub_part',
+                       LOWER(index_type) AS 'Index_type',
+                       index_comment AS 'Index_comment'#{optional_columns}
+                FROM information_schema.statistics
+                WHERE table_schema = #{schema}
+                  AND table_name IN (#{quoted_table_names(group)})
+                  AND index_name != 'PRIMARY'
+                ORDER BY table_name, index_name, seq_in_index
+              SQL
+
+              group.index_with { |table| build_indexes(rows_for(by_name, table)) }
+            end
+          end
+
+          def build_indexes(rows)
+            indexes = []
+            current_index = nil
+            rows.each do |row|
+              if current_index != row["Key_name"]
+                current_index = row["Key_name"]
+
+                mysql_index_type = row["Index_type"].to_sym
+                case mysql_index_type
+                when :fulltext, :spatial
+                  index_type = mysql_index_type
+                when :btree, :hash
+                  index_using = mysql_index_type
+                end
+
+                index = [
+                  row["Table"],
+                  row["Key_name"],
+                  row["Non_unique"].to_i == 0,
+                  [],
+                  lengths: {},
+                  orders: {},
+                  type: index_type,
+                  using: index_using,
+                  comment: row["Index_comment"].presence,
+                ]
+
+                if supports_disabling_indexes?
+                  index[-1][:enabled] = row["Enabled"] == "YES"
+                end
+
+                indexes << index
+              end
+
+              if expression = row["Expression"]
+                expression = expression.gsub("\\'", "'")
+                expression = +"(#{expression})" unless expression.start_with?("(")
+                indexes.last[-2] << expression
+                indexes.last[-1][:expressions] ||= {}
+                indexes.last[-1][:expressions][expression] = expression
+                indexes.last[-1][:orders][expression] = :desc if row["Collation"] == "D"
+              else
+                indexes.last[-2] << row["Column_name"]
+                indexes.last[-1][:lengths][row["Column_name"]] = row["Sub_part"].to_i if row["Sub_part"]
+                indexes.last[-1][:orders][row["Column_name"]] = :desc if row["Collation"] == "D"
+              end
+            end
+
+            indexes.map do |index|
+              options = index.pop
+
+              if expressions = options.delete(:expressions)
+                orders = options.delete(:orders)
+                lengths = options.delete(:lengths)
+
+                columns = index[-1].to_h { |name|
+                  [ name.to_sym, expressions[name] || +quote_column_name(name) ]
+                }
+
+                index[-1] = add_options_for_index_columns(
+                  columns, order: orders, length: lengths
+                ).values.join(", ")
+              end
+              MySQL::IndexDefinition.new(*index, **options)
+            end
+          end
+
           CHARSETS_OF_4BYTES_MAXLEN = ["utf8mb4", "utf16", "utf16le", "utf32"].freeze
 
           def row_format_dynamic_by_default?
@@ -266,6 +295,10 @@ module ActiveRecord
             scope[:name] = quote(name) if name
             scope[:type] = quote(type) if type
             scope
+          end
+
+          def bare_table_name(table)
+            unquote_identifier(extract_schema_qualified_name(table).last)
           end
 
           def extract_schema_qualified_name(string)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -68,7 +68,7 @@ module ActiveRecord
           end
 
           def exclusion_constraints_in_create(table, stream)
-            if (exclusion_constraints = @connection.exclusion_constraints(table)).any?
+            if (exclusion_constraints = @exclusion_constraints[table]).any?
               exclusion_constraint_statements = exclusion_constraints.map do |exclusion_constraint|
                 parts = [ exclusion_constraint.expression.inspect ]
                 parts << "where: #{exclusion_constraint.where.inspect}" if exclusion_constraint.where
@@ -84,7 +84,7 @@ module ActiveRecord
           end
 
           def unique_constraints_in_create(table, stream)
-            if (unique_constraints = @connection.unique_constraints(table)).any?
+            if (unique_constraints = @unique_constraints[table]).any?
               unique_constraint_statements = unique_constraints.map do |unique_constraint|
                 parts = [ unique_constraint.column.inspect ]
                 parts << "nulls_not_distinct: #{unique_constraint.nulls_not_distinct.inspect}" if unique_constraint.nulls_not_distinct

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -96,76 +96,8 @@ module ActiveRecord
 
         # Returns an array of indexes for the given table.
         def indexes(table_name) # :nodoc:
-          scope = quoted_scope(table_name)
-
-          result = query_rows(<<~SQL)
-            SELECT distinct i.relname, d.indisunique, d.indkey, pg_get_indexdef(d.indexrelid),
-                            pg_catalog.obj_description(i.oid, 'pg_class') AS comment, d.indisvalid,
-                            ARRAY(
-                              SELECT pg_get_indexdef(d.indexrelid, k + 1, true)
-                              FROM generate_subscripts(d.indkey, 1) AS k
-                              ORDER BY k
-                            ) AS columns
-            FROM pg_class t
-            INNER JOIN pg_index d ON t.oid = d.indrelid
-            INNER JOIN pg_class i ON d.indexrelid = i.oid
-            LEFT JOIN pg_namespace n ON n.oid = t.relnamespace
-            WHERE i.relkind IN ('i', 'I')
-              AND d.indisprimary = 'f'
-              AND t.relname = #{scope[:name]}
-              AND n.nspname = #{scope[:schema]}
-            ORDER BY i.relname
-          SQL
-
-          result.map do |row|
-            index_name = row[0]
-            unique = row[1]
-            indkey = row[2].split(" ").map(&:to_i)
-            inddef = row[3]
-            comment = row[4]
-            valid = row[5]
-            columns = decode_string_array(row[6]).map { |c| Utils.unquote_identifier(c.strip.gsub('""', '"')) }
-
-            using, expressions, include, nulls_not_distinct, where = inddef.scan(/ USING (\w+?) \((.+?)\)(?: INCLUDE \((.+?)\))?( NULLS NOT DISTINCT)?(?: WHERE (.+))?\z/m).flatten
-
-            orders = {}
-            opclasses = {}
-            include_columns = include ? include.split(",").map { |c| Utils.unquote_identifier(c.strip.gsub('""', '"')) } : []
-
-            if indkey.include?(0)
-              columns = expressions
-            else
-              # prevent INCLUDE columns from being matched
-              columns.reject! { |c| include_columns.include?(c) }
-
-              # add info on sort order (only desc order is explicitly specified, asc is the default)
-              # and non-default opclasses
-              expressions.scan(/(?<column>\w+)"?\s?(?<opclass>(?:\w+\.)?\w+_ops(_\w+)?)?\s?(?<desc>DESC)?\s?(?<nulls>NULLS (?:FIRST|LAST))?/).each do |column, opclass, desc, nulls|
-                opclasses[column] = opclass.split(".").last.to_sym if opclass
-
-                if nulls
-                  orders[column] = [desc, nulls].compact.join(" ")
-                else
-                  orders[column] = :desc if desc
-                end
-              end
-            end
-
-            IndexDefinition.new(
-              table_name,
-              index_name,
-              unique,
-              columns,
-              orders: orders,
-              opclasses: opclasses,
-              where: where,
-              using: using.to_sym,
-              include: include_columns.presence,
-              nulls_not_distinct: nulls_not_distinct.present?,
-              comment: comment.presence,
-              valid: valid
-            )
-          end
+          result = fetch_indexes(Array(table_name).map(&:to_s))
+          table_name.is_a?(Array) ? result : result[table_name.to_s]
         end
 
         def table_options(table_name) # :nodoc:
@@ -589,16 +521,8 @@ module ActiveRecord
         end
 
         def primary_keys(table_name) # :nodoc:
-          query_values(<<~SQL)
-            SELECT a.attname
-            FROM pg_index i
-            JOIN pg_attribute a
-              ON a.attrelid = i.indrelid
-              AND a.attnum = ANY(i.indkey)
-            WHERE i.indrelid = #{quote(quote_table_name(table_name))}::regclass
-              AND i.indisprimary
-            ORDER BY array_position(i.indkey, a.attnum)
-          SQL
+          result = fetch_primary_keys(Array(table_name).map(&:to_s))
+          table_name.is_a?(Array) ? result : result[table_name.to_s]
         end
 
         # Renames a table.
@@ -744,59 +668,8 @@ module ActiveRecord
         end
 
         def foreign_keys(table_name)
-          scope = quoted_scope(table_name)
-          conenforced_column = supports_enforced_foreign_keys? ? ", c.conenforced AS enforced" : ""
-          fk_info = query_all(<<~SQL)
-            SELECT t2.oid::regclass::text AS to_table, c.conname AS name, c.confupdtype AS on_update, c.confdeltype AS on_delete, c.convalidated AS valid, c.condeferrable AS deferrable, c.condeferred AS deferred, c.conrelid, c.confrelid#{conenforced_column},
-              (
-                SELECT array_agg(a.attname ORDER BY idx)
-                FROM (
-                  SELECT idx, c.conkey[idx] AS conkey_elem
-                  FROM generate_subscripts(c.conkey, 1) AS idx
-                ) indexed_conkeys
-                JOIN pg_attribute a ON a.attrelid = t1.oid
-                AND a.attnum = indexed_conkeys.conkey_elem
-              ) AS conkey_names,
-              (
-                SELECT array_agg(a.attname ORDER BY idx)
-                FROM (
-                  SELECT idx, c.confkey[idx] AS confkey_elem
-                  FROM generate_subscripts(c.confkey, 1) AS idx
-                ) indexed_confkeys
-                JOIN pg_attribute a ON a.attrelid = t2.oid
-                AND a.attnum = indexed_confkeys.confkey_elem
-              ) AS confkey_names
-            FROM pg_constraint c
-            JOIN pg_class t1 ON c.conrelid = t1.oid
-            JOIN pg_class t2 ON c.confrelid = t2.oid
-            JOIN pg_namespace n ON c.connamespace = n.oid
-            WHERE c.contype = 'f'
-              AND t1.relname = #{scope[:name]}
-              AND n.nspname = #{scope[:schema]}
-            ORDER BY c.conname
-          SQL
-
-          fk_info.map do |row|
-            to_table = Utils.extract_schema_qualified_name(row["to_table"]).to_s
-
-            column = decode_string_array(row["conkey_names"])
-            primary_key = decode_string_array(row["confkey_names"])
-
-            options = {
-              column: column.size == 1 ? column.first : column,
-              name: row["name"],
-              primary_key: primary_key.size == 1 ? primary_key.first : primary_key
-            }
-
-            options[:on_delete] = extract_foreign_key_action(row["on_delete"])
-            options[:on_update] = extract_foreign_key_action(row["on_update"])
-            options[:deferrable] = extract_constraint_deferrable(row["deferrable"], row["deferred"])
-
-            options[:validate] = row["valid"]
-            options[:enforced] = row["enforced"] if supports_enforced_foreign_keys?
-
-            ForeignKeyDefinition.new(table_name, to_table, options)
-          end
+          result = fetch_foreign_keys(Array(table_name).map(&:to_s))
+          table_name.is_a?(Array) ? result : result[table_name.to_s]
         end
 
         def foreign_tables
@@ -808,101 +681,24 @@ module ActiveRecord
         end
 
         def check_constraints(table_name) # :nodoc:
-          scope = quoted_scope(table_name)
-
-          check_info = query_all(<<-SQL)
-            SELECT conname, pg_get_constraintdef(c.oid, true) AS constraintdef, c.convalidated AS valid
-            FROM pg_constraint c
-            JOIN pg_class t ON c.conrelid = t.oid
-            JOIN pg_namespace n ON n.oid = c.connamespace
-            WHERE c.contype = 'c'
-              AND t.relname = #{scope[:name]}
-              AND n.nspname = #{scope[:schema]}
-          SQL
-
-          check_info.map do |row|
-            options = {
-              name: row["conname"],
-              validate: row["valid"]
-            }
-            expression = row["constraintdef"][/CHECK \((.+)\)/m, 1]
-
-            CheckConstraintDefinition.new(table_name, expression, options)
-          end
+          result = fetch_check_constraints(Array(table_name).map(&:to_s))
+          table_name.is_a?(Array) ? result : result[table_name.to_s]
         end
 
-        # Returns an array of exclusion constraints for the given table.
+        # Returns an array of exclusion constraints for the given table, or a Hash of
+        # them keyed by table name when given an Array of tables.
         # The exclusion constraints are represented as ExclusionConstraintDefinition objects.
         def exclusion_constraints(table_name)
-          scope = quoted_scope(table_name)
-
-          exclusion_info = query_all(<<-SQL)
-            SELECT conname, pg_get_constraintdef(c.oid) AS constraintdef, c.condeferrable, c.condeferred
-            FROM pg_constraint c
-            JOIN pg_class t ON c.conrelid = t.oid
-            JOIN pg_namespace n ON n.oid = c.connamespace
-            WHERE c.contype = 'x'
-              AND t.relname = #{scope[:name]}
-              AND n.nspname = #{scope[:schema]}
-          SQL
-
-          exclusion_info.map do |row|
-            method_and_elements, predicate = row["constraintdef"].split(" WHERE ")
-            method_and_elements_parts = method_and_elements.match(/EXCLUDE(?: USING (?<using>\S+))? \((?<expression>.+)\)/)
-            predicate.remove!(/ DEFERRABLE(?: INITIALLY (?:IMMEDIATE|DEFERRED))?/) if predicate
-            predicate = predicate.from(2).to(-3) if predicate # strip 2 opening and closing parentheses
-
-            deferrable = extract_constraint_deferrable(row["condeferrable"], row["condeferred"])
-
-            options = {
-              name: row["conname"],
-              using: method_and_elements_parts["using"].to_sym,
-              where: predicate,
-              deferrable: deferrable
-            }
-
-            ExclusionConstraintDefinition.new(table_name, method_and_elements_parts["expression"], options)
-          end
+          result = fetch_exclusion_constraints(Array(table_name).map(&:to_s))
+          table_name.is_a?(Array) ? result : result[table_name.to_s]
         end
 
-        # Returns an array of unique constraints for the given table.
+        # Returns an array of unique constraints for the given table, or a Hash of them
+        # keyed by table name when given an Array of tables.
         # The unique constraints are represented as UniqueConstraintDefinition objects.
         def unique_constraints(table_name)
-          scope = quoted_scope(table_name)
-
-          unique_info = query_all(<<~SQL)
-            SELECT c.conname, c.conrelid, c.condeferrable, c.condeferred, pg_get_constraintdef(c.oid) AS constraintdef,
-            (
-              SELECT array_agg(a.attname ORDER BY idx)
-              FROM (
-                SELECT idx, c.conkey[idx] AS conkey_elem
-                FROM generate_subscripts(c.conkey, 1) AS idx
-              ) indexed_conkeys
-              JOIN pg_attribute a ON a.attrelid = t.oid
-              AND a.attnum = indexed_conkeys.conkey_elem
-            ) AS conkey_names
-            FROM pg_constraint c
-            JOIN pg_class t ON c.conrelid = t.oid
-            JOIN pg_namespace n ON n.oid = c.connamespace
-            WHERE c.contype = 'u'
-              AND t.relname = #{scope[:name]}
-              AND n.nspname = #{scope[:schema]}
-          SQL
-
-          unique_info.map do |row|
-            columns = decode_string_array(row["conkey_names"])
-
-            nulls_not_distinct = row["constraintdef"].start_with?("UNIQUE NULLS NOT DISTINCT")
-            deferrable = extract_constraint_deferrable(row["condeferrable"], row["condeferred"])
-
-            options = {
-              name: row["conname"],
-              nulls_not_distinct: nulls_not_distinct,
-              deferrable: deferrable
-            }
-
-            UniqueConstraintDefinition.new(table_name, columns, options)
-          end
+          result = fetch_unique_constraints(Array(table_name).map(&:to_s))
+          table_name.is_a?(Array) ? result : result[table_name.to_s]
         end
 
         # Adds a new exclusion constraint to the table. +expression+ is a String
@@ -1199,6 +995,278 @@ module ActiveRecord
         end
 
         private
+          def fetch_indexes(tables)
+            fetch_by_schema(tables) do |schema, group|
+              # t.relname comes last so #build_indexes can keep reading columns by position.
+              rows = query_rows(<<~SQL)
+                SELECT distinct i.relname, d.indisunique, d.indkey, pg_get_indexdef(d.indexrelid),
+                                pg_catalog.obj_description(i.oid, 'pg_class') AS comment, d.indisvalid,
+                                ARRAY(
+                                  SELECT pg_get_indexdef(d.indexrelid, k + 1, true)
+                                  FROM generate_subscripts(d.indkey, 1) AS k
+                                  ORDER BY k
+                                ) AS columns, t.relname
+                FROM pg_class t
+                INNER JOIN pg_index d ON t.oid = d.indrelid
+                INNER JOIN pg_class i ON d.indexrelid = i.oid
+                LEFT JOIN pg_namespace n ON n.oid = t.relnamespace
+                WHERE i.relkind IN ('i', 'I')
+                  AND d.indisprimary = 'f'
+                  AND n.nspname = #{schema} AND t.relname IN (#{quoted_table_names(group)})
+                ORDER BY i.relname
+              SQL
+              by_name = rows.group_by(&:last)
+
+              group.index_with { |table| build_indexes(table, rows_for(by_name, table)) }
+            end
+          end
+
+          def fetch_primary_keys(tables)
+            fetch_by_schema(tables) do |schema, group|
+              # An unqualified name resolves to the first schema on the search path
+              # that has it, the way ::regclass would for a single table.
+              by_name = query_all(<<~SQL).group_by { |row| row["table_name"] }
+                SELECT t.relname AS table_name, a.attname AS column_name
+                FROM pg_index i
+                JOIN (
+                  SELECT DISTINCT ON (c.relname) c.oid, c.relname
+                  FROM pg_class c
+                  JOIN pg_namespace n ON n.oid = c.relnamespace
+                  WHERE n.nspname = #{schema}
+                    AND c.relname IN (#{quoted_table_names(group)})
+                  ORDER BY c.relname, array_position(current_schemas(false), n.nspname)
+                ) t ON t.oid = i.indrelid
+                JOIN pg_attribute a
+                  ON a.attrelid = i.indrelid
+                  AND a.attnum = ANY(i.indkey)
+                WHERE i.indisprimary
+                ORDER BY t.relname, array_position(i.indkey, a.attnum)
+              SQL
+
+              group.index_with { |table| rows_for(by_name, table).map { |row| row["column_name"] } }
+            end
+          end
+
+          def build_indexes(table_name, result)
+            result.map do |row|
+              index_name = row[0]
+              unique = row[1]
+              indkey = row[2].split(" ").map(&:to_i)
+              inddef = row[3]
+              comment = row[4]
+              valid = row[5]
+              columns = decode_string_array(row[6]).map { |c| Utils.unquote_identifier(c.strip.gsub('""', '"')) }
+
+              using, expressions, include, nulls_not_distinct, where = inddef.scan(/ USING (\w+?) \((.+?)\)(?: INCLUDE \((.+?)\))?( NULLS NOT DISTINCT)?(?: WHERE (.+))?\z/m).flatten
+
+              orders = {}
+              opclasses = {}
+              include_columns = include ? include.split(",").map { |c| Utils.unquote_identifier(c.strip.gsub('""', '"')) } : []
+
+              if indkey.include?(0)
+                columns = expressions
+              else
+                # prevent INCLUDE columns from being matched
+                columns.reject! { |c| include_columns.include?(c) }
+
+                # add info on sort order (only desc order is explicitly specified, asc is the default)
+                # and non-default opclasses
+                expressions.scan(/(?<column>\w+)"?\s?(?<opclass>(?:\w+\.)?\w+_ops(_\w+)?)?\s?(?<desc>DESC)?\s?(?<nulls>NULLS (?:FIRST|LAST))?/).each do |column, opclass, desc, nulls|
+                  opclasses[column] = opclass.split(".").last.to_sym if opclass
+
+                  if nulls
+                    orders[column] = [desc, nulls].compact.join(" ")
+                  else
+                    orders[column] = :desc if desc
+                  end
+                end
+              end
+
+              IndexDefinition.new(
+                table_name,
+                index_name,
+                unique,
+                columns,
+                orders: orders,
+                opclasses: opclasses,
+                where: where,
+                using: using.to_sym,
+                include: include_columns.presence,
+                nulls_not_distinct: nulls_not_distinct.present?,
+                comment: comment.presence,
+                valid: valid
+              )
+            end
+          end
+
+          def fetch_foreign_keys(tables)
+            fetch_by_schema(tables) do |schema, group|
+              conenforced_column = supports_enforced_foreign_keys? ? ", c.conenforced AS enforced" : ""
+
+              rows = query_all(<<~SQL)
+                SELECT t1.relname AS from_table, t2.oid::regclass::text AS to_table, c.conname AS name, c.confupdtype AS on_update, c.confdeltype AS on_delete, c.convalidated AS valid, c.condeferrable AS deferrable, c.condeferred AS deferred, c.conrelid, c.confrelid#{conenforced_column},
+                  (
+                    SELECT array_agg(a.attname ORDER BY idx)
+                    FROM (
+                      SELECT idx, c.conkey[idx] AS conkey_elem
+                      FROM generate_subscripts(c.conkey, 1) AS idx
+                    ) indexed_conkeys
+                    JOIN pg_attribute a ON a.attrelid = t1.oid
+                    AND a.attnum = indexed_conkeys.conkey_elem
+                  ) AS conkey_names,
+                  (
+                    SELECT array_agg(a.attname ORDER BY idx)
+                    FROM (
+                      SELECT idx, c.confkey[idx] AS confkey_elem
+                      FROM generate_subscripts(c.confkey, 1) AS idx
+                    ) indexed_confkeys
+                    JOIN pg_attribute a ON a.attrelid = t2.oid
+                    AND a.attnum = indexed_confkeys.confkey_elem
+                  ) AS confkey_names
+                FROM pg_constraint c
+                JOIN pg_class t1 ON c.conrelid = t1.oid
+                JOIN pg_class t2 ON c.confrelid = t2.oid
+                JOIN pg_namespace n ON c.connamespace = n.oid
+                WHERE c.contype = 'f'
+                  AND n.nspname = #{schema} AND t1.relname IN (#{quoted_table_names(group)})
+                ORDER BY c.conname
+              SQL
+              by_name = rows.group_by { |row| row["from_table"] }
+
+              group.index_with { |table| build_foreign_keys(table, rows_for(by_name, table)) }
+            end
+          end
+
+          def build_foreign_keys(table_name, fk_info)
+            fk_info.map do |row|
+              to_table = Utils.extract_schema_qualified_name(row["to_table"]).to_s
+
+              column = decode_string_array(row["conkey_names"])
+              primary_key = decode_string_array(row["confkey_names"])
+
+              options = {
+                column: column.size == 1 ? column.first : column,
+                name: row["name"],
+                primary_key: primary_key.size == 1 ? primary_key.first : primary_key
+              }
+
+              options[:on_delete] = extract_foreign_key_action(row["on_delete"])
+              options[:on_update] = extract_foreign_key_action(row["on_update"])
+              options[:deferrable] = extract_constraint_deferrable(row["deferrable"], row["deferred"])
+
+              options[:validate] = row["valid"]
+              options[:enforced] = row["enforced"] if supports_enforced_foreign_keys?
+
+              ForeignKeyDefinition.new(table_name, to_table, options)
+            end
+          end
+
+          def fetch_check_constraints(tables)
+            fetch_by_schema(tables) do |schema, group|
+              rows = query_all(<<~SQL)
+                SELECT t.relname AS table_name, conname, pg_get_constraintdef(c.oid, true) AS constraintdef, c.convalidated AS valid
+                FROM pg_constraint c
+                JOIN pg_class t ON c.conrelid = t.oid
+                JOIN pg_namespace n ON n.oid = c.connamespace
+                WHERE c.contype = 'c'
+                  AND n.nspname = #{schema} AND t.relname IN (#{quoted_table_names(group)})
+              SQL
+              by_name = rows.group_by { |row| row["table_name"] }
+
+              group.index_with { |table| build_check_constraints(table, rows_for(by_name, table)) }
+            end
+          end
+
+          def build_check_constraints(table_name, check_info)
+            check_info.map do |row|
+              options = {
+                name: row["conname"],
+                validate: row["valid"]
+              }
+              expression = row["constraintdef"][/CHECK \((.+)\)/m, 1]
+
+              CheckConstraintDefinition.new(table_name, expression, options)
+            end
+          end
+
+          def fetch_exclusion_constraints(tables)
+            fetch_by_schema(tables) do |schema, group|
+              rows = query_all(<<~SQL)
+                SELECT t.relname AS table_name, conname, pg_get_constraintdef(c.oid) AS constraintdef, c.condeferrable, c.condeferred
+                FROM pg_constraint c
+                JOIN pg_class t ON c.conrelid = t.oid
+                JOIN pg_namespace n ON n.oid = c.connamespace
+                WHERE c.contype = 'x'
+                  AND n.nspname = #{schema} AND t.relname IN (#{quoted_table_names(group)})
+              SQL
+              by_name = rows.group_by { |row| row["table_name"] }
+
+              group.index_with { |table| build_exclusion_constraints(table, rows_for(by_name, table)) }
+            end
+          end
+
+          def build_exclusion_constraints(table_name, exclusion_info)
+            exclusion_info.map do |row|
+              method_and_elements, predicate = row["constraintdef"].split(" WHERE ")
+              method_and_elements_parts = method_and_elements.match(/EXCLUDE(?: USING (?<using>\S+))? \((?<expression>.+)\)/)
+              predicate.remove!(/ DEFERRABLE(?: INITIALLY (?:IMMEDIATE|DEFERRED))?/) if predicate
+              predicate = predicate.from(2).to(-3) if predicate # strip 2 opening and closing parentheses
+
+              deferrable = extract_constraint_deferrable(row["condeferrable"], row["condeferred"])
+
+              options = {
+                name: row["conname"],
+                using: method_and_elements_parts["using"].to_sym,
+                where: predicate,
+                deferrable: deferrable
+              }
+
+              ExclusionConstraintDefinition.new(table_name, method_and_elements_parts["expression"], options)
+            end
+          end
+
+          def fetch_unique_constraints(tables)
+            fetch_by_schema(tables) do |schema, group|
+              rows = query_all(<<~SQL)
+                SELECT t.relname AS table_name, c.conname, c.conrelid, c.condeferrable, c.condeferred, pg_get_constraintdef(c.oid) AS constraintdef,
+                (
+                  SELECT array_agg(a.attname ORDER BY idx)
+                  FROM (
+                    SELECT idx, c.conkey[idx] AS conkey_elem
+                    FROM generate_subscripts(c.conkey, 1) AS idx
+                  ) indexed_conkeys
+                  JOIN pg_attribute a ON a.attrelid = t.oid
+                  AND a.attnum = indexed_conkeys.conkey_elem
+                ) AS conkey_names
+                FROM pg_constraint c
+                JOIN pg_class t ON c.conrelid = t.oid
+                JOIN pg_namespace n ON n.oid = c.connamespace
+                WHERE c.contype = 'u'
+                  AND n.nspname = #{schema} AND t.relname IN (#{quoted_table_names(group)})
+              SQL
+              by_name = rows.group_by { |row| row["table_name"] }
+
+              group.index_with { |table| build_unique_constraints(table, rows_for(by_name, table)) }
+            end
+          end
+
+          def build_unique_constraints(table_name, unique_info)
+            unique_info.map do |row|
+              columns = decode_string_array(row["conkey_names"])
+
+              nulls_not_distinct = row["constraintdef"].start_with?("UNIQUE NULLS NOT DISTINCT")
+              deferrable = extract_constraint_deferrable(row["condeferrable"], row["condeferred"])
+
+              options = {
+                name: row["conname"],
+                nulls_not_distinct: nulls_not_distinct,
+                deferrable: deferrable
+              }
+
+              UniqueConstraintDefinition.new(table_name, columns, options)
+            end
+          end
+
           def create_table_definition(name, **options)
             PostgreSQL::TableDefinition.new(self, name, **options)
           end
@@ -1372,6 +1440,10 @@ module ActiveRecord
             scope[:name] = quote(name) if name
             scope[:type] = type if type
             scope
+          end
+
+          def bare_table_name(table)
+            extract_schema_qualified_name(table).last
           end
 
           def extract_schema_qualified_name(string)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
@@ -6,51 +6,8 @@ module ActiveRecord
       module SchemaStatements # :nodoc:
         # Returns an array of indexes for the given table.
         def indexes(table_name)
-          query_all("PRAGMA index_list(#{quote_table_name(table_name)})").filter_map do |row|
-            # Indexes SQLite creates implicitly for internal use start with "sqlite_".
-            # See https://www.sqlite.org/fileformat2.html#intschema
-            next if row["name"].start_with?("sqlite_")
-
-            index_sql = query_value(<<~SQL)
-              SELECT sql
-              FROM sqlite_master
-              WHERE name = #{quote(row['name'])} AND type = 'index'
-              UNION ALL
-              SELECT sql
-              FROM sqlite_temp_master
-              WHERE name = #{quote(row['name'])} AND type = 'index'
-            SQL
-
-            /\bON\b\s*"?(\w+?)"?\s*\((?<expressions>.+?)\)(?:\s*WHERE\b\s*(?<where>.+?))?(?:\s*\/\*.*\*\/)?\s*\z/im =~ index_sql
-
-            columns = query_all("PRAGMA index_info(#{quote(row['name'])})").map do |col|
-              col["name"]
-            end
-
-            where = where.sub(/\s*\/\*.*\*\/\z/, "") if where
-            orders = {}
-
-            if columns.any?(&:nil?) # index created with an expression
-              columns = expressions
-            else
-              # Add info on sort order for columns (only desc order is explicitly specified,
-              # asc is the default)
-              if index_sql # index_sql can be null in case of primary key indexes
-                index_sql.scan(/"(\w+)" DESC/).flatten.each { |order_column|
-                  orders[order_column] = :desc
-                }
-              end
-            end
-
-            IndexDefinition.new(
-              table_name,
-              row["name"],
-              row["unique"] != 0,
-              columns,
-              where: where,
-              orders: orders
-            )
-          end
+          result = fetch_indexes(Array(table_name).map(&:to_s))
+          table_name.is_a?(Array) ? result : result[table_name.to_s]
         end
 
         def add_foreign_key(from_table, to_table, if_not_exists: false, **options)
@@ -82,19 +39,8 @@ module ActiveRecord
         end
 
         def check_constraints(table_name)
-          table_sql = query_value(<<-SQL)
-            SELECT sql
-            FROM sqlite_master
-            WHERE name = #{quote(table_name)} AND type = 'table'
-            UNION ALL
-            SELECT sql
-            FROM sqlite_temp_master
-            WHERE name = #{quote(table_name)} AND type = 'table'
-          SQL
-
-          table_sql.to_s.scan(/CONSTRAINT\s+(?<name>\w+)\s+CHECK\s+\((?<expression>(:?[^()]|\(\g<expression>\))+)\)/i).map do |name, expression|
-            CheckConstraintDefinition.new(table_name, expression, name: name)
-          end
+          result = fetch_check_constraints(Array(table_name).map(&:to_s))
+          table_name.is_a?(Array) ? result : result[table_name.to_s]
         end
 
         def add_check_constraint(table_name, expression, if_not_exists: false, **options)
@@ -123,6 +69,74 @@ module ActiveRecord
         end
 
         private
+          def fetch_indexes(tables)
+            tables.index_with do |table_name|
+              query_all("PRAGMA index_list(#{quote_table_name(table_name)})").filter_map do |row|
+                # Indexes SQLite creates implicitly for internal use start with "sqlite_".
+                # See https://www.sqlite.org/fileformat2.html#intschema
+                next if row["name"].start_with?("sqlite_")
+
+                index_sql = query_value(<<~SQL)
+                  SELECT sql
+                  FROM sqlite_master
+                  WHERE name = #{quote(row['name'])} AND type = 'index'
+                  UNION ALL
+                  SELECT sql
+                  FROM sqlite_temp_master
+                  WHERE name = #{quote(row['name'])} AND type = 'index'
+                SQL
+
+                /\bON\b\s*"?(\w+?)"?\s*\((?<expressions>.+?)\)(?:\s*WHERE\b\s*(?<where>.+?))?(?:\s*\/\*.*\*\/)?\s*\z/im =~ index_sql
+
+                columns = query_all("PRAGMA index_info(#{quote(row['name'])})").map do |col|
+                  col["name"]
+                end
+
+                where = where.sub(/\s*\/\*.*\*\/\z/, "") if where
+                orders = {}
+
+                if columns.any?(&:nil?) # index created with an expression
+                  columns = expressions
+                else
+                  # Add info on sort order for columns (only desc order is explicitly specified,
+                  # asc is the default)
+                  if index_sql # index_sql can be null in case of primary key indexes
+                    index_sql.scan(/"(\w+)" DESC/).flatten.each { |order_column|
+                      orders[order_column] = :desc
+                    }
+                  end
+                end
+
+                IndexDefinition.new(
+                  table_name,
+                  row["name"],
+                  row["unique"] != 0,
+                  columns,
+                  where: where,
+                  orders: orders
+                )
+              end
+            end
+          end
+
+          def fetch_check_constraints(tables)
+            tables.index_with do |table_name|
+              table_sql = query_value(<<-SQL)
+                SELECT sql
+                FROM sqlite_master
+                WHERE name = #{quote(table_name)} AND type = 'table'
+                UNION ALL
+                SELECT sql
+                FROM sqlite_temp_master
+                WHERE name = #{quote(table_name)} AND type = 'table'
+              SQL
+
+              table_sql.to_s.scan(/CONSTRAINT\s+(?<name>\w+)\s+CHECK\s+\((?<expression>(:?[^()]|\(\g<expression>\))+)\)/i).map do |name, expression|
+                CheckConstraintDefinition.new(table_name, expression, name: name)
+              end
+            end
+          end
+
           def valid_table_definition_options
             super + [:rename]
           end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -333,8 +333,8 @@ module ActiveRecord
       # SCHEMA STATEMENTS ========================================
 
       def primary_keys(table_name) # :nodoc:
-        pks = table_structure(table_name).select { |f| f["pk"] > 0 }
-        pks.sort_by { |f| f["pk"] }.map { |f| f["name"] }
+        result = fetch_primary_keys(Array(table_name).map(&:to_s))
+        table_name.is_a?(Array) ? result : result[table_name.to_s]
       end
 
       def remove_index(table_name, column_name = nil, **options) # :nodoc:
@@ -469,43 +469,8 @@ module ActiveRecord
       FK_REGEX = /.*FOREIGN KEY\s+\("([^"]+)"\)\s+REFERENCES\s+"(\w+)"\s+\("(\w+)"\)/
       DEFERRABLE_REGEX = /DEFERRABLE INITIALLY (\w+)/
       def foreign_keys(table_name)
-        # SQLite returns 1 row for each column of composite foreign keys.
-        fk_info = query_all("PRAGMA foreign_key_list(#{quote(table_name)})")
-        # Deferred or immediate foreign keys and the constraint name can only be
-        # seen in the CREATE TABLE sql.
-        fk_defs = table_structure_sql(table_name)
-                    .select do |column_string|
-                      column_string.start_with?("CONSTRAINT") &&
-                      column_string.include?("FOREIGN KEY")
-                    end
-                    .to_h do |fk_string|
-                      _, from, table, to = fk_string.match(FK_REGEX).to_a
-                      _, mode = fk_string.match(DEFERRABLE_REGEX).to_a
-                      _, name = fk_string.match(FK_NAME_REGEX).to_a
-                      deferred = mode&.downcase&.to_sym || false
-                      [[table, from, to], { deferrable: deferred, name: name }]
-                    end
-
-        grouped_fk = fk_info.group_by { |row| row["id"] }.values.each { |group| group.sort_by! { |row| row["seq"] } }
-        grouped_fk.map do |group|
-          row = group.first
-          fk_def = fk_defs[[row["table"], row["from"], row["to"]]]
-          options = {
-            on_delete: extract_foreign_key_action(row["on_delete"]),
-            on_update: extract_foreign_key_action(row["on_update"]),
-            deferrable: fk_def && fk_def[:deferrable],
-            name: fk_def && fk_def[:name],
-          }
-
-          if group.one?
-            options[:column] = row["from"]
-            options[:primary_key] = row["to"]
-          else
-            options[:column] = group.map { |row| row["from"] }
-            options[:primary_key] = group.map { |row| row["to"] }
-          end
-          ForeignKeyDefinition.new(table_name, row["table"], options)
-        end
+        result = fetch_foreign_keys(Array(table_name).map(&:to_s))
+        table_name.is_a?(Array) ? result : result[table_name.to_s]
       end
 
       def build_insert_sql(insert) # :nodoc:
@@ -564,6 +529,55 @@ module ActiveRecord
       EXTENDED_TYPE_MAPS = Concurrent::Map.new
 
       private
+        def fetch_primary_keys(tables)
+          tables.index_with do |table|
+            pks = table_structure(table).select { |f| f["pk"] > 0 }
+            pks.sort_by { |f| f["pk"] }.map { |f| f["name"] }
+          end
+        end
+
+        def fetch_foreign_keys(tables)
+          tables.index_with do |table_name|
+            # SQLite returns 1 row for each column of composite foreign keys.
+            fk_info = query_all("PRAGMA foreign_key_list(#{quote(table_name)})")
+            # Deferred or immediate foreign keys and the constraint name can only be
+            # seen in the CREATE TABLE sql.
+            fk_defs = table_structure_sql(table_name)
+                        .select do |column_string|
+                          column_string.start_with?("CONSTRAINT") &&
+                          column_string.include?("FOREIGN KEY")
+                        end
+                        .to_h do |fk_string|
+                          _, from, table, to = fk_string.match(FK_REGEX).to_a
+                          _, mode = fk_string.match(DEFERRABLE_REGEX).to_a
+                          _, name = fk_string.match(FK_NAME_REGEX).to_a
+                          deferred = mode&.downcase&.to_sym || false
+                          [[table, from, to], { deferrable: deferred, name: name }]
+                        end
+
+            grouped_fk = fk_info.group_by { |row| row["id"] }.values.each { |group| group.sort_by! { |row| row["seq"] } }
+            grouped_fk.map do |group|
+              row = group.first
+              fk_def = fk_defs[[row["table"], row["from"], row["to"]]]
+              options = {
+                on_delete: extract_foreign_key_action(row["on_delete"]),
+                on_update: extract_foreign_key_action(row["on_update"]),
+                deferrable: fk_def && fk_def[:deferrable],
+                name: fk_def && fk_def[:name],
+              }
+
+              if group.one?
+                options[:column] = row["from"]
+                options[:primary_key] = row["to"]
+              else
+                options[:column] = group.map { |row| row["from"] }
+                options[:primary_key] = group.map { |row| row["to"] }
+              end
+              ForeignKeyDefinition.new(table_name, row["table"], options)
+            end
+          end
+        end
+
         # See https://www.sqlite.org/limits.html,
         # the default value is 999 when not configured.
         def bind_params_length

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -151,10 +151,21 @@ module ActiveRecord
       def virtual_tables(stream)
       end
 
+      def read_schema_metadata(tables)
+        @primary_keys = @connection.primary_keys(tables)
+        @indexes = @connection.indexes(tables)
+        @foreign_keys = @connection.foreign_keys(tables) if @connection.supports_foreign_keys?
+        @check_constraints = @connection.check_constraints(tables) if @connection.supports_check_constraints?
+        @exclusion_constraints = @connection.exclusion_constraints(tables) if @connection.supports_exclusion_constraints?
+        @unique_constraints = @connection.unique_constraints(tables) if @connection.supports_unique_constraints?
+      end
+
       def tables(stream)
         sorted_tables = @connection.tables.sort
 
         not_ignored_tables = sorted_tables.reject { |table_name| ignored?(table_name) }
+
+        read_schema_metadata(not_ignored_tables)
 
         not_ignored_tables.each_with_index do |table_name, index|
           table(table_name, stream)
@@ -183,7 +194,8 @@ module ActiveRecord
           tbl = StringIO.new
 
           # first dump primary key column
-          pk = @connection.primary_key(table)
+          pk = @primary_keys[table]
+          pk = pk.first unless pk.size > 1
 
           tbl.print "  create_table #{relation_name(remove_prefix_and_suffix(table)).inspect}"
 
@@ -262,14 +274,14 @@ module ActiveRecord
       end
 
       def indexes_in_create(table, stream)
-        if (indexes = @connection.indexes(table)).any?
-          if @connection.supports_exclusion_constraints? && (exclusion_constraints = @connection.exclusion_constraints(table)).any?
+        if (indexes = @indexes[table]).any?
+          if @connection.supports_exclusion_constraints? && (exclusion_constraints = @exclusion_constraints[table]).any?
             exclusion_constraint_names = exclusion_constraints.collect(&:name)
 
             indexes = indexes.reject { |index| exclusion_constraint_names.include?(index.name) }
           end
 
-          if @connection.supports_unique_constraints? && (unique_constraints = @connection.unique_constraints(table)).any?
+          if @connection.supports_unique_constraints? && (unique_constraints = @unique_constraints[table]).any?
             unique_constraint_names = unique_constraints.collect(&:name)
 
             indexes = indexes.reject { |index| unique_constraint_names.include?(index.name) }
@@ -302,7 +314,7 @@ module ActiveRecord
       end
 
       def check_constraints_in_create(table, stream)
-        if (check_constraints = @connection.check_constraints(table)).any?
+        if (check_constraints = @check_constraints[table]).any?
           check_valid, check_invalid = check_constraints.partition { |chk| chk.validate? }
 
           unless check_valid.empty?
@@ -335,7 +347,7 @@ module ActiveRecord
       end
 
       def foreign_keys(table, stream)
-        if (foreign_keys = @connection.foreign_keys(table)).any?
+        if (foreign_keys = @foreign_keys[table]).any?
           add_foreign_key_statements = foreign_keys.map do |foreign_key|
             parts = [
               relation_name(remove_prefix_and_suffix(foreign_key.from_table)).inspect,

--- a/activerecord/test/cases/connection_adapters/schema_statements_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_statements_test.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+module ActiveRecord
+  module ConnectionAdapters
+    class SchemaStatementsTest < ActiveRecord::TestCase
+      self.use_transactional_tests = false
+
+      WHOLE_SCHEMA_READERS = %i[
+        indexes primary_keys foreign_keys
+        check_constraints exclusion_constraints unique_constraints
+      ].freeze
+
+      def setup
+        @connection = ActiveRecord::Base.lease_connection
+      end
+
+      def test_a_list_reads_exactly_the_tables_it_is_given
+        some = @connection.tables.sort.first(3)
+
+        each_reader do |reader|
+          assert_equal some.sort, @connection.public_send(reader, some).keys.sort,
+            "#{reader} did not read exactly the tables it was given"
+        end
+      end
+
+      def test_a_list_returns_what_asking_for_each_table_returns
+        tables = @connection.tables
+
+        each_reader do |reader|
+          listed = @connection.public_send(reader, tables)
+
+          tables.each do |table|
+            assert_equal attributes(@connection.public_send(reader, table)),
+              attributes(listed.fetch(table)),
+              "#{reader} disagreed about #{table}"
+          end
+        end
+      end
+
+      def test_a_list_does_not_scale_with_the_number_of_tables
+        tables = @connection.tables
+        assert_operator tables.size, :>, 10, "need a decent number of tables for this to mean anything"
+
+        queries = {}
+        each_reader do |reader|
+          queries[reader] = capture_sql(include_schema: true) { @connection.public_send(reader, tables) }.size
+        end
+
+        cheaper_than_one_read_per_table = queries.select { |_, count| count < tables.size }
+
+        if cheaper_than_one_read_per_table.empty?
+          skip "#{@connection.adapter_name} reads every table one at a time"
+        end
+
+        cheaper_than_one_read_per_table.each do |reader, count|
+          assert_operator count, :<=, 2,
+            "#{reader} took #{count} queries to read #{tables.size} tables; expected a constant few"
+        end
+      end
+
+      def test_an_empty_list_reads_nothing
+        each_reader do |reader|
+          queries = capture_sql(include_schema: true) do
+            assert_empty @connection.public_send(reader, [])
+          end
+
+          assert_empty queries, "#{reader}([]) queried the database"
+        end
+      end
+
+      def test_a_list_keys_a_qualified_name_by_the_name_it_was_given
+        qualifier = schema_qualifier
+        skip "#{@connection.adapter_name} does not qualify table names" unless qualifier
+
+        each_reader do |reader|
+          # A table with nothing to report would compare empty to empty.
+          table = @connection.tables.sort.find { |name| @connection.public_send(reader, name).any? }
+          next unless table
+
+          qualified = "#{qualifier}.#{table}"
+          listed = @connection.public_send(reader, [qualified])
+
+          assert_equal [qualified], listed.keys, "#{reader} did not key by the name it was given"
+          assert_equal attributes(@connection.public_send(reader, qualified)),
+            attributes(listed.fetch(qualified)),
+            "#{reader} disagreed about #{qualified}"
+          assert_not_empty listed.fetch(qualified), "#{reader} found nothing for #{qualified}"
+        end
+      end
+
+      private
+        def each_reader
+          checked = 0
+
+          WHOLE_SCHEMA_READERS.each do |reader|
+            next unless @connection.respond_to?(reader)
+            next unless supported?(reader)
+
+            checked += 1
+            yield reader
+          end
+
+          skip "#{@connection.adapter_name} has none of #{WHOLE_SCHEMA_READERS.join(", ")}" if checked.zero?
+        end
+
+        # SQLite has no schema qualifier its readers understand.
+        def schema_qualifier
+          case @connection.adapter_name
+          when /postgres/i then @connection.current_schema
+          when /mysql|trilogy/i then @connection.current_database
+          end
+        end
+
+        def supported?(reader)
+          case reader
+          when :check_constraints then @connection.supports_check_constraints?
+          when :exclusion_constraints then @connection.supports_exclusion_constraints?
+          when :unique_constraints then @connection.supports_unique_constraints?
+          else true
+          end
+        end
+
+        # Definitions inherit Object#==, which compares identity, so compare the
+        # attributes the dumper actually reads instead.
+        def attributes(value)
+          case value
+          when Array
+            value.all?(String) ? value : value.map { |element| attributes(element) }.sort_by(&:to_s)
+          when String, nil then value
+          else value.instance_variables.sort.index_with { |ivar| value.instance_variable_get(ivar) }
+          end
+        end
+    end
+  end
+end


### PR DESCRIPTION
### Summary

Schema dumping asks the database about each table separately, so the number of round trips grows with the size of the schema. Per table, the dumper issues a separate statement for the primary key, the indexes, the foreign keys and the check constraints — plus, on MySQL, an extra `SHOW TABLE STATUS` purely to read the table's collation. PostgreSQL also queries exclusion and unique constraints *twice* per table, once to filter index names and again to dump them.

Most databases can answer any of those for many tables at once from their catalog, so this lets the readers do that.

### Motivation

At Gusto our primary development database has around 2,300 tables, and `bin/rails db:migrate` spends more time dumping the schema than running the migrations. We're also a multi-database app, so one `db:migrate` writes about a dozen schema files and pays the per-table cost on each.

### The change

`indexes`, `primary_keys`, `foreign_keys`, `check_constraints`, `exclusion_constraints` and `unique_constraints` now accept a list of tables as well as a single one:

```ruby
connection.indexes(:users)            # => [IndexDefinition, ...]
connection.indexes([:users, :posts])  # => { "users" => [...], "posts" => [...] }
```

The caller says which tables it wants; there is no "everything" form.

Each reader is a thin wrapper over one array-based implementation, so a single table is read through the same path and unwrapped:

```ruby
def check_constraints(table_name)
  result = fetch_check_constraints(Array(table_name).map(&:to_s))
  table_name.is_a?(Array) ? result : result[table_name.to_s]
end
```

That leaves one implementation per reader rather than two.

One read filters by one schema, so tables naming different schemas are read a schema at a time — a list of unqualified names is a single query, and `["a.posts", "b.posts"]` is two. SQLite has no catalog to read many tables from, so it loops internally. Every adapter implements the whole interface, so the dumper needs no capability check or hook.

MySQL reads indexes from `information_schema.statistics`, asking only for the columns the server actually has:

```ruby
optional_columns << ", expression AS 'Expression'" if supports_expression_index?
if supports_disabling_indexes?
  optional_columns << (mariadb? ? ", IF(ignored = 'NO', 'YES', 'NO') AS 'Enabled'" : ", is_visible AS 'Enabled'")
end
```

So MariaDB — which has `IGNORED` but neither `EXPRESSION` nor `IS_VISIBLE` — and MySQL before 8.0.13 read in bulk too, instead of falling back to `SHOW KEYS` per table. Verified against MariaDB 11.8: the dump is byte-identical and index reads drop from one statement per table to one, including an `ALTER INDEX ... IGNORED` index correctly reported as disabled. This also drops a `rescue StatementInvalid` that only existed because `SHOW KEYS FROM` raises for a missing table, where `information_schema` returns no rows.

Credit for the conditional-column approach goes to @hmcguire-shopify, who is working on batching column reads along similar lines.

Every table is a key even when it has none of that metadata, so the value is always a collection and callers don't have to handle a missing entry. An empty list reads nothing and issues no query to find that out — which matters, because it is a real case: dumping a database with no tables.

Schema-qualified names work in the list form too, keyed by the name you passed:

```ruby
connection.indexes(["s1.posts", "s2.posts"])
# => { "s1.posts" => [...], "s2.posts" => [...] }
```

The dumper asks for the tables it is about to dump, so ignored tables — `schema_migrations`, `ar_internal_metadata`, anything in `SchemaDumper.ignore_tables` — are never read.

Passing every table in one `IN (...)` is cheap: on a ~2,300-table schema the list adds 69 KB to the query and 11 ms (58 ms → 69 ms) against a 64 MB `max_allowed_packet`; on PostgreSQL, 23 KB and 6 ms. It stays flat well past any real schema — 200,000 names in a 5.9 MB query still runs in 0.22 s.

### Numbers

Statement counts are deterministic. Wall times are best-of-5 on a busy dev laptop, so treat them as indicative of the ratio rather than the absolute.

| | statements | wall |
|---|---|---|
| **MySQL**, ~2,300 tables | 16,203 → **4,695** (−71%) | 16.1s → **5.0s** |
| **PostgreSQL**, ~1,500 tables | 18,272 → **6,122** (−66%) | 3.7s → **1.4s** |

The MySQL row is one of Gusto's real development databases; the PostgreSQL row is a generated schema exercising expression, partial and GIN indexes, composite primary keys, and check/unique/exclusion constraints. Both were measured against this branch's merge base on the same databases.

### What is left

After this, the six readers account for 8 statements of a ~2,300-table MySQL dump. The remainder is `SHOW FULL FIELDS` and `SHOW CREATE TABLE`, one of each per table — column definitions and table options, both out of scope here.

### The output does not change

Verified by dumping before and after and comparing bytes — identical on both adapters.

### Also fixes a latent MySQL bug

Collations were read with `SHOW TABLE STATUS LIKE <name>`, taking the first row. `_` and `%` are wildcards in a `LIKE` pattern, so a table whose name contains one could match a *different* table and inherit its collation. With tables `ab_c` (`utf8mb4_0900_ai_ci`) and `ab c` (`utf8mb4_general_ci`), the old lookup for `ab_c` returns `utf8mb4_general_ci`. Reading from `information_schema.tables` removes the pattern match entirely.

### Two behaviour changes worth calling out

A blank table name no longer raises `ArgumentError`. On `main` only MySQL validated, and only in `foreign_keys` and `primary_keys` — `indexes(nil)` already returned nil there, and PostgreSQL and SQLite returned nil from all of them. Every reader on every adapter now answers alike. Removed per @byroot's note that the validation was overly defensive: keeping it alongside a permitted empty list required `unless table_name.is_a?(Array) || table_name.present?`, and tightening that to plain `present?` (per @skipkayhil) would reject `[]`, which breaks dumping a database with no tables.

On PostgreSQL, `primary_keys` for a table that doesn't exist now returns `[]` where it previously raised `ActiveRecord::StatementInvalid`. The single-table read used to resolve the name with `::regclass`, which raises for a missing relation; the shared implementation filters on `pg_class` instead. `indexes` and `foreign_keys` already returned `[]` for a missing table, so `primary_keys` is now consistent with them. No test depended on the raise, and `[]` seems the friendlier contract, but it is a change.

### Tests

`ActiveRecord::ConnectionAdapters::SchemaStatementsTest` covers the contract on every adapter:

- a list reads exactly the tables it is given and no others
- what it returns for a table equals what asking for that table alone returns
- reading a list doesn't scale with the number of tables (skipped where an adapter reads table by table anyway)
- an empty list reads nothing and queries nothing
- a qualified name in a list is keyed by the name it was given

I mutation-tested them. Forcing every table into one schema group, keeping the qualifier in the row lookup, omitting missing tables instead of answering empty, dropping all but one schema group, letting an empty list reach the database, dropping MySQL's index prefix lengths, and dropping composite-primary-key ordering on either adapter each produce a failure.

Two of those escaped at first and the tests are stronger for it. The primary-key ordering one escaped because the comparison sorted column arrays, so order is now compared as ordered. The qualifier one escaped because the test picked the alphabetically first table, which has a primary key and nothing else — it now picks, per reader, a table that actually has that metadata, and asserts the result is non-empty.


