### PR TITLE
Restore support for custom Active Support notifiers

### DIFF
--- a/activesupport/lib/active_support/notifications.rb
+++ b/activesupport/lib/active_support/notifications.rb
@@ -353,10 +353,14 @@ module ActiveSupport
         end
 
         def record_subscriptions
-          subscriptions = {
-            string_subscribers: Hash[notifier.string_subscribers.keys.zip(notifier.string_subscribers.values)],
-            other_subscribers: notifier.other_subscribers,
-          }
+          subscriptions = if notifier.respond_to?(:string_subscribers)
+            {
+              string_subscribers: Hash[notifier.string_subscribers.keys.zip(notifier.string_subscribers.values)],
+              other_subscribers: notifier.other_subscribers,
+            }
+          else
+            { string_subscribers: {}, other_subscribers: [] }
+          end
 
           self.notifier_subscriptions = ActiveSupport::Ractors.try_make_shareable(subscriptions, copy: true)
         end

--- a/activesupport/test/notifications_test.rb
+++ b/activesupport/test/notifications_test.rb
@@ -313,6 +313,69 @@ module Notifications
     end
   end
 
+  class CustomNotifierTest < ActiveSupport::TestCase
+    class CustomNotifier
+      attr_reader :published
+
+      def initialize
+        @published = []
+      end
+
+      def publish(name, *args)
+        @published << name
+      end
+
+      def publish_event(event)
+        @published << event.name
+      end
+
+      def start(name, id, payload)
+      end
+
+      def finish(name, id, payload, listener_state = nil)
+        @published << name
+      end
+
+      def listening?(name)
+        true
+      end
+
+      def subscribe(pattern = nil, callable = nil, monotonic: false, &block)
+      end
+
+      def unsubscribe(subscriber_or_name)
+      end
+
+      def wait
+      end
+    end
+
+    def setup
+      @old_notifier = ActiveSupport::Notifications.notifier
+    end
+
+    def teardown
+      ActiveSupport::Notifications.notifier = @old_notifier
+    end
+
+    def test_notifier_can_be_set_to_a_custom_queue
+      notifier = CustomNotifier.new
+
+      ActiveSupport::Notifications.notifier = notifier
+
+      assert_same notifier, ActiveSupport::Notifications.notifier
+    end
+
+    def test_instrumenting_through_a_custom_queue
+      notifier = CustomNotifier.new
+      ActiveSupport::Notifications.notifier = notifier
+
+      ActiveSupport::Notifications.instrument("custom.event") { }
+
+      assert_equal ["custom.event"], notifier.published
+    end
+  end
+
   class InspectTest < TestCase
     def test_inspect_output_is_small
       expected = "#<ActiveSupport::Notifications::Fanout (2 patterns)>"


### PR DESCRIPTION
### Motivation / Background

`ActiveSupport::Notifications` documents that its queue is replaceable:

> Notifications ships with a queue implementation that consumes and publishes events to all log subscribers. You can use any queue implementation you want.

That is no longer true. `ActiveSupport::Notifications.notifier=` used to be a plain accessor, but since a6b2abf05e it also snapshots the subscriptions of the object being assigned, using accessors that only `ActiveSupport::Notifications::Fanout` provides. Assigning anything else raises before a single event is published:

```ruby
class MyQueue
  def publish(name, *args); end
  def start(name, id, payload); end
  def finish(name, id, payload, listener_state = nil); end
  def listening?(name); true; end
  def subscribe(pattern = nil, callable = nil, monotonic: false, &block); end
  def unsubscribe(subscriber_or_name); end
  def wait; end
end

ActiveSupport::Notifications.notifier = MyQueue.new
# => NoMethodError: undefined method 'string_subscribers' for an instance of MyQueue
```

The snapshot exists so that a Ractor can rebuild the subscriptions on its own `Fanout`. A queue that is not a `Fanout` has nothing to snapshot, so this Pull Request records an empty set of subscriptions for it rather than raising.

### Detail

This Pull Request makes the subscription snapshot conditional on the notifier exposing the accessors it reads, so assigning a custom queue works again and the Ractor path keeps a usable snapshot.

### Additional information

Tests cover both assigning a custom queue and instrumenting through one.

`activesupport/test/notifications_test.rb`: 43 runs, 94 assertions, 0 failures.

cc @Edouard-chin

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.