### PR TITLE
Mark the routes as loaded when the routes reloader runs standalone

### DIFF
--- a/railties/lib/rails/application/routes_reloader.rb
+++ b/railties/lib/rails/application/routes_reloader.rb
@@ -41,7 +41,10 @@ module Rails
       end
 
       def execute
-        updater.execute
+        @load_lock.synchronize do
+          updater.execute
+          @load_state ||= :loaded
+        end
       end
 
       def execute_unless_loaded

--- a/railties/test/application/routes_reloader_test.rb
+++ b/railties/test/application/routes_reloader_test.rb
@@ -26,6 +26,32 @@ class RoutesReloaderTest < ActiveSupport::TestCase
     assert reloader.loaded
   end
 
+  test "execute marks the routes as loaded" do
+    reloader = build_reloader { }
+
+    reloader.execute
+
+    assert reloader.loaded
+  end
+
+  test "execute does not leave the routes to be drawn again" do
+    draws = 0
+    reloader = build_reloader { draws += 1 }
+
+    reloader.execute
+
+    assert_equal false, reloader.execute_unless_loaded
+    assert_equal 1, draws
+  end
+
+  test "a failed execute leaves the routes unloaded" do
+    reloader = build_reloader { raise "invalid routes" }
+
+    assert_raises(RuntimeError) { reloader.execute }
+
+    assert_not reloader.loaded
+  end
+
   test "a failed initial load is surfaced to waiting threads and retried" do
     draw_started = Queue.new
     draw_resume = Queue.new


### PR DESCRIPTION
### Motivation / Background

`Rails::Application::RoutesReloader#execute` draws and finalizes the routes, and it used to record that they were loaded. Since be08bdce21 it no longer does, so the reloader reports the routes as not loaded even though they are fully drawn:

```ruby
reloader.execute
reloader.loaded # => false
```

The reloader hook installed by the application finisher calls `execute` that way, and `Engine::LazyRouteSet` then finds the routes unloaded the next time a url helper is missing. It draws every route a second time and runs the `after_routes_loaded` hooks again. This is reachable from `reload!` in the console and from a development request that arrives after application files have changed.

`loaded` was restored as a reader in 115f92b4d8, but nothing sets it on this path.

### Detail

This Pull Request marks the routes as loaded once `execute` has drawn them, while leaving the load state alone when `execute` is called as part of `execute_unless_loaded`, which holds the state across its own load hooks and marks the routes loaded itself once they have run.

### Additional information

Three tests are added: that `execute` marks the routes as loaded, that the routes are not drawn a second time afterwards, and that a failed `execute` leaves the routes unloaded so they are retried.

* `railties/test/application/routes_reloader_test.rb`: 5 runs, 11 assertions, 0 failures
* `railties/test/application/routing_test.rb`: 34 runs, 0 failures
* `railties/test/application/loading_test.rb`: 22 runs, 0 failures
* `railties/test/application/initializers/frameworks_test.rb`: 28 runs, 0 failures

cc @rafaelfranca

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.