### PR TITLE
Keep the controller middleware proxy in sync with its stack

### DIFF
--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -18,22 +18,38 @@ module ActionController
   #
   class MiddlewareStack < ActionDispatch::MiddlewareStack # :nodoc:
     class Proxy # :nodoc:
-      delegate_missing_to :@stack
+      delegate_missing_to :middleware_stack
 
       def initialize(controller)
         @controller = controller
-        @stack = @controller.middleware_stack
       end
 
       %w(unshift insert insert_before insert_after swap delete delete! move move_before move_after use).each do |method|
         class_eval(<<~CODE, __FILE__, __LINE__ + 1)
           def #{method}(...)
-            @controller.middleware_stack = @controller.middleware_stack.dup
-            @controller.middleware_stack.public_send(__method__, ...)
-            ActiveSupport::Ractors.try_make_shareable(@controller.middleware_stack)
+            stack = middleware_stack.dup
+            result = stack.#{method}(...)
+            replace_middleware_stack(stack)
+            result
           end
         CODE
       end
+
+      def middlewares=(middlewares)
+        stack = middleware_stack.dup
+        stack.middlewares = middlewares
+        replace_middleware_stack(stack)
+        middlewares
+      end
+
+      private
+        def middleware_stack
+          @controller.middleware_stack
+        end
+
+        def replace_middleware_stack(stack)
+          @controller.middleware_stack = ActiveSupport::Ractors.try_make_shareable(stack)
+        end
     end
 
     class Middleware < ActionDispatch::MiddlewareStack::Middleware # :nodoc:

--- a/actionpack/test/controller/new_base/middleware_test.rb
+++ b/actionpack/test/controller/new_base/middleware_test.rb
@@ -105,6 +105,35 @@ module MiddlewareTest
       assert_nil result[1]["Middleware-Order"]
     end
 
+    test "the middleware proxy reads the stack it has mutated" do
+      middleware = Class.new(ActionController::Metal).middleware
+
+      middleware.use MyMiddleware
+
+      assert_equal 1, middleware.size
+      assert_equal [MyMiddleware], middleware.map(&:klass)
+    end
+
+    test "deleting a middleware that is not in the stack returns nil" do
+      middleware = Class.new(ActionController::Metal).middleware
+      middleware.use MyMiddleware
+
+      assert_nil middleware.delete(BlockMiddleware)
+      assert_equal 1, middleware.size
+    end
+
+    test "assigning middlewares refreezes the stack" do
+      old = ActiveSupport::Ractors.unshareable_proc_action
+      ActiveSupport::Ractors.unshareable_proc_action = :raise
+      controller = Class.new(ActionController::Metal)
+
+      controller.middleware.middlewares = []
+
+      assert_ractor_shareable(controller.middleware_stack)
+    ensure
+      ActiveSupport::Ractors.unshareable_proc_action = old
+    end
+
     test "middleware stack is frozen" do
       old = ActiveSupport::Ractors.unshareable_proc_action
       ActiveSupport::Ractors.unshareable_proc_action = :raise


### PR DESCRIPTION
### Motivation / Background

Since dd67a577d9 `ActionController::Metal.middleware` returns a proxy rather than the stack itself, so that mutations can copy the stack and refreeze it. The proxy captures the stack it was built from, and reads fall through to that captured object. A proxy that has been used to mutate the stack therefore reports the state from before the mutation:

```ruby
middleware = PostsController.middleware
middleware.use Mw

middleware.size            # => 0
PostsController.middleware_stack.size # => 1
```

Two smaller divergences come from the same place:

* The proxied methods return the stack rather than what the stack returned, so `delete` no longer returns `nil` when the middleware is not found, which is the value it documents.
* `middlewares=` is not among the proxied methods, so it falls through to the stack and mutates it in place. As with the methods corrected in #58342, that raises `FrozenError` once the stack has been frozen.

All three behave as described here before dd67a577d9, when `middleware` was the stack.

### Detail

This Pull Request has the proxy read the controller's current stack instead of one captured at construction, return the value each proxied method produced, and proxy `middlewares=` alongside the other mutating methods.

### Additional information

Three tests are added: that reads through a proxy reflect the mutations made through it, that `delete` returns `nil` for a middleware that is not in the stack, and that assigning `middlewares` leaves the stack shareable.

`actionpack` full suite: 4278 runs, 20060 assertions, 0 failures.

Follow-up to #58342.

cc @Edouard-chin

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.