### PR TITLE
Stop deserializing column defaults

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -22,7 +22,7 @@ module ActiveRecord
         @cast_type = cast_type
         @sql_type_metadata = sql_type_metadata
         @null = null
-        @default = default.nil? || cast_type.mutable? ? default : cast_type.deserialize(default)
+        @default = default
         @default_function = default_function
         @collation = collation
         @comment = comment

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -581,6 +581,10 @@ module ActiveRecord
           case default
           when /^null$/i
             nil
+          when /^false$/i
+            false
+          when /^true$/i
+            true
           # Quoted types
           when /^'([^|]*)'$/m
             $1.gsub("''", "'")
@@ -593,8 +597,6 @@ module ActiveRecord
           # Binary columns
           when /x'(.*)'/
             [ $1 ].pack("H*")
-          when "TRUE", "FALSE"
-            default
           else
             # Anything else is blank or some function
             # and we can't know the value of that, so return nil.

--- a/activerecord/test/cases/adapters/postgresql/money_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/money_test.rb
@@ -39,7 +39,7 @@ class PostgresqlMoneyTest < ActiveRecord::PostgreSQLTestCase
   def test_default
     assert_equal BigDecimal("150.55"), PostgresqlMoney.column_defaults["depth"]
     assert_equal BigDecimal("150.55"), PostgresqlMoney.new.depth
-    assert_equal BigDecimal("150.55"), PostgresqlMoney.new.depth_before_type_cast
+    assert_equal "150.55", PostgresqlMoney.new.depth_before_type_cast
   end
 
   def test_money_values

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -654,7 +654,7 @@ module ActiveRecord
           column = @conn.columns("ex").find { |x|
             x.name == "number"
           }
-          assert_equal 10, column.default
+          assert_equal "10", column.default
         end
       end
 

--- a/activerecord/test/cases/attributes_test.rb
+++ b/activerecord/test/cases/attributes_test.rb
@@ -4,6 +4,7 @@ require "cases/helper"
 
 class OverloadedType < ActiveRecord::Base
   attribute :overloaded_float, :integer
+  attribute :overloaded_boolean, :integer
   attribute :overloaded_string_with_limit, :string, limit: 50
   attribute :non_existent_decimal, :decimal
   attribute :string_with_default, :string, default: "the overloaded default"
@@ -25,11 +26,26 @@ module ActiveRecord
     test "overloading types" do
       data = OverloadedType.new
 
+      assert_equal 500, data.overloaded_float
+      assert_nil data.unoverloaded_float
+
       data.overloaded_float = "1.1"
       data.unoverloaded_float = "1.1"
 
       assert_equal 1, data.overloaded_float
       assert_equal 1.1, data.unoverloaded_float
+    end
+
+    if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
+      test "overloading boolean types" do
+        # On MySQL-like databases `tinyint(1)` can easily be confused with a boolean.
+        data = OverloadedType.new
+
+        assert_equal 0, data.overloaded_boolean
+        data.overloaded_boolean = "2"
+        data.save!
+        assert_equal 2, data.overloaded_boolean
+      end
     end
 
     test "overloaded properties save" do

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -42,19 +42,19 @@ class DefaultNumbersTest < ActiveRecord::TestCase
   def test_default_positive_integer
     record = DefaultNumber.new
     assert_equal 7, record.positive_integer
-    assert_equal 7, record.positive_integer_before_type_cast
+    assert_equal "7", record.positive_integer_before_type_cast
   end
 
   def test_default_negative_integer
     record = DefaultNumber.new
     assert_equal (-5), record.negative_integer
-    assert_equal (-5), record.negative_integer_before_type_cast
+    assert_equal "-5", record.negative_integer_before_type_cast
   end
 
   def test_default_decimal_number
     record = DefaultNumber.new
     assert_equal BigDecimal("2.78"), record.decimal_number
-    assert_equal BigDecimal("2.78"), record.decimal_number_before_type_cast
+    assert_equal "2.78", record.decimal_number_before_type_cast
   end
 end
 

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -72,7 +72,7 @@ module ActiveRecord
         assert_equal "hello", one.default
         assert_equal true, two.cast_type.deserialize(two.default)
         assert_equal false, three.cast_type.deserialize(three.default)
-        assert_equal 1, four.default
+        assert_equal "1", four.default
         assert_equal "hello", five.default unless mysql
       end
 

--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -55,13 +55,13 @@ module ActiveRecord
         add_column "test_models", "salary", :integer, default: 70000
 
         default_before = connection.columns("test_models").find { |c| c.name == "salary" }.default
-        assert_equal 70000, default_before
+        assert_equal "70000", default_before
 
         rename_column "test_models", "salary", "annual_salary"
 
         assert_includes TestModel.column_names, "annual_salary"
         default_after = connection.columns("test_models").find { |c| c.name == "annual_salary" }.default
-        assert_equal 70000, default_after
+        assert_equal "70000", default_after
       end
 
       if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
@@ -247,7 +247,7 @@ module ActiveRecord
         change_column "test_models", "user_id", :bigint
 
         new_column = connection.columns("test_models").find { |c| c.name == "user_id" }
-        assert_equal 0, new_column.default
+        assert_equal "0", new_column.default
         assert_equal false, new_column.null
       end
 

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -1317,7 +1317,7 @@ if ActiveRecord::Base.lease_connection.supports_bulk_alter?
 
       assert_equal 8, columns.size
       [:name, :qualification, :experience].each { |s| assert_equal :string, column(s).type }
-      assert_equal 0, column(:age).default
+      assert_equal "0", column(:age).default
       assert_equal "This is a comment", column(:birthdate).comment
     end
 

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1460,6 +1460,7 @@ ActiveRecord::Schema.define do
     t.string :overloaded_string_with_limit, limit: 255
     t.string :string_with_default, default: "the original default"
     t.string :inferred_string, limit: 255
+    t.boolean :overloaded_boolean, default: 0
     t.datetime :starts_at, :ends_at
   end
 


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/54585
Ref: https://github.com/rails/rails/pull/54683

Fix: https://github.com/rails/rails/issues/58292
Close: https://github.com/rails/rails/pull/58381

This was introduced in Rails 8.1.0 as a fix for
https://github.com/rails/rails/issues/54556

However the solution caused more problem than it solved, because of the attribute type is overridden later on, the already deserialized default may no longer be castable to the new type (e.g. `boolean -> integer`).

We could of course keep the `default_before_type_cast` around, but since we already had to work around mutable types, it really feels like it wasn't quite a correct change in the first place.
