### PR TITLE
Deprecate `create` alias of `insert` in connection adapters

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Deprecate `ActiveRecord::ConnectionAdapters::DatabaseStatements#create`
+    in favor of `#insert`.
+
+    `create` was an alias of `insert`, but it reads like a DDL statement
+    (compare `create_table`, `create_database`) rather than the SQL `INSERT`
+    it actually performs. Use `insert` directly instead.
+
+    *Ryuta Kamizono*
+
 *   Use bind parameters for array-form arguments in `find_by_sql` and
     `count_by_sql`, matching the `where` behavior the API doc already
     claimed.

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -307,6 +307,7 @@ module ActiveRecord
         end
       end
       alias create insert
+      deprecate create: :insert, deprecator: ActiveRecord.deprecator
 
       # Executes the update statement and returns the number of rows affected.
       def update(arel_or_sql, name = nil, binds = [])

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -484,12 +484,12 @@ module ActiveRecord
       @connection = ActiveRecord::Base.lease_connection
     end
 
-    def test_create_with_query_cache
+    def test_insert_with_query_cache
       @connection.enable_query_cache!
 
       count = Post.count
 
-      @connection.create("INSERT INTO posts(title, body) VALUES ('', '')")
+      @connection.insert("INSERT INTO posts(title, body) VALUES ('', '')")
 
       assert_equal count + 1, Post.count
     ensure

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -579,7 +579,7 @@ module ActiveRecord
       def test_select_rows
         with_example_table do
           2.times do |i|
-            @conn.create "INSERT INTO ex (number) VALUES (#{i})"
+            @conn.insert "INSERT INTO ex (number) VALUES (#{i})"
           end
           rows = @conn.select_rows "select number, id from ex"
           assert_equal [[0, 1], [1, 2]], rows
@@ -601,7 +601,7 @@ module ActiveRecord
           count_sql = "select count(*) from ex"
 
           @conn.begin_db_transaction
-          @conn.create "INSERT INTO ex (number) VALUES (10)"
+          @conn.insert "INSERT INTO ex (number) VALUES (10)"
 
           assert_equal 1, @conn.select_rows(count_sql).first.first
           @conn.rollback_db_transaction

--- a/activerecord/test/cases/database_statements_test.rb
+++ b/activerecord/test/cases/database_statements_test.rb
@@ -15,11 +15,15 @@ class DatabaseStatementsTest < ActiveRecord::TestCase
   end
 
   def test_insert_should_return_the_inserted_id
-    assert_not_nil return_the_inserted_id(method: :insert)
+    id = @connection.insert("INSERT INTO accounts (firm_id,credit_limit) VALUES (42,5000)")
+    assert_not_nil id
   end
 
-  def test_create_should_return_the_inserted_id
-    assert_not_nil return_the_inserted_id(method: :create)
+  def test_create_is_deprecated_alias_of_insert
+    id = assert_deprecated(/create is deprecated/, ActiveRecord.deprecator) do
+      @connection.create("INSERT INTO accounts (firm_id,credit_limit) VALUES (42,5000)")
+    end
+    assert_not_nil id
   end
 
   def test_insert_with_scalar_returning_returns_scalar
@@ -104,9 +108,4 @@ class DatabaseStatementsTest < ActiveRecord::TestCase
       assert_equal 1, affected
     end
   end
-
-  private
-    def return_the_inserted_id(method:)
-      @connection.send(method, "INSERT INTO accounts (firm_id,credit_limit) VALUES (42,5000)")
-    end
 end


### PR DESCRIPTION
`insert`, `update`, `delete` correspond to their SQL DML verbs, but `create` reads like DDL (`create_table`, `create_database`) rather than the `INSERT` it actually performs. The alias is confusing and offers no value over calling `insert` directly.
