### PR TITLE
Use bind parameters for array-form arguments in `find_by_sql` / `count_by_sql`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Use bind parameters for array-form arguments in `find_by_sql` and
+    `count_by_sql`, matching the `where` behavior the API doc already
+    claimed.
+
+    *Ryuta Kamizono*
+
 *   Append `TRADITIONAL` instead of `STRICT_ALL_TABLES` to MySQL's `sql_mode`
     by default.
 

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -77,7 +77,7 @@ module ActiveRecord
     end
 
     def _query_by_sql(connection, sql, binds = [], preparable: nil, async: false, allow_retry: false) # :nodoc:
-      connection.select_all(sanitize_sql(sql), "#{name} Load", binds, preparable: preparable, async: async, allow_retry: allow_retry)
+      connection.select_all(_sql_for_find(sql), "#{name} Load", binds, preparable: preparable, async: async, allow_retry: allow_retry)
     end
 
     def _load_from_sql(result_set, &block) # :nodoc:
@@ -120,15 +120,23 @@ module ActiveRecord
     # * +sql+ - An SQL statement which should return a count query from the database, see the example above.
     def count_by_sql(sql)
       with_connection do |c|
-        c.select_value(sanitize_sql(sql), "#{name} Count").to_i
+        c.select_value(_sql_for_find(sql), "#{name} Count").to_i
       end
     end
 
     # Same as #count_by_sql but perform the query asynchronously and returns an ActiveRecord::Promise.
     def async_count_by_sql(sql)
       with_connection do |c|
-        c.select_value(sanitize_sql(sql), "#{name} Count", async: true).then(&:to_i)
+        c.select_value(_sql_for_find(sql), "#{name} Count", async: true).then(&:to_i)
       end
     end
+
+    private
+      def _sql_for_find(sql)
+        return sql unless sql.is_a?(Array)
+
+        statement, *values = sql
+        bound_sql_literal_for(statement, values)
+      end
   end
 end

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1697,12 +1697,8 @@ module ActiveRecord
         when String
           if rest.empty?
             parts = [Arel.sql(opts)]
-          elsif rest.first.is_a?(Hash) && /:\w+/.match?(opts)
-            parts = [build_named_bound_sql_literal(opts, rest.first)]
-          elsif opts.include?("?")
-            parts = [build_bound_sql_literal(opts, rest)]
           else
-            parts = [Arel.sql(model.sanitize_sql([opts, *rest]))]
+            parts = [model.bound_sql_literal_for("(#{opts})", rest)]
           end
         when Hash
           opts = opts.transform_keys do |key|
@@ -1752,37 +1748,6 @@ module ActiveRecord
     private
       def async
         spawn.async!
-      end
-
-      def build_named_bound_sql_literal(statement, values)
-        bound_values = values.transform_values { bind_value_for_sql_literal(_1) }
-
-        begin
-          Arel::Nodes::BoundSqlLiteral.new("(#{statement})", nil, bound_values)
-        rescue Arel::BindError => error
-          raise ActiveRecord::PreparedStatementInvalid, error.message
-        end
-      end
-
-      def bind_value_for_sql_literal(value)
-        if ActiveRecord::Relation === value
-          Arel.sql(value.to_sql)
-        elsif value.respond_to?(:map) && !value.acts_like?(:string)
-          values = value.map { |v| v.respond_to?(:id_for_database) ? v.id_for_database : v }
-          values.empty? ? nil : values
-        else
-          value.respond_to?(:id_for_database) ? value.id_for_database : value
-        end
-      end
-
-      def build_bound_sql_literal(statement, values)
-        bound_values = values.map { bind_value_for_sql_literal(_1) }
-
-        begin
-          Arel::Nodes::BoundSqlLiteral.new("(#{statement})", bound_values, nil)
-        rescue Arel::BindError => error
-          raise ActiveRecord::PreparedStatementInvalid, error.message
-        end
       end
 
       def lookup_table_klass_from_join_dependencies(table_name)

--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -182,6 +182,20 @@ module ActiveRecord
         end
       end
 
+      def bound_sql_literal_for(statement, values) # :nodoc:
+        if values.first.is_a?(Hash) && /:\w+/.match?(statement)
+          bound_values = values.first.transform_values { bind_value_for_sql_literal(_1) }
+          Arel::Nodes::BoundSqlLiteral.new(statement, nil, bound_values)
+        elsif statement.include?("?")
+          bound_values = values.map { bind_value_for_sql_literal(_1) }
+          Arel::Nodes::BoundSqlLiteral.new(statement, bound_values, nil)
+        else
+          Arel.sql(sanitize_sql([statement, *values]))
+        end
+      rescue Arel::BindError => error
+        raise ActiveRecord::PreparedStatementInvalid, error.message
+      end
+
       def disallow_raw_sql!(args, permit: adapter_class.column_name_matcher) # :nodoc:
         unexpected = nil
         args.each do |arg|
@@ -202,6 +216,17 @@ module ActiveRecord
       end
 
       private
+        def bind_value_for_sql_literal(value)
+          if ActiveRecord::Relation === value
+            Arel.sql(value.to_sql)
+          elsif value.respond_to?(:map) && !value.acts_like?(:string)
+            values = value.map { |v| v.respond_to?(:id_for_database) ? v.id_for_database : v }
+            values.empty? ? nil : values
+          else
+            value.respond_to?(:id_for_database) ? value.id_for_database : value
+          end
+        end
+
         def replace_bind_variables(connection, statement, values)
           raise_if_bind_arity_mismatch(statement, statement.count("?"), values.size)
           bound = values.dup

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -771,6 +771,32 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal(topics(:second).title, topics.first.title)
   end
 
+  if ActiveRecord::Base.lease_connection.prepared_statements
+    def test_find_by_sql_with_positional_placeholder_binds_the_value
+      payload = capture_query_payload("Topic Load") do
+        Topic.find_by_sql ["SELECT * FROM topics WHERE author_name = ?", "Mary"]
+      end
+      assert_equal ["Mary"], payload[:binds]
+      assert_no_match(/'Mary'/, payload[:sql])
+    end
+
+    def test_find_by_sql_with_named_placeholder_binds_the_value
+      payload = capture_query_payload("Topic Load") do
+        Topic.find_by_sql ["SELECT * FROM topics WHERE author_name = :name", { name: "Mary" }]
+      end
+      assert_equal ["Mary"], payload[:binds]
+      assert_no_match(/'Mary'/, payload[:sql])
+    end
+
+    def test_count_by_sql_with_positional_placeholder_binds_the_value
+      payload = capture_query_payload("Topic Count") do
+        Topic.count_by_sql ["SELECT COUNT(*) FROM topics WHERE author_name = ?", "Mary"]
+      end
+      assert_equal ["Mary"], payload[:binds]
+      assert_no_match(/'Mary'/, payload[:sql])
+    end
+  end
+
   def test_find_by_sql_with_sti_on_joined_table
     accounts = Account.find_by_sql("SELECT * FROM accounts INNER JOIN companies ON companies.id = accounts.firm_id")
     assert_equal [Account], accounts.collect(&:class).uniq
@@ -2135,5 +2161,16 @@ class FinderTest < ActiveRecord::TestCase
           "MercedesCar"
         end
       end)
+    end
+
+    def capture_query_payload(name)
+      payload = nil
+      subscription = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, event_payload|
+        payload = event_payload if event_payload[:name] == name
+      end
+      yield
+      payload
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscription) if subscription
     end
 end


### PR DESCRIPTION
The API doc claims parity with `where`, but array-form values were eagerly interpolated via `sanitize_sql`. Route them through `Arel::Nodes::BoundSqlLiteral` and consolidate the placeholder dispatch shared with `build_where_clause` into `Sanitization#bound_sql_literal_for`.
