### PR TITLE
Fix LengthValidator crash with proc minimum and nil value

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Fix `LengthValidator` raising `NoMethodError` when a `:minimum` (or `:is`)
+    constraint is given as a proc and the validated value is `nil`.
+
+    The proc was resolved only when the value was present, so for a `nil` value
+    it leaked unresolved into the error message and was invoked with the message
+    options hash instead of the record. It is now resolved before the error is
+    built, producing the expected `"is too short"` message.
+
+    ```ruby
+    validates_length_of :title, minimum: ->(record) { record.min_length }
+    # title = nil now yields "is too short (minimum is N characters)"
+    # instead of raising NoMethodError
+    ```
+
+    *Ben Younes*
+
 *   Fix `normalizes` re-applying normalizations on every validation of an
     unpersisted record, and speed up validation of normalized attributes.
 

--- a/activemodel/lib/active_model/validations/length.rb
+++ b/activemodel/lib/active_model/validations/length.rb
@@ -51,8 +51,9 @@ module ActiveModel
         CHECKS.each do |key, validity_check|
           next unless check_value = options[key]
 
+          check_value = resolve_value(record, check_value)
+
           if !value.nil? || skip_nil_check?(key)
-            check_value = resolve_value(record, check_value)
             next if value_length.public_send(validity_check, check_value)
           end
 

--- a/activemodel/test/cases/validations/length_validation_test.rb
+++ b/activemodel/test/cases/validations/length_validation_test.rb
@@ -496,4 +496,30 @@ class LengthValidationTest < ActiveModel::TestCase
     t.title = ""
     assert_predicate t, :valid?
   end
+
+  def test_validates_length_of_using_proc_as_minimum_with_nil_value
+    Topic.define_method(:min_title_length) { 5 }
+    Topic.validates_length_of :title, minimum: Proc.new(&:min_title_length)
+
+    t = Topic.new("title" => "long enough", "content" => "whatever")
+    assert_predicate t, :valid?
+
+    t.title = nil
+    assert_predicate t, :invalid?
+    assert_predicate t.errors[:title], :any?
+    assert_equal ["is too short (minimum is 5 characters)"], t.errors[:title]
+  end
+
+  def test_validates_length_of_using_proc_as_is_with_nil_value
+    Topic.define_method(:exact_title_length) { 5 }
+    Topic.validates_length_of :title, is: Proc.new(&:exact_title_length)
+
+    t = Topic.new("title" => "valid", "content" => "whatever")
+    assert_predicate t, :valid?
+
+    t.title = nil
+    assert_predicate t, :invalid?
+    assert_predicate t.errors[:title], :any?
+    assert_equal ["is the wrong length (should be 5 characters)"], t.errors[:title]
+  end
 end


### PR DESCRIPTION
### Motivation / Background

Fixes #40642.

`LengthValidator` raises `NoMethodError` when a `:minimum` (or `:is`) length
constraint is given as a proc and the validated value is `nil`:

```ruby
class Foo
  include ActiveModel::Validations
  validates :bar, length: { minimum: ->(record) { record.one + 2 } }
  def one = 1
  def bar = nil
end

Foo.new.errors.messages
# => NoMethodError: undefined method 'one' for an instance of Hash
```

The proc was resolved (`resolve_value`) only inside the branch guarded by the
value being present:

```ruby
if !value.nil? || skip_nil_check?(key)
  check_value = resolve_value(record, check_value)
  ...
end
errors_options[:count] = check_value
```

`skip_nil_check?` is only true for `:maximum`, so for a `nil` value with a
`:minimum`/`:is` proc the branch is skipped and the **raw proc** is stored in
`errors_options[:count]`. It then leaks into I18n interpolation and is invoked
with the message options hash instead of the record, raising `NoMethodError`.

### Detail

Resolve the check value once, before the error is built, so `:count` is always
a concrete value. Currently-working paths are unchanged: `resolve_value` is
idempotent for concrete integers, and the proc is still invoked exactly once
per check. (Symbols were already resolved correctly downstream and are not
affected.)

```diff
         CHECKS.each do |key, validity_check|
           next unless check_value = options[key]

+          check_value = resolve_value(record, check_value)
+
           if !value.nil? || skip_nil_check?(key)
-            check_value = resolve_value(record, check_value)
             next if value_length.public_send(validity_check, check_value)
           end
```

### Additional information

#### Test verification (RED → GREEN)

Two regression tests were added (proc as `:minimum` and as `:is`, both with a
`nil` value).

**RED** — `activemodel/lib/active_model/validations/length.rb` at its unmodified
`main` state, with only the new tests applied:

```
Error:
LengthValidationTest#test_validates_length_of_using_proc_as_minimum_with_nil_value:
NoMethodError: undefined method 'min_title_length' for an instance of Hash
Error:
LengthValidationTest#test_validates_length_of_using_proc_as_is_with_nil_value:
NoMethodError: undefined method 'exact_title_length' for an instance of Hash
43 runs, 295 assertions, 0 failures, 2 errors, 0 skips
```

**GREEN** — with the fix applied (full Active Model suite):

```
1197 runs, 5378 assertions, 0 failures, 0 errors, 0 skips
```

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.
