### PR TITLE
Fix BroadcastLogger#tagged when broadcasting to multiple tagging loggers

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -9,6 +9,25 @@
 
     *Said Kaldybaev*
 
+*   Fix `ActiveSupport::BroadcastLogger#tagged` when broadcasting to more than
+    one tagging logger.
+
+    Without a block, `#tagged` fell through to `method_missing` and returned an
+    `Array` of the individual loggers instead of a logger, so the result could
+    not be logged to (`NoMethodError`). With a block, the block was executed once
+    per tagging logger instead of a single time. `#tagged` is now defined
+    directly on `BroadcastLogger`: without a block it returns a new
+    `BroadcastLogger` whose tagging-capable broadcasts are tagged (non-tagging
+    broadcasts are left untouched), and with a block it applies the tags to every
+    tagging logger while yielding once.
+
+    ```ruby
+    broadcast = ActiveSupport::BroadcastLogger.new(logger1, logger2)
+    broadcast.tagged("BCX").info("Hello") # => both loggers log "[BCX] Hello"
+    ```
+
+    *Ben Younes*
+
 *   Fix `Range#sum` with a falsey initial value.
 
     Summing an integer range with a falsey starting value (such as nil or false)

--- a/activesupport/lib/active_support/broadcast_logger.rb
+++ b/activesupport/lib/active_support/broadcast_logger.rb
@@ -209,6 +209,27 @@ module ActiveSupport
       dispatch(:fatal!)
     end
 
+    # Add the +tags+ to every broadcast that supports tagged logging.
+    #
+    # Without a block, it returns a new BroadcastLogger whose tagging-capable
+    # broadcasts are tagged, so the result can be logged to directly. Broadcasts
+    # that don't support tagging are kept as-is so they keep receiving messages.
+    #
+    #   broadcast.tagged("BCX").info("Hello") # All broadcasts log "[BCX] Hello"
+    #
+    # With a block, the tags are applied to every tagging-capable broadcast for
+    # the duration of the block, which is yielded once with the broadcast logger.
+    #
+    #   broadcast.tagged("BCX") { |logger| logger.info("Hello") }
+    def tagged(*tags, &block)
+      unless block
+        return self.class.new(*@broadcasts.map { |logger| logger.respond_to?(:tagged) ? logger.tagged(*tags) : logger })
+      end
+
+      tagging_loggers = @broadcasts.select { |logger| logger.respond_to?(:tagged) }
+      tagged_yielding_self(tagging_loggers, tags, &block)
+    end
+
     def initialize_copy(other)
       @broadcasts = []
       @progname = other.progname.dup
@@ -217,6 +238,16 @@ module ActiveSupport
     end
 
     private
+      # Applies +tags+ to each tagging-capable +loggers+ by nesting their own
+      # block form (so each cleans up its tags via its own +ensure+, even if the
+      # block raises), then yields +self+ exactly once with every tag active.
+      def tagged_yielding_self(loggers, tags, &block)
+        return yield(self) if loggers.empty?
+
+        logger, *rest = loggers
+        logger.tagged(*tags) { tagged_yielding_self(rest, tags, &block) }
+      end
+
       def dispatch(method, *args, **kwargs, &block)
         if block_given?
           # Maintain semantics that the first logger yields the block

--- a/activesupport/test/broadcast_logger_test.rb
+++ b/activesupport/test/broadcast_logger_test.rb
@@ -340,6 +340,67 @@ module ActiveSupport
       assert_equal [[::Logger::INFO, "#{{ foo: "bar" }} Hello", nil]], logger.broadcasts.sole.adds
     end
 
+    test "#tagged without a block returns a usable logger when broadcasting to multiple tagging loggers" do
+      io1, io2 = StringIO.new, StringIO.new
+      logger = BroadcastLogger.new(
+        ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(io1)),
+        ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(io2))
+      )
+
+      tagged_logger = logger.tagged("BCX")
+
+      assert_kind_of BroadcastLogger, tagged_logger
+      tagged_logger.info("Hello")
+
+      assert_includes io1.string, "[BCX] Hello"
+      assert_includes io2.string, "[BCX] Hello"
+    end
+
+    test "#tagged with a block yields once and applies the tags to every tagging logger" do
+      io1, io2 = StringIO.new, StringIO.new
+      logger = BroadcastLogger.new(
+        ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(io1)),
+        ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(io2))
+      )
+
+      yielded = 0
+      logger.tagged("BCX") do |log|
+        yielded += 1
+        log.info("Hello")
+      end
+
+      assert_equal 1, yielded
+      assert_includes io1.string, "[BCX] Hello"
+      assert_includes io2.string, "[BCX] Hello"
+    end
+
+    test "#tagged pops the tags from every logger when the block raises" do
+      io1, io2 = StringIO.new, StringIO.new
+      logger = BroadcastLogger.new(
+        ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(io1)),
+        ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(io2))
+      )
+
+      assert_raises(RuntimeError) do
+        logger.tagged("BCX") { raise "boom" }
+      end
+
+      logger.info("After")
+      assert_not_includes io1.string, "[BCX] After"
+      assert_not_includes io2.string, "[BCX] After"
+    end
+
+    test "#tagged keeps broadcasting to loggers that do not support tagging" do
+      io = StringIO.new
+      plain = FakeLogger.new
+      logger = BroadcastLogger.new(ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(io)), plain)
+
+      logger.tagged("BCX").info("Hello")
+
+      assert_includes io.string, "[BCX] Hello"
+      assert_equal [::Logger::INFO, "Hello", nil], plain.adds.first
+    end
+
     class CustomLogger
       attr_reader :adds, :closed, :chevrons
       attr_accessor :level, :progname, :formatter, :local_level


### PR DESCRIPTION
### Motivation / Background

Fixes #49757 (and the block-form variant reported in #49745).

`ActiveSupport::BroadcastLogger` does not define `#tagged`, so calls fall
through to `method_missing`. When broadcasting to **more than one** logger that
supports tagging, this breaks:

```ruby
logger = ActiveSupport::BroadcastLogger.new(
  ActiveSupport::TaggedLogging.new(Logger.new($stdout)),
  ActiveSupport::TaggedLogging.new(Logger.new($stderr))
)

logger.tagged("BCX").info("Hello")
# => NoMethodError: undefined method `info' for an instance of Array
```

`method_missing` returns `loggers.map { ... }` (an `Array`) when 2+ loggers
respond to `:tagged`, so the no-block form returns an array instead of a
logger. With a block, `method_missing` calls each logger's `#tagged` with the
block, so the block runs **once per tagging logger** instead of a single time.

### Detail

Define `#tagged` directly on `BroadcastLogger`:

* **Without a block** it returns a new `BroadcastLogger` whose tagging-capable
  broadcasts are tagged, so the result can be logged to directly. Broadcasts
  that don't support tagging are kept as-is so they keep receiving messages.
* **With a block** it nests each tagging logger's own block form (via a small
  recursive helper) and yields the broadcast logger **exactly once** with every
  tag active. Nesting reuses each logger's `ensure`-based tag cleanup, so the
  tags are popped even if the block raises.

Both the block and no-block paths select broadcasts consistently with
`respond_to?(:tagged)`.

### Additional information

#### Test verification (RED → GREEN)

Four tests were added to `activesupport/test/broadcast_logger_test.rb`
(no-block returns a usable logger, block yields once, tags cleaned up when the
block raises, and non-tagging broadcasts keep receiving messages).

**RED** — `activesupport/lib/active_support/broadcast_logger.rb` at its
unmodified `main` state, with only the new tests applied:

```
ActiveSupport::BroadcastLoggerTest#test_#tagged_without_a_block_returns_a_usable_logger... :
Expected [#<ActiveSupport::Logger...>, #<ActiveSupport::Logger...>] to be a kind of
ActiveSupport::BroadcastLogger, not Array.

ActiveSupport::BroadcastLoggerTest#test_#tagged_with_a_block_yields_once... :
Expected: 1
  Actual: 2

ActiveSupport::BroadcastLoggerTest#test_#tagged_keeps_broadcasting_to_loggers_that_do_not_support_tagging :
Expected: [1, "Hello", nil]
  Actual: nil

52 runs, 105 assertions, 3 failures, 0 errors, 0 skips
```

**GREEN** — with the fix applied:

```
52 runs, 113 assertions, 0 failures, 0 errors, 0 skips
```

`tagged_logging_test.rb` also stays green (`30 runs, 0 failures`).

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.
