### PR TITLE
Point ERB syntax errors at the template source

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Fix ERB syntax errors pointing to generated method wrapper lines instead of the original template source.
+
+    The reported line number, the annotated source, and the leading backtrace
+    frame now all point at the offending line of the template, so the debug
+    page renders an "Extracted source" pane around it instead of an empty one.
+
+    *David Paluy*
+
 *   Configuring ERB options is now to be made on the ActionView::Base class.
 
     The `ActionView::Template::Handlers::ERB` class is now private API. Applications

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -552,12 +552,14 @@ module ActionView
       # regardless of the original source encoding.
       def compile(mod)
         begin
-          mod.module_eval(compiled_source, identifier, offset)
+          compiled = compiled_source
+          mod.module_eval(compiled, identifier, offset)
         rescue SyntaxError
           # Account for when code in the template is not syntactically valid; e.g. if we're using
           # ERB and the user writes <%= foo( %>, attempting to call a helper `foo` and interpolate
           # the result into the template, but missing an end parenthesis.
-          raise SyntaxErrorInTemplate.new(self, encode!)
+          template_source = encode!
+          raise SyntaxErrorInTemplate.new(self, template_source, **syntax_error_options(compiled, template_source))
         end
 
         return unless strict_locals?
@@ -597,6 +599,21 @@ module ActionView
         else
           0
         end
+      end
+
+      # Returns the keyword arguments for SyntaxErrorInTemplate that locate the
+      # error in the template source.
+      def syntax_error_options(compiled_source, template_source)
+        return {} unless compiled_source && @handler.respond_to?(:syntax_error_line_number)
+
+        {
+          line_number: @handler.syntax_error_line_number(compiled_source, template_source),
+          line_number_translation_attempted: true,
+        }
+      rescue StandardError
+        # Locating the error is best-effort: a failure here must never replace
+        # the original SyntaxError.
+        { line_number_translation_attempted: true }
       end
 
       def handle_render_error(e)

--- a/actionview/lib/action_view/template/error.rb
+++ b/actionview/lib/action_view/template/error.rb
@@ -254,8 +254,10 @@ module ActionView
   TemplateError = Template::Error
 
   class SyntaxErrorInTemplate < TemplateError # :nodoc:
-    def initialize(template, offending_code_string)
+    def initialize(template, offending_code_string, line_number: nil, line_number_translation_attempted: false)
       @offending_code_string = offending_code_string
+      @syntax_error_line_number = line_number&.to_s
+      @line_number_translation_attempted = line_number_translation_attempted
       super(template)
     end
 
@@ -269,11 +271,51 @@ module ActionView
       end
     end
 
-    def annotated_source_code
-      @offending_code_string.split("\n").map.with_index(1) { |line, index|
-        indentation = " " * 4
-        "#{index}:#{indentation}#{line}"
-      }
+    def line_number
+      return @syntax_error_line_number if @line_number_translation_attempted
+
+      super
     end
+
+    # The cause is a SyntaxError whose message carries the line number of the
+    # generated method, not of the template. ActiveSupport::SyntaxErrorProxy
+    # turns that message into the leading backtrace frames, which is what the
+    # debug pages read to build the "Extracted source" pane. Prepend a frame
+    # pointing at the template so that pane, and the trace links, agree with
+    # #line_number.
+    #
+    # The stale frames are kept rather than dropped: the message is multi-line
+    # on Ruby 3.4+, so it expands to several frames and there is no reliable
+    # count to remove.
+    def backtrace
+      return super unless @syntax_error_line_number
+
+      [syntax_error_backtrace_frame] + Array(super)
+    end
+
+    def backtrace_locations
+      return super unless @syntax_error_line_number
+      return unless locations = super
+
+      [ActiveSupport::SyntaxErrorProxy::BacktraceLocation.new(
+        template.identifier, @syntax_error_line_number.to_i, syntax_error_backtrace_frame
+      )] + locations
+    end
+
+    def annotated_source_code
+      if template.is_a?(Template::Inline) || !@syntax_error_line_number
+        @offending_code_string.split("\n").map.with_index(1) { |line, index|
+          indentation = " " * 4
+          "#{index}:#{indentation}#{line}"
+        }
+      else
+        super
+      end
+    end
+
+    private
+      def syntax_error_backtrace_frame
+        "#{template.identifier}:#{@syntax_error_line_number}: syntax error"
+      end
   end
 end

--- a/actionview/lib/action_view/template/handlers/erb.rb
+++ b/actionview/lib/action_view/template/handlers/erb.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "strscan"
+require "prism"
 require "active_support/core_ext/erb/util"
 
 module ActionView
@@ -62,6 +63,27 @@ module ActionView
           nil
         end
 
+        def syntax_error_line_number(compiled_source, source)
+          result = Prism.parse(compiled_source)
+          compiled_lines = compiled_source.lines
+          last_compiled_line = compiled_lines.length
+          location = unmatched_end_location(result, last_compiled_line) ||
+            unclosed_delimiter_location(result.value) ||
+            result.errors.find { |error| error.location.length > 0 }&.location
+          return unless location
+
+          spot = {
+            first_lineno: location.start_line,
+            last_lineno: location.end_line,
+            first_column: location.start_column + 1,
+            last_column: location.end_column,
+            script_lines: compiled_lines,
+            snippet: compiled_lines[location.start_line - 1],
+          }
+
+          translate_location(spot, nil, source)&.dig(:first_lineno)
+        end
+
         def call(template, source)
           # First, convert to BINARY, so in case the encoding is
           # wrong, we can still find an encoding tag
@@ -94,6 +116,33 @@ module ActionView
         end
 
       private
+        def unmatched_end_location(result, last_compiled_line)
+          error_location = result.errors.first&.location
+          return unless error_location&.slice == "end"
+          return unless error_location.start_line == last_compiled_line
+
+          definition = result.value.statements.body.find { |node| node.is_a?(Prism::DefNode) }
+          location = definition&.end_keyword_loc
+          location if location && location.start_line < error_location.start_line
+        end
+
+        # Prism reports an unclosed delimiter at the end of the input rather
+        # than where it was opened, so the error locations all point at the
+        # generated method. Find the node that was never closed instead.
+        def unclosed_delimiter_location(root)
+          queue = [root]
+
+          while (node = queue.shift)
+            if node.respond_to?(:opening_loc) && node.respond_to?(:closing_loc)
+              return node.opening_loc if node.opening_loc && node.closing_loc&.length == 0
+            end
+
+            queue.concat(node.compact_child_nodes)
+          end
+
+          nil
+        end
+
         def valid_encoding(string, encoding)
           # If a magic encoding comment was found, tag the
           # String with this encoding. This is for a case

--- a/actionview/test/fixtures/test/syntax_error_unmatched_end.html.erb
+++ b/actionview/test/fixtures/test/syntax_error_unmatched_end.html.erb
@@ -1,0 +1,16 @@
+<p style="color: green"><%= notice %></p>
+
+<% content_for :title, "Posts" %>
+
+<h1>Posts</h1>
+
+<div id="posts">
+  <%# @posts.each do |post| %>
+    <%#= render post %>
+    <p>
+      <%= link_to "Show this post", post %>
+    </p>
+  <% end %>
+</div>
+
+<%= link_to "New post", new_post_path %>

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -212,7 +212,156 @@ module RenderTestCases
   def test_render_template_with_syntax_error
     e = assert_raises(ActionView::Template::Error) { silence_warnings { @view.render(template: "test/syntax_error") } }
     assert_match %r!syntax!, e.message
-    assert_equal "1:    <%= foo(", e.annotated_source_code[0].strip
+    assert_equal "1", e.line_number
+    assert_equal "1: <%= foo(", e.annotated_source_code[0].strip
+  end
+
+  def test_render_template_with_unmatched_end_syntax_error
+    error = assert_raises(ActionView::SyntaxErrorInTemplate) do
+      silence_warnings { @view.render(template: "test/syntax_error_unmatched_end") }
+    end
+
+    assert_equal "13", error.line_number
+    assert_includes error.annotated_source_code.map(&:strip), "13:   <% end %>"
+  end
+
+  # The debug pages build the "Extracted source" pane from the backtrace, not
+  # from #line_number, so the translated line has to reach the backtrace too.
+  def test_syntax_error_backtrace_points_at_the_template
+    error = assert_raises(ActionView::SyntaxErrorInTemplate) do
+      silence_warnings { @view.render(template: "test/syntax_error_unmatched_end") }
+    end
+
+    assert_match %r{syntax_error_unmatched_end\.html\.erb:13:}, error.backtrace.first
+
+    location = error.backtrace_locations.first
+    assert_equal 13, location.lineno
+    assert_match %r{syntax_error_unmatched_end\.html\.erb\z}, location.path
+  end
+
+  # The frames synthesized from the SyntaxError message are kept, so nothing
+  # that was previously reachable through the backtrace is lost.
+  def test_syntax_error_backtrace_retains_the_original_frames
+    error = assert_raises(ActionView::SyntaxErrorInTemplate) do
+      silence_warnings { @view.render(template: "test/syntax_error_unmatched_end") }
+    end
+
+    assert_equal error.cause.backtrace, error.backtrace.drop(1)
+  end
+
+  def test_syntax_error_backtrace_is_untouched_when_translation_fails
+    handler = Class.new do
+      def call(_template, _source)
+        "invalid ("
+      end
+
+      def syntax_error_line_number(_compiled_source, _source)
+        nil
+      end
+    end.new
+    template = ActionView::Template.new("original", "custom template", handler, locals: [], virtual_path: "custom", format: :html)
+
+    error = assert_raises(ActionView::SyntaxErrorInTemplate) do
+      template.send(:compile, Module.new)
+    end
+
+    # Compared by value: each call to the proxy's #backtrace_locations builds
+    # fresh delegator objects, so the arrays are never identical.
+    assert_equal error.cause.backtrace, error.backtrace
+    assert_equal error.cause.backtrace_locations.map(&:to_s), error.backtrace_locations.map(&:to_s)
+  end
+
+  def test_render_inline_template_with_syntax_error
+    error = assert_raises(ActionView::SyntaxErrorInTemplate) do
+      silence_warnings { @view.render(inline: "<% [ %>") }
+    end
+
+    assert_equal ["1:    <% [ %>"], error.annotated_source_code
+  end
+
+  # Handlers that do not implement `syntax_error_line_number` keep the legacy
+  # behavior: `line_number` is scraped from the backtrace of the compiled
+  # method, so it points at a line of the wrapper, not at the template line.
+  # The assertions below only characterize that value as present and stable,
+  # they do not claim it is correct.
+  def test_non_erb_syntax_error_annotation_is_independent_of_line_number_call_order
+    handler = Class.new do
+      def call(_template, _source)
+        "invalid ("
+      end
+    end.new
+    source = (1..8).map { |line| "line #{line}" }.join("\n")
+    template = ActionView::Template.new(source, "custom template", handler, locals: [], virtual_path: "custom", format: :html)
+
+    error = assert_raises(ActionView::SyntaxErrorInTemplate) do
+      template.send(:compile, Module.new)
+    end
+
+    annotated_source_code = error.annotated_source_code
+    assert_equal 8, annotated_source_code.length
+    assert error.line_number
+    assert_equal annotated_source_code, error.annotated_source_code
+
+    line_number_first_template = ActionView::Template.new(
+      source, "custom template", handler, locals: [], virtual_path: "custom", format: :html
+    )
+    line_number_first_error = assert_raises(ActionView::SyntaxErrorInTemplate) do
+      line_number_first_template.send(:compile, Module.new)
+    end
+
+    assert line_number_first_error.line_number
+    assert_equal annotated_source_code, line_number_first_error.annotated_source_code
+  end
+
+  def test_render_template_handler_syntax_error_is_wrapped
+    handler = Class.new do
+      def call(_template, _source)
+        raise SyntaxError, "handler syntax error"
+      end
+    end.new
+    template = ActionView::Template.new("original", "custom template", handler, locals: [], virtual_path: "custom", format: :html)
+
+    assert_raises(ActionView::SyntaxErrorInTemplate) do
+      template.send(:compile, Module.new)
+    end
+  end
+
+  def test_render_template_with_syntax_error_location_failure
+    handler = Class.new do
+      def call(_template, _source)
+        "invalid ("
+      end
+
+      def syntax_error_line_number(_compiled_source, _source)
+        raise NoMethodError, "location failure"
+      end
+    end.new
+    template = ActionView::Template.new("original", "custom template", handler, locals: [], virtual_path: "custom", format: :html)
+
+    error = assert_raises(ActionView::SyntaxErrorInTemplate) do
+      template.send(:compile, Module.new)
+    end
+
+    assert_nil error.line_number
+    assert_equal ["1:    original"], error.annotated_source_code
+  end
+
+  def test_render_erb_template_with_untranslatable_syntax_error
+    template = ActionView::Template.new(
+      "prefix\n<% yield( %>\nbody\n",
+      "erb template",
+      ActionView::Template::Handlers::ERB.new,
+      locals: [],
+      virtual_path: "erb_template",
+      format: :html
+    )
+
+    error = assert_raises(ActionView::SyntaxErrorInTemplate) do
+      template.send(:compile, Module.new)
+    end
+
+    assert_nil error.line_number
+    assert_equal ["1:    prefix", "2:    <% yield( %>", "3:    body"], error.annotated_source_code
   end
 
   def test_render_runtime_error


### PR DESCRIPTION
### Motivation / Background

Fixes #51092

A syntax error in an ERB template is reported against the method that Action View compiles the template into, not against the template itself. The reported line number is therefore often past the end of the template file, and when it is, the error page shows no source at all.

Using the template from the issue, a 16 line file with an unmatched `<% end %>` on line 13:

  **Before**

```
  ActionView::SyntaxErrorInTemplate
  Encountered a syntax error while rendering template located at: posts/index

  Extracted source (around line #19):
                                      <- empty, line 19 does not exist in a 16 line file
```

<img width="1280" height="633" alt="erb-syntax-error-before" src="https://github.com/user-attachments/assets/25accb49-5a9d-400c-8f0a-dba392bca335" />

  **After**

```
ActionView::SyntaxErrorInTemplate
Encountered a syntax error while rendering template located at: posts/index

  Extracted source (around line #13):
  11    <% end %>
  12
  13    <% end %>                     <- highlighted
  14
  15  </div>
  16 </div>
```

<img width="1280" height="633" alt="erb-syntax-error-after" src="https://github.com/user-attachments/assets/dc4c6620-9009-4de6-a0af-c2676ada24d0" />

### Detail

`Template#compile` now asks the handler to locate the error when `module_eval` raises a `SyntaxError`.

The ERB handler gains `#syntax_error_line_number`. It parses the compiled source with Prism, it picks the location that corresponds to the mistake and maps it back to the template through the existing `#translate_location` hook. Two cases need help, because Prism reports both of them at the end of the input rather than where the problem started:

  * an unmatched `end`, which Prism blames on the generated method's own `end`
  * an unclosed delimiter such as `<%= foo(`, which Prism reports at EOF

The translated line is then prepended to the backtrace by `SyntaxErrorInTemplate#backtrace` and `#backtrace_locations`. This is the part that makes the page render, because `ExceptionWrapper#source_extracts` builds the "Extracted source" pane from the backtrace, not from `#line_number`. Correcting `#line_number` alone leaves the pane empty. The frames synthesized from the original `SyntaxError` message are kept rather than dropped, since that message is multi-line on Ruby 3.4+ and expands to a variable number of frames.

Locating the error is a best effort. When it fails, the previous behavior is kept: no line is claimed, and the whole template is dumped.

### Additional information

Prism is required at the top of the ERB handler. It is a default gem, and ActionView's `required_ruby_version` is `>= 3.3.1`, so it is always available. ActionView already requires it unconditionally in `action_view/render_parser.rb`.

Coverage by error class:

  | Error | Before | After |
  | --- | --- | --- |
  | Unmatched `<% end %>` | line past EOF, empty pane | correct line |
  | Unclosed delimiter, `<%= foo(` | no line, whole template dumped | correct line |
  | Unterminated `<% if %>` block | no line, whole template dumped | unchanged |
  | Unterminated string or regex | line past EOF, empty pane | no line, whole template dumped |

The last two are not fixed. Prism reports only zero length error locations for them, so there is nothing to translate. They are no worse than before, and the third row is an improvement in that a wrong line is no longer claimed.

An earlier draft of this change also located unterminated blocks, but it needed a hardcoded list of Prism `*_keyword_loc` reader names and an AST walk with several special cases. That was about 50 lines of fragile heuristics for one error class, so it was dropped.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex:  `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.