### PR TITLE
Fix partial path de-duplication when controller and model namespaces overlap

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -7,6 +7,21 @@
 
     *Kenta Ishizaki*
 
+*   Fix partial path de-duplication when the controller and model namespaces
+    overlap.
+
+    When `prefix_partial_path_with_controller_namespace` is enabled, the
+    controller namespace is merged into the model's partial path. The previous
+    logic compared segments position by position and stopped at the first match,
+    which dropped non-overlapping segments (e.g. `learning/quiz/extra` +
+    `courses/quiz/questions` became `learning/courses/quiz/questions`) and failed
+    to de-duplicate when the namespaces were not aligned (e.g.
+    `learning/courses/quiz/questions` + `courses/quiz/questions` repeated
+    `courses/quiz`). The overlap between the trailing controller segments and the
+    leading model segments is now detected regardless of alignment.
+
+    *Ben Younes*
+
 *   `current_page?` matches HTTP QUERY requests
     ([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008)) with
     `method: :query`. The default `method: :get` deliberately does not match

--- a/actionview/lib/action_view/renderer/abstract_renderer.rb
+++ b/actionview/lib/action_view/renderer/abstract_renderer.rb
@@ -91,16 +91,19 @@ module ActionView
 
         def merge_prefix_into_object_path(prefix, object_path)
           if prefix.include?(?/) && object_path.include?(?/)
-            prefixes = []
             prefix_array = File.dirname(prefix).split("/")
             object_path_array = object_path.split("/")[0..-3] # skip model dir & partial
 
-            prefix_array.each_with_index do |dir, index|
-              break if dir == object_path_array[index]
-              prefixes << dir
-            end
+            # Drop the longest run of trailing controller-namespace segments that
+            # matches the leading object-namespace segments, so overlapping
+            # namespaces are de-duplicated regardless of how the two namespaces
+            # are aligned. Segments are compared whole so `quiz` never matches
+            # `quiztime`. `overlap` bottoms out at 0 (both `last(0)`/`first(0)`
+            # are `[]`), so no explicit guard is needed.
+            overlap = [prefix_array.length, object_path_array.length].min
+            overlap -= 1 until prefix_array.last(overlap) == object_path_array.first(overlap)
 
-            (prefixes << object_path).join("/")
+            (prefix_array.first(prefix_array.length - overlap) << object_path).join("/")
           else
             object_path
           end

--- a/actionview/test/activerecord/render_partial_with_record_identification_test.rb
+++ b/actionview/test/activerecord/render_partial_with_record_identification_test.rb
@@ -211,3 +211,86 @@ class RenderPartialWithRecordIdentificationAndNestedDeeperControllersWithoutPref
     ActionView::Base.prefix_partial_path_with_controller_namespace = old_config
   end
 end
+
+module Courses
+  module Quiz
+    class Question
+      extend ActiveModel::Naming
+      include ActiveModel::Conversion
+    end
+
+    # Controller and model namespaces fully overlap (`courses/quiz`) -> the
+    # duplicated namespace is removed once.
+    class QuestionsController < ActionController::Base
+      ROUTES = test_routes do
+        get :render_with_record, to: "courses/quiz/questions#render_with_record"
+      end
+
+      def render_with_record
+        render partial: Courses::Quiz::Question.new
+      end
+    end
+  end
+end
+
+module Learning
+  module Quiz
+    module Extra
+      # The controller's trailing `quiz/extra` does not match the model's
+      # leading `courses/quiz`, so nothing is de-duplicated.
+      class QuestionsController < ActionController::Base
+        ROUTES = test_routes do
+          get :render_with_record, to: "learning/quiz/extra/questions#render_with_record"
+        end
+
+        def render_with_record
+          render partial: ::Courses::Quiz::Question.new
+        end
+      end
+    end
+  end
+
+  module Courses
+    module Quiz
+      # The controller's trailing `courses/quiz` matches the model's leading
+      # `courses/quiz`, so the repeated namespace is removed once even though the
+      # controller carries an extra leading `learning` segment.
+      class QuestionsController < ActionController::Base
+        ROUTES = test_routes do
+          get :render_with_record, to: "learning/courses/quiz/questions#render_with_record"
+        end
+
+        def render_with_record
+          render partial: ::Courses::Quiz::Question.new
+        end
+      end
+    end
+  end
+end
+
+class RenderPartialWithOverlappingControllerAndModelNamespaceTest < ActiveRecordTestCase
+  tests Courses::Quiz::QuestionsController
+
+  def test_dedups_fully_overlapping_controller_and_model_namespace
+    get :render_with_record
+    assert_equal "Duplication", @response.body
+  end
+end
+
+class RenderPartialWithNonOverlappingControllerAndModelNamespaceTest < ActiveRecordTestCase
+  tests Learning::Quiz::Extra::QuestionsController
+
+  def test_keeps_namespaces_when_controller_suffix_does_not_match_model_prefix
+    get :render_with_record
+    assert_equal "Collision", @response.body
+  end
+end
+
+class RenderPartialWithRepeatedControllerAndModelNamespaceTest < ActiveRecordTestCase
+  tests Learning::Courses::Quiz::QuestionsController
+
+  def test_dedups_repeated_namespace_with_leading_controller_segment
+    get :render_with_record
+    assert_equal "Repetition", @response.body
+  end
+end

--- a/actionview/test/fixtures/courses/quiz/questions/_question.erb
+++ b/actionview/test/fixtures/courses/quiz/questions/_question.erb
@@ -1,0 +1,1 @@
+Duplication

--- a/actionview/test/fixtures/learning/courses/quiz/questions/_question.erb
+++ b/actionview/test/fixtures/learning/courses/quiz/questions/_question.erb
@@ -1,0 +1,1 @@
+Repetition

--- a/actionview/test/fixtures/learning/quiz/extra/courses/quiz/questions/_question.erb
+++ b/actionview/test/fixtures/learning/quiz/extra/courses/quiz/questions/_question.erb
@@ -1,0 +1,1 @@
+Collision


### PR DESCRIPTION
### Motivation / Background

Fixes #50916

When `config.action_view.prefix_partial_path_with_controller_namespace` is
enabled (the default), the controller namespace is merged into a model's
partial path so that, e.g., an `Admin::UsersController` renders
`admin/users/_user` instead of `users/_user`. The merge is done by
`AbstractRenderer#merge_prefix_into_object_path`.

The previous implementation compared the controller and model namespace
segments *position by position* and stopped at the first match. That is wrong
in two ways when the controller and model namespaces overlap but are not
aligned at the same offset:

1. A positional match in the middle dropped the remaining, non-overlapping
   controller segments.
2. A shared run of segments at a different offset was never detected, so the
   namespace was repeated in the resolved path.

### Detail

Given a `Courses::Quiz::Question` model (partial path
`courses/quiz/questions/question`):

| Controller | Before (wrong) | After (expected) |
| --- | --- | --- |
| `Courses::Quiz::QuestionsController` | `courses/quiz/questions/question` | `courses/quiz/questions/question` |
| `Learning::Quiz::Extra::QuestionsController` | `learning/courses/quiz/questions/question` (drops `extra`) | `learning/quiz/extra/courses/quiz/questions/question` |
| `Learning::Courses::Quiz::QuestionsController` | `learning/courses/quiz/courses/quiz/questions/question` (repeats `courses/quiz`) | `learning/courses/quiz/questions/question` |

`merge_prefix_into_object_path` now finds the longest run of *trailing*
controller-namespace segments that equals the *leading* model-namespace
segments, and removes only that overlap — regardless of how the two namespaces
are aligned. Segments are compared whole, so `quiz` never matches `quiztime`.
Fully-overlapping and non-overlapping cases are unchanged.

### Additional information

Tests were added to `render_partial_with_record_identification_test.rb`
alongside the existing controller-namespace prefix tests, reproducing the two
broken cases from the issue plus the already-working full-overlap case as a
regression anchor.

**RED (upstream `main`, new tests applied, fix reverted):**

```
RenderPartialWithRepeatedControllerAndModelNamespaceTest#test_dedups_repeated_namespace_with_leading_controller_segment:
ActionView::MissingTemplate: Missing partial learning/courses/quiz/courses/quiz/questions/_question ...
RenderPartialWithNonOverlappingControllerAndModelNamespaceTest#test_keeps_namespaces_when_controller_suffix_does_not_match_model_prefix:
  Expected: "Collision"  Actual: "Repetition"

18 runs, 17 assertions, 1 failures, 1 errors, 0 skips
```

**GREEN (with the fix):**

```
# actionview/test/activerecord/render_partial_with_record_identification_test.rb
18 runs, 18 assertions, 0 failures, 0 errors, 0 skips

# actionview/test/template/render_test.rb (regression)
560 runs, 1986 assertions, 0 failures, 0 errors, 0 skips
```

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why (`[Fix #50916]`).
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.
