### PR TITLE
Render error page for invalid multipart request with routes exceptions_app

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Render the error page instead of a 500 when an invalid `multipart/form-data`
+    request is received and `Rails.application.routes` is used as the
+    `exceptions_app`.
+
+    The invalid body's parse error was recorded on the request env and re-raised
+    when the routes exceptions app read the params while dispatching, which
+    turned the intended `/400` response into a failsafe 500. The poisoned body is
+    now neutralized before the request is handed to the exceptions app.
+
+    *Ben Younes*
+
 *   Check `PATCH` and `QUERY` in `assert_recognizes` and `assert_routing` with `method: :all`.
 
     Both assertions only recognized the path for `GET`, `POST`, `PUT` and

--- a/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
@@ -50,6 +50,7 @@ module ActionDispatch
         request.set_header "action_dispatch.original_path", request.path_info
         request.set_header "action_dispatch.original_request_method", request.raw_request_method
         fallback_to_html_format_if_invalid_mime_type(request)
+        fallback_to_octet_stream_when_invalid_multipart(request, wrapper)
         request.path_info = "/#{status}"
         request.request_method = "GET"
         response = @exceptions_app.call(request.env)
@@ -78,6 +79,23 @@ module ActionDispatch
         rescue ActionDispatch::Http::MimeNegotiation::InvalidType
           request.set_header "HTTP_ACCEPT", "text/html"
         end
+      end
+
+      # When the request that raised the exception carried an invalid
+      # `multipart/form-data` body, the parse error is recorded on the env and
+      # re-raised every time the params are read. Since the exceptions app is
+      # handed the same env (and a routes-based exceptions app reads params
+      # while dispatching), it would re-raise and produce a 500 instead of the
+      # intended error page. Neutralize the poisoned body so the exceptions app
+      # can render normally.
+      def fallback_to_octet_stream_when_invalid_multipart(request, wrapper)
+        rack_error = wrapper.wrapped_causes.find { |wrapped| wrapped.exception.is_a?(::EOFError) }
+        return if rack_error.nil? || !request.form_data?
+
+        request.set_header "CONTENT_TYPE", "application/octet-stream"
+        # `rack.request.form_error` only exists on Rack 3; actionpack still
+        # supports Rack 2 (see the gemspec floor), so guard the constant.
+        request.delete_header(Rack::RACK_REQUEST_FORM_ERROR) if defined?(Rack::RACK_REQUEST_FORM_ERROR)
       end
 
       def pass_response(status)

--- a/railties/test/application/middleware/exceptions_test.rb
+++ b/railties/test/application/middleware/exceptions_test.rb
@@ -117,6 +117,36 @@ module ApplicationTests
       end
     end
 
+    test "renders when a multipart form is invalid and routes are used as the custom exceptions app" do
+      controller :foo, <<~'RUBY'
+        class FooController < ActionController::Base
+          def index
+            render plain: "rendering index!"
+          end
+
+          def bad_request
+            render plain: "Oh no!", status: :bad_request
+          end
+        end
+      RUBY
+
+      routes <<~'RUBY'
+        post "/foo", to: "foo#index"
+        match "/400", to: "foo#bad_request", via: :all
+      RUBY
+
+      add_to_config "config.exceptions_app = self.routes"
+      add_to_config "config.action_dispatch.show_exceptions = :all"
+      add_to_config "config.consider_all_requests_local = false"
+
+      quietly do
+        post "/foo", {}, { "HTTPS" => "on", "CONTENT_TYPE" => "multipart/form-data; boundary=----WebKitFormBoundaryxQm6bAVJJEu1FxWw", input: "---invalid" }
+      end
+
+      assert_equal 400, last_response.status
+      assert_equal "Oh no!", last_response.body
+    end
+
     test "uses custom exceptions app" do
       add_to_config <<~'RUBY'
         config.exceptions_app = lambda do |env|


### PR DESCRIPTION
### Motivation / Background

Fixes #54096

When an application uses `Rails.application.routes` as its `exceptions_app`
(`config.exceptions_app = self.routes`), sending an invalid `multipart/form-data`
request returns a `500 Internal Server Error` instead of the intended error page
(e.g. the `/400` route).

Rack records the parse error of an invalid multipart body on the request env and
re-raises it every time the params are read. `ActionDispatch::ShowExceptions#render_exception`
hands the *same* env to the exceptions app; when that app is the router,
dispatching to the matched controller reads the params again, the parse error is
re-raised uncaught, and the `render_exception` failsafe `rescue` turns the
response into a `500`.

### Detail

`render_exception` already neutralizes an invalid MIME type before re-dispatching
(`fallback_to_html_format_if_invalid_mime_type`). This adds the analogous
handling for an invalid multipart body: when the wrapped cause is an `EOFError`
on form data, the content type is reset to `application/octet-stream` and the
recorded `rack.request.form_error` header is cleared, so the exceptions app can
read the params and render normally.

`rack.request.form_error` only exists on Rack 3, and actionpack still supports
Rack 2 (`rack >= 2.2.4`), so the header delete is guarded with `defined?`.

This revives the approach from the previously-closed #54925; the Rack 2/3
compatibility detail that stalled it is handled by the `defined?` guard.

### Additional information

Test added to `railties/test/application/middleware/exceptions_test.rb`,
alongside the existing "routes as the custom exceptions app" cases.

**RED (upstream `main`, new test applied, no production fix):**

```
Failure:
ApplicationTests::MiddlewareExceptionsTest#test_renders_when_a_multipart_form_is_invalid_and_routes_are_used_as_the_custom_exceptions_app:
Expected: 400
  Actual: 500

18 runs, 51 assertions, 1 failures, 0 errors, 0 skips
```

**GREEN (with the fix):**

```
# railties/test/application/middleware/exceptions_test.rb (full file)
18 runs, 52 assertions, 0 failures, 0 errors, 0 skips

# actionpack/test/dispatch/show_exceptions_test.rb (regression)
10 runs, 53 assertions, 0 failures, 0 errors, 0 skips
```

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why (`[Fix #54096]`).
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.


### Rebase validation (2026-09-02)

Rebased onto current `main` again to clear the changelog merge conflict. The production and test patch remains the same; only the commit was replayed and the Action Pack changelog entry was placed above the current top entry.

**RED (upstream `main`, regression test applied, no production fix):**

```
Failure:
ApplicationTests::MiddlewareExceptionsTest#test_renders_when_a_multipart_form_is_invalid_and_routes_are_used_as_the_custom_exceptions_app:
Expected: 400
  Actual: 500

18 runs, 51 assertions, 1 failures, 0 errors, 0 skips
```

**GREEN (rebased branch):**

```
# focused regression
1 runs, 2 assertions, 0 failures, 0 errors, 0 skips

# run-ci.sh affected files
railties/test/application/middleware/exceptions_test.rb: 18 runs, 52 assertions, 0 failures, 0 errors, 0 skips
actionpack/test/dispatch/show_exceptions_test.rb: 10 runs, 53 assertions, 0 failures, 0 errors, 0 skips

# RuboCop
2 files inspected, no offenses detected

# changed production-line trace coverage
show_exceptions.rb lines 53, 92, 93, 95, 98 all executed
```

### Rebase validation (2026-09-08)

Rebased onto the latest `main` to resolve the current changelog conflict. The
production and regression-test patch is unchanged; the Action Pack changelog
entry was replayed above the new upstream entries.

**RED (latest upstream `main`, regression test applied, no production fix):**

```
Failure:
ApplicationTests::MiddlewareExceptionsTest#test_renders_when_a_multipart_form_is_invalid_and_routes_are_used_as_the_custom_exceptions_app:
Expected: 400
  Actual: 500

18 runs, 51 assertions, 1 failures, 0 errors, 0 skips
```

**GREEN (rebased branch):**

```
# focused regression
1 runs, 2 assertions, 0 failures, 0 errors, 0 skips

# local affected-CI replay, upstream baseline -> rebased branch
actionpack/test/controller/show_exceptions_test.rb: 9 runs, 28 assertions -> 9 runs, 28 assertions; 0 failures
railties/test/application/middleware/exceptions_test.rb: 17 runs, 50 assertions -> 18 runs, 52 assertions; 0 failures

# RuboCop
2 files inspected, no offenses detected

# changed production-line trace coverage
show_exceptions.rb lines 53, 92, 93, 95, 98 all executed (5/5, 100%)
```
