### PR TITLE
Keep the string subscribers default when rebuilding a Fanout

### DIFF
--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -55,7 +55,7 @@ module ActiveSupport
     #
     # This class is thread safe. All methods are reentrant.
     class Fanout
-      attr_accessor :string_subscribers, :other_subscribers # :nodoc:
+      attr_reader :string_subscribers, :other_subscribers # :nodoc:
 
       def initialize
         @mutex = Mutex.new
@@ -63,6 +63,16 @@ module ActiveSupport
         @other_subscribers = []
         @all_listeners_for = Concurrent::Map.new
         @groups_for = Concurrent::Map.new
+      end
+
+      def string_subscribers=(subscribers) # :nodoc:
+        string_subscribers = Concurrent::Map.new { |h, k| h.compute_if_absent(k) { [] } }
+        subscribers.each { |name, list| string_subscribers[name] = list.dup }
+        @string_subscribers = string_subscribers
+      end
+
+      def other_subscribers=(subscribers) # :nodoc:
+        @other_subscribers = subscribers.dup
       end
 
       def inspect # :nodoc:

--- a/activesupport/test/notifications_test.rb
+++ b/activesupport/test/notifications_test.rb
@@ -577,6 +577,16 @@ module Notifications
       super
     end
 
+    test "instrumenting an event with no subscribers inside a Ractor" do
+      ActiveSupport::Notifications.subscribe("subscribed.event") { }
+
+      value = on_ractor do
+        ActiveSupport::Notifications.instrument("unsubscribed.event") { :ran }
+      end
+
+      assert_equal :ran, value
+    end
+
     test "record and set subscriptions" do
       ActiveSupport::Notifications.subscribe("active_record.sql") { |event| event.payload[:called] = true }
 


### PR DESCRIPTION
Follow-up to #58060 
cc @Edouard-chin 

Non-main Ractors build their notifier from the recorded subscriptions snapshot, but assigning the snapshot replaced the string subscribers defaulting map with a plain frozen Hash: `all_listeners_for` concatenates the list for the instrumented name with the other subscribers, so any name with no string subscriber returned nil and crashed the first instrumentation of an unsubscribed event inside a Ractor. Rebuild the defaulting `Concurrent::Map` and dup the lists when assigning.
