### PR TITLE
Fix truncation and disabling referential integrity with same-named tables across different schemas

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -657,7 +657,7 @@ module ActiveRecord
       end
 
       def empty_all_tables # :nodoc:
-        truncate_tables(*tables)
+        truncate_tables(*qualified_tables)
       end
 
       def empty_insert_statement_value(primary_key = nil)

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -363,7 +363,8 @@ module ActiveRecord
       end
 
       def truncate_tables(*table_names) # :nodoc:
-        table_names -= [pool.schema_migration.table_name, pool.internal_metadata.table_name]
+        excluded = [pool.schema_migration.table_name, pool.internal_metadata.table_name]
+        table_names.delete_if { |name| excluded.any? { |e| name == e || name.end_with?(".#{e}") } }
 
         return if table_names.empty?
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -51,6 +51,13 @@ module ActiveRecord
         query_values(data_source_sql(type: "BASE TABLE"))
       end
 
+      # Returns an array of table names defined in the database, each prefixed
+      # with its schema name. For adapters that do not support multiple schemas
+      # this is identical to #tables.
+      def qualified_tables
+        tables
+      end
+
       # Checks to see if the table +table_name+ exists on the database.
       #
       #   table_exists?(:developers)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
@@ -12,7 +12,7 @@ module ActiveRecord
 
             begin
               transaction(requires_new: true) do
-                execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} DISABLE TRIGGER ALL" }.join(";"))
+                execute(qualified_tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} DISABLE TRIGGER ALL" }.join(";"))
               end
             rescue ActiveRecord::ActiveRecordError => e
               original_exception = e
@@ -35,7 +35,7 @@ module ActiveRecord
 
             begin
               transaction(requires_new: true) do
-                execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} ENABLE TRIGGER ALL" }.join(";"))
+                execute(qualified_tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} ENABLE TRIGGER ALL" }.join(";"))
               end
             rescue ActiveRecord::ActiveRecordError
             end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -803,6 +803,10 @@ module ActiveRecord
           query_values(data_source_sql(type: "FOREIGN TABLE"))
         end
 
+        def qualified_tables
+          query_values(qualified_data_source_sql(type: "BASE TABLE"))
+        end
+
         def foreign_table_exists?(table_name)
           query_values(data_source_sql(table_name, type: "FOREIGN TABLE")).any? if table_name.present?
         end
@@ -1346,10 +1350,15 @@ module ActiveRecord
           end
 
           def data_source_sql(name = nil, type: nil)
+            qualified_data_source_sql(name, type: type, include_schema: false)
+          end
+
+          def qualified_data_source_sql(name = nil, type: nil, include_schema: true)
             scope = quoted_scope(name, type: type)
             scope[:type] ||= "'r','v','m','p','f'" # (r)elation/table, (v)iew, (m)aterialized view, (p)artitioned table, (f)oreign table
 
-            sql = +"SELECT c.relname FROM pg_class c LEFT JOIN pg_namespace n ON n.oid = c.relnamespace"
+            select_expr = include_schema ? "format('%I.%I', n.nspname, c.relname)" : "c.relname"
+            sql = +"SELECT #{select_expr} FROM pg_class c LEFT JOIN pg_namespace n ON n.oid = c.relnamespace"
             sql << " WHERE n.nspname = #{scope[:schema]}"
             sql << " AND c.relname = #{scope[:name]}" if scope[:name]
             sql << " AND c.relkind IN (#{scope[:type]})"

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -234,7 +234,7 @@ module ActiveRecord
 
       def truncate_tables(db_config)
         with_temporary_connection(db_config) do |conn|
-          conn.truncate_tables(*conn.tables)
+          conn.truncate_tables(*conn.qualified_tables)
         end
       end
       private :truncate_tables

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -534,6 +534,41 @@ module ActiveRecord
       reset_fixtures("posts", "authors", "author_addresses")
     end
 
+    def test_truncate_tables_ignores_schema_qualified_internal_tables
+      internal_metadata = @connection.pool.internal_metadata
+      internal_metadata[:foo] = "bar"
+
+      assert_operator Post.count, :>, 0
+      assert_operator internal_metadata.count, :>, 0
+
+      @connection.truncate_tables("posts", "myschema.#{internal_metadata.table_name}")
+
+      assert_equal 0, Post.count
+      assert_operator internal_metadata.count, :>, 0
+
+      original_prefix = ActiveRecord::Base.table_name_prefix
+      ActiveRecord::Base.table_name_prefix = "myschema."
+      begin
+        @connection.truncate_tables("myschema.#{internal_metadata.table_name}")
+
+        assert_operator internal_metadata.count, :>, 0
+
+        @connection.truncate_tables(internal_metadata.table_name)
+
+        assert_operator internal_metadata.count, :>, 0
+      ensure
+        ActiveRecord::Base.table_name_prefix = original_prefix
+      end
+
+      @connection.truncate_tables("public.#{internal_metadata.table_name}")
+
+      assert_operator internal_metadata.count, :>, 0
+    ensure
+      ActiveRecord::Base.table_name_prefix = original_prefix if defined?(original_prefix)
+      reset_fixtures("posts")
+      internal_metadata.delete_all_entries
+    end
+
     def test_truncate_tables_with_query_cache
       @connection.enable_query_cache!
 

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -120,6 +120,56 @@ class SchemaTest < ActiveRecord::PostgreSQLTestCase
     assert_includes schema_names, "hint_plan" if @connection.supports_optimizer_hints?
   end
 
+  def test_qualified_tables
+    tables = @connection.qualified_tables
+    assert_not_empty tables
+    assert tables.all? { |t| t.include?(".") }
+    assert_not_includes tables, "test_schema.#{TABLE_NAME}"
+    assert_not_includes tables, "test_schema2.#{TABLE_NAME}"
+  end
+
+  def test_qualified_tables_with_search_path
+    with_schema_search_path "public,test_schema,test_schema2" do
+      tables = @connection.qualified_tables
+      assert_not_empty tables
+      assert tables.all? { |t| t.include?(".") }
+      assert_includes tables, "test_schema.#{TABLE_NAME}"
+      assert_includes tables, "test_schema2.#{TABLE_NAME}"
+    end
+  end
+
+  def test_qualified_tables_quotes_identifiers_containing_dots
+    with_schema_search_path "public,test_schema" do
+      tables = @connection.qualified_tables
+      assert_includes tables, %(test_schema."#{TABLE_NAME}.table")
+    end
+  end
+
+  def test_truncate_tables_with_dotted_table_name
+    with_schema_search_path "public,test_schema" do
+      qualified_name = @connection.qualified_tables.find { |t| t == %(test_schema."#{TABLE_NAME}.table") }
+
+      @connection.execute %(INSERT INTO #{SCHEMA_NAME}."#{TABLE_NAME}.table" (id) VALUES (1))
+
+      @connection.truncate_tables(qualified_name)
+
+      assert_equal 0, @connection.select_value(%(SELECT count(*) FROM #{SCHEMA_NAME}."#{TABLE_NAME}.table"))
+    end
+  end
+
+  def test_truncate_tables_excludes_schema_qualified_internal_metadata_table
+    internal_metadata_table = @connection.pool.internal_metadata.table_name
+
+    @connection.execute "CREATE TABLE #{SCHEMA_NAME}.#{internal_metadata_table} (id serial primary key)"
+    @connection.execute "INSERT INTO #{SCHEMA_NAME}.#{internal_metadata_table} DEFAULT VALUES"
+    @connection.execute "INSERT INTO #{SCHEMA_NAME}.#{TABLE_NAME} (id) VALUES (1)"
+
+    @connection.truncate_tables("#{SCHEMA_NAME}.#{internal_metadata_table}", "#{SCHEMA_NAME}.#{TABLE_NAME}")
+
+    assert_equal 1, @connection.select_value("SELECT count(*) FROM #{SCHEMA_NAME}.#{internal_metadata_table}")
+    assert_equal 0, @connection.select_value("SELECT count(*) FROM #{SCHEMA_NAME}.#{TABLE_NAME}")
+  end
+
   def test_create_schema
     @connection.create_schema "test_schema3"
     assert @connection.schema_names.include? "test_schema3"


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because truncation and disabling of referential integrity incorrectly skip certain tables in different schemas which have the same name (e.g. `my_schema.books` and `other_schema.books`, one of which is skipped). This particularly affects truncating test databases and loading fixtures. The reason is that the Postgres adapter's `tables` method does not return schema-qualified names, so affected table names are the same and ambiguous. Then when e.g. truncation happens, the table targeted is the one in the schema which comes earlier in the search path.

### Detail

This Pull Request is based on the change in #58125, and:
1. Introduces a new method on the abstract adapter called `qualified_tables`, which just calls `tables`
2. Specialises this method for Postgres so that it returns schema-qualified tables (with changes to `data_source_sql` to enable this)
3. Updates relevant callers of `tables` to use `qualified_tables`: `DatabaseTasks#truncate_tables`, `empty_all_tables` on the adapter, and for Postgres also `ReferentialIntegrity#disable_referential_integrity`

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

To reproduce:

```ruby
require "active_record"

ActiveRecord::Base.establish_connection(adapter: "postgresql", database: "repro_schema_bug")
conn = ActiveRecord::Base.connection

conn.execute("CREATE SCHEMA shop_one")
conn.execute("CREATE SCHEMA shop_two")
conn.execute("CREATE TABLE shop_one.orders (id serial primary key)")
conn.execute("CREATE TABLE shop_two.orders (id serial primary key)")
conn.execute("INSERT INTO shop_one.orders DEFAULT VALUES")
conn.execute("INSERT INTO shop_two.orders DEFAULT VALUES")

conn.schema_search_path = "shop_one,shop_two"

conn.tables # => ["orders", "orders"]

conn.empty_all_tables

conn.select_value("SELECT count(*) FROM shop_one.orders") # => 0 (truncated)
conn.select_value("SELECT count(*) FROM shop_two.orders") # => 1 (not truncated)
```

And analogously with disabling referential integrity, only the first table would be targeted.

The main reason for not changing `tables` directly was to avoid a breaking change.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
