### PR TITLE
Fix PostgreSQL schema dump foreign key order

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -7,6 +7,20 @@
 
     *Ryuta Kamizono*
 
+*   Fix PostgreSQL schema dumps with foreign keys across multiple schemas.
+
+    When `ActiveRecord.dump_schemas` covers more than one schema, `schema.rb`
+    grouped the `add_foreign_key` statements of each schema right after that
+    schema's tables. A foreign key pointing at a schema dumped later then
+    referenced a table that did not exist yet, and `db:schema:load` or
+    `db:test:prepare` aborted with
+    `PG::UndefinedTable: ERROR: relation "..." does not exist`.
+
+    All table definitions are now dumped before any foreign keys. Dumps of a
+    single schema, and of every other adapter, are unchanged.
+
+    *David Paluy*
+
 *   Use bind parameters for array-form arguments in `find_by_sql` and
     `count_by_sql`, matching the `where` behavior the API doc already
     claimed.

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -58,12 +58,22 @@ module ActiveRecord
             end
           end
 
+          # Foreign keys can point at a table living in another schema, so every
+          # table definition is dumped before any foreign key. Otherwise loading
+          # the dump fails on a reference to a schema dumped later on.
           def tables(stream)
+            tables_by_schema = {}
             previous_schema_had_tables = false
+
             within_each_schema do
+              tables = tables_by_schema[schema_name] = not_ignored_tables
               stream.puts if previous_schema_had_tables
-              super
-              previous_schema_had_tables = @connection.tables.any?
+              table_definitions(tables, stream)
+              previous_schema_had_tables = tables.any?
+            end
+
+            within_each_schema do
+              dump_foreign_keys(tables_by_schema.fetch(schema_name), stream)
             end
           end
 

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -152,19 +152,23 @@ module ActiveRecord
       end
 
       def tables(stream)
-        sorted_tables = @connection.tables.sort
+        tables = not_ignored_tables
+        table_definitions(tables, stream)
+        dump_foreign_keys(tables, stream)
+      end
 
-        not_ignored_tables = sorted_tables.reject { |table_name| ignored?(table_name) }
-
-        not_ignored_tables.each_with_index do |table_name, index|
+      def table_definitions(tables, stream)
+        tables.each_with_index do |table_name, index|
           table(table_name, stream)
-          stream.puts if index < not_ignored_tables.count - 1
+          stream.puts if index < tables.count - 1
         end
+      end
 
+      def dump_foreign_keys(tables, stream)
         # dump foreign keys at the end to make sure all dependent tables exist.
         if @connection.supports_foreign_keys?
           foreign_keys_stream = StringIO.new
-          not_ignored_tables.each do |tbl|
+          tables.each do |tbl|
             foreign_keys(tbl, foreign_keys_stream)
           end
 
@@ -173,6 +177,10 @@ module ActiveRecord
 
           stream.print foreign_keys_string
         end
+      end
+
+      def not_ignored_tables
+        @connection.tables.sort.reject { |table_name| ignored?(table_name) }
       end
 
       def table(table, stream)

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -1123,4 +1123,40 @@ class DumpSchemasTest < ActiveRecord::PostgreSQLTestCase
       assert_not_includes output, 'add_foreign_key "test_schema.cross_schema_fk_table", "test_schema.test_schema2.referenced_table"'
     end
   end
+
+  def test_schema_dump_emits_foreign_keys_after_all_tables
+    with_dump_schemas(:all) do
+      assert_foreign_keys_dumped_after_tables(dump_all_table_schema)
+    end
+  end
+
+  def test_schema_dump_emits_foreign_keys_after_all_tables_with_schema_search_path
+    with_dump_schemas(:schema_search_path) do
+      # test_schema is dumped first and holds a foreign key on a table of
+      # test_schema2, which is dumped last.
+      with_schema_search_path("test_schema,test_schema2") do
+        output = dump_all_table_schema
+        referenced_table = 'create_table "test_schema2.referenced_table"'
+        foreign_key = 'add_foreign_key "test_schema.cross_schema_fk_table", "test_schema2.referenced_table"'
+
+        assert_includes output, referenced_table
+        assert_includes output, foreign_key
+        assert_operator output.index(referenced_table), :<, output.index(foreign_key)
+        assert_foreign_keys_dumped_after_tables(output)
+      end
+    end
+  end
+
+  private
+    # A dump is only loadable if no add_foreign_key comes before a create_table,
+    # because a foreign key can point at a table of any other schema.
+    def assert_foreign_keys_dumped_after_tables(output)
+      last_table = output.rindex("create_table ")
+      first_foreign_key = output.index("add_foreign_key ")
+
+      assert last_table, "expected the dump to contain table definitions"
+      assert first_foreign_key, "expected the dump to contain foreign keys"
+      assert_operator last_table, :<, first_foreign_key,
+        "expected every add_foreign_key to come after every create_table:\n#{output}"
+    end
 end


### PR DESCRIPTION
### Motivation / Background

  When `ActiveRecord.dump_schemas` covers more than one PostgreSQL schema, the schema dumper groups the `add_foreign_key` statements of each schema directly after that schema's table definitions. A foreign key that points at a table of a schema dumped later than references a table that does not exist yet, so `db:schema:load` and `db:test:prepare` abort with `PG::UndefinedTable: ERROR: relation "..." does not exist`.

  Fixes #56070
  Fixes #56557

  ### Detail

  This Pull Request changes the PostgreSQL schema dumper to emit all `create_table` statements before any `add_foreign_key` statement, across all dumped schemas. The foreign keys are still collected schema by schema, with the search path set to the schema that contains them, so unqualified relation names continue to resolve correctly.

To support this, the shared `SchemaDumper#tables` is split into `table_definitions` and `dump_foreign_keys` so the PostgreSQL dumper can call the two halves in separate passes. This is a pure extraction: dumps of a single PostgreSQL schema, and dumps of every other adapter, are byte for byte identical.

Two tests cover the fix. One asserts that every `add_foreign_key` comes after every `create_table` with `dump_schemas = :all`. The other reproduces the issue directly: with `schema_search_path = "test_schema,test_schema2"`, a foreign key in `test_schema` points at a table of `test_schema2`, which is dumped last.

### Additional information

The schema name duplication also reported in #56070 (references like `"test_schema.test_schema2.referenced_table"`) was already fixed by 23efba233c; this PR resolves the remaining ordering problem.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.