### PR TITLE
Introduce builder method for alter table definitions

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -348,6 +348,19 @@ module ActiveRecord
         table_definition
       end
 
+      # Returns an AlterTable object containing information about changes that
+      # would be made to +table_name+.
+      #
+      #   alter_table = build_alter_table_definition(:suppliers) do |table|
+      #     table.add_column(:qualification, :string)
+      #   end
+      #
+      def build_alter_table_definition(table_name) # :nodoc:
+        alter_table = create_alter_table(table_name)
+        yield alter_table if block_given?
+        alter_table
+      end
+
       # Creates a new join table with the name created using the lexical order of the first two
       # arguments. These arguments can be a String or a Symbol.
       #
@@ -689,7 +702,7 @@ module ActiveRecord
       def add_column(table_name, column_name, type, **options)
         return if options[:if_not_exists] == true && column_exists?(table_name, column_name)
 
-        at = create_alter_table(table_name)
+        at = build_alter_table_definition(table_name)
         at.add_column(column_name, type, **options)
         execute_alter_table(at)
       end
@@ -712,7 +725,7 @@ module ActiveRecord
           raise ArgumentError.new("You must specify at least one column name. Example: remove_columns(:people, :first_name)")
         end
 
-        at = create_alter_table(table_name)
+        at = build_alter_table_definition(table_name)
         column_names.each { |column_name| at.remove_column(column_name) }
         execute_alter_table(at)
       end
@@ -741,7 +754,7 @@ module ActiveRecord
       def remove_column(table_name, column_name, type = nil, **options)
         return if options[:if_exists] == true && !column_exists?(table_name, column_name)
 
-        at = create_alter_table(table_name)
+        at = build_alter_table_definition(table_name)
         at.remove_column(column_name)
         execute_alter_table(at)
       end
@@ -1263,7 +1276,7 @@ module ActiveRecord
         options = foreign_key_options(from_table, to_table, options)
         return if options[:if_not_exists] == true && foreign_key_exists?(from_table, to_table, **options.slice(:column, :primary_key))
 
-        at = create_alter_table from_table
+        at = build_alter_table_definition from_table
         at.add_foreign_key to_table, options
 
         execute_alter_table(at)
@@ -1306,7 +1319,7 @@ module ActiveRecord
 
         fk_name_to_delete = foreign_key_for!(from_table, to_table: to_table, **options).name
 
-        at = create_alter_table from_table
+        at = build_alter_table_definition from_table
         at.drop_foreign_key fk_name_to_delete
 
         execute_alter_table(at)
@@ -1392,7 +1405,7 @@ module ActiveRecord
         options = check_constraint_options(table_name, expression, options)
         return if if_not_exists && check_constraint_exists?(table_name, **options)
 
-        at = create_alter_table(table_name)
+        at = build_alter_table_definition(table_name)
         at.add_check_constraint(expression, options)
 
         execute_alter_table(at)
@@ -1424,7 +1437,7 @@ module ActiveRecord
 
         chk_name_to_delete = check_constraint_for!(table_name, expression: expression, **options).name
 
-        at = create_alter_table(table_name)
+        at = build_alter_table_definition(table_name)
         at.drop_check_constraint(chk_name_to_delete)
 
         execute_alter_table(at)
@@ -1442,7 +1455,7 @@ module ActiveRecord
       end
 
       def remove_constraint(table_name, constraint_name) # :nodoc:
-        at = create_alter_table(table_name)
+        at = build_alter_table_definition(table_name)
         at.drop_constraint(constraint_name)
 
         execute_alter_table(at)
@@ -1556,7 +1569,7 @@ module ActiveRecord
       #   add_timestamps(:suppliers, null: true)
       #
       def add_timestamps(table_name, **options)
-        at = create_alter_table(table_name)
+        at = build_alter_table_definition(table_name)
         at.add_timestamps(**options)
         execute_alter_table(at)
       end
@@ -1667,7 +1680,7 @@ module ActiveRecord
       end
 
       def bulk_change_table(table_name, operations) # :nodoc:
-        alter_table = create_alter_table(table_name)
+        alter_table = build_alter_table_definition(table_name)
 
         operations.each do |command, args, kwargs|
           args.shift # remove table_name
@@ -1676,7 +1689,7 @@ module ActiveRecord
             alter_table.public_send(command, *args, **kwargs)
           else
             execute_alter_table(alter_table)
-            alter_table = create_alter_table(table_name)
+            alter_table = build_alter_table_definition(table_name)
             send(command, table_name, *args, **kwargs)
           end
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -410,7 +410,7 @@ module ActiveRecord
       end
 
       def change_column_default(table_name, column_name, default_or_changes) # :nodoc:
-        at = create_alter_table(table_name)
+        at = build_alter_table_definition(table_name)
         at.change_column_default(column_name, default_or_changes)
         execute_alter_table(at)
       end
@@ -431,13 +431,13 @@ module ActiveRecord
       end
 
       def change_column(table_name, column_name, type, **options) # :nodoc:
-        at = create_alter_table(table_name)
+        at = build_alter_table_definition(table_name)
         at.change_column(column_name, type, **options)
         execute_alter_table(at)
       end
 
       def rename_column(table_name, column_name, new_column_name, **options) # :nodoc:
-        at = create_alter_table(table_name)
+        at = build_alter_table_definition(table_name)
         at.rename_column(column_name, new_column_name, **options)
         execute_alter_table(at)
         rename_column_indexes(table_name, column_name, new_column_name)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -640,14 +640,14 @@ module ActiveRecord
 
         def change_column(table_name, column_name, type, **options) # :nodoc:
           clear_cache!
-          at = create_alter_table(table_name)
+          at = build_alter_table_definition(table_name)
           at.change_column(column_name, type, **options)
           execute_alter_table(at)
         end
 
         # Changes the default value of a table column.
         def change_column_default(table_name, column_name, default_or_changes) # :nodoc:
-          at = create_alter_table(table_name)
+          at = build_alter_table_definition(table_name)
           at.change_column_default(column_name, default_or_changes)
           execute_alter_table(at)
         end
@@ -678,7 +678,7 @@ module ActiveRecord
         # Renames a column in a table.
         def rename_column(table_name, column_name, new_column_name) # :nodoc:
           clear_cache!
-          at = create_alter_table(table_name)
+          at = build_alter_table_definition(table_name)
           at.rename_column(column_name, new_column_name)
           execute_alter_table(at)
           rename_column_indexes(table_name, column_name, new_column_name)
@@ -925,7 +925,7 @@ module ActiveRecord
         #   Specify an exclusion constraint on a subset of the table (internally PostgreSQL creates a partial index for this).
         def add_exclusion_constraint(table_name, expression, **options)
           options = exclusion_constraint_options(table_name, expression, options)
-          at = create_alter_table(table_name)
+          at = build_alter_table_definition(table_name)
           at.add_exclusion_constraint(expression, options)
 
           execute_alter_table(at)
@@ -987,7 +987,7 @@ module ActiveRecord
         #   Note: only supported by PostgreSQL version 15.0.0 and greater.
         def add_unique_constraint(table_name, column_name = nil, **options)
           options = unique_constraint_options(table_name, column_name, options)
-          at = create_alter_table(table_name)
+          at = build_alter_table_definition(table_name)
           at.add_unique_constraint(column_name, options)
 
           execute_alter_table(at)
@@ -1094,7 +1094,7 @@ module ActiveRecord
         #
         #   validate_constraint :accounts, :constraint_name
         def validate_constraint(table_name, constraint_name)
-          at = create_alter_table table_name
+          at = build_alter_table_definition table_name
           at.validate_constraint constraint_name
 
           execute_alter_table(at)

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/connection_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/connection_test.rb
@@ -193,7 +193,7 @@ class ConnectionTest < ActiveRecord::AbstractMysqlTestCase
   def test_logs_name_rename_column_via_alter_table
     @connection.execute "CREATE TABLE `bar_baz` (`foo` varchar(255))"
     @subscriber.logged.clear
-    at = @connection.send(:create_alter_table, "bar_baz")
+    at = @connection.build_alter_table_definition("bar_baz")
     at.rename_column("foo", "foo2")
     if @connection.send(:supports_rename_column?)
       assert_empty @subscriber.logged

--- a/activerecord/test/cases/migration/schema_definitions_test.rb
+++ b/activerecord/test/cases/migration/schema_definitions_test.rb
@@ -30,6 +30,22 @@ module ActiveRecord
         assert_predicate id_column, :present?
       end
 
+      def test_build_alter_table_definition_with_block
+        at = connection.build_alter_table_definition(:test) do |t|
+          t.add_column(:foo, :string)
+        end
+
+        assert_equal "test", at.name.to_s
+        assert_equal "foo", at.operations.first.column.name
+      end
+
+      def test_build_alter_table_definition_without_block
+        at = connection.build_alter_table_definition(:test)
+
+        assert_equal "test", at.name.to_s
+        assert_empty at.operations
+      end
+
       def test_build_create_join_table_definition_with_block
         assert connection.table_exists?(:posts)
         assert connection.table_exists?(:comments)
@@ -83,7 +99,7 @@ module ActiveRecord
             t.column :foo, :string
           end
 
-          at = connection.send(:create_alter_table, :test)
+          at = connection.build_alter_table_definition(:test)
           at.change_column(:foo, :integer)
 
           op = at.operations.first
@@ -97,7 +113,7 @@ module ActiveRecord
             t.column :foo, :string
           end
 
-          at = connection.send(:create_alter_table, :test)
+          at = connection.build_alter_table_definition(:test)
           at.change_column_default(:foo, "new")
 
           op = at.operations.first


### PR DESCRIPTION
### Motivation / Background

Follow up to https://github.com/rails/rails/pull/58264

Introduce a new builder method `build_alter_table_definition` that returns an AlterTable object containing information about changes that would be made to a table. This allows for a more consistent and flexible way to define alterations to tables, similar to how create table definitions are built.

### Additional information

We rely on the various schema statement builder methods for generating schema statement DDL in order to send that DDL to a centralized migrations manager, so this PR unblocks us being able to do that without calling `connection.send(:create_alter_table, table_name)`.

Most of the existing methods are `nodoc'ed` so I've left this one as `:nodoc:` as well, though `build_create_table_definition` is public.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
