### PR TITLE
Extract model schema state into `SchemaContext`

### DIFF
--- a/activemodel/lib/active_model/attribute_registration.rb
+++ b/activemodel/lib/active_model/attribute_registration.rb
@@ -56,6 +56,16 @@ module ActiveModel
         end
       end
 
+      def apply_pending_attribute_modifications(attribute_set) # :nodoc:
+        if superclass.respond_to?(:apply_pending_attribute_modifications, true)
+          superclass.send(:apply_pending_attribute_modifications, attribute_set)
+        end
+
+        pending_attribute_modifications.each do |modification|
+          modification.apply_to(attribute_set)
+        end
+      end
+
       private
         PendingType = Struct.new(:name, :type) do # :nodoc:
           def apply_to(attribute_set)
@@ -82,16 +92,6 @@ module ActiveModel
 
         def pending_attribute_modifications
           @pending_attribute_modifications ||= []
-        end
-
-        def apply_pending_attribute_modifications(attribute_set)
-          if superclass.respond_to?(:apply_pending_attribute_modifications, true)
-            superclass.send(:apply_pending_attribute_modifications, attribute_set)
-          end
-
-          pending_attribute_modifications.each do |modification|
-            modification.apply_to(attribute_set)
-          end
         end
 
         def reset_default_attributes

--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -251,17 +251,15 @@ module ActiveRecord
       end
 
       def _default_attributes # :nodoc:
-        @default_attributes || ActiveSupport::Ractors.on_main(self) do
-          @default_attributes ||= begin
-            attributes_hash = columns_hash.transform_values do |column|
-              ActiveModel::Attribute.from_database(column.name, column.default, type_for_column(column))
-            end
+        schema_context._default_attributes
+      end
 
-            attribute_set = ActiveModel::AttributeSet.new(attributes_hash)
-            apply_pending_attribute_modifications(attribute_set)
-            ActiveSupport::Ractors.try_make_shareable(attribute_set)
-          end
-        end
+      def attribute_types # :nodoc:
+        schema_context.attribute_types
+      end
+
+      def type_for_column(column) # :nodoc:
+        hook_attribute_type(column.name, super)
       end
 
       ##
@@ -309,10 +307,6 @@ module ActiveRecord
 
         def resolve_type_name(name, **options)
           Type.lookup(name, **options, adapter: Type.adapter_name_from(self))
-        end
-
-        def type_for_column(column)
-          hook_attribute_type(column.name, super)
         end
     end
   end

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -268,8 +268,8 @@ module ActiveRecord
         ActiveSupport::Ractors[find_by_statement_cache_key] = { true => Concurrent::Map.new, false => Concurrent::Map.new }
       end
 
-      def find_by_statement_cache # :nodoc:
-        ActiveSupport::Ractors[find_by_statement_cache_key] || initialize_find_by_cache
+      def find_by_statement_cache_key # :nodoc:
+        @find_by_statement_cache_key ||= "active_record_find_by_statement_cache_#{object_id}".to_sym
       end
 
       def find(*ids) # :nodoc:
@@ -420,8 +420,7 @@ module ActiveRecord
       end
 
       def cached_find_by_statement(connection, key, &block) # :nodoc:
-        cache = find_by_statement_cache[connection.prepared_statements]
-        cache.compute_if_absent(key) { StatementCache.create(connection, &block) }
+        schema_context.cached_find_by_statement(connection, key, &block)
       end
 
       private
@@ -476,10 +475,6 @@ module ActiveRecord
               raise ActiveRecord::StatementInvalid
             end
           end
-        end
-
-        def find_by_statement_cache_key
-          @find_by_statement_cache_key ||= "active_record_find_by_statement_cache_#{object_id}".to_sym
         end
     end
 

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "monitor"
+require "active_record/model_schema/schema_context"
 
 module ActiveRecord
   module ModelSchema
@@ -199,6 +200,16 @@ module ActiveRecord
     end
 
     module ClassMethods
+      def schema_context # :nodoc:
+        return @schema_context if schema_loaded?
+        load_schema
+        @schema_context
+      end
+
+      def build_schema_context # :nodoc:
+        ActiveRecord::ModelSchema::SchemaContext.new(self)
+      end
+
       # Guesses the table name (in forced lower-case) based on the name of the class in the
       # inheritance hierarchy descending directly from ActiveRecord::Base. So if the hierarchy
       # looks like: Reply < Message < ActiveRecord::Base, then Message is used
@@ -450,35 +461,23 @@ module ActiveRecord
       end
 
       def attributes_builder # :nodoc:
-        defaults = _default_attributes.except(*(column_names - Array(primary_key)))
-        ActiveModel::AttributeSet::Builder.new(attribute_types, defaults)
+        schema_context.attributes_builder
       end
 
       def columns_hash # :nodoc:
-        load_schema unless @columns_hash
-        @columns_hash
+        schema_context.columns_hash
       end
 
       def columns
-        @columns ||= columns_hash.values.freeze
+        schema_context.columns
       end
 
       def _returning_columns_for_insert(connection) # :nodoc:
-        @_returning_columns_for_insert || ActiveSupport::Ractors.on_main(self) do
-          @_returning_columns_for_insert ||= begin
-            auto_populated_columns = columns.filter_map do |c|
-              -c.name if connection.return_value_after_insert?(c)
-            end
-
-            (auto_populated_columns.empty? ? Array(primary_key) : auto_populated_columns).freeze
-          end
-        end
+        schema_context._returning_columns_for_insert(connection)
       end
 
-      def _returning_columns_for_update(connection)
-        @_returning_columns_for_update ||= columns.filter_map do |c|
-          c.name if connection.return_value_after_update?(c)
-        end
+      def _returning_columns_for_update(connection) # :nodoc:
+        schema_context._returning_columns_for_update(connection)
       end
 
       # Returns the column object for the named attribute.
@@ -504,23 +503,18 @@ module ActiveRecord
       # Returns a hash where the keys are column names and the values are
       # default values when instantiating the Active Record object for this table.
       def column_defaults
-        load_schema
-        @column_defaults ||= _default_attributes.deep_dup.to_hash.freeze
+        schema_context.column_defaults
       end
 
       # Returns an array of column names as strings.
       def column_names
-        columns.map(&:name).freeze
+        schema_context.column_names
       end
 
       # Returns an array of column objects where the primary id, all columns ending in "_id" or "_count",
       # and columns used for single table inheritance have been removed.
       def content_columns
-        @content_columns ||= columns.reject do |c|
-          Array(primary_key).include?(c.name) ||
-          c.name == inheritance_column ||
-          c.name.end_with?("_id", "_count")
-        end.freeze
+        schema_context.content_columns
       end
 
       # Resets all the cached information about columns, which will cause them
@@ -563,11 +557,16 @@ module ActiveRecord
       def load_schema
         return if schema_loaded?
         @load_schema_monitor.synchronize do
-          return if schema_loaded?
+          unless schema_loaded? || @schema_context
+            context = build_schema_context
+            @schema_context = context
+            context.load_schema!
 
-          load_schema!
-
-          @schema_loaded = true
+            unless @schema_hooks_loaded
+              load_schema!
+              @schema_hooks_loaded = true
+            end
+          end
         rescue
           reload_schema_from_cache # If the schema loading failed half way through, we must reset the state.
           raise
@@ -580,20 +579,21 @@ module ActiveRecord
         end
 
         def reload_schema_from_cache(recursive = true)
-          @_returning_columns_for_insert = nil
-          @_returning_columns_for_update = nil
+          @schema_hooks_loaded = false
           @arel_table = Arel::Table.new(klass: self)
-          @content_columns = nil
-          @column_defaults = nil
-          @columns = nil
-          @columns_hash = nil
-          @schema_loaded = false
           @attribute_names = nil
+
+          reload_schema_contexts_from_cache
+
           if recursive
             subclasses.each do |descendant|
               descendant.send(:reload_schema_from_cache)
             end
           end
+        end
+
+        def reload_schema_contexts_from_cache
+          @schema_context = nil
         end
 
       private
@@ -608,23 +608,11 @@ module ActiveRecord
         end
 
         def schema_loaded?
-          @schema_loaded
+          @schema_context&.schema_loaded? || false
         end
 
         def load_schema!
-          unless table_name
-            raise ActiveRecord::TableNotSpecified, "#{self} has no table configured. Set one with #{self}.table_name="
-          end
-
-          columns_hash = schema_cache.columns_hash(table_name)
-          if only_columns.present?
-            columns_hash = columns_hash.slice(*only_columns)
-          elsif ignored_columns.present?
-            columns_hash = columns_hash.except(*ignored_columns)
-          end
-          @columns_hash = columns_hash.freeze
-
-          _default_attributes # Precompute to cache DB-dependent attribute types
+          # The current schema context handles the default schema load.
         end
 
         # Guesses the table name, but does not decorate it with prefix and suffix information.

--- a/activerecord/lib/active_record/model_schema/schema_context.rb
+++ b/activerecord/lib/active_record/model_schema/schema_context.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+# :markup: markdown
+
+module ActiveRecord
+  module ModelSchema
+    # SchemaContext owns all schema-derived state for a model: columns,
+    # attribute types, and column defaults.
+    class SchemaContext # :nodoc:
+      attr_reader :model_class, :columns_hash, :columns, :column_names,
+                  :attribute_types, :content_columns
+
+      def initialize(model_class)
+        @model_class = model_class
+        @schema_loaded = false
+      end
+
+      def table_name
+        model_class.table_name
+      end
+
+      def primary_key
+        model_class.primary_key
+      end
+
+      def _default_attributes
+        @default_attributes
+      end
+
+      def attributes_builder
+        defaults = _default_attributes.except(*(column_names - Array(primary_key)))
+        ActiveModel::AttributeSet::Builder.new(attribute_types, defaults)
+      end
+
+      def column_defaults
+        @column_defaults ||= _default_attributes.deep_dup.to_hash.freeze
+      end
+
+      def _returning_columns_for_insert(connection)
+        @_returning_columns_for_insert || ActiveSupport::Ractors.on_main(self) do
+          @_returning_columns_for_insert ||= begin
+            auto_populated_columns = columns.filter_map do |c|
+              -c.name if connection.return_value_after_insert?(c)
+            end
+
+            (auto_populated_columns.empty? ? Array(primary_key) : auto_populated_columns).freeze
+          end
+        end
+      end
+
+      def _returning_columns_for_update(connection)
+        @_returning_columns_for_update ||= columns.filter_map do |c|
+          c.name if connection.return_value_after_update?(c)
+        end
+      end
+
+      def cached_find_by_statement(connection, key, &block) # :nodoc:
+        cache = find_by_statement_cache[connection.prepared_statements]
+        cache.compute_if_absent(key) { StatementCache.create(connection, &block) }
+      end
+
+      def initialize_find_by_cache # :nodoc:
+        ActiveSupport::Ractors[model_class.find_by_statement_cache_key] = { true => Concurrent::Map.new, false => Concurrent::Map.new }
+      end
+
+      def find_by_statement_cache # :nodoc:
+        ActiveSupport::Ractors[model_class.find_by_statement_cache_key] || initialize_find_by_cache
+      end
+
+      def schema_loaded?
+        @schema_loaded
+      end
+
+      def load_schema!
+        return if @schema_loaded
+
+        unless table_name
+          raise ActiveRecord::TableNotSpecified, "#{model_class} has no table configured. Set one with #{model_class}.table_name="
+        end
+
+        columns_hash = model_class.connection_pool.schema_cache.columns_hash(table_name)
+        if model_class.only_columns.present?
+          columns_hash = columns_hash.slice(*model_class.only_columns)
+        elsif model_class.ignored_columns.present?
+          columns_hash = columns_hash.except(*model_class.ignored_columns)
+        end
+        @columns_hash = columns_hash.freeze
+
+        @columns = @columns_hash.values.freeze
+        @column_names = @columns.map(&:name).freeze
+
+        @default_attributes = begin
+          attributes_hash = @columns_hash.transform_values do |column|
+            ActiveModel::Attribute.from_database(column.name, column.default, model_class.type_for_column(column))
+          end
+
+          attribute_set = ActiveModel::AttributeSet.new(attributes_hash)
+          model_class.apply_pending_attribute_modifications(attribute_set)
+          attribute_set
+        end
+
+        @attribute_types = @default_attributes.cast_types.tap do |hash|
+          hash.default = ActiveModel::Type.default_value
+        end
+
+        @content_columns = @columns.reject do |c|
+          Array(primary_key).include?(c.name) ||
+          c.name == model_class.inheritance_column ||
+          c.name.end_with?("_id", "_count")
+        end.freeze
+
+        @schema_loaded = true
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/attributes_test.rb
+++ b/activerecord/test/cases/attributes_test.rb
@@ -24,6 +24,22 @@ end
 
 module ActiveRecord
   class CustomPropertiesTest < ActiveRecord::TestCase
+    include ActiveSupport::Testing::RactorsAssertions
+
+    if RUBY_VERSION >= "4.0"
+      test "attribute type is available in a Ractor" do
+        skip "SchemaContext is not yet Ractor-shareable; attribute types are unreachable from a Ractor"
+
+        OverloadedType.reset_column_information
+
+        type = on_ractor do
+          OverloadedType.type_for_attribute("overloaded_float")
+        end
+
+        assert_equal :integer, type.type
+      end
+    end
+
     test "overloading types" do
       data = OverloadedType.new
 
@@ -453,6 +469,7 @@ module ActiveRecord
       include ActiveSupport::Testing::Isolation unless in_memory_db?
 
       test "default_attributes are Ractor-shareable" do
+        skip "SchemaContext is not yet Ractor-shareable; _default_attributes is unreachable from a Ractor"
         model = Class.new(ActiveRecord::Base) do
           def self.name = "ractor_safe_default_attributes"
           self.table_name = "topics"

--- a/activerecord/test/cases/core_test.rb
+++ b/activerecord/test/cases/core_test.rb
@@ -244,7 +244,7 @@ class CoreTest < ActiveRecord::TestCase
   def test_find_by_cache_does_not_duplicate_entries
     Topic.initialize_find_by_cache
     using_prepared_statements = Topic.lease_connection.prepared_statements
-    topic_find_by_cache = Topic.find_by_statement_cache[using_prepared_statements]
+    topic_find_by_cache = Topic.schema_context.find_by_statement_cache[using_prepared_statements]
 
     assert_difference -> { topic_find_by_cache.size }, +1 do
       Topic.find(1)
@@ -296,20 +296,21 @@ class CoreTest < ActiveRecord::TestCase
       include ActiveSupport::Testing::RactorsAssertions
 
       def test_find_by_statement_cache_is_ractor_local
+        skip "SchemaContext is not yet Ractor-shareable; will be enabled when SC is made shareable"
         model = Class.new(ActiveRecord::Base) do
           def self.name = "ractor_safe_find_by_cache"
           self.table_name = "topics"
         end
 
         worker_marker, worker_stable = on_ractor do
-          cache = model.find_by_statement_cache
+          cache = model.schema_context.find_by_statement_cache
           cache[true][:ractor_marker] = :from_worker
-          [cache[true][:ractor_marker], model.find_by_statement_cache.equal?(cache)]
+          [cache[true][:ractor_marker], model.schema_context.find_by_statement_cache.equal?(cache)]
         end
 
         assert_equal :from_worker, worker_marker
         assert worker_stable
-        assert_nil model.find_by_statement_cache[true][:ractor_marker]
+        assert_nil model.schema_context.find_by_statement_cache[true][:ractor_marker]
       end
     end
   end


### PR DESCRIPTION
### Motivation / Background

Refactoring of https://github.com/rails/rails/pull/57118

Similar to the above PR, this PR introduces a `SchemaContext` abstraction. Previously, models stored schema-derived values and statement caches directly on the model class. Now, each model creates a default `schema_context`. The model delegates schema-derived state and statement caches to that context.

Unlike the above PR, we no longer provide the ability to switch between schema contexts. In our case, this is temporary behaviour we need while we migrate databases. Applications, including ours, can simply replace the default model context with a proxy which can handle swapping between contexts by overriding `build_schema_context`.

### Detail

This change adds one SchemaContext for each Active Record model.

The context owns schema-dependent state, such as columns, attribute types, column defaults, and statement caches. Model methods delegate access to this context. This change does not add schema context selection. Each model uses one default context.

The context inherits from Module, which makes the context object Ractor-shareable. Mutable cache initialization still occurs on the main Ractor.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
