### PR TITLE
Render the `EncryptedFile#read` exception list as a list

### DIFF
--- a/activesupport/lib/active_support/encrypted_file.rb
+++ b/activesupport/lib/active_support/encrypted_file.rb
@@ -63,6 +63,7 @@ module ActiveSupport
     # Reads the file and returns the decrypted content.
     #
     # Raises:
+    #
     # - MissingKeyError if the key is missing and `raise_if_missing_key` is true.
     # - MissingContentError if the encrypted file does not exist or otherwise
     #   if the key is missing.


### PR DESCRIPTION
`ActiveSupport::EncryptedFile#read` documents the exceptions it raises as a list. Since 17831794cc the items render as a single paragraph instead:

    <p>Raises: - MissingKeyError if the key is missing and <code>raise_if_missing_key</code>
    is true. - MissingContentError if the encrypted file does not exist or otherwise
    if the key is missing. - ActiveSupport::MessageEncryptor::InvalidMessage if the
    content cannot be decrypted or verified.</p>

With this change the output matches what it was before the conversion:

    <p>Raises:</p>
    <ul><li>
    <p>MissingKeyError if the key is missing and <code>raise_if_missing_key</code> is true.</p>
    </li><li>
    <p>MissingContentError if the encrypted file does not exist or otherwise if the key is missing.</p>
    </li><li>
    <p>ActiveSupport::MessageEncryptor::InvalidMessage if the content cannot be decrypted or verified.</p>
    </li></ul>

cc @fxn