### PR TITLE
Render Markdown lists that collapse into paragraphs

### DIFF
--- a/actioncable/lib/action_cable/channel/test_case.rb
+++ b/actioncable/lib/action_cable/channel/test_case.rb
@@ -34,6 +34,7 @@ module ActionCable
     # ## Basic example
     #
     # Functional tests are written as follows:
+    #
     # 1.  First, one uses the `subscribe` method to simulate subscription creation.
     # 2.  Then, one asserts whether the current state is as expected. "State" can be
     #     anything: transmitted messages, subscribed streams, etc.

--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -86,6 +86,7 @@ module ActionController
   #     end
   #
   # Common keys you might want to exclude:
+  #
   # - `:active_record_connected_to_stack` - Database connection routing and roles
   # - `:active_record_prohibit_shard_swapping` - Shard swapping restrictions
   #

--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -116,6 +116,7 @@ module ActionController
     #
     # The `action_on_open_redirect` configuration option controls the behavior when an unsafe
     # redirect is detected:
+    #
     # * `:log` - Logs a warning but allows the redirect
     # * `:notify` - Sends an Active Support notification and structured event for monitoring
     # * `:raise` - Raises an UnsafeRedirectError

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -263,6 +263,7 @@ module ActionController
   # ## Basic example
   #
   # Functional tests are written as follows:
+  #
   # 1.  First, one uses the `get`, `post`, `patch`, `put`, `delete`, or `head`
   #     method to simulate an HTTP request.
   # 2.  Then, one asserts whether the current state is as expected. "State" can be

--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -17,11 +17,13 @@ module ActionDispatch
       # top-level domain (TLD) length.
       #
       # The module assumes a standard domain structure where domains consist of:
+      #
       # - Subdomains (optional, can be multiple levels)
       # - Domain name
       # - Top-level domain (TLD, can be multiple levels like .co.uk)
       #
       # For example, in "api.staging.example.co.uk":
+      #
       # - Subdomains: ["api", "staging"]
       # - Domain: "example.co.uk" (with tld_length=2)
       # - TLD: "co.uk"

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -24,6 +24,7 @@ module ActiveSupport
     # This is currently the most popular cache store for production websites.
     #
     # Special features:
+    #
     # - Clustering and load balancing. One can specify multiple memcached servers,
     #   and `MemCacheStore` will load balance between all available servers. If a
     #   server goes down, then `MemCacheStore` will ignore it until it comes back up.

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -99,8 +99,9 @@ module ActiveSupport
       # Creates a new Redis cache store.
       #
       # The `:url` param can be:
-      #    - A string used to create a RedisClient::Pooled instance.
-      #    - An array of strings used to create a `RedisClient::HashRing` instance.
+      #
+      # - A string used to create a RedisClient::Pooled instance.
+      # - An array of strings used to create a `RedisClient::HashRing` instance.
       #
       # ```
       # Option  Class       Result

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -792,8 +792,11 @@ module ActiveSupport
         # ```
         #
         # Output:
-        #   - save
-        #   saved
+        #
+        # ```
+        # - save
+        # saved
+        # ```
         #
         # When if option returns false, callback is NOT skipped.
         #

--- a/activesupport/lib/active_support/dot_env_configuration.rb
+++ b/activesupport/lib/active_support/dot_env_configuration.rb
@@ -11,6 +11,7 @@ module ActiveSupport
   # and thus allows all three to serve as interchangeable backends for `Rails.app.creds`.
   #
   # The .env file format supports:
+  #
   # - Lines with KEY=value pairs
   # - Comments starting with #
   # - Empty lines (ignored)


### PR DESCRIPTION
Follow-up to #58439. Sweeping every `:markup: markdown` file under `*/lib` turned up nine more lists that render as a single run-on paragraph, plus one block of sample output in the same state.

For example, `ActionController::TestCase`:

    Functional tests are written as follows: 1. First, one uses the get, post, patch,
    put, delete, or head method to simulate an HTTP request. 2. Then, one asserts
    whether the current state is as expected. “State” can be anything: the controller’s
    HTTP response, the database contents, etc.

and `ActionDispatch::Http::URL::DomainExtractor`:

    The module assumes a standard domain structure where domains consist of: -
    Subdomains (optional, can be multiple levels) - Domain name - Top-level domain
    (TLD, can be multiple levels like .co.uk) For example, in “api.staging.example.co.uk”:
    - Subdomains: ["api", "staging"] - Domain: "example.co.uk" (with tld_length=2) -
    TLD: "co.uk"

Affected pages:

| Page | |
| --- | --- |
| `ActionController::TestCase` | ordered list |
| `ActionCable::Channel::TestCase` | ordered list |
| `ActionController::Live` | list |
| `ActionController::Redirecting` | list |
| `ActionDispatch::Http::URL::DomainExtractor` | two lists |
| `ActiveSupport::DotEnvConfiguration` | list |
| `ActiveSupport::Cache::RedisCacheStore` | list |
| `ActiveSupport::Cache::MemCacheStore` | list |
| `ActiveSupport::Callbacks::ClassMethods#skip_callback` | sample output |

`skip_callback` is the odd one out: the affected block is the output of the example above it, not a list, so it becomes a code block. The second `Output:` in that same comment already renders that way.

Each change was verified by generating the HTML with `rdoc` and confirming the `<ol>`/`<ul>`/`<pre>` is back on the page.

cc @fxn