### PR TITLE
Wrap PostgreSQL null byte error in ActiveRecord::NullByteError

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,23 @@
+*   Wrap the PostgreSQL driver's null byte error in `ActiveRecord::NullByteError`.
+
+    PostgreSQL cannot store null bytes (`\0`) in text columns. Previously the
+    `pg` gem raised a `ArgumentError`, which surfaced as an unhandled 500.
+    It is now wrapped in `ActiveRecord::NullByteError` and mapped to `:bad_request`
+    in the default `rescue_responses`, so it is rendered as a 400 in production.
+
+    Applications can rescue it to strip the null bytes, validate the input, or
+    reject the request, without any change to stored data or query behavior.
+
+    ```ruby
+    begin
+      Book.create!(name: "a\0b")
+    rescue ActiveRecord::NullByteError
+      # handle invalid input
+    end
+    ```
+
+    *Simon Isler*
+
 *   Deprecate `ActiveRecord::ConnectionAdapters::DatabaseStatements#create`
     in favor of `#insert`.
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -946,6 +946,10 @@ module ActiveRecord
         QUERY_CANCELED        = "57014"
 
         def translate_exception(exception, message:, sql:, binds:)
+          if exception.is_a?(ArgumentError) && exception.message.include?("string contains null byte")
+            return NullByteError.new(message, sql: sql, binds: binds, connection_pool: @pool)
+          end
+
           return exception unless exception.respond_to?(:result)
 
           case exception.result.try(:error_field, PG::PG_DIAG_SQLSTATE)

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -314,6 +314,15 @@ module ActiveRecord
   class RangeError < StatementInvalid
   end
 
+  # Raised when a string containing a null byte (+\0+) is used in a statement
+  # against a database that cannot store it, such as a text column in PostgreSQL.
+  #
+  # The underlying driver error is wrapped so that applications can rescue it
+  # and, for example, respond with a 400 Bad Request instead of an unhandled
+  # 500.
+  class NullByteError < StatementInvalid
+  end
+
   # Raised when a statement produces an SQL warning.
   class SQLWarning < AdapterError
     attr_reader :code, :level

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -24,7 +24,8 @@ module ActiveRecord
       "ActiveRecord::RecordNotFound"   => :not_found,
       "ActiveRecord::StaleObjectError" => :conflict,
       "ActiveRecord::RecordInvalid"    => ActionDispatch::Constants::UNPROCESSABLE_CONTENT,
-      "ActiveRecord::RecordNotSaved"   => ActionDispatch::Constants::UNPROCESSABLE_CONTENT
+      "ActiveRecord::RecordNotSaved"   => ActionDispatch::Constants::UNPROCESSABLE_CONTENT,
+      "ActiveRecord::NullByteError"    => :bad_request
     )
 
     config.active_record.use_schema_cache_dump = true

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -1681,6 +1681,24 @@ module ActiveRecord
         assert_not_equal stored_column.hash, virtual_column.hash
       end
 
+      def test_null_byte_in_bind_raises_null_byte_error
+        with_example_table do
+          error = assert_raises ActiveRecord::NullByteError do
+            @connection.exec_query("INSERT INTO ex (data) VALUES ($1)", "SQL", [ActiveRecord::Relation::QueryAttribute.new("data", "a\0b", ActiveRecord::Type::String.new)])
+          end
+          assert_kind_of ActiveRecord::StatementInvalid, error
+        end
+      end
+
+      def test_null_byte_in_inline_quoting_raises_null_byte_error
+        with_example_table do
+          error = assert_raises ActiveRecord::NullByteError do
+            @connection.execute("INSERT INTO ex (data) VALUES (#{@connection.quote("a\0b")})")
+          end
+          assert_kind_of ActiveRecord::StatementInvalid, error
+        end
+      end
+
       private
         def with_postgresql_apdater_decode_dates
           PostgreSQLAdapter.decode_dates = true


### PR DESCRIPTION
### Motivation / Background

PostgreSQL cannot store null bytes (\0) in text columns. The pg gem raises a bare ArgumentError ("string contains null byte") before the query reaches the server, which surfaces to applications as an unhandled 500.

The solution is to wrap the argument error in a new `ActiveRecord::NullByteError` via the PostgreSQL adapter's and map it to `:bad_request` in the default rescue_responses so it renders as a 400 in production.

Unlike stripping the bytes (as in https://github.com/rails/rails/pull/57306), this changes no stored data and keeps both spellings of a query (`where(col: ...)` and `where("col = ?", ...)`) behaving identically. Applications remain free to rescue it and strip, validate, or reject the input as they see fit.

### Additional information

This PR replaces https://github.com/rails/rails/pull/57306 with the solution suggested by @flavorjones in https://discuss.rubyonrails.org/t/handling-null-bytes-in-postgres/89924/2.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
