### PR TITLE
Safeguard exceptions app from unparseable query strings

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Strip invalid query strings before invoking the exceptions app.
+
+    Custom exceptions apps (e.g. `config.exceptions_app = self.routes`) raised a 500
+    when they would read unparseable query strings. The invalid query string is
+    now removed from the request before the exceptions app is called, so the
+    configured error page renders with the intended status (400).
+
+    *Josua Schmid*
+
 *   Split keyword arguments off `#args` on `Rails.application.middleware` entries.
 
     Middleware entries now expose keyword arguments through a new `#kwargs`

--- a/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
@@ -49,6 +49,7 @@ module ActionDispatch
         status = wrapper.status_code
         request.set_header "action_dispatch.original_path", request.path_info
         request.set_header "action_dispatch.original_request_method", request.raw_request_method
+        strip_query_string_if_invalid(request)
         fallback_to_html_format_if_invalid_mime_type(request)
         request.path_info = "/#{status}"
         request.request_method = "GET"
@@ -62,6 +63,14 @@ module ActionDispatch
           "If you are the administrator of this website, then please read this web " \
           "application's log file and/or the web server's log file to find out what " \
           "went wrong."]]
+      end
+
+      def strip_query_string_if_invalid(request)
+        # If the query string is invalid the @exceptions_app would crash on it
+        # just like the app did. Remove it so the error page can render.
+        request.query_parameters
+      rescue ActionController::BadRequest
+        request.set_header "QUERY_STRING", ""
       end
 
       def fallback_to_html_format_if_invalid_mime_type(request)

--- a/actionpack/test/dispatch/request/query_string_parsing_test.rb
+++ b/actionpack/test/dispatch/request/query_string_parsing_test.rb
@@ -147,6 +147,19 @@ class QueryStringParsingTest < ActionDispatch::IntegrationTest
     )
   end
 
+  test "query string with invalid percent-encoding returns a bad request" do
+    with_routing do |set|
+      set.draw do
+        ActionDispatch.deprecator.silence do
+          get ":action", to: ::QueryStringParsingTest::TestController
+        end
+      end
+
+      get "/parse", headers: { "QUERY_STRING" => "unfinished=escape+seq+%A" }
+      assert_response :bad_request
+    end
+  end
+
   test "ambiguous query string returns a bad request" do
     with_routing do |set|
       set.draw do

--- a/actionpack/test/dispatch/show_exceptions_test.rb
+++ b/actionpack/test/dispatch/show_exceptions_test.rb
@@ -17,6 +17,12 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
         rescue
           raise ActionDispatch::Http::Parameters::ParseError
         end
+      when "/bad_query"
+        begin
+          raise Rack::QueryParser::InvalidParameterError, "invalid %-encoding (unfinished=escape+seq+%A)"
+        rescue
+          raise ActionController::BadRequest.new("Invalid query parameters: invalid %-encoding (unfinished=escape+seq+%A)")
+        end
       when "/method_not_allowed"
         raise ActionController::MethodNotAllowed, "PUT"
       when "/unknown_http_method"
@@ -169,6 +175,19 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
     assert_equal "application/json; charset=utf-8", response.headers["content-type"]
     assert_response 400
     assert_equal("{\"status\":400,\"error\":\"Bad Request\"}", body)
+  end
+
+  test "invalid query string stays a bad request when the exceptions app reads the bad query parameters" do
+    exceptions_app = lambda do |env|
+      ActionDispatch::Request.new(env).query_parameters
+      [400, { "content-type" => "text/plain" }, ["custom 400 error page"]]
+    end
+
+    @app = build_app(exceptions_app)
+
+    get "/bad_query", headers: { "QUERY_STRING" => "unfinished=escape+seq+%A" }, env: { "action_dispatch.show_exceptions" => :all }
+
+    assert_response :bad_request
   end
 
   test "failsafe prevents raising if exceptions_app raises" do


### PR DESCRIPTION
Complex exceptions apps (e.g. `config.exception_apps = self.routes`) might read query parameters (e.g. for locales) and fail with a 500 if they are unparseable. We now check whether the query parameters are even parseable and drop them if not so. The behaviour is similar to `fallback_to_html_format_if_invalid_mime_type`.