### PR TITLE
Compile non-strict templates Ractor-locally

### DIFF
--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -177,7 +177,7 @@ module ActionView # :nodoc:
     cattr_accessor :automatically_disable_submit_tag, default: true
 
     # Annotate rendered view with file names
-    cattr_accessor :annotate_rendered_view_with_filenames, default: false
+    class_attribute :annotate_rendered_view_with_filenames, default: false
 
     class_attribute :_routes
     class_attribute :logger

--- a/actionview/lib/action_view/template/handlers/erb.rb
+++ b/actionview/lib/action_view/template/handlers/erb.rb
@@ -22,7 +22,7 @@ module ActionView
         # Strip trailing newlines from rendered output
         class_attribute :strip_trailing_newlines, default: false
 
-        ENCODING_TAG = Regexp.new("\\A(<%#{ENCODING_FLAG}-?%>)[ \\t]*")
+        ENCODING_TAG = Regexp.new("\\A(<%#{ENCODING_FLAG}-?%>)[ \\t]*").freeze
 
         LocationParsingError = Class.new(StandardError) # :nodoc:
 

--- a/actionview/lib/action_view/unbound_template.rb
+++ b/actionview/lib/action_view/unbound_template.rb
@@ -19,17 +19,34 @@ module ActionView
     end
 
     def bind_locals(locals)
-      @strict_locals_template || @templates[locals] || build_bound_template(locals)
+      if @strict_locals_template
+        @strict_locals_template
+      elsif frozen?
+        templates = ractor_local_templates
+        unless template = templates[locals]
+          normalized_locals = normalize_locals(locals)
+          template = templates.compute_if_absent(normalized_locals) { build_template(normalized_locals) }
+          templates[locals.dup] = template
+        end
+        template
+      else
+        @templates[locals] || build_bound_template(locals)
+      end
     end
 
     def built_templates # :nodoc:
-      @strict_locals_template ? [@strict_locals_template] : @templates.values
+      if @strict_locals_template
+        [@strict_locals_template]
+      elsif @templates
+        @templates.values
+      else
+        templates = ractor_local_store[self]
+        templates ? templates.values : []
+      end
     end
 
     def freeze # :nodoc:
-      unless bind_locals([]).strict_locals?
-        raise ArgumentError, "Cannot freeze #{@virtual_path.inspect}: templates must declare strict locals (e.g. `<%# locals: () %>`) to be frozen."
-      end
+      bind_locals([])
       @source.freeze
       @identifier.freeze
       @virtual_path.freeze
@@ -41,6 +58,14 @@ module ActionView
     end
 
     private
+      def ractor_local_templates
+        ractor_local_store.compute_if_absent(self) { Concurrent::Map.new }
+      end
+
+      def ractor_local_store
+        ActiveSupport::Ractors.store_if_absent(:action_view_bound_templates) { Concurrent::Map.new }
+      end
+
       def build_bound_template(locals)
         @write_lock.synchronize do
           return @strict_locals_template if @strict_locals_template

--- a/actionview/lib/action_view/unbound_template.rb
+++ b/actionview/lib/action_view/unbound_template.rb
@@ -77,6 +77,7 @@ module ActionView
 
           if template.strict_locals?
             @strict_locals_template = template
+            @templates = { normalized_locals => template }.freeze
           else
             # This may have already been assigned, but we've already de-dup'd so
             # reassignment is fine.

--- a/actionview/test/template/file_system_resolver_test.rb
+++ b/actionview/test/template/file_system_resolver_test.rb
@@ -79,24 +79,33 @@ class FileSystemResolverTest < ActiveSupport::TestCase
     assert_predicate templates[0], :frozen?
   end
 
-  def test_freeze_raises_for_non_strict_partial
+  def test_freeze_keeps_non_strict_templates_renderable
     with_file "test/_card.html.erb", "<%= post %>"
     resolver = ActionView::FileSystemResolver.new(tmpdir)
-    resolver.eager_load_templates
+    resolver.eager_load_templates(compile_view)
+    resolver.freeze
 
-    error = assert_raises(ArgumentError) { resolver.freeze }
-    assert_match "test/_card", error.message
-    assert_match "strict locals", error.message
+    assert_ractor_shareable resolver
+
+    template = find_all(resolver, "card", "test", true, [:post])[0]
+    assert_not_predicate template, :frozen?
+    assert_equal "hello", template.render(compile_view, { post: "hello" })
   end
 
-  def test_freeze_raises_for_non_strict_template
-    with_file "test/hello_world.html.erb", "no locals here"
+  def test_frozen_non_strict_templates_are_cached_per_locals
+    with_file "test/_card.html.erb", "<%= post %>"
     resolver = ActionView::FileSystemResolver.new(tmpdir)
-    resolver.eager_load_templates
+    resolver.eager_load_templates(compile_view)
+    resolver.freeze
 
-    error = assert_raises(ArgumentError) { resolver.freeze }
-    assert_match "test/hello_world", error.message
-    assert_match "strict locals", error.message
+    a = find_all(resolver, "card", "test", true, [:post])[0]
+    b = find_all(resolver, "card", "test", true, [:post])[0]
+    c = find_all(resolver, "card", "test", true, [:post, :other])[0]
+    d = find_all(resolver, "card", "test", true, [:other, :post])[0]
+
+    assert_same a, b
+    assert_not_same a, c
+    assert_same c, d
   end
 
   def test_frozen_resolver_returns_empty_for_missing_template
@@ -106,5 +115,53 @@ class FileSystemResolverTest < ActiveSupport::TestCase
     resolver.freeze
 
     assert_empty find_all(resolver, "nonexistent")
+  end
+end
+
+class FileSystemResolverRactorTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::Isolation
+  include ActiveSupport::Testing::RactorsAssertions
+
+  # Compiling methods into FakeView from another Ractor is how frozen non-strict templates
+  # are compiled in a ractorized application, with the view class container built in the
+  # main Ractor and other Ractors compiling methods into it. This might stop working with
+  # https://bugs.ruby-lang.org/issues/22226, which would require compiling into a
+  # Ractor-local container instead.
+  class FakeView
+    def compiled_method_container
+      self.class
+    end
+
+    def _run(method, template, locals, buffer, add_to_stack:, has_strict_locals:, &block)
+      @output_buffer = buffer
+      public_send(method, locals, buffer, &block)
+    end
+  end
+
+  test "non-strict templates compile inside a non-main Ractor" do
+    Dir.mktmpdir do |dir|
+      Dir.mkdir(File.join(dir, "test"))
+      File.write(File.join(dir, "test", "_card.html.erb"), "<%= post %>")
+
+      Mime.eager_load!
+      ActionView::Template::Handlers::ERB.escape_ignore_list.freeze
+
+      # Make sure subscriptions are Ractor-shareable
+      ActiveSupport::Ractors.unshareable_proc_action = :raise
+      # Nothing subscribes after, so record manually
+      ActiveSupport::Notifications.send(:record_subscriptions)
+
+      resolver = ActionView::FileSystemResolver.new(dir)
+      resolver.eager_load_templates
+      resolver.freeze
+
+      rendered = on_ractor(resolver) do |resolver|
+        details = { locale: [:en].freeze, formats: [:html].freeze, variants: [].freeze, handlers: [:erb].freeze }.freeze
+        template = resolver.find_all("card", "test", true, details, nil, [:post])[0]
+        template.render(FakeView.new, { post: "hello" })
+      end
+
+      assert_equal "hello", rendered
+    end
   end
 end

--- a/actionview/test/template/file_system_resolver_test.rb
+++ b/actionview/test/template/file_system_resolver_test.rb
@@ -108,6 +108,18 @@ class FileSystemResolverTest < ActiveSupport::TestCase
     assert_same c, d
   end
 
+  def test_strict_locals_templates_bind_once_for_any_locals
+    with_file "test/hello_world.html.erb", "<%# locals: () %>Hi"
+    resolver = ActionView::FileSystemResolver.new(tmpdir)
+    key = ActionView::TemplateDetails::Requested.new(**DETAILS)
+
+    a = resolver.find_all("hello_world", "test", false, DETAILS, key, [])[0]
+    b = resolver.find_all("hello_world", "test", false, DETAILS, key, [:extra])[0]
+
+    assert_same a, b
+    assert_equal [a], resolver.built_templates
+  end
+
   def test_frozen_resolver_returns_empty_for_missing_template
     with_file "test/hello_world.html.erb", "<%# locals: () %>Hi"
     resolver = ActionView::FileSystemResolver.new(tmpdir)

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -677,6 +677,7 @@ module Rails
         view = ActionView::LookupContext.view_context_class.new(ActionView::LookupContext.new([]), {}, nil)
         ActionView::PathRegistry.all_file_system_resolvers.each do |resolver|
           resolver.eager_load_templates(view)
+          resolver.freeze
         end
       end
 

--- a/railties/test/application/ractors_test.rb
+++ b/railties/test/application/ractors_test.rb
@@ -41,8 +41,12 @@ if RUBY_VERSION >= "4.0" && ENV["RACK"] == "head"
 
         ractorize!
 
-        templates = ActionView::PathRegistry.all_file_system_resolvers.flat_map(&:built_templates)
-        assert_not_empty templates
+        resolvers = ActionView::PathRegistry.all_file_system_resolvers
+        assert_not_empty resolvers
+        resolvers.each do |resolver|
+          assert_predicate resolver, :frozen?
+          assert_ractor_shareable resolver
+        end
       end
 
       test "error reporting works after the application is ractorized" do


### PR DESCRIPTION
Follow-up to #58396

This allows using non-strict templates from Ractors. While this is not advisable, this allows to render views from Ractor without requiring templates to have strict locals.

When an `UnboundTemplate` is frozen, this uses a Ractor-local `Concurrent::Map` to store the templates per `UnboundTemplate` (replacing the `@templates` instance variable), then another layer of `Concurrent::Map` to prevent race conditions (replacing the mutex). The aliasing (multiple non-normalized locals pointing to the same normalized-locals-bound template) is preserved, to avoid adding local normalizing in the fast path.

The third commit fixes an issue with released versions of Rails where strict-locals unbound templates failed to report their built template (since it was the default of the Hash `@templates`, `@templates.values` was not returning it), causing the backtrace to not be fixed in `ActionDispatch::ExceptionWrapper#build_backtrace`.

For non-ractorized applications, except the third commit which improves backtraces, this changes very little, adding one ivar  check (whether the unbound template has a `@strict_locals_template`), and one `frozen?` check for non-strict-locals templates, and swapping a Hash index with default fallback for the instance variable read for strict-locals templates.