### PR TITLE
Fix where clauses with column-tuple syntax referencing other tables

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -133,7 +133,8 @@ module ActiveRecord
           if key.is_a?(Array)
             queries = Array(value).map do |ids_set|
               raise ArgumentError, "Expected corresponding value for #{key} to be an Array" unless ids_set.is_a?(Array)
-              expand_from_hash(key.zip(ids_set).to_h)
+              attributes = convert_dot_notation_to_hash(key.zip(ids_set).to_h)
+              expand_from_hash(attributes)
             end
             grouping_queries(queries)
           elsif value.is_a?(Hash) && !table.has_column?(key)

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -149,6 +149,18 @@ module ActiveRecord
       end
     end
 
+    def test_where_with_tuple_syntax_referencing_another_table
+      categorization = categorizations(:mary_thinking_general)
+
+      key = [:category_id, "authors.name"]
+
+      conditions = [
+        [categorization.category_id, categorization.author.name],
+      ]
+
+      assert_equal [categorization], Categorization.joins(:author).where(key => conditions)
+    end
+
     def test_where_with_nil_cpk_association
       order = Cpk::Order.create!(id: [1, 2])
       book = order.books.create!(id: [3, 4])


### PR DESCRIPTION
The array of columns queried against was assumed to be on the model you were querying against, however if you specified a column as `other_table_name.column_name`, it'd end up prepending the model's table to that (ie. `"model_table_name"."other_table_name.column_name"`).

That led to an error like:
```
ActiveRecord::StatementInvalid: SQLite3::SQLException: no such column: categorizations.authors.name:
SELECT "categorizations".* FROM "categorizations" INNER JOIN "authors" ON "authors"."id" = "categorizations"."author_id" WHERE "categorizations"."category_id" = ? AND "categorizations"."authors.name" = ?
```

Now dot notation column keys are converted to hashes first so the model's table name is no longer prefixed unnecessarily.

If this is a minor enough bug fix to be backported to v8.1, that'd be much appreciated! Thanks.