### PR TITLE
Fix PostgreSQL foreign key lookup for schema qualified tables

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Fix `foreign_key_exists?` and `remove_foreign_key` on PostgreSQL when the
+    target table is schema qualified and its schema is on the `search_path`.
+
+    `foreign_keys` reports the target through `regclass`, which omits the schema
+    when the relation is reachable through the `search_path`, so a schema
+    qualified `to_table` never matched. Reverting an `add_reference` with such a
+    `to_table` raised `ArgumentError` as a result.
+
+    *Tobias Egli*
+
 *   Deprecate `ActiveRecord::ConnectionAdapters::DatabaseStatements#create`
     in favor of `#insert`.
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -1199,6 +1199,24 @@ module ActiveRecord
         end
 
         private
+          # #foreign_keys reports the target through +regclass+, which omits the schema
+          # when the relation is reachable through the search path. Resolve +to_table+
+          # the same way so both sides of the comparison use the same name.
+          def foreign_key_for(from_table, **options)
+            if options[:to_table] && use_foreign_keys?
+              options = options.merge(to_table: canonical_relation_name(options[:to_table]))
+            end
+
+            super
+          end
+
+          def canonical_relation_name(table_name)
+            name = Utils.extract_schema_qualified_name(table_name.to_s)
+            return table_name unless name.schema
+
+            query_value("SELECT to_regclass(#{quote(name.quoted)})::text", "SCHEMA") || table_name
+          end
+
           def create_table_definition(name, **options)
             PostgreSQL::TableDefinition.new(self, name, **options)
           end

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -645,6 +645,7 @@ end
 
 class SchemaForeignKeyTest < ActiveRecord::PostgreSQLTestCase
   include SchemaDumpingHelper
+  include PGSchemaHelper
 
   setup do
     @connection = ActiveRecord::Base.lease_connection
@@ -689,6 +690,38 @@ class SchemaForeignKeyTest < ActiveRecord::PostgreSQLTestCase
     assert @connection.foreign_key_exists?("my_other_schema.wagons", "my_schema.trains")
   ensure
     @connection.drop_schema "my_other_schema", if_exists: true
+  end
+
+  def test_remove_foreign_key_when_target_is_on_the_search_path
+    @connection.create_table "my_schema.trains"
+    @connection.create_table "wagons" do |t|
+      t.integer :train_id
+    end
+    @connection.add_foreign_key "wagons", "my_schema.trains"
+
+    with_schema_search_path("public,my_schema") do
+      @connection.remove_foreign_key "wagons", to_table: "my_schema.trains"
+      assert_empty @connection.foreign_keys("wagons")
+    end
+  ensure
+    @connection.drop_table "wagons", if_exists: true
+  end
+
+  def test_foreign_key_does_not_match_a_same_named_table_in_another_schema
+    @connection.create_table "my_schema.trains"
+    @connection.create_table "public.trains"
+    @connection.create_table "wagons" do |t|
+      t.integer :train_id
+    end
+    @connection.add_foreign_key "wagons", "my_schema.trains"
+
+    with_schema_search_path("public,my_schema") do
+      assert @connection.foreign_key_exists?("wagons", to_table: "my_schema.trains")
+      assert_not @connection.foreign_key_exists?("wagons", to_table: "public.trains")
+    end
+  ensure
+    @connection.drop_table "wagons", if_exists: true
+    @connection.drop_table "public.trains", if_exists: true
   end
 end
 


### PR DESCRIPTION
### Motivation / Background

Fixes #52888.

`add_reference` with a schema qualified `to_table` can't be rolled back when that schema is on the `search_path`:

```ruby
add_reference :orders, :user, foreign_key: { to_table: "test.users" }
```

```
ArgumentError: Table 'orders' has no foreign key for test.users
```

### Detail

`#foreign_keys` reads the target through `regclass`, which drops the schema when the table is reachable through the `search_path`, so it reports `users`. That gets compared against the `test.users` from the migration and never matches.

`to_table` now goes through the same resolution before the comparison. Only schema qualified names do the extra lookup.

### Additional information

The issue suggests splitting the `search_path` and matching each schema by hand. That gets the ambiguous case wrong: with the same table name in two schemas on the path, the short name belongs to whichever comes first.

`to_regclass` rather than a `::regclass` cast, since the cast raises for a missing relation and aborts the surrounding transaction, which would break `remove_foreign_key ... if foreign_key_exists?(...)`. Available since PG 9.4.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.