### PR TITLE
Ensure Active Record models define all attributes

### DIFF
--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -301,6 +301,7 @@ module ActiveRecord
         end
 
         def reset_default_attributes
+          ([self] + descendants).each(&:undefine_attribute_methods)
           reload_schema_from_cache
         end
 

--- a/activerecord/test/cases/attributes_test.rb
+++ b/activerecord/test/cases/attributes_test.rb
@@ -305,6 +305,37 @@ module ActiveRecord
       assert_equal(:bar, child.new(foo: :bar).foo)
     end
 
+    test "attributes added after attribute methods are generated still define methods" do
+      klass = Class.new(ActiveRecord::Base) do
+        self.table_name = "topics"
+      end
+      klass.new
+      assert_predicate klass, :attribute_methods_generated?
+
+      klass.attribute(:foo, Type::Value.new)
+      klass.define_attribute_methods
+
+      assert klass.method_defined?(:foo)
+      assert klass.method_defined?(:foo=)
+      assert klass.method_defined?(:foo_changed?)
+    end
+
+    test "attributes added after subclasses load define methods on the subclass" do
+      parent = Class.new(ActiveRecord::Base) do
+        self.table_name = "topics"
+      end
+
+      child = Class.new(parent)
+      child.new
+      assert_predicate child, :attribute_methods_generated?
+
+      parent.attribute(:foo, Type::Value.new)
+      child.define_attribute_methods
+
+      assert child.method_defined?(:foo)
+      assert child.method_defined?(:foo=)
+    end
+
     test "attributes not backed by database columns are not dirty when unchanged" do
       assert_not_predicate OverloadedType.new, :non_existent_decimal_changed?
     end


### PR DESCRIPTION
Previously, there were a few cases where `attribute`s could be added to an Active Record model after it had generated attribute methods and those newly added `attribute`s would then fall back to "dynamic" attribute behavior.

This commit fixes those edge cases so that Active Record models always generate methods for all `attribute`s.