### PR TITLE
Don't constrain owner key columns in composite where(association: nil)

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,10 +1,10 @@
-*   Don't emit `IS NULL` on shared columns when querying a composite foreign
+*   Don't emit `IS NULL` on owner key columns when querying a composite foreign
     key association with `nil`.
 
-    When a composite foreign key shares a column with the target's primary key
-    (e.g. a tenant key like `shop_id` in `[:shop_id, :item_id]` referencing
-    `[:shop_id, :id]`), `where(association: nil)` constrained every column of
-    the key to `NULL`, including the shared one. Combined with a scope on that
+    When a composite foreign key includes one of the owner's query constraint
+    or primary key columns (e.g. a tenant key like `shop_id` in
+    `[:shop_id, :item_id]`), `where(association: nil)` constrained every column
+    of the key to `NULL`, including the owner key. Combined with a scope on that
     column — such as a tenant scope — this produced an impossible
     `shop_id = ? AND shop_id IS NULL` condition. Only the columns identifying
     the target row are now constrained:

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,24 @@
+*   Don't emit `IS NULL` on shared columns when querying a composite foreign
+    key association with `nil`.
+
+    When a composite foreign key shares a column with the target's primary key
+    (e.g. a tenant key like `shop_id` in `[:shop_id, :item_id]` referencing
+    `[:shop_id, :id]`), `where(association: nil)` constrained every column of
+    the key to `NULL`, including the shared one. Combined with a scope on that
+    column — such as a tenant scope — this produced an impossible
+    `shop_id = ? AND shop_id IS NULL` condition. Only the columns identifying
+    the target row are now constrained:
+
+    ```ruby
+    Order.where(shop_id: 1).where(first_item: nil)
+    # Before: WHERE shop_id = 1 AND shop_id IS NULL AND first_item_id IS NULL
+    # After:  WHERE shop_id = 1 AND first_item_id IS NULL
+    ```
+
+    Fixes #57904.
+
+    *michaelg100*
+
 *   Deprecate `ActiveRecord::ConnectionAdapters::DatabaseStatements#create`
     in favor of `#insert`.
 

--- a/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
@@ -23,10 +23,10 @@ module ActiveRecord
         attr_reader :reflection, :value
 
         # A `nil` association is queried by `IS NULL` on the foreign key, but
-        # columns the foreign key shares with the association's target (e.g. a
-        # tenant key like `shop_id` in `[:shop_id, :item_id]` referencing
-        # `[:shop_id, :id]`) don't identify the target row, and `IS NULL` on
-        # them would contradict any tenant scope on the relation.
+        # columns the foreign key shares with the owner (e.g. a tenant key like
+        # `shop_id` in `[:shop_id, :item_id]`) don't identify the target row,
+        # and `IS NULL` on them would contradict any tenant scope on the
+        # relation.
         def prune_shared_columns(clause)
           return clause unless clause.values.all?(&:nil?)
 
@@ -35,9 +35,8 @@ module ActiveRecord
         end
 
         def shared_columns
-          Array(reflection.join_foreign_key).zip(Array(primary_key)).filter_map do |foreign_key_column, primary_key_column|
-            foreign_key_column.to_s if foreign_key_column.to_s == primary_key_column.to_s
-          end
+          owner_key = ActiveRecord::Key.for(reflection.active_record.composite_query_constraints_list)
+          ActiveRecord::Key.for(reflection.join_foreign_key).select { |column| owner_key.include?(column) }
         end
 
         def ids

--- a/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
@@ -13,11 +13,32 @@ module ActiveRecord
         id_list = ids
         id_list = id_list.pluck(primary_key) if key.composite? && id_list.is_a?(Relation)
 
-        key.where_clauses(id_list)
+        clauses = key.where_clauses(id_list)
+        return clauses unless key.composite?
+
+        clauses.map { |clause| prune_shared_columns(clause) }
       end
 
       private
         attr_reader :reflection, :value
+
+        # A `nil` association is queried by `IS NULL` on the foreign key, but
+        # columns the foreign key shares with the association's target (e.g. a
+        # tenant key like `shop_id` in `[:shop_id, :item_id]` referencing
+        # `[:shop_id, :id]`) don't identify the target row, and `IS NULL` on
+        # them would contradict any tenant scope on the relation.
+        def prune_shared_columns(clause)
+          return clause unless clause.values.all?(&:nil?)
+
+          pruned = clause.except(*shared_columns)
+          pruned.empty? ? clause : pruned
+        end
+
+        def shared_columns
+          Array(reflection.join_foreign_key).zip(Array(primary_key)).filter_map do |foreign_key_column, primary_key_column|
+            foreign_key_column.to_s if foreign_key_column.to_s == primary_key_column.to_s
+          end
+        end
 
         def ids
           case value

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -17,6 +17,7 @@ require "models/topic"
 require "models/treasure"
 require "models/vertex"
 require "models/cpk"
+require "models/sharded"
 require "support/stubs/strong_parameters"
 
 module ActiveRecord
@@ -156,6 +157,43 @@ module ActiveRecord
 
       book.update!(order: nil)
       assert_includes Cpk::Book.where(order: nil), book
+    end
+
+    def test_where_with_nil_cpk_association_does_not_constrain_shared_columns
+      order = Cpk::Order.create!(id: [1, 2])
+      book_with_order = order.books.create!(id: [3, 4])
+      book_without_order = Cpk::Book.create!(id: [3, 5], shop_id: order.shop_id)
+
+      relation = Cpk::Book.where(order: nil)
+
+      assert_includes relation, book_without_order
+      assert_not_includes relation, book_with_order
+    end
+
+    def test_where_with_nil_association_on_query_constrained_model_keeps_tenant_scope
+      blog = Sharded::Blog.create!
+      blog_post = Sharded::BlogPost.create!(blog_id: blog.id)
+      comment_with_post = Sharded::Comment.create!(blog_id: blog.id, blog_post_id: blog_post.id)
+      comment_without_post = Sharded::Comment.create!(blog_id: blog.id)
+
+      relation = Sharded::Comment.where(blog_id: blog.id).where(blog_post: nil)
+
+      assert_includes relation, comment_without_post
+      assert_not_includes relation, comment_with_post
+    end
+
+    def test_where_with_array_of_nil_and_record_for_cpk_association
+      order = Cpk::Order.create!(id: [1, 2])
+      other_order = Cpk::Order.create!(id: [1, 3])
+      book_with_order = order.books.create!(id: [3, 4])
+      book_with_other_order = other_order.books.create!(id: [3, 5])
+      book_without_order = Cpk::Book.create!(id: [3, 6], shop_id: order.shop_id)
+
+      relation = Cpk::Book.where(order: [nil, order])
+
+      assert_includes relation, book_without_order
+      assert_includes relation, book_with_order
+      assert_not_includes relation, book_with_other_order
     end
 
     def test_belongs_to_shallow_where

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -159,17 +159,6 @@ module ActiveRecord
       assert_includes Cpk::Book.where(order: nil), book
     end
 
-    def test_where_with_nil_cpk_association_does_not_constrain_shared_columns
-      order = Cpk::Order.create!(id: [1, 2])
-      book_with_order = order.books.create!(id: [3, 4])
-      book_without_order = Cpk::Book.create!(id: [3, 5], shop_id: order.shop_id)
-
-      relation = Cpk::Book.where(order: nil)
-
-      assert_includes relation, book_without_order
-      assert_not_includes relation, book_with_order
-    end
-
     def test_where_with_nil_association_on_query_constrained_model_keeps_tenant_scope
       blog = Sharded::Blog.create!
       blog_post = Sharded::BlogPost.create!(blog_id: blog.id)
@@ -182,18 +171,42 @@ module ActiveRecord
       assert_not_includes relation, comment_with_post
     end
 
-    def test_where_with_array_of_nil_and_record_for_cpk_association
+    def test_where_with_nil_association_prunes_owner_key_with_custom_target_key_name
+      blog = Sharded::Blog.create!
+      blog_post = Sharded::BlogPost.create!(blog_id: blog.id, revision: blog.id)
+      comment_with_post = Sharded::Comment.create!(blog_id: blog.id, blog_post_id: blog_post.id)
+      comment_without_post = Sharded::Comment.create!(blog_id: blog.id)
+
+      relation = Sharded::Comment.where(blog_id: blog.id).where(blog_post_with_custom_primary_key: nil)
+
+      assert_includes relation, comment_without_post
+      assert_not_includes relation, comment_with_post
+    end
+
+    def test_where_with_nil_cpk_association_constrains_non_owner_columns
       order = Cpk::Order.create!(id: [1, 2])
-      other_order = Cpk::Order.create!(id: [1, 3])
       book_with_order = order.books.create!(id: [3, 4])
-      book_with_other_order = other_order.books.create!(id: [3, 5])
-      book_without_order = Cpk::Book.create!(id: [3, 6], shop_id: order.shop_id)
+      book_without_order = Cpk::Book.create!(id: [3, 5], shop_id: order.shop_id)
 
-      relation = Cpk::Book.where(order: [nil, order])
+      relation = Cpk::Book.where(order: nil)
 
-      assert_includes relation, book_without_order
-      assert_includes relation, book_with_order
-      assert_not_includes relation, book_with_other_order
+      assert_not_includes relation, book_without_order
+      assert_not_includes relation, book_with_order
+    end
+
+    def test_where_with_array_of_nil_and_record_for_query_constrained_association
+      blog = Sharded::Blog.create!
+      blog_post = Sharded::BlogPost.create!(blog_id: blog.id)
+      other_blog_post = Sharded::BlogPost.create!(blog_id: blog.id)
+      comment_with_post = Sharded::Comment.create!(blog_id: blog.id, blog_post_id: blog_post.id)
+      comment_with_other_post = Sharded::Comment.create!(blog_id: blog.id, blog_post_id: other_blog_post.id)
+      comment_without_post = Sharded::Comment.create!(blog_id: blog.id)
+
+      relation = Sharded::Comment.where(blog_post: [nil, blog_post])
+
+      assert_includes relation, comment_without_post
+      assert_includes relation, comment_with_post
+      assert_not_includes relation, comment_with_other_post
     end
 
     def test_belongs_to_shallow_where

--- a/activerecord/test/models/sharded/comment.rb
+++ b/activerecord/test/models/sharded/comment.rb
@@ -12,6 +12,10 @@ module Sharded
       foreign_key: [:blog_id, :blog_post_id],
       primary_key: [:blog_id, :id],
       inverse_of: :comments_with_inverse
+    belongs_to :blog_post_with_custom_primary_key,
+      class_name: "Sharded::BlogPost",
+      foreign_key: [:blog_id, :blog_post_id],
+      primary_key: [:revision, :id]
     belongs_to :blog
   end
 end


### PR DESCRIPTION
## Motivation / Background

Fixes #57904.

When a composite foreign key includes a column from the owner model's query constraints or primary key, `where(association: nil)` currently constrains every foreign-key column to `NULL`. For a tenant key such as `blog_id`, combining that predicate with an existing tenant scope produces the impossible condition `blog_id = ? AND blog_id IS NULL` and silently returns no records.

## Detail

`AssociationQueryValue#queries` now removes owner query-constraint and primary-key columns from an all-`nil` composite association predicate. The remaining foreign-key columns still determine whether the association is absent. Mixed queries such as `where(association: [nil, record])` preserve the owner constraint in the record branch while pruning it from the `nil` branch.

The detection is based on the owner key rather than matching foreign-key columns to the target primary key by name. This also handles custom mappings where the owner tenant column and target tenant column have different names.

## Intentional scope

This is deliberately narrower than #57905. A plain composite-key association whose foreign key is not part of the owner's query constraints or primary key continues to constrain every foreign-key column to `NULL`. For example, `Cpk::Book.where(order: nil)` with a non-null `shop_id` does not match merely because `order_id` is null.

The conservative rule is: never null the owner's identity or scoping columns, while leaving ordinary composite-association nil semantics unchanged. Tests cover this distinction explicitly so maintainers can evaluate that trade-off.

## Tests

The focused relation and belongs-to suites pass with 250 runs and 722 assertions.
