### PR TITLE
Add load hooks to Active Storage controllers

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Add load hooks to Active Storage controllers, so applications can apply their
+    own logic such as authentication or authorization.
+
+    ```ruby
+    ActiveSupport.on_load(:active_storage_blobs_proxy_controller) do
+      include BlobAuthorization
+    end
+    ```
+
+    *Shouichi Kamiya*
+
 *   Allow `config.active_storage.variant_processor` to be set to a transformer class.
 
     `config.active_storage.variant_processor` now accepts a class, in addition to `:vips`,

--- a/activestorage/app/controllers/active_storage/blobs/proxy_controller.rb
+++ b/activestorage/app/controllers/active_storage/blobs/proxy_controller.rb
@@ -20,16 +20,27 @@
 # Anyone who knows the URL can access the file, even if the rest of your application requires
 # authentication. If your files require access control consider implementing
 # {Authenticated Controllers}[https://guides.rubyonrails.org/active_storage_overview.html#authenticated-controllers].
+#
+# Authorization can be added through the +:active_storage_blobs_proxy_controller+ load hook:
+#
+#   ActiveSupport.on_load(:active_storage_blobs_proxy_controller) do
+#     include MyBlobAuthorization
+#   end
+#
+# WARNING: Responses are publicly cacheable by default. You must set +public_cache+
+# to +false+ so that CDNs do not cache authorized files.
 class ActiveStorage::Blobs::ProxyController < ActiveStorage::BaseController
   include ActiveStorage::SetBlob
   include ActiveStorage::Streaming
   include ActiveStorage::DisableSession
 
+  class_attribute :public_cache, default: true
+
   def show
     if request.headers["Range"].present?
       send_blob_byte_range_data @blob, request.headers["Range"]
     else
-      http_cache_forever public: true, last_modified: @blob.created_at do
+      http_cache_forever public: public_cache, last_modified: @blob.created_at do
         response.headers["Accept-Ranges"] = "bytes"
         response.headers["Content-Length"] = @blob.byte_size.to_s
 
@@ -38,3 +49,5 @@ class ActiveStorage::Blobs::ProxyController < ActiveStorage::BaseController
     end
   end
 end
+
+ActiveSupport.run_load_hooks :active_storage_blobs_proxy_controller, ActiveStorage::Blobs::ProxyController

--- a/activestorage/app/controllers/active_storage/blobs/redirect_controller.rb
+++ b/activestorage/app/controllers/active_storage/blobs/redirect_controller.rb
@@ -22,6 +22,12 @@
 # Anyone who knows the URL can access the file, even if the rest of your application requires
 # authentication. If your files require access control consider implementing
 # {Authenticated Controllers}[https://guides.rubyonrails.org/active_storage_overview.html#authenticated-controllers].
+#
+# Authorization can be added through the +:active_storage_blobs_redirect_controller+ load hook:
+#
+#   ActiveSupport.on_load(:active_storage_blobs_redirect_controller) do
+#     include MyBlobAuthorization
+#   end
 class ActiveStorage::Blobs::RedirectController < ActiveStorage::BaseController
   include ActiveStorage::SetBlob
 
@@ -30,3 +36,5 @@ class ActiveStorage::Blobs::RedirectController < ActiveStorage::BaseController
     redirect_to @blob.url(disposition: params[:disposition]), allow_other_host: true
   end
 end
+
+ActiveSupport.run_load_hooks :active_storage_blobs_redirect_controller, ActiveStorage::Blobs::RedirectController

--- a/activestorage/app/controllers/active_storage/direct_uploads_controller.rb
+++ b/activestorage/app/controllers/active_storage/direct_uploads_controller.rb
@@ -3,6 +3,12 @@
 # Creates a new blob on the server side in anticipation of a direct-to-service upload from the client side.
 # When the client-side upload is completed, the signed_blob_id can be submitted as part of the form to reference
 # the blob that was created up front.
+#
+# Authorization can be added through the +:active_storage_direct_uploads_controller+ load hook:
+#
+#   ActiveSupport.on_load(:active_storage_direct_uploads_controller) do
+#     include MyDirectUploadAuthorization
+#   end
 class ActiveStorage::DirectUploadsController < ActiveStorage::BaseController
   def create
     blob = ActiveStorage::Blob.create_before_direct_upload!(**blob_args)
@@ -21,3 +27,5 @@ class ActiveStorage::DirectUploadsController < ActiveStorage::BaseController
       })
     end
 end
+
+ActiveSupport.run_load_hooks :active_storage_direct_uploads_controller, ActiveStorage::DirectUploadsController

--- a/activestorage/app/controllers/active_storage/disk_controller.rb
+++ b/activestorage/app/controllers/active_storage/disk_controller.rb
@@ -4,6 +4,12 @@
 # This means using expiring, signed URLs that are meant for immediate access, not permanent linking.
 # Always go through the BlobsController, or your own authenticated controller, rather than directly
 # to the service URL.
+#
+# Authorization can be added through the +:active_storage_disk_controller+ load hook:
+#
+#   ActiveSupport.on_load(:active_storage_disk_controller) do
+#     include MyDiskAuthorization
+#   end
 class ActiveStorage::DiskController < ActiveStorage::BaseController
   include ActiveStorage::FileServer
 
@@ -61,3 +67,5 @@ class ActiveStorage::DiskController < ActiveStorage::BaseController
       token[:content_type] == request.content_mime_type && token[:content_length] == request.content_length
     end
 end
+
+ActiveSupport.run_load_hooks :active_storage_disk_controller, ActiveStorage::DiskController

--- a/activestorage/app/controllers/active_storage/representations/proxy_controller.rb
+++ b/activestorage/app/controllers/active_storage/representations/proxy_controller.rb
@@ -20,13 +20,26 @@
 # Anyone who knows the URL can access the file, even if the rest of your application requires
 # authentication. If your files require access control consider implementing
 # {Authenticated Controllers}[https://guides.rubyonrails.org/active_storage_overview.html#authenticated-controllers].
+#
+# Authorization can be added through the +:active_storage_representations_proxy_controller+ load hook:
+#
+#   ActiveSupport.on_load(:active_storage_representations_proxy_controller) do
+#     include MyBlobAuthorization
+#   end
+#
+# WARNING: Responses are publicly cacheable by default. You must set +public_cache+
+# to +false+ so that CDNs do not cache authorized files.
 class ActiveStorage::Representations::ProxyController < ActiveStorage::Representations::BaseController
   include ActiveStorage::Streaming
   include ActiveStorage::DisableSession
 
+  class_attribute :public_cache, default: true
+
   def show
-    http_cache_forever public: true do
+    http_cache_forever public: public_cache do
       send_blob_stream @representation, disposition: params[:disposition]
     end
   end
 end
+
+ActiveSupport.run_load_hooks :active_storage_representations_proxy_controller, ActiveStorage::Representations::ProxyController

--- a/activestorage/app/controllers/active_storage/representations/redirect_controller.rb
+++ b/activestorage/app/controllers/active_storage/representations/redirect_controller.rb
@@ -23,9 +23,17 @@
 # Anyone who knows the URL can access the file, even if the rest of your application requires
 # authentication. If your files require access control consider implementing
 # {Authenticated Controllers}[https://guides.rubyonrails.org/active_storage_overview.html#authenticated-controllers].
+#
+# Authorization can be added through the +:active_storage_representations_redirect_controller+ load hook:
+#
+#   ActiveSupport.on_load(:active_storage_representations_redirect_controller) do
+#     include MyBlobAuthorization
+#   end
 class ActiveStorage::Representations::RedirectController < ActiveStorage::Representations::BaseController
   def show
     expires_in ActiveStorage.service_urls_expire_in
     redirect_to @representation.url(disposition: params[:disposition]), allow_other_host: true
   end
 end
+
+ActiveSupport.run_load_hooks :active_storage_representations_redirect_controller, ActiveStorage::Representations::RedirectController

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -77,7 +77,10 @@ module ActiveStorage
 
     config.eager_load_namespaces << ActiveStorage
 
-    guard_load_hooks(:active_storage_record, :active_storage_attachment, :active_storage_blob, :active_storage_variant_record)
+    guard_load_hooks(:active_storage_record, :active_storage_attachment, :active_storage_blob, :active_storage_variant_record,
+      :active_storage_blobs_proxy_controller, :active_storage_blobs_redirect_controller,
+      :active_storage_representations_proxy_controller, :active_storage_representations_redirect_controller,
+      :active_storage_direct_uploads_controller, :active_storage_disk_controller)
 
     initializer "active_storage.deprecator", before: :load_environment_config do |app|
       app.deprecators[:active_storage] = ActiveStorage.deprecator

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -631,7 +631,67 @@ even if the rest of your application requires authentication. Also, the
 not apply to Active Storage’s built-in controllers.
 
 If your files require stricter access control, such as “a user may only view
-their own files”, you can replace the built-in controllers with your own
+their own files”, you have two options: add your own authorization to the
+built-in controllers through their [load hooks](configuring.html#load-hooks), or
+replace them entirely with your own controllers.
+
+#### Adding Authorization to the Built-in Controllers
+
+Each controller runs a load hook, so you can include your own module into it
+from an initializer:
+
+```ruby
+# config/initializers/active_storage_authorization.rb
+%i[
+  active_storage_blobs_proxy_controller
+  active_storage_blobs_redirect_controller
+  active_storage_representations_proxy_controller
+  active_storage_representations_redirect_controller
+].each do |hook|
+  ActiveSupport.on_load(hook) do
+    include BlobAuthorization
+  end
+end
+
+# The direct uploads controller has no blob to authorize yet.
+ActiveSupport.on_load(:active_storage_direct_uploads_controller) do
+  before_action { head :unauthorized unless Current.user }
+end
+```
+
+```ruby
+# app/controllers/concerns/blob_authorization.rb
+module BlobAuthorization
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :authorize_blob
+  end
+
+  private
+    def authorize_blob
+      head :not_found unless Current.user&.owns?(@blob)
+    end
+end
+```
+
+The proxy controllers send `Cache-Control: public` by default, so a CDN may serve a
+cached copy to everybody. You must set `public_cache` to `false` to prevent that:
+
+```ruby
+%i[
+  active_storage_blobs_proxy_controller
+  active_storage_representations_proxy_controller
+].each do |hook|
+  ActiveSupport.on_load(hook) do
+    self.public_cache = false
+  end
+end
+```
+
+#### Replacing the Built-in Controllers
+
+Alternatively, you can replace the built-in controllers with your own
 authenticated controllers. These controllers should wrap the behavior of the
 following built-in controllers but apply your own authorization logic before
 serving the file :

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -4428,6 +4428,12 @@ These are the load hooks you can use in your own code. To hook into the initiali
 | `ActiveStorage::VariantRecord`       | `active_storage_variant_record`      |
 | `ActiveStorage::Blob`                | `active_storage_blob`                |
 | `ActiveStorage::Record`              | `active_storage_record`              |
+| `ActiveStorage::Blobs::ProxyController`              | `active_storage_blobs_proxy_controller`              |
+| `ActiveStorage::Blobs::RedirectController`           | `active_storage_blobs_redirect_controller`           |
+| `ActiveStorage::DirectUploadsController`             | `active_storage_direct_uploads_controller`           |
+| `ActiveStorage::DiskController`                      | `active_storage_disk_controller`                     |
+| `ActiveStorage::Representations::ProxyController`    | `active_storage_representations_proxy_controller`    |
+| `ActiveStorage::Representations::RedirectController` | `active_storage_representations_redirect_controller` |
 | `ActiveSupport::TestCase`            | `active_support_test_case`           |
 | `i18n`                               | `i18n`                               |
 

--- a/railties/test/application/active_storage/controller_load_hooks_integration_test.rb
+++ b/railties/test/application/active_storage/controller_load_hooks_integration_test.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+require "rack/test"
+
+module ApplicationTests
+  class ControllerLoadHooksIntegrationTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+    include Rack::Test::Methods
+
+    self.file_fixture_path = "test/fixtures/files"
+
+    def setup
+      build_app
+    end
+
+    def teardown
+      teardown_app
+    end
+
+    def test_initializer_can_authorize_direct_uploads_through_the_load_hook
+      app_file "config/initializers/active_storage_authorization.rb", <<~RUBY
+        ActiveSupport.on_load(:active_storage_direct_uploads_controller) do
+          before_action { head :forbidden unless request.headers["X-Api-Token"] == "secret" }
+        end
+      RUBY
+
+      rails "active_storage:install"
+      rails "db:migrate"
+
+      app("development")
+
+      post "/rails/active_storage/direct_uploads", direct_upload_params.to_json,
+        "CONTENT_TYPE" => "application/json"
+      assert_equal 403, last_response.status
+
+      post "/rails/active_storage/direct_uploads", direct_upload_params.to_json,
+        "CONTENT_TYPE" => "application/json", "HTTP_X_API_TOKEN" => "secret"
+      assert_equal 200, last_response.status
+    end
+
+    def test_initializer_can_disable_the_public_cache_through_the_load_hook
+      app_file "config/initializers/active_storage_authorization.rb", <<~RUBY
+        ActiveSupport.on_load(:active_storage_blobs_proxy_controller) do
+          self.public_cache = false
+        end
+      RUBY
+
+      rails "active_storage:install"
+      rails "db:migrate"
+
+      app("development")
+
+      blob = ActiveStorage::Blob.create_and_upload!(
+        io: file_fixture("racecar.jpg").open, filename: "racecar.jpg", content_type: "image/jpeg"
+      )
+
+      get "/rails/active_storage/blobs/proxy/#{blob.signed_id}/#{blob.filename}"
+      assert_equal 200, last_response.status
+      assert_includes last_response.headers["Cache-Control"], "private"
+    end
+
+    private
+      def direct_upload_params
+        file = file_fixture("racecar.jpg")
+
+        { blob: {
+          key: SecureRandom.base58(24),
+          filename: file.basename.to_s,
+          content_type: "image/jpeg",
+          byte_size: file.size,
+          checksum: OpenSSL::Digest::MD5.new(file.read).base64digest
+        } }
+      end
+  end
+end


### PR DESCRIPTION
### Motivation / Background

Many applications need to authenticate requests to Active Storage controllers. The current guide suggests to reimplement built-in controllers just for that, which is tedious.

### Detail

Add load hooks to Active Storage controllers, so applications can apply their own logic such as authentication or authorization.

```ruby
ActiveSupport.on_load(:active_storage_blobs_proxy_controller) do
  include BlobAuthorization
end
```

### Additional information

Close https://github.com/rails/rails/issues/34961.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
