### PR TITLE
Fix mojibake for non-ASCII strict locals defaults

### DIFF
--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -517,8 +517,9 @@ module ActionView
           end
         end_src
 
-        # Make sure the source is in the encoding of the returned code
-        source.force_encoding(code.encoding)
+        # Make sure the source is in the encoding of the returned code, unless
+        # the code is ASCII-only and its tag says nothing about the rest of the source
+        source.force_encoding(code.encoding) unless code.ascii_only?
 
         # In case we get back a String from a handler that is not in
         # BINARY or the default_internal, encode it to the default_internal

--- a/actionview/test/template/template_test.rb
+++ b/actionview/test/template/template_test.rb
@@ -360,6 +360,16 @@ class TestERBTemplate < ActiveSupport::TestCase
     assert_equal "<p>caf\u{E9} \u{FC}</p>", render
   end
 
+  def test_strict_locals_with_non_ascii_default_values_in_an_ascii_only_template
+    # \xC3\xA9 = U+00E9 (e with acute)
+    source = "<%# locals: (label: \"caf\xC3\xA9\") -%>\n<p><%= label %></p>"
+    assert_equal Encoding::ASCII_8BIT, source.encoding
+
+    @template = new_template(source)
+    assert_equal Encoding::UTF_8, render.encoding
+    assert_equal "<p>caf\u{E9}</p>", render
+  end
+
   def test_error_when_template_isnt_valid_utf8
     e = assert_raises ActionView::Template::Error do
       @template = new_template("hello \xFCmlat", virtual_path: nil)


### PR DESCRIPTION
### Motivation / Background

Fixes #58456

A strict locals default value with non-ASCII characters renders as mojibake when the template body itself is ASCII-only. Nothing raises, the wrong characters simply reach the page. This is the other half of #56904: #56906 removed the `Encoding::CompatibilityError`, but the compiled source is still left tagged ASCII-8BIT.

`compiled_source` force-encodes the generated method definition to the encoding of the handler output. Erubi builds its source buffer with `String.new`, so an ASCII-only template comes back tagged ASCII-8BIT even though the source handed to it was UTF-8. The strict locals declaration is interpolated into that same method definition, so the default value's string literal gets retagged ASCII-8BIT before it is eval'd.

### Detail

This Pull Request skips the `force_encoding` when the handler output is ASCII-only. Its tag then says nothing about the encoding of the rest of the source, and the interpolation has already settled on the correct one. When the handler output does contain non-ASCII bytes, nothing changes.

### Additional information

The reproduction script in #58456 renders the expected string with this change applied.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.