### PR TITLE
Show next steps after rails new

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Show next steps (the application name and Rails version, how to `cd` into
+    it, how to boot the server, and a link to the Rails guides) after
+    running `rails new`, next to the same Rails mark as the `bin/rails
+    console` banner.
+
+    *Carl Dawson*
+
 *   Show a Rails-flavored startup banner (a small logo, Rails/Ruby
     version, a rotating tip about console helpers like `app`/`reload!`, and
     `Rails.root`) when starting `bin/rails console`.

--- a/railties/lib/rails/commands/console/irb_console.rb
+++ b/railties/lib/rails/commands/console/irb_console.rb
@@ -2,6 +2,7 @@
 
 require "irb/helper_method"
 require "irb/command"
+require "rails/logo"
 
 module Rails
   class Console
@@ -79,8 +80,6 @@ module Rails
         '"source_location" shows where a method was defined, e.g. method(:reload!).source_location',
       ].freeze
 
-      LOGO = %w[⠀⢀⠀⢡⣶⣿⠟⡛⠢ ⠠⠀⣰⣿⣿⠁⠄⠀⠀ ⠶⢠⣿⣿⣿⠰⠆⠀⠀ ⠶⢸⣿⣿⣿⡄⠰⠆⠀].freeze
-
       def initialize(app)
         @app = app
 
@@ -131,7 +130,6 @@ module Rails
       def show_startup_banner
         return $stderr.puts(Rails::Console.startup_lines(@app.sandbox)) unless IRB.conf[:SHOW_BANNER]
 
-        logo_lines = unicode_logo
         tip_line = show_tips? ? "TIP: #{colorize_tip(TIPS.sample)}" : ""
         info_lines = [
           "#{IRB::Color.colorize('Rails', [:BOLD])} v#{Rails.version} - Ruby #{RUBY_VERSION}  (#{colorized_env})",
@@ -140,20 +138,14 @@ module Rails
           Rails::Console::HELP_HINT,
         ]
 
-        output = if logo_lines
-          logo_lines.zip(info_lines).map { |logo, info| "#{IRB::Color.colorize(logo.to_s, [:RED, :BOLD])}  #{info}" }.join("\n")
-        else
-          info_lines.join("\n")
+        output = Rails::Logo.beside(info_lines, io: $stderr) do |logo|
+          IRB::Color.colorize(logo, [:RED, :BOLD])
         end
 
         $stderr.puts
         $stderr.puts output
         $stderr.puts IRB::Color.colorize("\nSandbox mode: changes rolled back on exit", [:YELLOW]) if @app.sandbox
         $stderr.puts
-      end
-
-      def unicode_logo
-        ($stderr.external_encoding || Encoding.default_external) == Encoding::UTF_8 ? LOGO : nil
       end
 
       def show_tips?

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -2,6 +2,7 @@
 
 require "rails/generators/app_base"
 require "rails/generators/rails/devcontainer/devcontainer_generator"
+require "rails/logo"
 
 module Rails
   module ActionMethods # :nodoc:
@@ -307,8 +308,6 @@ module Rails
   module Generators
     class AppGenerator < AppBase
       # :stopdoc:
-
-      LOGO = %w[⠀⢀⠀⢡⣶⣿⠟⡛⠢ ⠠⠀⣰⣿⣿⠁⠄⠀⠀ ⠶⢠⣿⣿⣿⠰⠆⠀⠀ ⠶⢸⣿⣿⣿⡄⠰⠆⠀].freeze
 
       add_shared_options_for "application"
 
@@ -619,16 +618,8 @@ module Rails
           "New to Rails? https://guides.rubyonrails.org",
         ]
 
-        logo_lines = unicode_logo
-
-        output = if logo_lines
-          logo_lines.zip(info_lines).map { |logo, info| "#{set_color(logo.to_s, :red, :bold)}  #{info}".rstrip }.join("\n")
-        else
-          info_lines.join("\n")
-        end
-
         say ""
-        say output
+        say Rails::Logo.beside(info_lines, io: $stdout) { |logo| set_color(logo, :red, :bold) }
         say ""
       end
 
@@ -639,10 +630,6 @@ module Rails
     # :startdoc:
 
     private
-      def unicode_logo
-        ($stdout.external_encoding || Encoding.default_external) == Encoding::UTF_8 ? LOGO : nil
-      end
-
       def cd_step
         "cd #{app_path}" unless app_path.delete_suffix("/") == "."
       end

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -308,6 +308,8 @@ module Rails
     class AppGenerator < AppBase
       # :stopdoc:
 
+      LOGO = %w[⠀⢀⠀⢡⣶⣿⠟⡛⠢ ⠠⠀⣰⣿⣿⠁⠄⠀⠀ ⠶⢠⣿⣿⣿⠰⠆⠀⠀ ⠶⢸⣿⣿⣿⡄⠰⠆⠀].freeze
+
       add_shared_options_for "application"
 
       # Add rails command options
@@ -607,6 +609,29 @@ module Rails
         @after_bundle_callbacks.each(&:call)
       end
 
+      def display_next_steps
+        return if options[:pretend] || options[:dummy_app]
+
+        info_lines = [
+          "#{set_color(app_name, :bold)} is ready (Rails #{Rails::VERSION::STRING})",
+          cd_step.to_s,
+          "Boot the server with bin/rails server",
+          "New to Rails? https://guides.rubyonrails.org",
+        ]
+
+        logo_lines = unicode_logo
+
+        output = if logo_lines
+          logo_lines.zip(info_lines).map { |logo, info| "#{set_color(logo.to_s, :red, :bold)}  #{info}".rstrip }.join("\n")
+        else
+          info_lines.join("\n")
+        end
+
+        say ""
+        say output
+        say ""
+      end
+
       def self.banner
         "rails new #{arguments.map(&:usage).join(' ')} [options]"
       end
@@ -614,6 +639,14 @@ module Rails
     # :startdoc:
 
     private
+      def unicode_logo
+        ($stdout.external_encoding || Encoding.default_external) == Encoding::UTF_8 ? LOGO : nil
+      end
+
+      def cd_step
+        "cd #{app_path}" unless app_path.delete_suffix("/") == "."
+      end
+
       def remove_new_framework_defaults?(target_version, current_version)
         Gem::Version.new(target_version.to_s) >= Gem::Version.new(current_version.to_s)
       end

--- a/railties/lib/rails/logo.rb
+++ b/railties/lib/rails/logo.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# :markup: markdown
+
+module Rails
+  module Logo # :nodoc:
+    LINES = %w[⠀⢀⠀⢡⣶⣿⠟⡛⠢ ⠠⠀⣰⣿⣿⠁⠄⠀⠀ ⠶⢠⣿⣿⣿⠰⠆⠀⠀ ⠶⢸⣿⣿⣿⡄⠰⠆⠀].freeze
+
+    def self.lines_for(io)
+      (io.external_encoding || Encoding.default_external) == Encoding::UTF_8 ? LINES : nil
+    end
+
+    def self.beside(info_lines, io:)
+      lines = lines_for(io)
+      return info_lines.join("\n") unless lines
+
+      lines.zip(info_lines).map { |logo, info| "#{yield logo}  #{info}".rstrip }.join("\n")
+    end
+  end
+end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1867,6 +1867,27 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_next_steps_are_shown
+    output = run_generator [destination_root]
+
+    assert_match(/is ready \(Rails #{Regexp.escape(Rails::VERSION::STRING)}\)/, output)
+  end
+
+  def test_next_steps_are_not_shown_when_pretending
+    output = run_generator [destination_root, "--pretend"]
+
+    assert_no_match(/is ready/, output)
+  end
+
+  def test_next_steps_omit_cd_when_generating_into_the_current_directory
+    generator [destination_root]
+    generator.stub(:app_path, ".") do
+      output = capture(:stdout) { generator.display_next_steps }
+
+      assert_no_match(/cd /, output)
+    end
+  end
+
   private
     def assert_load_defaults
       assert_file "config/application.rb", /\s+config\.load_defaults #{Rails::VERSION::STRING.to_f}/


### PR DESCRIPTION
### Motivation / Background

I think the Rails logo added to the console in #58455 is super neat and thought it would be nice to see this also after running `rails new`.

Looking for similar PRs that mention that output from `rails new`, I found #47620 and have tried to include the points from the review in this PR, namely:

> It is very common to see people generating a new application and not knowing they need to `cd` to the directory. But I'm ok with the next steps banner. (rafaelfranca)

> Like the reminder on how to start a server. [...] I think either we point to rails help or we point to the guides, but not both. Then fine keeping the rest of the next step banner, and removing the stuff on the splash screen. (dhh)

### Detail

`rails new` now ends with a short banner:

<img width="688" height="148" alt="Screenshot 2026-08-13 at 20 11 39" src="https://github.com/user-attachments/assets/1e272044-f7a7-43f8-86e6-eff59eaab864" />

- The `cd` line is omitted when generating into the current directory (`rails new .`).
- Nothing prints under `--pretend`, under `--quiet`, or for a plugin's dummy app.
- On a non-UTF-8 terminal the mark is dropped and the four lines print as plain text.
- I've opted for the new guides rather than `rails help`, as per dhh's comment

The first commit adds the banner and duplicates the logo constant out of `IRBConsole`. The second extracts both copies into `Rails::Logo` so the console and the generator share one definition. I split them because there might be a better way to do the refactor.

### Additional information

This picks up #47620, which stalled after its review. The idea and the shape of the banner come from there.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.