### PR TITLE
Raise IrreversibleMigration for update/insert/delete in change

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Raise `IrreversibleMigration` when rolling back `update` / `insert` / `delete`
+    (and other connection SQL helpers such as `select_value`) used inside `change`.
+
+    These used to run again silently on rollback because they were forwarded to
+    the connection instead of being recorded. `execute` already raised; schema
+    predicates like `table_exists?` are unchanged so guarded reversible
+    migrations keep working. Wrap data SQL in `reversible` / `up_only`, or use
+    `up`/`down`.
+
+    Fixes #51570.
+
+    *Sankalp Thakur*
+
 *   Deprecate `ActiveRecord::ConnectionAdapters::DatabaseStatements#create`
     in favor of `#insert`.
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,13 +1,10 @@
 *   Raise `IrreversibleMigration` when rolling back `update` / `insert` / `delete`
-    (and other connection SQL helpers such as `select_value`) used inside `change`.
+    used inside `change`.
 
     These used to run again silently on rollback because they were forwarded to
     the connection instead of being recorded. `execute` already raised; schema
-    predicates like `table_exists?` are unchanged so guarded reversible
-    migrations keep working. Wrap data SQL in `reversible` / `up_only`, or use
-    `up`/`down`.
-
-    Fixes #51570.
+    predicates like `table_exists?` still delegate. Wrap data SQL in
+    `reversible` / `up_only`, or use `up`/`down`.
 
     *Sankalp Thakur*
 

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -62,9 +62,7 @@ module ActiveRecord
         :create_schema, :drop_schema,
         :create_virtual_table, :drop_virtual_table,
         :enable_index, :disable_index,
-        :update, :insert, :delete, :truncate, :truncate_tables,
-        :select_all, :select_one, :select_value, :select_values, :select_rows,
-        :exec_query, :exec_insert, :exec_delete, :exec_update
+        :update, :insert, :delete
       ].freeze
 
       attr_accessor :commands, :delegate, :reverting

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -61,7 +61,10 @@ module ActiveRecord
         :create_enum, :drop_enum, :rename_enum, :add_enum_value, :rename_enum_value,
         :create_schema, :drop_schema,
         :create_virtual_table, :drop_virtual_table,
-        :enable_index, :disable_index
+        :enable_index, :disable_index,
+        :update, :insert, :delete, :truncate, :truncate_tables,
+        :select_all, :select_one, :select_value, :select_values, :select_rows,
+        :exec_query, :exec_insert, :exec_delete, :exec_update
       ].freeze
 
       attr_accessor :commands, :delegate, :reverting

--- a/activerecord/test/cases/invertible_migration_test.rb
+++ b/activerecord/test/cases/invertible_migration_test.rb
@@ -558,6 +558,7 @@ module ActiveRecord
 
     def test_update_in_change_raises_on_rollback_without_reexecuting
       InvertibleMigration.new.migrate(:up)
+      Horse.reset_column_information
       horse = Horse.create!(content: "original")
       migration = UpdateInChangeMigration.new
       migration.migrate(:up)

--- a/activerecord/test/cases/invertible_migration_test.rb
+++ b/activerecord/test/cases/invertible_migration_test.rb
@@ -235,12 +235,6 @@ module ActiveRecord
       end
     end
 
-    class SelectValueInChangeMigration < SilentMigration
-      def change
-        select_value("SELECT 1")
-      end
-    end
-
     class RevertUniqueConstraintWithInvalidOption < SilentMigration
       def change
         add_unique_constraint :horses, :place_id, invalid: :option
@@ -571,13 +565,6 @@ module ActiveRecord
 
       assert_raises(IrreversibleMigration) { migration.migrate(:down) }
       assert_equal "changed", horse.reload.content
-    end
-
-    def test_select_value_in_change_raises_on_rollback
-      InvertibleMigration.new.migrate(:up)
-      migration = SelectValueInChangeMigration.new
-      migration.migrate(:up)
-      assert_raises(IrreversibleMigration) { migration.migrate(:down) }
     end
 
     def test_up_only

--- a/activerecord/test/cases/invertible_migration_test.rb
+++ b/activerecord/test/cases/invertible_migration_test.rb
@@ -229,6 +229,18 @@ module ActiveRecord
       end
     end
 
+    class UpdateInChangeMigration < SilentMigration
+      def change
+        update("UPDATE horses SET content = 'changed'")
+      end
+    end
+
+    class SelectValueInChangeMigration < SilentMigration
+      def change
+        select_value("SELECT 1")
+      end
+    end
+
     class RevertUniqueConstraintWithInvalidOption < SilentMigration
       def change
         add_unique_constraint :horses, :place_id, invalid: :option
@@ -548,6 +560,24 @@ module ActiveRecord
 
       assert_not connection.index_exists?(:horses, [:remind_at, :place_id]),
              "index on remind_at and place_id should not exist"
+    end
+
+    def test_update_in_change_raises_on_rollback_without_reexecuting
+      InvertibleMigration.new.migrate(:up)
+      horse = Horse.create!(content: "original")
+      migration = UpdateInChangeMigration.new
+      migration.migrate(:up)
+      assert_equal "changed", horse.reload.content
+
+      assert_raises(IrreversibleMigration) { migration.migrate(:down) }
+      assert_equal "changed", horse.reload.content
+    end
+
+    def test_select_value_in_change_raises_on_rollback
+      InvertibleMigration.new.migrate(:up)
+      migration = SelectValueInChangeMigration.new
+      migration.migrate(:up)
+      assert_raises(IrreversibleMigration) { migration.migrate(:down) }
     end
 
     def test_up_only

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -48,6 +48,29 @@ module ActiveRecord
         end
       end
 
+      def test_irreversible_update_insert_delete_raise_on_revert
+        %i[update insert delete].each do |method|
+          recorder = CommandRecorder.new(ActiveRecord::Base.lease_connection)
+          assert_raises(ActiveRecord::IrreversibleMigration, "expected #{method} to be irreversible") do
+            recorder.revert { recorder.public_send(method, "SQL") }
+          end
+        end
+      end
+
+      def test_irreversible_select_value_raises_on_revert
+        assert_raises(ActiveRecord::IrreversibleMigration) do
+          @recorder.revert { @recorder.select_value("SELECT 1") }
+        end
+      end
+
+      def test_schema_predicates_still_delegate_on_revert
+        @recorder.create_table :horses
+        @recorder.revert do
+          assert_respond_to @recorder, :table_exists?
+          assert_equal false, @recorder.table_exists?(:horses)
+        end
+      end
+
       def test_record
         @recorder.create_table :system_settings
         assert_equal 1, @recorder.commands.length

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -57,12 +57,6 @@ module ActiveRecord
         end
       end
 
-      def test_irreversible_select_value_raises_on_revert
-        assert_raises(ActiveRecord::IrreversibleMigration) do
-          @recorder.revert { @recorder.select_value("SELECT 1") }
-        end
-      end
-
       def test_schema_predicates_still_delegate_on_revert
         @recorder.create_table :horses
         @recorder.revert do


### PR DESCRIPTION
### Motivation / Background

`update`, `insert`, and `delete` inside `change` currently run again on rollback, with no log line, instead of raising `ActiveRecord::IrreversibleMigration` the way `execute` does.

Fixes #51570

#56308 listed these three methods and was closed because `select_value("drop database")` would still slip through. Recording `select_*` / `exec_*` as well broke Buildkite (those go through the recorder on some adapters). fatkodima noted that covering every SQL helper is not actually possible.

### Detail

Record `update` / `insert` / `delete` on the command recorder so rollback raises, matching `execute`.

Schema predicates such as `table_exists?` still delegate, so reversible migrations that inspect the schema keep working. Raw SQL via `execute` was already irreversible.

### Additional information

Local: `activerecord/bin/test test/cases/migration/command_recorder_test.rb test/cases/invertible_migration_test.rb` (sqlite3_mem) — 123 runs, 0 failures.

Wrap data SQL in `reversible` / `up_only`, or use `up`/`down`.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

### AI/LLM disclosure

- AI coding tools (including Grok and/or Codex agent-assisted editing) were used to help draft or modify code and this PR description.
- I reviewed the complete change, understand the reasoning, and ran the reported local tests before submitting.
- This submission is original work of authorship under the project contributor terms; AI output was not pasted unreviewed.