### PR TITLE
Introduce `to_ractor_snapshot` / `load_ractor_snapshot` protocol for notifiers

### DIFF
--- a/activesupport/lib/active_support/notifications.rb
+++ b/activesupport/lib/active_support/notifications.rb
@@ -352,18 +352,18 @@ module ActiveSupport
           ActiveSupport::IsolatedExecutionState[:active_support_notifications_registry] ||= {}
         end
 
+        # Snapshot subscriptions so a Ractor can restore them onto its own
+        # notifier. Skipped for notifiers that don't opt into the protocol.
         def record_subscriptions
-          subscriptions = {
-            string_subscribers: Hash[notifier.string_subscribers.keys.zip(notifier.string_subscribers.values)],
-            other_subscribers: notifier.other_subscribers,
-          }
-
-          self.notifier_subscriptions = ActiveSupport::Ractors.try_make_shareable(subscriptions, copy: true)
+          return unless notifier.respond_to?(:to_ractor_snapshot)
+          self.notifier_subscriptions = ActiveSupport::Ractors.try_make_shareable(
+            notifier.to_ractor_snapshot, copy: true
+          )
         end
 
         def set_subscriptions(fanout)
-          fanout.string_subscribers = notifier_subscriptions[:string_subscribers]
-          fanout.other_subscribers = notifier_subscriptions[:other_subscribers]
+          return unless notifier_subscriptions && fanout.respond_to?(:load_ractor_snapshot)
+          fanout.load_ractor_snapshot(notifier_subscriptions)
         end
     end
 

--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -55,8 +55,6 @@ module ActiveSupport
     #
     # This class is thread safe. All methods are reentrant.
     class Fanout
-      attr_reader :string_subscribers, :other_subscribers # :nodoc:
-
       def initialize
         @mutex = Mutex.new
         @string_subscribers = Concurrent::Map.new { |h, k| h.compute_if_absent(k) { [] } }
@@ -65,14 +63,18 @@ module ActiveSupport
         @groups_for = Concurrent::Map.new
       end
 
-      def string_subscribers=(subscribers) # :nodoc:
-        string_subscribers = Concurrent::Map.new { |h, k| h.compute_if_absent(k) { [] } }
-        subscribers.each { |name, list| string_subscribers[name] = list.dup }
-        @string_subscribers = string_subscribers
+      def to_ractor_snapshot # :nodoc:
+        {
+          string_subscribers: Hash[@string_subscribers.keys.zip(@string_subscribers.values)],
+          other_subscribers: @other_subscribers,
+        }
       end
 
-      def other_subscribers=(subscribers) # :nodoc:
-        @other_subscribers = subscribers.dup
+      def load_ractor_snapshot(snapshot) # :nodoc:
+        string_subscribers = Concurrent::Map.new { |h, k| h.compute_if_absent(k) { [] } }
+        snapshot[:string_subscribers].each { |name, list| string_subscribers[name] = list.dup }
+        @string_subscribers = string_subscribers
+        @other_subscribers = snapshot[:other_subscribers].dup
       end
 
       def inspect # :nodoc:

--- a/activesupport/test/notifications_test.rb
+++ b/activesupport/test/notifications_test.rb
@@ -622,4 +622,51 @@ module Notifications
       end
     end
   end
+
+  class CustomNotifierTest < ActiveSupport::TestCase
+    class MinimalNotifier
+      attr_reader :published
+
+      def initialize
+        @published = []
+      end
+
+      def listening?(name); true; end
+      def subscribe(pattern = nil, callable = nil, monotonic: false, prepend: false, &block); end
+      def start(name, id, payload); end
+      def finish(name, id, payload, listener_state = nil); @published << name; end
+    end
+
+    def setup
+      @old_notifier = ActiveSupport::Notifications.notifier
+    end
+
+    def teardown
+      ActiveSupport::Notifications.notifier = @old_notifier
+    end
+
+    test "assigning a notifier that does not implement the snapshot protocol does not raise" do
+      notifier = MinimalNotifier.new
+      assert_nothing_raised do
+        ActiveSupport::Notifications.notifier = notifier
+      end
+      assert_same notifier, ActiveSupport::Notifications.notifier
+    end
+
+    test "instrumenting through a notifier without the snapshot protocol works" do
+      notifier = MinimalNotifier.new
+      ActiveSupport::Notifications.notifier = notifier
+
+      ActiveSupport::Notifications.instrument("custom.event") { }
+
+      assert_equal ["custom.event"], notifier.published
+    end
+
+    test "subscribe on a notifier without the snapshot protocol does not raise" do
+      ActiveSupport::Notifications.notifier = MinimalNotifier.new
+      assert_nothing_raised do
+        ActiveSupport::Notifications.subscribe("custom.event") { }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Since #58060, `Notifications.record_subscriptions` reached into `Fanout`'s `string_subscribers` / `other_subscribers`, so custom `notifier=` targets had to mimic Fanout's shape or crash. Move it behind a `respond_to?`-gated protocol on the notifier; custom queues become plain targets and may opt into Ractor sharing by implementing it.

A shareable `Fanout` would remove the snapshot entirely but needs a COW rewrite of its `Concurrent::Map`-backed state, so this change stays with the snapshot; that refactor can happen independently.

cc @gmcgibbon @Edouard-chin 