### PR TITLE
Allow ffmpeg and ffprobe input arguments to be configured

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,24 @@
+*   Allow ffmpeg and ffprobe input arguments to be configured.
+
+    Two new configuration parameters are introduced.
+    `config.active_storage.video_preview_input_arguments` is passed to ffmpeg before `-i`, and
+    `config.active_storage.ffprobe_arguments` is passed to ffprobe before the file path. Both
+    default to `""`.
+
+    ffmpeg's flags are position dependent, and these parameters carry the ones that apply to the
+    input, such as `-codec_whitelist`, `-f`, and `-protocol_whitelist`. For example, an
+    application that accepts only H.264 video with AAC audio:
+
+    ```ruby
+    config.active_storage.video_preview_input_arguments = "-codec_whitelist h264,aac"
+    config.active_storage.ffprobe_arguments = "-codec_whitelist h264,aac"
+    ```
+
+    `ffprobe_arguments` applies to both `ActiveStorage::Analyzer::VideoAnalyzer` and
+    `ActiveStorage::Analyzer::AudioAnalyzer`.
+
+    *Mike Dalessio*
+
 *   Allow `config.active_storage.variant_processor` to be set to a transformer class.
 
     `config.active_storage.variant_processor` now accepts a class, in addition to `:vips`,

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -385,6 +385,10 @@ module ActiveStorage
 
   mattr_accessor :video_preview_arguments, default: "-y -vframes 1 -f image2"
 
+  mattr_accessor :video_preview_input_arguments, default: ""
+
+  mattr_accessor :ffprobe_arguments, default: ""
+
   module Transformers
     extend ActiveSupport::Autoload
 

--- a/activestorage/lib/active_storage/analyzer/audio_analyzer.rb
+++ b/activestorage/lib/active_storage/analyzer/audio_analyzer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "shellwords"
+
 module ActiveStorage
   # = Active Storage Audio \Analyzer
   #
@@ -60,6 +62,7 @@ module ActiveStorage
             "-show_streams",
             "-show_format",
             "-v", "error",
+            *Shellwords.split(ActiveStorage.ffprobe_arguments),
             file.path
           ]) do |output|
             JSON.parse(output.read)

--- a/activestorage/lib/active_storage/analyzer/video_analyzer.rb
+++ b/activestorage/lib/active_storage/analyzer/video_analyzer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "shellwords"
+
 module ActiveStorage
   # = Active Storage Video \Analyzer
   #
@@ -140,6 +142,7 @@ module ActiveStorage
             "-show_streams",
             "-show_format",
             "-v", "error",
+            *Shellwords.split(ActiveStorage.ffprobe_arguments),
             file.path
           ]) do |output|
             JSON.parse(output.read)

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -175,6 +175,8 @@ module ActiveStorage
         ActiveStorage.content_types_allowed_inline = app.config.active_storage.content_types_allowed_inline || []
         ActiveStorage.binary_content_type = app.config.active_storage.binary_content_type || "application/octet-stream"
         ActiveStorage.video_preview_arguments = app.config.active_storage.video_preview_arguments || "-y -vframes 1 -f image2"
+        ActiveStorage.video_preview_input_arguments = app.config.active_storage.video_preview_input_arguments || ""
+        ActiveStorage.ffprobe_arguments = app.config.active_storage.ffprobe_arguments || ""
         ActiveStorage.track_variants = app.config.active_storage.track_variants || false
         ActiveStorage.analyze = app.config.active_storage.analyze || :later
         ActiveStorage.streaming_chunk_max_size = app.config.active_storage.streaming_chunk_max_size || 100.megabytes

--- a/activestorage/lib/active_storage/previewer/video_previewer.rb
+++ b/activestorage/lib/active_storage/previewer/video_previewer.rb
@@ -30,7 +30,11 @@ module ActiveStorage
 
     private
       def draw_relevant_frame_from(file, &block)
-        draw self.class.ffmpeg_path, "-i", file.path, *Shellwords.split(ActiveStorage.video_preview_arguments), "-", &block
+        draw self.class.ffmpeg_path,
+          *Shellwords.split(ActiveStorage.video_preview_input_arguments),
+          "-i", file.path,
+          *Shellwords.split(ActiveStorage.video_preview_arguments),
+          "-", &block
       end
   end
 end

--- a/activestorage/test/analyzer/audio_analyzer_test.rb
+++ b/activestorage/test/analyzer/audio_analyzer_test.rb
@@ -18,6 +18,17 @@ class ActiveStorage::Analyzer::AudioAnalyzerTest < ActiveSupport::TestCase
     assert_equal "Lavc57.64", metadata[:tags][:encoder]
   end
 
+  test "analyzing an audio file with ffprobe arguments that exclude the audio stream" do
+    blob = create_file_blob(filename: "audio.mp3", content_type: "audio/mp3")
+
+    ActiveStorage.with(ffprobe_arguments: "-select_streams v") do
+      metadata = extract_metadata_from(blob)
+
+      assert_not metadata[:duration]
+      assert_not metadata[:bit_rate]
+    end
+  end
+
   test "instrumenting analysis" do
     blob = create_file_blob(filename: "audio.mp3", content_type: "audio/mp3")
 

--- a/activestorage/test/analyzer/video_analyzer_test.rb
+++ b/activestorage/test/analyzer/video_analyzer_test.rb
@@ -92,6 +92,18 @@ class ActiveStorage::Analyzer::VideoAnalyzerTest < ActiveSupport::TestCase
     assert_not metadata[:audio]
   end
 
+  test "analyzing a video with ffprobe arguments that exclude the video stream" do
+    blob = create_file_blob(filename: "video.mp4", content_type: "video/mp4")
+
+    ActiveStorage.with(ffprobe_arguments: "-select_streams a") do
+      metadata = extract_metadata_from(blob)
+
+      assert metadata[:audio]
+      assert_not metadata[:video]
+      assert_not metadata[:width]
+    end
+  end
+
   test "instrumenting analysis" do
     blob = create_file_blob(filename: "video.mp4", content_type: "video/mp4")
 

--- a/activestorage/test/previewer/video_previewer_test.rb
+++ b/activestorage/test/previewer/video_previewer_test.rb
@@ -26,6 +26,16 @@ class ActiveStorage::Previewer::VideoPreviewerTest < ActiveSupport::TestCase
     end
   end
 
+  test "previewing a video that the input arguments exclude" do
+    blob = create_file_blob(filename: "video.mp4", content_type: "video/mp4")
+
+    ActiveStorage.with(video_preview_input_arguments: "-codec_whitelist none") do
+      assert_raises ActiveStorage::PreviewError do
+        ActiveStorage::Previewer::VideoPreviewer.new(blob).preview
+      end
+    end
+  end
+
   test "previewing a video that can't be previewed" do
     blob = create_file_blob(filename: "report.pdf", content_type: "video/mp4")
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -3792,6 +3792,29 @@ The default value depends on the `config.load_defaults` target version:
 | (original)            | `"-y -vframes 1 -f image2"` |
 | 7.0                   | `"-vf 'select=eq(n\\,0)+eq(key\\,1)+gt(scene\\,0.015)"`<sup><mark><strong><em>1</em></strong></mark></sup> <br> `+ ",loop=loop=-1:size=2,trim=start_frame=1'"`<sup><mark><strong><em>2</em></strong></mark></sup><br> `+ " -frames:v 1 -f image2"` <br><br> <ol><li>Select the first video frame, plus keyframes, plus frames that meet the scene change threshold.</li> <li>Use the first video frame as a fallback when no other frames meet the criteria by looping the first (one or) two selected frames, then dropping the first looped frame.</li></ol> |
 
+#### `config.active_storage.video_preview_input_arguments`
+
+Arguments passed to ffmpeg before `-i` when generating video preview images.
+ffmpeg's flags are position dependent, so arguments that apply to the input,
+such as `-codec_whitelist` and `-protocol_whitelist`, belong here.
+
+The default value is `""`.
+
+See [Media Processing of File Uploads](security.html#media-processing-of-file-uploads)
+in the Security Guide.
+
+#### `config.active_storage.ffprobe_arguments`
+
+Arguments passed to ffprobe before the file path when analyzing videos and
+audio. Applies to both `ActiveStorage::Analyzer::VideoAnalyzer` and
+`ActiveStorage::Analyzer::AudioAnalyzer`. Arguments that make ffprobe reject a
+file will fail that file's analysis.
+
+The default value is `""`.
+
+See [Media Processing of File Uploads](security.html#media-processing-of-file-uploads)
+in the Security Guide.
+
 #### `config.active_storage.multiple_file_field_include_hidden`
 
 In Rails 7.1 and beyond, Active Storage `has_many_attached` relationships will

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -685,6 +685,23 @@ The popular Apache web server has an option called DocumentRoot. This is the hom
 
 _If your Apache DocumentRoot points to Rails' /public directory, do not put file uploads in it_, store files at least one level upwards.
 
+### Media Processing of File Uploads
+
+WARNING: _ffmpeg and ffprobe decode untrusted media in memory-unsafe code. Restrict the codecs and formats they will accept._
+
+Active Storage shells out to ffmpeg to generate video previews, and to ffprobe to extract video and audio metadata. Neither tool is shipped by Rails, and a stock ffmpeg build registers several hundred decoders and demuxers where an application needs a handful. Attachments are analyzed on upload by default, so ffprobe reads attacker-supplied bytes without any further interaction.
+
+Narrow that attack surface by naming the codecs these tools may decode. An application that accepts only H.264 video with AAC audio would configure:
+
+```ruby
+config.active_storage.video_preview_input_arguments = "-codec_whitelist h264,aac"
+config.active_storage.ffprobe_arguments = "-codec_whitelist h264,aac"
+```
+
+Alongside `-codec_whitelist`, `-f` forces a single demuxer and `-protocol_whitelist` restricts the protocols an input may reference.
+
+Every codec present in a stored file must appear in the list, audio codecs included. ffprobe exits with an error on a file that uses any other codec, and analysis of that file then raises `JSON::ParserError`. Codec names vary between ffmpeg builds, so check the list against `ffmpeg -decoders` for the build you deploy.
+
 ### File Downloads
 
 NOTE: _Make sure users cannot download arbitrary files._

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -4423,6 +4423,34 @@ module ApplicationTests
         ActiveStorage.video_preview_arguments
     end
 
+    test "ActiveStorage.video_preview_input_arguments is empty by default" do
+      app "development"
+
+      assert_equal "", ActiveStorage.video_preview_input_arguments
+    end
+
+    test "ActiveStorage.video_preview_input_arguments can be configured" do
+      add_to_config 'config.active_storage.video_preview_input_arguments = "-codec_whitelist h264"'
+
+      app "development"
+
+      assert_equal "-codec_whitelist h264", ActiveStorage.video_preview_input_arguments
+    end
+
+    test "ActiveStorage.ffprobe_arguments is empty by default" do
+      app "development"
+
+      assert_equal "", ActiveStorage.ffprobe_arguments
+    end
+
+    test "ActiveStorage.ffprobe_arguments can be configured" do
+      add_to_config 'config.active_storage.ffprobe_arguments = "-codec_whitelist h264"'
+
+      app "development"
+
+      assert_equal "-codec_whitelist h264", ActiveStorage.ffprobe_arguments
+    end
+
     test "ActiveStorage.variant_processor uses mini_magick without Rails 7 defaults" do
       remove_from_config '.*config\.load_defaults.*\n'
 


### PR DESCRIPTION
### Motivation / Background

Constraining which demuxers and decoders ffmpeg and ffprobe will use is a hardening measure for the media-processing attack surface, and Active Storage cannot express that constraint.

ffmpeg's flags are position dependent. `-codec_whitelist` and `-protocol_whitelist` must appear before `-i`, and `config.active_storage.video_preview_arguments` is inserted after it.

ffprobe has no argument configuration at all.

Applying an allowlist therefore means overriding a private method in `ActiveStorage::Previewer::VideoPreviewer` or in either analyzer. An override of `probe_from` restates the whole argument list, so it drifts whenever Rails changes the probe.

### Detail

This Pull Request introduces two new configuration parameters:

* `config.active_storage.video_preview_input_arguments`, passed to ffmpeg before `-i`
* `config.active_storage.ffprobe_arguments`, passed to ffprobe before the file path

Both default to `""`, so the command lines are unchanged for an application that does not set them.

`ffprobe_arguments` is named for the tool because `ActiveStorage::Analyzer::VideoAnalyzer` and `ActiveStorage::Analyzer::AudioAnalyzer` build the same ffprobe command line.

As an example, an application that accepts only H.264 video with AAC audio would configure:

```ruby
config.active_storage.video_preview_input_arguments = "-codec_whitelist h264,aac"
config.active_storage.ffprobe_arguments = "-codec_whitelist h264,aac"
```

With that example configuration, the previewer command line changes from:

```
ffmpeg -i /tmp/blob.mp4 -vf 'select=...' -frames:v 1 -f image2 -
```

to:

```
ffmpeg -codec_whitelist h264,aac -i /tmp/blob.mp4 -vf 'select=...' -frames:v 1 -f image2 -
```

and both analyzer command lines change from:

```
ffprobe -print_format json -show_streams -show_format -v error /tmp/blob.mp4
```

to:

```
ffprobe -print_format json -show_streams -show_format -v error -codec_whitelist h264,aac /tmp/blob.mp4
```

The security guide gains a "Media Processing of File Uploads" section covering these parameters and the input flags listed above.

### Additional information

This is not itself a security fix. It gives an application the means to harden media processing where it needs to.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
