### PR TITLE
Remove attribute_method_patterns_cache

### DIFF
--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -69,10 +69,9 @@ module ActiveModel
     EMPTY_HASH = Hash.new([].freeze).freeze # :nodoc:
 
     included do
-      @attribute_method_patterns_cache = Concurrent::Map.new(initial_capacity: 4)
       class_attribute :attribute_aliases, instance_writer: false, default: {}.freeze
       @aliases_by_attribute_name = EMPTY_HASH
-      class_attribute :attribute_method_patterns, instance_writer: false, default: [ ClassMethods::AttributeMethodPattern.new ].freeze
+      class_attribute :attribute_method_patterns, instance_writer: false, default: ClassMethods::AttributeMethodPatternSet.new([ ClassMethods::AttributeMethodPattern.new ])
     end
 
     module ClassMethods
@@ -227,7 +226,6 @@ module ActiveModel
           attribute_method_patterns.each do |pattern|
             alias_attribute_method_definition(code_generator, pattern, new_name, old_name)
           end
-          @attribute_method_patterns_cache.clear
         end
       end
 
@@ -321,7 +319,6 @@ module ActiveModel
           attribute_method_patterns.each do |pattern|
             define_attribute_method_pattern(pattern, attr_name, owner: owner, as: as)
           end
-          @attribute_method_patterns_cache.clear
         end
       end
 
@@ -384,14 +381,12 @@ module ActiveModel
         @generated_attribute_methods&.module_eval do
           undef_method(*instance_methods)
         end
-        @attribute_method_patterns_cache.clear
       end
 
       private
         def inherited(base) # :nodoc:
           super
           base.class_eval do
-            @attribute_method_patterns_cache = Concurrent::Map.new(initial_capacity: 4)
             @aliases_by_attribute_name = EMPTY_HASH
             @generated_attribute_methods = nil
           end
@@ -407,12 +402,6 @@ module ActiveModel
 
         def instance_method_already_implemented?(method_name)
           @generated_attribute_methods&.method_defined?(method_name)
-        end
-
-        def attribute_method_patterns_matching(method_name)
-          @attribute_method_patterns_cache.compute_if_absent(method_name) do
-            attribute_method_patterns.filter_map { |pattern| pattern.match(method_name) }
-          end
         end
 
         # Define a method `name` in `mod` that dispatches to `send`
@@ -474,22 +463,64 @@ module ActiveModel
             @prefix = -prefix
             @suffix = -suffix
             @parameters = parameters.nil? ? "..." : (parameters.is_a?(String) ? -parameters : parameters)
-            @regex = /\A(?:#{Regexp.escape(@prefix)})(.*)(?:#{Regexp.escape(@suffix)})\z/
+            @prefix_length = @prefix.length
+            @affix_length = @prefix.length + @suffix.length
+            @unaffixed = @prefix.empty? && @suffix.empty?
             @proxy_target = "#{@prefix}attribute#{@suffix}".freeze
             @define_method_proxy_target = :"define_method_#{@proxy_target}"
             @method_name = "#{prefix}%s#{suffix}".freeze
             freeze
           end
 
-          def match(method_name)
-            if @regex =~ method_name
-              AttributeMethod.new(proxy_target, $1)
-            end
+          def matched_attribute_name(method_name)
+            return method_name if @unaffixed
+            return if method_name.length < @affix_length
+            return unless method_name.end_with?(@suffix) && method_name.start_with?(@prefix)
+            method_name[@prefix_length, method_name.length - @affix_length]
+          end
+
+          def method_for_attr(attr_name)
+            AttributeMethod.new(@proxy_target, attr_name)
           end
 
           def method_name(attr_name)
             @method_name % attr_name
           end
+        end
+
+        class AttributeMethodPatternSet # :nodoc:
+          def initialize(patterns)
+            @patterns = patterns.freeze
+            @unaffixed = patterns.select { |pattern| pattern.prefix.empty? && pattern.suffix.empty? }.freeze
+
+            @prefixes = patterns.map(&:prefix).reject(&:empty?).uniq.freeze
+            @suffixes = patterns.map(&:suffix).reject(&:empty?).uniq.freeze
+
+            freeze
+          end
+
+          def each(&block)
+            @patterns.each(&block)
+          end
+
+          def +(other)
+            AttributeMethodPatternSet.new(@patterns + other)
+          end
+
+          def ==(other)
+            other.is_a?(AttributeMethodPatternSet) && patterns == other.patterns
+          end
+
+          def matching(method_name)
+            if method_name.end_with?(*@suffixes) || method_name.start_with?(*@prefixes)
+              @patterns
+            else
+              @unaffixed
+            end
+          end
+
+          protected
+            attr_reader :patterns
         end
     end
 
@@ -544,8 +575,19 @@ module ActiveModel
       # Returns a struct representing the matching attribute method.
       # The struct's attributes are prefix, base and suffix.
       def matched_attribute_method(method_name)
-        matches = self.class.send(:attribute_method_patterns_matching, method_name)
-        matches.detect { |match| attribute_method?(match.attr_name) }
+        patterns = self.class.attribute_method_patterns.matching(method_name)
+        index = 0
+        len = patterns.length
+
+        while index < len
+          pattern = patterns[index]
+          attr_name = pattern.matched_attribute_name(method_name)
+          if attr_name && attribute_method?(attr_name)
+            return pattern.method_for_attr(attr_name)
+          end
+          index += 1
+        end
+        nil
       end
 
       def missing_attribute(attr_name, stack)

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -81,7 +81,6 @@ module ActiveRecord
         attribute_method_patterns.each do |pattern|
           alias_attribute_method_definition(code_generator, pattern, new_name, old_name)
         end
-        @attribute_method_patterns_cache.clear
       end
 
       def alias_attribute_method_definition(code_generator, pattern, new_name, old_name) # :nodoc:


### PR DESCRIPTION
This cache is designed to cache the extraction of attributes from method names so that "dynamic" respond_to? can be made much faster.

As an example: if we call `respond_to?(:something_will_change!)`, then the cache stores `something_will_change!` -> `something, attribute_will_change!`.

Unfortunately, this cache has two problems:
- its unbounded
- it won't work with Ractors

So in this commit I'm removing it, and replacing it with a bunch of micro-optimizations to restore some of the lost performance. As I mentioned already, the performance loss is _only_ for methods that are not defined on a model. In practice, that means "dynamic" attributes (such as when a query ends up selecting non-column values) and methods that the model actually doesn't respond to.

The following benchmark shows the slowdown for three cases:
- `to_hash` (`respond_to?` `false`)
- `permitted?` (`respond_to?` `false` but it matches one of the patterns)
- `tenderlove` (`respond_to? `true`, a dynamic attribute)

```ruby
# frozen_string_literal: true

require "benchmark/ips"
require "active_record"

STAGE = ENV.fetch("STAGE", "after")

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.lease_connection.create_table(:posts) { |t| t.string :title }
class Post < ActiveRecord::Base; end

row   = Post.create!(title: "x")
extra = Post.select("id, title, 10 as tenderlove").first

CASES = {
  "to_hash"    => -> { row.respond_to?(:to_hash) },      # rejected by prefilter
  "permitted?" => -> { row.respond_to?(:permitted?) },   # scans all patterns (? suffix)
  "tenderlove" => -> { extra.respond_to?(:tenderlove) }, # dynamic attribute
}

CASES.each do |label, block|
  puts
  Benchmark.ips do |x|
    x.config(time: 3, warmup: 1)
    x.save!("/tmp/bench_#{label}.hold")
    x.report("#{label} (#{STAGE})") { block.call }
    x.compare!
  end
end
```

```
$ STAGE=after bundle exec ruby --yjit activemodel/bench_attribute_method_patterns.rb

ruby 4.0.3 (2026-04-21 revision 85ddef263a) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
     to_hash (after)   232.619k i/100ms
Calculating -------------------------------------
     to_hash (after)      2.447M (± 1.7%) i/s  (408.63 ns/i) -      7.444M in   3.041733s

Comparison:
to_hash (before):  3953529.3 i/s
 to_hash (after):  2447226.0 i/s - 1.62x  slower

ruby 4.0.3 (2026-04-21 revision 85ddef263a) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
  permitted? (after)   132.058k i/100ms
Calculating -------------------------------------
  permitted? (after)      1.340M (± 1.6%) i/s  (746.15 ns/i) -      4.094M in   3.054570s

Comparison:
permitted? (before):  3650315.1 i/s
 permitted? (after):  1340220.7 i/s - 2.72x  slower

ruby 4.0.3 (2026-04-21 revision 85ddef263a) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
  tenderlove (after)   171.493k i/100ms
Calculating -------------------------------------
  tenderlove (after)      1.753M (± 1.6%) i/s  (570.61 ns/i) -      5.316M in   3.033504s

Comparison:
tenderlove (before):  3010374.6 i/s
 tenderlove (after):  1752522.2 i/s - 1.72x  slower
```