### PR TITLE
Only generate the CI checks group when it has steps

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -410,6 +410,10 @@ module Rails
         options[:skip_ci]
       end
 
+      def any_ci_check_steps?
+        !skip_rubocop? || !skip_bundler_audit? || !skip_brakeman? || using_node? || using_importmap?
+      end
+
       def skip_devcontainer?
         !options[:devcontainer]
       end

--- a/railties/lib/rails/generators/rails/app/templates/config/ci.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/ci.rb.tt
@@ -2,6 +2,7 @@
 
 CI.run do
   step "Setup", "bin/setup --skip-server"
+<% if any_ci_check_steps? || !options[:skip_test] -%>
 
   group "Checks", parallel: 2 do
 <% unless options.skip_rubocop? -%>
@@ -20,7 +21,7 @@ CI.run do
     step "Security: Brakeman code analysis", "bin/brakeman --quiet --no-pager --exit-on-warn --exit-on-error"
 <% end -%>
 <% unless options[:skip_test] -%>
-
+<%= "\n" if any_ci_check_steps? -%>
     group "Tests" do
       step "Tests: Rails", "bin/rails test"
 <% unless options.skip_active_record? -%>
@@ -31,6 +32,7 @@ CI.run do
     end
 <% end -%>
   end
+<% end -%>
 
   # Optional: set a green GitHub commit status to unblock PR merge.
   # Requires the `gh` CLI and `gh extension install basecamp/gh-signoff`.

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -731,6 +731,22 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_config_ci_does_not_start_the_checks_group_with_a_blank_line
+    run_generator [destination_root, "--skip-rubocop", "--skip-brakeman", "--skip-bundler-audit", "--skip-javascript"]
+
+    assert_file "config/ci.rb" do |content|
+      assert_no_match(/group "Checks".*do\n\n/, content)
+    end
+  end
+
+  def test_config_ci_omits_the_checks_group_when_nothing_would_go_in_it
+    run_generator [destination_root, "--skip-rubocop", "--skip-brakeman", "--skip-bundler-audit", "--skip-javascript", "--skip-test"]
+
+    assert_file "config/ci.rb" do |content|
+      assert_no_match(/group "Checks"/, content)
+    end
+  end
+
   def test_config_ci_does_not_include_seed_step_when_skip_active_record_is_given
     run_generator [destination_root, "--skip-active-record"]
 


### PR DESCRIPTION
### Motivation / Background

If I generate an engine from current main and run `bin/rubocop` straight afterwards, I get a correctable:

```
test/dummy/config/ci.rb:7:1: C: [Correctable] Layout/EmptyLinesAroundBlockBody: Extra empty line detected at block body beginning.
```

The engine's RuboCop lints test/dummy, and dummy apps are generated with `skip_rubocop`, `skip_brakeman`, `skip_bundler_audit` and `skip_javascript`, which between them cover every step that would go in the `Checks` group. Tests aren't skipped, so the blank line that usually separates the checks from the `Tests` group ends up at the top of the group instead.

### Detail

This PR skips the `Checks` group when there's nothing to go inside of it. An app generated with `rails new --minimal` which then adds `rubocop-rails-omakase` later will have the same issue. I'll also open another PR to skip ci in engine dummies, but I think this change still makes sense.

### Additional information

This is a followup to #58206. I don't think any releases are affected, the grouping structure came in #56774
