### PR TITLE
Don't raise LoadError when a test:* folder is missing

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Report zero tests instead of raising a `LoadError` when a `bin/rails test:*`
+    folder command names a folder the application does not have.
+
+    A generated application has no `test/system` folder, so the `system-test`
+    job in the generated `.github/workflows/ci.yml` failed on the first push
+    with `cannot load such file -- <app>/test/system (LoadError)`. The same
+    happened for `bin/rails test:channels`, `test:jobs`, `test:mailboxes`,
+    `test:units`, `test:functionals`, and `test:generators`, which all name
+    folders that an application does not necessarily have.
+
+    *Ariel Rzezak*
+
 *   Add `--no-banner` to `bin/rails console` to suppress the startup banner.
 
     Users can already set `IRB.conf[:SHOW_BANNER] = false` in `.irbrc`; this

--- a/railties/lib/rails/commands/test/test_command.rb
+++ b/railties/lib/rails/commands/test/test_command.rb
@@ -37,7 +37,7 @@ module Rails
       Rails::TestUnit::Runner::TEST_FOLDERS.each do |name|
         desc name, "Run tests in test/#{name}"
         define_method(name) do |*args|
-          perform("test/#{name}", *args)
+          perform(*test_folders("test/#{name}"), *args)
         end
       end
 
@@ -48,26 +48,33 @@ module Rails
 
       desc "functionals", "Run tests in test/controllers, test/mailers, and test/functional"
       def functionals(*args)
-        perform("test/controllers", "test/mailers", "test/functional", *args)
+        perform(*test_folders("test/controllers", "test/mailers", "test/functional"), *args)
       end
 
       desc "units", "Run tests in test/models, test/helpers, and test/unit"
       def units(*args)
-        perform("test/models", "test/helpers", "test/unit", *args)
+        perform(*test_folders("test/models", "test/helpers", "test/unit"), *args)
       end
 
       desc "system", "Run system tests only"
       def system(*args)
-        perform("test/system", *args)
+        perform(*test_folders("test/system"), *args)
       end
 
       desc "generators", "Run tests in test/lib/generators"
       def generators(*args)
-        perform("test/lib/generators", *args)
+        perform(*test_folders("test/lib/generators"), *args)
       end
 
       private
         EXACT_TEST_ARGUMENT_PATTERN = %r{^-n|^--name\b|^(?!/.+/$)[.\w]*[/\\]}
+
+        # The runner requires a path that is not an existing folder as if it
+        # were a test file, so name a glob that matches nothing instead.
+        # Dropping the folder would leave no patterns, which runs every test.
+        def test_folders(*folders)
+          folders.map { |folder| Dir.exist?(folder) ? folder : "#{folder}/**/*_test.rb" }
+        end
 
         def run_prepare_task
           Rails::Command::RakeCommand.perform("test:prepare", [], {})

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -113,6 +113,28 @@ module ApplicationTests
       assert_match "FooTest", rails("test:generators", "--verbose")
     end
 
+    def test_run_system_when_the_folder_does_not_exist
+      assert_not File.directory?("#{app_path}/test/system")
+
+      assert_match "0 runs, 0 assertions, 0 failures, 0 errors, 0 skips", rails("test:system")
+    end
+
+    def test_run_folder_command_when_the_folder_does_not_exist
+      assert_not File.directory?("#{app_path}/test/jobs")
+
+      assert_match "0 runs, 0 assertions, 0 failures, 0 errors, 0 skips", rails("test:jobs")
+    end
+
+    def test_run_units_when_one_of_the_folders_does_not_exist
+      create_test_file :models, "foo"
+      assert_not File.directory?("#{app_path}/test/unit")
+
+      rails("test:units").tap do |output|
+        assert_match "FooTest", output
+        assert_match "1 runs, 1 assertions, 0 failures", output
+      end
+    end
+
     def test_run_channels
       create_test_file :channels, "foo_channel"
       create_test_file :channels, "bar_channel"


### PR DESCRIPTION
### Motivation / Background

`bin/rails test:system` raises `LoadError` when an application has no `test/system` folder:

```
cannot load such file -- <app>/test/system (LoadError)
  railties/lib/rails/test_unit/runner.rb:70:in 'load_tests'
```

Since ea8736b49f ("Skip all system test files on app generation") an application generated by `rails new` has no `test/system` folder, while the `.github/workflows/ci.yml` it also generates still runs `bin/rails db:test:prepare test:system`. The first push of an untouched application therefore gets a red CI run.

Minimal reproduction, against `main` at 7b911de2d1:

```
$ rails new blog
$ cd blog
$ bin/rails db:migrate
$ bin/rails test:system
cannot load such file -- /tmp/blog/test/system (LoadError)
```

This is #56853 (closed without a fix) and #57893.

`test/system` is not the only folder an application does not necessarily have. A generated application has `test/models`, `test/helpers`, `test/controllers`, `test/mailers` and `test/integration`, so every other folder command raises the same `LoadError`:

```
$ bin/rails test:jobs
cannot load such file -- /tmp/blog/test/jobs (LoadError)
```

On a stock `rails new` application, seven of the folder commands fail this way and pass after the change:

| Command | Folder | Before | After |
| --- | --- | --- | --- |
| `test:system` | `test/system` | `LoadError` | `0 runs` |
| `test:channels` | `test/channels` | `LoadError` | `0 runs` |
| `test:jobs` | `test/jobs` | `LoadError` | `0 runs` |
| `test:mailboxes` | `test/mailboxes` | `LoadError` | `0 runs` |
| `test:units` | `test/unit` | `LoadError` | runs `test/models` and `test/helpers` |
| `test:functionals` | `test/functional` | `LoadError` | runs `test/controllers` and `test/mailers` |
| `test:generators` | `test/lib/generators` | `LoadError` | `0 runs` |

### Detail

The folder commands in `Rails::Command::TestCommand` pass a folder name straight to `Rails::TestUnit::Runner`. `Runner.extract_filters` turns a path into a `**/*_test.rb` glob when `Dir.exist?` is true, and otherwise treats the path as a test file and requires it, which is where the `LoadError` comes from.

This maps a missing folder to a glob that matches nothing, so the command reports zero tests and exits successfully. A folder that does exist is passed through unchanged, so behaviour for an application that has the folder is untouched.

After the change:

```
$ bin/rails test:system
0 runs, 0 assertions, 0 failures, 0 errors, 0 skips
$ echo $?
0
```

Two notes on why it is shaped this way:

- I did not fix this in `Runner.extract_filters`. Its `else` branch is what gives an unknown path any signal at all, and a directory-shaped typo gets no `DidYouMean` corrections (`test/modles` and `test/systm` both produce none), so the raw `LoadError` naming the path is all the user has. Tolerating a missing directory there would silence that for every caller, including `rails/plugin/test.rb` and `tools/test.rb`, which only ever see user-typed paths. Whether a path was typed by the user or supplied by a shortcut is known only at the command layer, which is why the change lives there. For the same reason it is not applied inside `perform`, which is also the public `test [PATHS...]` entrypoint.
- The missing folder becomes a glob rather than being dropped. `Runner.list_tests` falls back to `default_test_glob` when the pattern list is empty, so dropping it would make `bin/rails test:system` on an application with no `test/system` run the whole suite.

### Relationship to the open CI-template PRs

#56856 and #57924 approach the same red CI run from the template side, by removing or commenting out the `system-test` job in `github/ci.yml.tt`. This fixes the command itself instead, which also covers `bin/ci`, a locally run `bin/rails test:system`, and the sibling folder commands above. The two are complementary: whichever template decision the team prefers, `bin/rails test:system` should report no tests rather than crash.

### Additional information

Verified against an application generated with `rails new --dev`, running all seven commands in the table above before and after the change.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.
