### PR TITLE
Fix don't null owner key columns querying a composite belongs_to with nil

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,27 @@
+*   Don't emit `IS NULL` on owner key columns when querying a non-polymorphic
+    composite `belongs_to` association with `nil`.
+
+    When a composite foreign key includes one of the owner's query constraint
+    or primary key columns (e.g. a tenant key like `shop_id` in
+    `[:shop_id, :item_id]`), `where(association: nil)` constrained every column
+    of the key to `NULL`, including the owner key. Combined with a scope on that
+    column — such as a tenant scope — this produced an impossible
+    `shop_id = ? AND shop_id IS NULL` condition. Only the columns identifying
+    the target row are now constrained:
+
+    ```ruby
+    Order.where(shop_id: 1).where(first_item: nil)
+    # Before: WHERE shop_id = 1 AND shop_id IS NULL AND first_item_id IS NULL
+    # After:  WHERE shop_id = 1 AND first_item_id IS NULL
+    ```
+
+    Negated predicates such as `where.not(first_item: nil)` use the same owner
+    key handling and only negate the columns identifying the target row.
+
+    Fixes #57904.
+
+    *michaelg100*
+
 *   Deprecate `ActiveRecord::ConnectionAdapters::DatabaseStatements#create`
     in favor of `#insert`.
 

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -157,8 +157,13 @@ module ActiveRecord
               )
             end
 
-            klass ||= AssociationQueryValue
-            queries = klass.new(associated_reflection, value).queries.map! do |query|
+            query_value = if klass
+              klass.new(associated_reflection, value)
+            else
+              AssociationQueryValue.new(associated_reflection, value, table.model)
+            end
+
+            queries = query_value.queries.map! do |query|
               # If the query produced is identical to attributes don't go any deeper.
               # Prevents stack level too deep errors when association and foreign_key are identical.
               query == attributes ? self[key, value] : expand_from_hash(query)

--- a/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
@@ -3,9 +3,10 @@
 module ActiveRecord
   class PredicateBuilder
     class AssociationQueryValue # :nodoc:
-      def initialize(reflection, value)
+      def initialize(reflection, value, model)
         @reflection = reflection
         @value = value
+        @model = model
       end
 
       def queries
@@ -13,11 +14,23 @@ module ActiveRecord
         id_list = ids
         id_list = id_list.pluck(primary_key) if key.composite? && id_list.is_a?(Relation)
 
-        key.where_clauses(id_list)
+        clauses = key.where_clauses(id_list)
+        return clauses unless key.composite? && reflection.belongs_to?
+
+        if value.is_a?(Array)
+          # `ids` and `where_clauses` preserve one clause per association value.
+          clauses.zip(value).map do |clause, association|
+            association.nil? ? prune_shared_columns(clause) : clause
+          end
+        elsif value.nil?
+          clauses.map { |clause| prune_shared_columns(clause) }
+        else
+          clauses
+        end
       end
 
       private
-        attr_reader :reflection, :value
+        attr_reader :reflection, :value, :model
 
         def ids
           case value
@@ -69,6 +82,20 @@ module ActiveRecord
           else
             value
           end
+        end
+
+        # A `nil` association is queried by `IS NULL` on the foreign key, but
+        # owner key columns don't identify the target row and can contradict a
+        # scope on the owner.
+        def prune_shared_columns(clause)
+          pruned = clause.except(*shared_columns)
+          # An empty predicate would match every record, so retain the original
+          # clause when the entire foreign key identifies the owner.
+          pruned.empty? ? clause : pruned
+        end
+
+        def shared_columns
+          Array(reflection.join_foreign_key) & model.composite_query_constraints_list
         end
     end
   end

--- a/activerecord/lib/active_record/table_metadata.rb
+++ b/activerecord/lib/active_record/table_metadata.rb
@@ -62,6 +62,10 @@ module ActiveRecord
 
     attr_reader :arel_table
 
+    def model
+      klass
+    end
+
     private
       attr_reader :klass
   end

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -17,6 +17,7 @@ require "models/topic"
 require "models/treasure"
 require "models/vertex"
 require "models/cpk"
+require "models/sharded"
 require "support/stubs/strong_parameters"
 
 module ActiveRecord
@@ -156,6 +157,95 @@ module ActiveRecord
 
       book.update!(order: nil)
       assert_includes Cpk::Book.where(order: nil), book
+    end
+
+    def test_where_with_nil_association_on_query_constrained_model_keeps_tenant_scope
+      blog = Sharded::Blog.create!
+      blog_post = Sharded::BlogPost.create!(blog_id: blog.id)
+      comment_with_post = Sharded::Comment.create!(blog_id: blog.id, blog_post_id: blog_post.id)
+      comment_without_post = Sharded::Comment.create!(blog_id: blog.id)
+
+      relation = Sharded::Comment.where(blog_id: blog.id).where(blog_post: nil)
+
+      assert_includes relation, comment_without_post
+      assert_not_includes relation, comment_with_post
+    end
+
+    def test_where_not_with_nil_association_on_query_constrained_model_keeps_tenant_scope
+      blog = Sharded::Blog.create!
+      blog_post = Sharded::BlogPost.create!(blog_id: blog.id)
+      comment_with_post = Sharded::Comment.create!(blog_id: blog.id, blog_post_id: blog_post.id)
+      comment_without_post = Sharded::Comment.create!(blog_id: blog.id)
+
+      relation = Sharded::Comment.where(blog_id: blog.id).where.not(blog_post: nil)
+
+      assert_includes relation, comment_with_post
+      assert_not_includes relation, comment_without_post
+    end
+
+    def test_where_with_nil_association_prunes_owner_key_with_custom_target_key_name
+      blog = Sharded::Blog.create!
+      blog_post = Sharded::BlogPost.create!(blog_id: blog.id, revision: blog.id)
+      comment_with_post = Sharded::Comment.create!(blog_id: blog.id, blog_post_id: blog_post.id)
+      comment_without_post = Sharded::Comment.create!(blog_id: blog.id)
+
+      relation = Sharded::Comment.where(blog_id: blog.id).where(blog_post_with_custom_primary_key: nil)
+
+      assert_includes relation, comment_without_post
+      assert_not_includes relation, comment_with_post
+    end
+
+    def test_where_with_nil_cpk_association_constrains_non_owner_columns
+      order = Cpk::Order.create!(id: [1, 2])
+      book_with_order = order.books.create!(id: [3, 4])
+      book_without_order = Cpk::Book.create!(id: [3, 5], shop_id: order.shop_id)
+
+      relation = Cpk::Book.where(order: nil)
+
+      assert_not_includes relation, book_without_order
+      assert_not_includes relation, book_with_order
+    end
+
+    def test_where_with_nil_inherited_association_uses_querying_model_constraints
+      order = Cpk::Order.create!(id: [1, 2])
+      book = Cpk::TenantScopedBook.create!(id: [3, 4], shop_id: order.shop_id)
+
+      relation = Cpk::TenantScopedBook.where(shop_id: order.shop_id).where(order: nil)
+
+      assert_includes relation, book
+    end
+
+    def test_where_with_unsaved_cpk_association_does_not_prune_nil_ids
+      blog = Sharded::Blog.create!
+      Sharded::Comment.create!(blog_id: blog.id)
+
+      relation = Sharded::Comment.where(blog_post: Sharded::BlogPost.new)
+
+      assert_empty relation
+    end
+
+    def test_where_with_nil_collection_association_does_not_prune_owner_columns
+      blog = Sharded::Blog.create!
+      blog_post = Sharded::BlogPost.create!(blog_id: blog.id)
+
+      relation = Sharded::BlogPost.where(comments_by_revision: nil)
+
+      assert_not_includes relation, blog_post
+    end
+
+    def test_where_with_array_of_nil_and_record_for_query_constrained_association
+      blog = Sharded::Blog.create!
+      blog_post = Sharded::BlogPost.create!(blog_id: blog.id)
+      other_blog_post = Sharded::BlogPost.create!(blog_id: blog.id)
+      comment_with_post = Sharded::Comment.create!(blog_id: blog.id, blog_post_id: blog_post.id)
+      comment_with_other_post = Sharded::Comment.create!(blog_id: blog.id, blog_post_id: other_blog_post.id)
+      comment_without_post = Sharded::Comment.create!(blog_id: blog.id)
+
+      relation = Sharded::Comment.where(blog_post: [nil, blog_post])
+
+      assert_includes relation, comment_without_post
+      assert_includes relation, comment_with_post
+      assert_not_includes relation, comment_with_other_post
     end
 
     def test_belongs_to_shallow_where

--- a/activerecord/test/models/cpk/book.rb
+++ b/activerecord/test/models/cpk/book.rb
@@ -25,6 +25,10 @@ module Cpk
   class BestSeller < Book
   end
 
+  class TenantScopedBook < Book
+    query_constraints :shop_id, :id
+  end
+
   class BrokenBook < Book
     belongs_to :order, class_name: "Cpk::OrderWithSpecialPrimaryKey"
   end

--- a/activerecord/test/models/sharded/blog_post.rb
+++ b/activerecord/test/models/sharded/blog_post.rb
@@ -24,6 +24,10 @@ module Sharded
       class_name: "Sharded::Comment",
       primary_key: [:blog_id, :id],
       foreign_key: [:blog_id, :blog_post_id]
+    has_many :comments_by_revision,
+      class_name: "Sharded::Comment",
+      primary_key: [:revision, :id],
+      foreign_key: [:blog_id, :blog_post_id]
 
     has_many :comments_with_inverse,
       class_name: "Sharded::Comment",

--- a/activerecord/test/models/sharded/comment.rb
+++ b/activerecord/test/models/sharded/comment.rb
@@ -12,6 +12,10 @@ module Sharded
       foreign_key: [:blog_id, :blog_post_id],
       primary_key: [:blog_id, :id],
       inverse_of: :comments_with_inverse
+    belongs_to :blog_post_with_custom_primary_key,
+      class_name: "Sharded::BlogPost",
+      foreign_key: [:blog_id, :blog_post_id],
+      primary_key: [:revision, :id]
     belongs_to :blog
   end
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

Thought it was an interesting issue. 

Fixes #57904.

When a non-polymorphic composite `belongs_to` foreign key includes one of the owner model’s query constraint or primary key columns, `where(association: nil)` currently constrains every foreign-key column to `NULL`. For a tenant key such as `shop_id`, combining this predicate with an existing tenant scope produces a contradictory condition:

`shop_id = ? AND shop_id IS NULL`

As a result, records with a missing association are silently excluded from the query.

### Detail

This Pull Request removes owner query-constraint and primary-key columns from composite `belongs_to` predicates created for an explicit nil association value.

For example:

`Order.where(shop_id: 1).where(first_item: nil)`

Changes from:

```sql
WHERE shop_id = 1 AND shop_id IS NULL AND first_item_id IS NULL
```

To:

```sql
WHERE shop_id = 1 AND first_item_id IS NULL
```

The querying model is used to identify owner key columns. This ensures the behavior also works when an inherited association is queried through a subclass with different query constraints. The change applies only to explicit nil values. Unsaved records whose composite IDs happen to contain only nil values retain the existing behavior. Mixed predicates such as:

`where(first_item: [nil, item])`

prune owner key columns only from the branch corresponding to the explicit nil.

The same predicate construction supports negated queries:

`Order.where(shop_id: 1).where.not(first_item: nil)`

The change is restricted to `belongs_to` associations so that `has_one` and collection reflections, whose join keys have different semantics, remain unchanged.

### Additional information

This is intentionally narrower than pruning foreign-key columns based on whether their names match the target’s primary-key columns. A composite foreign key that is not part of the owner model’s query constraints or primary key retains its existing all-columns-NULL behavior. This avoids changing the general semantics of partially null composite associations as part of this fix.

Polymorphic associations are also unchanged because they are handled separately by `PolymorphicArrayValue`.

The tests cover:

- Tenant-scoped `where(association: nil)`
- `where.not(association: nil)`
- Mixed arrays containing nil and a record
- Custom target primary-key column names
- Associations inherited by a model with different query constraints
- Unsaved records with all-nil composite IDs
- `has_many` predicate behavior
- Existing ordinary composite-primary-key behavior

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
