### PR TITLE
Restore performance for dynamic attribute read

### DIFF
--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -71,7 +71,7 @@ module ActiveModel
     included do
       class_attribute :attribute_aliases, instance_writer: false, default: {}.freeze
       @aliases_by_attribute_name = EMPTY_HASH
-      class_attribute :attribute_method_patterns, instance_writer: false, default: ClassMethods::AttributeMethodPatternSet.new([ ClassMethods::AttributeMethodPattern.new ])
+      class_attribute :attribute_method_patterns, instance_writer: false, default: ClassMethods::AttributeMethodPatternSet.new([ ClassMethods::AttributeMethodPattern::BASE ])
     end
 
     module ClassMethods
@@ -486,15 +486,17 @@ module ActiveModel
           def method_name(attr_name)
             @method_name % attr_name
           end
+
+          BASE = new
         end
 
         class AttributeMethodPatternSet # :nodoc:
           def initialize(patterns)
             @patterns = patterns.freeze
-            @unaffixed = patterns.select { |pattern| pattern.prefix.empty? && pattern.suffix.empty? }.freeze
+            @affixed = patterns.reject { |pattern| pattern.prefix.empty? && pattern.suffix.empty? }.freeze
 
-            @prefixes = patterns.map(&:prefix).reject(&:empty?).uniq.freeze
-            @suffixes = patterns.map(&:suffix).reject(&:empty?).uniq.freeze
+            @prefixes = @affixed.map(&:prefix).reject(&:empty?).uniq.freeze
+            @suffixes = @affixed.map(&:suffix).reject(&:empty?).uniq.freeze
 
             freeze
           end
@@ -512,11 +514,8 @@ module ActiveModel
           end
 
           def matching(method_name)
-            if method_name.end_with?(*@suffixes) || method_name.start_with?(*@prefixes)
-              @patterns
-            else
-              @unaffixed
-            end
+            return if @affixed.empty?
+            @affixed if method_name.end_with?(*@suffixes) || method_name.start_with?(*@prefixes)
           end
 
           protected
@@ -575,12 +574,17 @@ module ActiveModel
       # Returns a struct representing the matching attribute method.
       # The struct's attributes are prefix, base and suffix.
       def matched_attribute_method(method_name)
-        patterns = self.class.attribute_method_patterns.matching(method_name)
-        index = 0
-        len = patterns.length
+        pattern = ClassMethods::AttributeMethodPattern::BASE
+        attr_name = pattern.matched_attribute_name(method_name)
+        return pattern.method_for_attr(attr_name) if attr_name && attribute_method?(attr_name)
 
+        affixed = self.class.attribute_method_patterns.matching(method_name)
+        return unless affixed
+
+        index = 0
+        len = affixed.length
         while index < len
-          pattern = patterns[index]
+          pattern = affixed[index]
           attr_name = pattern.matched_attribute_name(method_name)
           if attr_name && attribute_method?(attr_name)
             return pattern.method_for_attr(attr_name)


### PR DESCRIPTION
Ref https://github.com/rails/rails/pull/58462

Following up the [previous commit][1] that removed the pattern cache. See that commit for benchmark.

```
ruby 4.0.3 (2026-04-21 revision 85ddef263a) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
     to_hash (after)   239.519k i/100ms
Calculating -------------------------------------
     to_hash (after)      2.503M (± 1.8%) i/s  (399.44 ns/i) -      7.665M in   3.061559s

Comparison:
to_hash (dd980d49):  4259266.5 i/s
   to_hash (after):  2503498.4 i/s - 1.70x  slower

ruby 4.0.3 (2026-04-21 revision 85ddef263a) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
  permitted? (after)   133.315k i/100ms
Calculating -------------------------------------
  permitted? (after)      1.366M (± 1.4%) i/s  (732.28 ns/i) -      4.133M in   3.026348s

Comparison:
permitted? (dd980d49):  3696870.1 i/s
   permitted? (after):  1365594.8 i/s - 2.71x  slower

ruby 4.0.3 (2026-04-21 revision 85ddef263a) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
  tenderlove (after)   300.245k i/100ms
Calculating -------------------------------------
  tenderlove (after)      3.172M (± 2.0%) i/s  (315.30 ns/i) -      9.608M in   3.029342s

Comparison:
   tenderlove (after):  3171593.0 i/s
tenderlove (dd980d49):  3042206.5 i/s - 1.04x  slower
```

[1]: https://github.com/rails/rails/commit/1a59302e642b98e78e88464edf0f3b7741359a92