### PR TITLE
Make ActiveSupport::LogSubscriber ractor safe

### DIFF
--- a/activesupport/lib/active_support/log_subscriber.rb
+++ b/activesupport/lib/active_support/log_subscriber.rb
@@ -79,15 +79,11 @@ module ActiveSupport
     }.freeze
 
     class << self
-      def logger
-        @logger ||= if defined?(Rails) && Rails.respond_to?(:logger)
-          Rails.logger
-        end
-      end
+      attr_reader :logger
 
       def logger=(logger)
-        @supports_flush = nil
         @logger = logger
+        @supports_flush = logger.respond_to?(:flush)
       end
 
       def attach_to(...) # :nodoc:
@@ -102,7 +98,6 @@ module ActiveSupport
 
       # Flush all log_subscribers' logger.
       def flush_all!
-        @supports_flush = logger.respond_to?(:flush) if @supports_flush.nil?
         logger.flush if @supports_flush
       end
 

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -184,5 +184,9 @@ module ActiveSupport
         ActiveSupport::Inflector::Inflections.all_instances.each(&:freeze)
       end
     end
+
+    initializer "active_support.set_log_subscriber_logger", after: :initialize_logger do
+      ActiveSupport::LogSubscriber.logger = Rails.logger
+    end
   end
 end

--- a/activesupport/test/log_subscriber_test.rb
+++ b/activesupport/test/log_subscriber_test.rb
@@ -206,6 +206,23 @@ class SyncLogSubscriberTest < ActiveSupport::TestCase
     assert_ractor_shareable MyLogSubscriber.log_levels
   end
 
+  if RUBY_VERSION >= "4.0"
+    def test_logger_is_ractor_safe
+      previous_logger = ActiveSupport::LogSubscriber.logger
+      logger = ActiveSupport::Ractors::Logger.new
+      ActiveSupport::Ractors.make_shareable(logger)
+      ActiveSupport::LogSubscriber.logger = logger
+      other_ractor_logger = on_ractor do
+        ActiveSupport::LogSubscriber.logger
+      end
+
+      assert_same logger, other_ractor_logger
+    ensure
+      ActiveSupport::LogSubscriber.logger = previous_logger
+      logger&.close
+    end
+  end
+
   private
     def instrument(*args, &block)
       ActiveSupport::Notifications.instrument(*args, &block)


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because lazy evaluation of log attribute class level ivars don't work well with ractors.

### Detail

This Pull Request changes the log subscriber class to eagerly calculate `@supports_flush` and remove assignment of the default Rails logger to an initializer instead.

### Additional information

These assignments are done on the main ractor, so request ractors should be able to safely reference the boolean and ractor compatible logger afterward.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
