### PR TITLE
Remove "missing" workarounds from Active Record

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -460,42 +460,6 @@ module ActiveRecord
     end
 
     private
-      def respond_to_missing?(name, include_private = false)
-        if self.class.define_attribute_methods
-          # Some methods weren't defined yet.
-          return true if self.class.method_defined?(name)
-          return true if include_private && self.class.private_method_defined?(name)
-        end
-
-        super
-      end
-
-      def method_missing(name, ...)
-        # We can't know whether some method was defined or not because
-        # multiple thread might be concurrently be in this code path.
-        # So the first one would define the methods and the others would
-        # appear to already have them.
-        self.class.define_attribute_methods
-
-        # So in all cases we must behave as if the method was just defined.
-        method = if self.class.public_method_defined?(name)
-          begin
-            self.class.public_instance_method(name)
-          rescue NameError
-            nil
-          end
-        end
-
-        # The method might be explicitly defined in the model, but call a generated
-        # method with super. So we must resume the call chain at the right step.
-        method = method.super_method while method && !method.owner.is_a?(GeneratedAttributeMethods)
-        if method
-          method.bind_call(self, ...)
-        else
-          super
-        end
-      end
-
       def attribute_method?(attr_name)
         @attributes&.key?(attr_name)
       end

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -1138,16 +1138,11 @@ class AttributeMethodsTest < ActiveRecord::TestCase
 
     topic = topic_class.new(title: "New topic")
     assert_equal("New topic", topic.subject_to_be_undefined)
-    assert_equal true, topic_class.method_defined?(:subject_to_be_undefined)
     topic_class.undefine_attribute_methods
-    assert_equal false, topic_class.method_defined?(:subject_to_be_undefined)
 
-    topic.subject_to_be_undefined
-    assert_equal true, topic_class.method_defined?(:subject_to_be_undefined)
-
-    topic_class.undefine_attribute_methods
-    assert_equal true, topic.respond_to?(:subject_to_be_undefined)
-    assert_equal true, topic_class.method_defined?(:subject_to_be_undefined)
+    assert_raises(NoMethodError, match: /undefined method [`']subject_to_be_undefined'/) do
+      topic.subject_to_be_undefined
+    end
   end
 
   test "#define_attribute_methods brings back undefined aliases" do
@@ -1200,54 +1195,6 @@ class AttributeMethodsTest < ActiveRecord::TestCase
 
     assert_nothing_raised { klass.define_attribute_method(:foo) }
     assert_nothing_raised { klass.define_attribute_method("bar") }
-  end
-
-  test "#method_missing define methods on the fly in a thread safe way" do
-    topic_class = Class.new(ActiveRecord::Base) do
-      self.table_name = "topics"
-    end
-
-    topic = topic_class.new(title: "New topic")
-    topic_class.undefine_attribute_methods
-    def topic.method_missing(...)
-      sleep 0.1 # required to cause a race condition
-      super
-    end
-
-    threads = 5.times.map do
-      Thread.new do
-        assert_equal "New topic", topic.title
-      end
-    end
-    threads.each(&:join)
-  ensure
-    threads&.each(&:kill)
-  end
-
-  test "#method_missing define methods on the fly in a thread safe way, even when decorated" do
-    topic_class = Class.new(ActiveRecord::Base) do
-      self.table_name = "topics"
-
-      def title
-        "title:#{super}"
-      end
-    end
-
-    topic = topic_class.new(title: "New topic")
-    topic_class.undefine_attribute_methods
-    def topic.method_missing(...)
-      sleep 0.1 # required to cause a race condition
-      super
-    end
-
-    threads = 5.times.map do
-      Thread.new do
-        assert_equal "title:New topic", topic.title
-      end
-    end
-    threads.each(&:join)
-  ensure
-    threads&.each(&:kill)
   end
 
   test "read_attribute with nil should not asplode" do

--- a/activerecord/test/cases/marshal_serialization_test.rb
+++ b/activerecord/test/cases/marshal_serialization_test.rb
@@ -16,6 +16,7 @@ class MarshalSerializationTest < ActiveRecord::TestCase
   end
 
   def test_deserializing_rails_6_1_marshal_basic
+    Topic.undefine_attribute_methods
     topic = Marshal.load(marshal_fixture("rails_6_1_topic"))
 
     assert_not_predicate topic, :new_record?
@@ -36,6 +37,7 @@ class MarshalSerializationTest < ActiveRecord::TestCase
   end
 
   def test_deserializing_rails_7_1_marshal_basic
+    Topic.undefine_attribute_methods
     topic = Marshal.load(marshal_fixture("rails_7_1_topic"))
 
     assert_not_predicate topic, :new_record?


### PR DESCRIPTION
Ref #50594
Ref #57382
Ref #58462
Ref #58466

These were needed when using the 6.1 Marshal format since Records could be loaded without explicitly having attribute methods defined. Now that the 6.1 format has been removed, these are no longer necessary.

Additionally, this has a good effect on performance for virtual attributes, and checking whether models respond to methods that actually don't exist.

Since I had to delete tests that depended on `method_missing` working like this, I replaced them with some "integration tests" which cover the original bug: `Marshal.load` with no attribute methods defined.


```
ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
       title (after)     1.826M i/100ms
Calculating -------------------------------------
       title (after)     20.246M (± 1.6%) i/s   (49.39 ns/i) -     62.092M in   3.066840s

Comparison:
 title (after): 20246365.6 i/s
title (before): 20186471.5 i/s - same-ish: difference falls within error

ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
  tenderlove (after)   209.596k i/100ms
Calculating -------------------------------------
  tenderlove (after)      2.181M (± 2.1%) i/s  (458.56 ns/i) -      6.707M in   3.075569s

Comparison:
 tenderlove (after):  2180758.1 i/s
tenderlove (before):  1305476.0 i/s - 1.67x  slower

ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
    rt title (after)   800.458k i/100ms
Calculating -------------------------------------
    rt title (after)      8.827M (± 1.8%) i/s  (113.29 ns/i) -     27.216M in   3.083283s

Comparison:
rt title (before):  8835575.5 i/s
 rt title (after):  8826816.1 i/s - same-ish: difference falls within error

ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
  rt to_hash (after)   279.702k i/100ms
Calculating -------------------------------------
  rt to_hash (after)      2.877M (± 2.0%) i/s  (347.53 ns/i) -      8.671M in   3.013317s

Comparison:
 rt to_hash (after):  2877480.9 i/s
rt to_hash (before):  2487292.0 i/s - 1.16x  slower

ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
rt permitted? (after)   143.433k i/100ms
Calculating -------------------------------------
rt permitted? (after)      1.442M (± 1.7%) i/s  (693.63 ns/i) -      4.446M in   3.084181s

Comparison:
 rt permitted? (after):  1441686.8 i/s
rt permitted? (before):  1359993.3 i/s - 1.06x  slower

ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
rt tenderlove (after)   417.483k i/100ms
Calculating -------------------------------------
rt tenderlove (after)      4.382M (± 1.7%) i/s  (228.22 ns/i) -     13.359M in   3.048908s

Comparison:
 rt tenderlove (after):  4381718.3 i/s
rt tenderlove (before):  3553127.1 i/s - 1.23x  slower
```

Bench:

```ruby
# frozen_string_literal: true

require "benchmark/ips"
require "active_record"

STAGE = ENV.fetch("STAGE", "after")

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.lease_connection.create_table(:posts) { |t| t.string :title }
class Post < ActiveRecord::Base; end

row   = Post.create!(title: "x")
extra = Post.select("id, title, 10 as tenderlove").first

CASES = {
  "title"      => -> { row.title },        # attribute method
  "tenderlove" => -> { extra.tenderlove }, # dynamic attribute
  "rt title"      => -> { row.respond_to?(:title) },        # attribute method
  "rt to_hash"    => -> { row.respond_to?(:to_hash) },      # rejected by prefilter
  "rt permitted?" => -> { row.respond_to?(:permitted?) },   # scans all patterns (? suffix)
  "rt tenderlove" => -> { extra.respond_to?(:tenderlove) }, # dynamic attribute
}

CASES.each do |label, block|
  puts
  Benchmark.ips do |x|
    x.config(time: 3, warmup: 1)
    x.save!("/tmp/bench_#{label}.hold")
    x.report("#{label} (#{STAGE})") { block.call }
    x.compare!
  end
end
```