### PR TITLE
Add --no-banner to bin/rails console

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Add `--no-banner` to `bin/rails console` to suppress the startup banner.
+
+    Users can already set `IRB.conf[:SHOW_BANNER] = false` in `.irbrc`; this
+    flag is for one-off or scripted sessions without editing config.
+
+    ```bash
+    bin/rails console --no-banner
+    ```
+
+    *Said Kaldybaev*
+
 *   Show a Rails-flavored startup banner (a small logo, Rails/Ruby
     version, a rotating tip about console helpers like `app`/`reload!`, and
     `Rails.root`) when starting `bin/rails console`.

--- a/railties/lib/rails/commands/console/console_command.rb
+++ b/railties/lib/rails/commands/console/console_command.rb
@@ -27,7 +27,7 @@ module Rails
 
       @console = app.config.console || begin
         require "rails/commands/console/irb_console"
-        IRBConsole.new(app)
+        IRBConsole.new(app, options)
       end
     end
 
@@ -58,6 +58,12 @@ module Rails
       Rails.env = environment
     end
 
+    # Whether to print a startup banner. Defaults to true; pass +--no-banner+
+    # to suppress it for one-off sessions.
+    def banner?
+      options.fetch(:banner, true)
+    end
+
     def show_default_startup_banner
       puts Rails::Console.startup_lines(sandbox?)
     end
@@ -65,7 +71,9 @@ module Rails
     def start
       set_environment! if environment?
 
-      show_default_startup_banner unless console.respond_to?(:show_startup_banner)
+      if banner?
+        show_default_startup_banner unless console.respond_to?(:show_startup_banner)
+      end
 
       console.start
     end
@@ -82,6 +90,9 @@ module Rails
 
       class_option :query_cache, type: :boolean, aliases: "-q", default: false,
         desc: "Enable the Active Record query cache for the session (ignored if --skip-executor or -w is used)"
+
+      class_option :banner, type: :boolean, default: true,
+        desc: "Show the console startup banner (use --no-banner to hide)"
 
       def initialize(args = [], local_options = {}, config = {})
         console_options = []

--- a/railties/lib/rails/commands/console/irb_console.rb
+++ b/railties/lib/rails/commands/console/irb_console.rb
@@ -81,8 +81,9 @@ module Rails
 
       LOGO = %w[⠀⢀⠀⢡⣶⣿⠟⡛⠢ ⠠⠀⣰⣿⣿⠁⠄⠀⠀ ⠶⢠⣿⣿⣿⠰⠆⠀⠀ ⠶⢸⣿⣿⣿⡄⠰⠆⠀].freeze
 
-      def initialize(app)
+      def initialize(app, options = {})
         @app = app
+        @options = options
 
         require "irb"
         require "irb/completion"
@@ -94,6 +95,8 @@ module Rails
 
       def start
         IRB.setup(nil)
+        # CLI --no-banner wins over IRB defaults / .irbrc.
+        IRB.conf[:SHOW_BANNER] = false if @options[:banner] == false
 
         if !Rails.env.local? && !ENV.key?("IRB_USE_AUTOCOMPLETE")
           IRB.conf[:USE_AUTOCOMPLETE] = false

--- a/railties/test/commands/console_test.rb
+++ b/railties/test/commands/console_test.rb
@@ -39,6 +39,12 @@ class Rails::ConsoleTest < ActiveSupport::TestCase
   def test_no_options
     console = Rails::Console.new(app, parse_arguments([]))
     assert_not_predicate console, :sandbox?
+    assert_predicate console, :banner?
+  end
+
+  def test_no_banner_option
+    console = Rails::Console.new(app, parse_arguments(["--no-banner"]))
+    assert_not_predicate console, :banner?
   end
 
   def test_start
@@ -47,6 +53,14 @@ class Rails::ConsoleTest < ActiveSupport::TestCase
     assert_predicate app.console, :started?
     assert_match(/Loading \w+ environment \(Rails/, output)
     assert_match(/Type 'help' for help/, output)
+  end
+
+  def test_start_with_no_banner
+    start ["--no-banner"]
+
+    assert_predicate app.console, :started?
+    assert_no_match(/Loading \w+ environment/, output)
+    assert_no_match(/Type 'help' for help/, output)
   end
 
   def test_start_with_sandbox


### PR DESCRIPTION
### Motivation / Background

Fixes #58470.

`bin/rails console` shows a startup banner (logo, version, tip, path). You can turn it off permanently with `IRB.conf[:SHOW_BANNER] = false` in `.irbrc`, but there is no one-shot CLI flag for scripts or CI.

### Detail

```bash
bin/rails console --no-banner
```

Sets `IRB.conf[:SHOW_BANNER] = false` after IRB setup so the flag wins over defaults and `.irbrc` for that session. Plain "Loading … environment" lines still print, same as when the conf option is off.

Also skips the default (non-IRB) startup banner when `--no-banner` is passed.

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.