### PR TITLE
Keep delayed variant transformations in a stable order

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Fix delayed variants being generated under an unreachable digest on queue backends that store job
+    arguments as jsonb.
+
+    `ActiveStorage::Variation#digest` derives a variant's identity from the transformations hash, and
+    `Marshal.dump` encodes its pairs in insertion order. Postgres `jsonb` columns do not keep that order,
+    so a variant with two or more transformations was generated under a digest no reader ever computes
+    and `processed?` stayed false forever. Transformations now travel to
+    `ActiveStorage::CreateVariantsJob` as pairs, which survive the round trip.
+
+    *Lazizbek Ergashev*
+
 *   Allow ffmpeg and ffprobe input arguments to be configured.
 
     Two new configuration parameters are introduced.

--- a/activestorage/app/jobs/active_storage/transform_job.rb
+++ b/activestorage/app/jobs/active_storage/transform_job.rb
@@ -7,6 +7,6 @@ class ActiveStorage::TransformJob < ActiveStorage::BaseJob
   retry_on ActiveStorage::IntegrityError, attempts: 10, wait: :polynomially_longer
 
   def perform(blob, transformations)
-    blob.representation(transformations).processed
+    blob.representation(transformations.to_h).processed
   end
 end

--- a/activestorage/app/models/active_storage/attachment.rb
+++ b/activestorage/app/models/active_storage/attachment.rb
@@ -219,7 +219,6 @@ class ActiveStorage::Attachment < ActiveStorage::Record
       end
 
       ActiveStorage::CreateVariantsJob.perform_now(blob, variants: immediate_variants, process: :immediately) if immediate_variants.any?
-      # Enqueue transformations as pairs: some queue backends store job arguments as jsonb, which drops Hash key order
       ActiveStorage::CreateVariantsJob.perform_later(blob, variants: later_variants.map(&:to_a), process: :later) if later_variants.any?
     end
 

--- a/activestorage/app/models/active_storage/attachment.rb
+++ b/activestorage/app/models/active_storage/attachment.rb
@@ -219,7 +219,8 @@ class ActiveStorage::Attachment < ActiveStorage::Record
       end
 
       ActiveStorage::CreateVariantsJob.perform_now(blob, variants: immediate_variants, process: :immediately) if immediate_variants.any?
-      ActiveStorage::CreateVariantsJob.perform_later(blob, variants: later_variants, process: :later) if later_variants.any?
+      # Enqueue transformations as pairs: some queue backends store job arguments as jsonb, which drops Hash key order
+      ActiveStorage::CreateVariantsJob.perform_later(blob, variants: later_variants.map(&:to_a), process: :later) if later_variants.any?
     end
 
     def purge_dependent_blob

--- a/activestorage/test/models/attachment_test.rb
+++ b/activestorage/test/models/attachment_test.rb
@@ -263,9 +263,20 @@ class ActiveStorage::AttachmentTest < ActiveSupport::TestCase
 
   test "enqueues create variants job to delay transformations after attach" do
     blob = create_file_blob
-    assert_create_variants_job blob:, variants: [{ resize_to_limit: [2, 2] }] do
+    assert_create_variants_job blob:, variants: [{ resize_to_limit: [2, 2], saver: { strip: true } }] do
       @user.avatar_with_later_variants.attach blob
     end
+  end
+
+  test "creates delayed variants readers can find when the queue does not preserve hash key order" do
+    blob = create_file_blob
+    @user.avatar_with_later_variants.attach blob
+
+    perform_enqueued_jobs do
+      ActiveJob::Base.execute reverse_hash_keys(ActiveJob::Base.queue_adapter.enqueued_jobs.last)
+    end
+
+    assert @user.avatar_with_later_variants.variant(:later_thumb).processed?
   end
 
   test "avoids enqueuing create variants job when lazy" do
@@ -494,7 +505,18 @@ class ActiveStorage::AttachmentTest < ActiveSupport::TestCase
     def assert_create_variants_job(blob:, variants:, &block)
       assert_enqueued_with(
         job: ActiveStorage::CreateVariantsJob,
-        args: [ blob, variants:, process: :later ], &block
+        args: [ blob, variants: variants.map(&:to_a), process: :later ], &block
       )
+    end
+
+    def reverse_hash_keys(value)
+      case value
+      when Hash
+        value.reverse_each.to_h.transform_values { |nested| reverse_hash_keys(nested) }
+      when Array
+        value.map { |nested| reverse_hash_keys(nested) }
+      else
+        value
+      end
     end
 end

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -164,7 +164,7 @@ class User < ActiveRecord::Base
     attachable.variant :immediate_thumb, resize_to_limit: [1, 1], process: :immediately
   end
   has_one_attached :avatar_with_later_variants do |attachable|
-    attachable.variant :later_thumb, resize_to_limit: [2, 2], process: :later
+    attachable.variant :later_thumb, resize_to_limit: [2, 2], saver: { strip: true }, process: :later
   end
   has_one_attached :avatar_with_lazy_variants do |attachable|
     attachable.variant :lazy_thumb, resize_to_limit: [3, 3], process: :lazily


### PR DESCRIPTION
### Motivation / Background

Fixes #58472.

`ActiveStorage::Variation#digest` identifies a variant by `Marshal.dump` of its transformations hash, and Marshal encodes a Hash in insertion order. That order does not survive every queue backend. Postgres `jsonb` columns store an object decomposed and hand the keys back sorted, and GoodJob keeps job arguments in one (`good_jobs.serialized_params`).

A variant declared with two or more transformations therefore gets generated by `ActiveStorage::CreateVariantsJob` under one digest and looked up by readers under another. The rendition is on disk with its `ActiveStorage::VariantRecord` row, but `representation(:name).image.attached?` stays false forever, so anything that renders only when `processed?` shows a placeholder for good. Single-transformation variants have no order to lose, which is what makes it easy to miss.

### Detail

The transformations are now enqueued as pairs rather than as a Hash. An Array keeps its order through any serializer, and `ActiveStorage::TransformJob` turns it back into a Hash before use, so jobs enqueued before the upgrade still run.

Normalizing the key order inside `#digest` would fix it too, but it changes the digest of every variant in every application and orphans the renditions already generated.

The regression test attaches a blob, reverses the key order of the enqueued job's serialized arguments the way jsonb does, then runs it and asks for the variant the ordinary way.

### Additional information

`ActiveStorage::TransformJob` still accepts a Hash, so the deprecated `ActiveStorage::PreviewImageJob` and any application enqueuing it directly are unaffected.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.