### PR TITLE
delegate ActiveModel::Type::Binary::Data#as_json to its value

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Implement `ActiveModel::Type::Binary::Data#as_json`
+
+    Delegates JSON conversion to the underlying binary data value (instead of
+    falling back to `Object#as_json` and exposing ivar name).
+
+    *Tiago Cardoso*
+
 *   Fix `normalizes` to run before the underlying type validates an assigned
     value.
 

--- a/activemodel/lib/active_model/type/binary.rb
+++ b/activemodel/lib/active_model/type/binary.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/object/json"
+
 module ActiveModel
   module Type
     # = Active Model \Binary \Type
@@ -48,6 +50,10 @@ module ActiveModel
           @value
         end
         alias_method :to_str, :to_s
+
+        def as_json(options = nil)
+          @value.as_json(options)
+        end
 
         def hex
           @value.unpack1("H*")

--- a/activemodel/test/cases/type/binary_test.rb
+++ b/activemodel/test/cases/type/binary_test.rb
@@ -61,6 +61,12 @@ module ActiveModel
         assert_equal "\xFF\x00".b, data.to_str
         assert_equal data, "\xFF\x00".b
       end
+
+      def test_data_as_json
+        data = Type::Binary::Data.new("\xFF\x00")
+
+        assert_equal "\xFF\x00".b.as_json, data.as_json
+      end
     end
   end
 end


### PR DESCRIPTION
### Motivation / Background

rails defines #as_json in most primitive objects and `ActiveModel::Type::Value`.

this does not work for binary data values however, where serialization wraps it in a `ActiveModel::Type::Binary::Data` object, which has no custom json conversion, and will therefore fallback to `Object#as_json`, which maps ivar-to-value; This does not make sense for binary data, which should just handle itself as a string.

This Pull Request has been created because I've had to monkeypatch this already a few times. It breaks particularly in situations where complex nested json objects are stored in the database using a wrapper object, such as the ones using the [store_model](https://github.com/DmitryTsepelev/store_model) gem.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
