### PR TITLE
Make Action View subscribers ractor safe

### DIFF
--- a/actionview/lib/action_view/log_subscriber.rb
+++ b/actionview/lib/action_view/log_subscriber.rb
@@ -6,11 +6,6 @@ module ActionView
 
     self.namespace = "action_view"
 
-    def initialize
-      @root = nil
-      super
-    end
-
     def render_template(event)
       info do
         message = +"  Rendered #{from_rails_root(event[:payload][:identifier])}"
@@ -62,9 +57,15 @@ module ActionView
     end
     event_log_level :render_start, :debug
 
-    def self.default_logger
-      ActionView::Base.logger
+    class << self
+      def default_logger
+        ActionView::Base.logger
+      end
+
+      attr_accessor :rails_root
     end
+
+    self.rails_root = "/"
 
     private
       def from_rails_root(string)
@@ -74,7 +75,7 @@ module ActionView
       end
 
       def rails_root # :doc:
-        @root ||= "#{Rails.root}/"
+        LogSubscriber.rails_root
       end
 
       def render_count(payload) # :doc:

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -100,6 +100,13 @@ module ActionView
       ActiveSupport.on_load(:action_view) { self.logger ||= Rails.logger }
     end
 
+    initializer "action_view.root" do
+      ActiveSupport.on_load(:action_view) do
+        ActionView::StructuredEventSubscriber.rails_root = "#{Rails.root}/".freeze
+        ActionView::LogSubscriber.rails_root = "#{Rails.root}/".freeze
+      end
+    end
+
     initializer "action_view.caching" do |app|
       ActiveSupport.on_load(:action_view) do
         if app.config.action_view.cache_template_loading.nil?

--- a/actionview/lib/action_view/structured_event_subscriber.rb
+++ b/actionview/lib/action_view/structured_event_subscriber.rb
@@ -6,11 +6,6 @@ module ActionView
   class StructuredEventSubscriber < ActiveSupport::StructuredEventSubscriber # :nodoc:
     VIEWS_PATTERN = /^app\/views\//
 
-    def initialize
-      @root = nil
-      super
-    end
-
     def render_template(event)
       emit_debug_event("action_view.render_template",
         identifier: from_rails_root(event.payload[:identifier]),
@@ -53,18 +48,34 @@ module ActionView
     end
     debug_only :render_collection
 
+    class << self
+      def rails_root
+        Utils.rails_root
+      end
+
+      def rails_root=(rails_root)
+        Utils.rails_root = rails_root
+      end
+    end
+
     module Utils # :nodoc:
+      class << self
+        attr_accessor :rails_root
+      end
+
+      self.rails_root = "/"
+
       private
         def from_rails_root(string)
           return unless string
 
-          string = string.sub("#{rails_root}/", "")
+          string = string.sub(rails_root, "")
           string.sub!(VIEWS_PATTERN, "")
           string
         end
 
         def rails_root # :doc:
-          @root ||= Rails.try(:root)
+          Utils.rails_root
         end
     end
 

--- a/actionview/test/template/log_subscriber_test.rb
+++ b/actionview/test/template/log_subscriber_test.rb
@@ -17,9 +17,13 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
 
   def setup
     super
-    @logger = ActiveSupport::LogSubscriber::TestHelper::MockLogger.new
+    @logger     = ActiveSupport::LogSubscriber::TestHelper::MockLogger.new
     @old_logger = ActionView::LogSubscriber.logger
+    @old_rails_root = ActionView::LogSubscriber.rails_root
+    @old_structured_rails_root = ActionView::StructuredEventSubscriber.rails_root
     ActionView::LogSubscriber.logger = @logger
+    ActionView::LogSubscriber.rails_root = "#{File.expand_path(FIXTURE_LOAD_PATH)}/".freeze
+    ActionView::StructuredEventSubscriber.rails_root = "#{File.expand_path(FIXTURE_LOAD_PATH)}/".freeze
 
     ActionView::LookupContext::DetailsKey.clear
 
@@ -27,20 +31,14 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
 
     lookup_context = ActionView::LookupContext.new(view_paths, {}, ["test"])
     @view          = ActionView::Base.with_empty_template_cache.with_context(lookup_context)
-
-    unless Rails.respond_to?(:root)
-      @defined_root = true
-      Rails.define_singleton_method(:root) { :defined_root } # Minitest `stub` expects the method to be defined.
-    end
   end
 
   def teardown
     super
     ActionView::LogSubscriber.logger = @old_logger
+    ActionView::LogSubscriber.rails_root = @old_rails_root
+    ActionView::StructuredEventSubscriber.rails_root = @old_structured_rails_root
     ActionController::Base.view_paths.map(&:clear_cache)
-
-    # We need to undef `root`, RenderTestCases don't want this to be defined
-    Rails.instance_eval { undef :root } if defined?(@defined_root)
   end
 
   def set_cache_controller
@@ -56,228 +54,192 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
   end
 
   def test_render_template_template
-    Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-      @view.render(template: "test/hello_world")
+    @view.render(template: "test/hello_world")
 
-      assert_equal 1, @logger.logged(:debug).size
-      assert_equal 1, @logger.logged(:info).size
-      assert_match(/Rendering test\/hello_world\.erb/, @logger.logged(:debug).last)
-      assert_match(/Rendered test\/hello_world\.erb/, @logger.logged(:info).last)
-    end
+    assert_equal 1, @logger.logged(:debug).size
+    assert_equal 1, @logger.logged(:info).size
+    assert_match(/Rendering test\/hello_world\.erb/, @logger.logged(:debug).last)
+    assert_match(/Rendered test\/hello_world\.erb/, @logger.logged(:info).last)
   end
 
   def test_render_template_with_layout
-    Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-      @view.render(template: "test/hello_world", layout: "layouts/yield")
+    @view.render(template: "test/hello_world", layout: "layouts/yield")
 
-      assert_equal 2, @logger.logged(:debug).size
-      assert_equal 2, @logger.logged(:info).size
+    assert_equal 2, @logger.logged(:debug).size
+    assert_equal 2, @logger.logged(:info).size
 
-      assert_match(/Rendering layout layouts\/yield\.erb/, @logger.logged(:debug).first)
-      assert_match(/Rendering test\/hello_world\.erb within layouts\/yield/, @logger.logged(:debug).last)
-      assert_match(/Rendered test\/hello_world\.erb within layouts\/yield/, @logger.logged(:info).first)
-      assert_match(/Rendered layout layouts\/yield\.erb/, @logger.logged(:info).last)
-    end
+    assert_match(/Rendering layout layouts\/yield\.erb/, @logger.logged(:debug).first)
+    assert_match(/Rendering test\/hello_world\.erb within layouts\/yield/, @logger.logged(:debug).last)
+    assert_match(/Rendered test\/hello_world\.erb within layouts\/yield/, @logger.logged(:info).first)
+    assert_match(/Rendered layout layouts\/yield\.erb/, @logger.logged(:info).last)
   end
 
   def test_render_file_template
-    Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-      @view.render(file: "#{FIXTURE_LOAD_PATH}/test/hello_world.erb")
+    @view.render(file: "#{FIXTURE_LOAD_PATH}/test/hello_world.erb")
 
-      assert_equal 1, @logger.logged(:debug).size
-      assert_equal 1, @logger.logged(:info).size
-      assert_match(/Rendering test\/hello_world\.erb/, @logger.logged(:debug).last)
-      assert_match(/Rendered test\/hello_world\.erb/, @logger.logged(:info).last)
-    end
+    assert_equal 1, @logger.logged(:debug).size
+    assert_equal 1, @logger.logged(:info).size
+    assert_match(/Rendering test\/hello_world\.erb/, @logger.logged(:debug).last)
+    assert_match(/Rendered test\/hello_world\.erb/, @logger.logged(:info).last)
   end
 
   def test_render_text_template
-    Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-      @view.render(plain: "TEXT")
+    @view.render(plain: "TEXT")
 
-      assert_equal 1, @logger.logged(:debug).size
-      assert_equal 1, @logger.logged(:info).size
-      assert_match(/Rendering text template/, @logger.logged(:debug).last)
-      assert_match(/Rendered text template/, @logger.logged(:info).last)
-    end
+    assert_equal 1, @logger.logged(:debug).size
+    assert_equal 1, @logger.logged(:info).size
+    assert_match(/Rendering text template/, @logger.logged(:debug).last)
+    assert_match(/Rendered text template/, @logger.logged(:info).last)
   end
 
   def test_render_inline_template
-    Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-      @view.render(inline: "<%= 'TEXT' %>")
+    @view.render(inline: "<%= 'TEXT' %>")
 
-      assert_equal 1, @logger.logged(:debug).size
-      assert_equal 1, @logger.logged(:info).size
-      assert_match(/Rendering inline template/, @logger.logged(:debug).last)
-      assert_match(/Rendered inline template/, @logger.logged(:info).last)
-    end
+    assert_equal 1, @logger.logged(:debug).size
+    assert_equal 1, @logger.logged(:info).size
+    assert_match(/Rendering inline template/, @logger.logged(:debug).last)
+    assert_match(/Rendered inline template/, @logger.logged(:info).last)
   end
 
   def test_render_partial_with_implicit_path
-    Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-      @view.render(Customer.new("david"), greeting: "hi")
+    @view.render(Customer.new("david"), greeting: "hi")
 
-      assert_equal 1, @logger.logged(:debug).size
-      assert_match(/Rendered customers\/_customer\.html\.erb/, @logger.logged(:debug).last)
-    end
+    assert_equal 1, @logger.logged(:debug).size
+    assert_match(/Rendered customers\/_customer\.html\.erb/, @logger.logged(:debug).last)
   end
 
   def test_render_partial_with_cache_missed
-    Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-      set_view_cache_dependencies
-      set_cache_controller
+    set_view_cache_dependencies
+    set_cache_controller
 
-      @view.render(partial: "test/cached_customer", locals: { cached_customer: Customer.new("david") })
+    @view.render(partial: "test/cached_customer", locals: { cached_customer: Customer.new("david") })
 
-      assert_equal 1, @logger.logged(:debug).size
-      assert_match(/Rendered test\/_cached_customer\.erb (.*) \[cache miss\]/, @logger.logged(:debug).last)
-    end
+    assert_equal 1, @logger.logged(:debug).size
+    assert_match(/Rendered test\/_cached_customer\.erb (.*) \[cache miss\]/, @logger.logged(:debug).last)
   end
 
   def test_render_partial_with_cache_hitted
-    Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-      set_view_cache_dependencies
-      set_cache_controller
+    set_view_cache_dependencies
+    set_cache_controller
 
-      # Second render should hit cache.
-      @view.render(partial: "test/cached_customer", locals: { cached_customer: Customer.new("david") })
-      @view.render(partial: "test/cached_customer", locals: { cached_customer: Customer.new("david") })
+    # Second render should hit cache.
+    @view.render(partial: "test/cached_customer", locals: { cached_customer: Customer.new("david") })
+    @view.render(partial: "test/cached_customer", locals: { cached_customer: Customer.new("david") })
 
-      assert_equal 2, @logger.logged(:debug).size
-      assert_match(/Rendered test\/_cached_customer\.erb (.*) \[cache hit\]/, @logger.logged(:debug).last)
-    end
+    assert_equal 2, @logger.logged(:debug).size
+    assert_match(/Rendered test\/_cached_customer\.erb (.*) \[cache hit\]/, @logger.logged(:debug).last)
   end
 
   def test_render_partial_as_layout
-    Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-      set_view_cache_dependencies
-      set_cache_controller
+    set_view_cache_dependencies
+    set_cache_controller
 
-      @view.render(layout: "layouts/yield_only") { "hello" }
+    @view.render(layout: "layouts/yield_only") { "hello" }
 
-      assert_equal 1, @logger.logged(:debug).size
-      assert_match(/Rendered layouts\/_yield_only\.erb/, @logger.logged(:debug).first)
-    end
+    assert_equal 1, @logger.logged(:debug).size
+    assert_match(/Rendered layouts\/_yield_only\.erb/, @logger.logged(:debug).first)
   end
 
   def test_render_partial_with_layout
-    Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-      set_view_cache_dependencies
-      set_cache_controller
+    set_view_cache_dependencies
+    set_cache_controller
 
-      @view.render(partial: "partial", layout: "layouts/yield_only")
+    @view.render(partial: "partial", layout: "layouts/yield_only")
 
-      assert_equal 1, @logger.logged(:debug).size
-      assert_match(/Rendered test\/_partial\.html\.erb within layouts\/_yield_only/, @logger.logged(:debug).first)
-    end
+    assert_equal 1, @logger.logged(:debug).size
+    assert_match(/Rendered test\/_partial\.html\.erb within layouts\/_yield_only/, @logger.logged(:debug).first)
   end
 
   def test_render_uncached_outer_partial_with_inner_cached_partial_wont_mix_cache_hits_or_misses
-    Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-      set_view_cache_dependencies
-      set_cache_controller
+    set_view_cache_dependencies
+    set_cache_controller
 
-      @view.render(partial: "test/nested_cached_customer", locals: { cached_customer: Customer.new("Stan") })
-      *, cached_inner, uncached_outer = @logger.logged(:debug)
-      assert_match(/Rendered test\/_cached_customer\.erb (.*) \[cache miss\]/, cached_inner)
-      assert_match(/Rendered test\/_nested_cached_customer\.erb \(Duration: .*?ms \| GC: .*?\)$/, uncached_outer)
+    @view.render(partial: "test/nested_cached_customer", locals: { cached_customer: Customer.new("Stan") })
+    *, cached_inner, uncached_outer = @logger.logged(:debug)
+    assert_match(/Rendered test\/_cached_customer\.erb (.*) \[cache miss\]/, cached_inner)
+    assert_match(/Rendered test\/_nested_cached_customer\.erb \(Duration: .*?ms \| GC: .*?\)$/, uncached_outer)
 
-      # Second render hits the cache for the _cached_customer partial. Outer template's log shouldn't be affected.
-      @view.render(partial: "test/nested_cached_customer", locals: { cached_customer: Customer.new("Stan") })
-      *, cached_inner, uncached_outer = @logger.logged(:debug)
-      assert_match(/Rendered test\/_cached_customer\.erb (.*) \[cache hit\]/, cached_inner)
-      assert_match(/Rendered test\/_nested_cached_customer\.erb \(Duration: .*?ms \| GC: .*?\)$/, uncached_outer)
-    end
+    # Second render hits the cache for the _cached_customer partial. Outer template's log shouldn't be affected.
+    @view.render(partial: "test/nested_cached_customer", locals: { cached_customer: Customer.new("Stan") })
+    *, cached_inner, uncached_outer = @logger.logged(:debug)
+    assert_match(/Rendered test\/_cached_customer\.erb (.*) \[cache hit\]/, cached_inner)
+    assert_match(/Rendered test\/_nested_cached_customer\.erb \(Duration: .*?ms \| GC: .*?\)$/, uncached_outer)
   end
 
   def test_render_cached_outer_partial_with_cached_inner_partial
-    Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-      set_view_cache_dependencies
-      set_cache_controller
+    set_view_cache_dependencies
+    set_cache_controller
 
+    @view.render(partial: "test/cached_nested_cached_customer", locals: { cached_customer: Customer.new("Stan") })
+    *, cached_inner, cached_outer = @logger.logged(:debug)
+    assert_match(/Rendered test\/_cached_customer\.erb (.*) \[cache miss\]/, cached_inner)
+    assert_match(/Rendered test\/_cached_nested_cached_customer\.erb (.*) \[cache miss\]/, cached_outer)
+
+    # One render: inner partial skipped, because the outer has been cached.
+    assert_difference -> { @logger.logged(:debug).size }, +1 do
       @view.render(partial: "test/cached_nested_cached_customer", locals: { cached_customer: Customer.new("Stan") })
-      *, cached_inner, cached_outer = @logger.logged(:debug)
-      assert_match(/Rendered test\/_cached_customer\.erb (.*) \[cache miss\]/, cached_inner)
-      assert_match(/Rendered test\/_cached_nested_cached_customer\.erb (.*) \[cache miss\]/, cached_outer)
-
-      # One render: inner partial skipped, because the outer has been cached.
-      assert_difference -> { @logger.logged(:debug).size }, +1 do
-        @view.render(partial: "test/cached_nested_cached_customer", locals: { cached_customer: Customer.new("Stan") })
-      end
-      assert_match(/Rendered test\/_cached_nested_cached_customer\.erb (.*) \[cache hit\]/, @logger.logged(:debug).last)
     end
+    assert_match(/Rendered test\/_cached_nested_cached_customer\.erb (.*) \[cache hit\]/, @logger.logged(:debug).last)
   end
 
   def test_render_partial_with_cache_hitted_and_missed
-    Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-      set_view_cache_dependencies
-      set_cache_controller
+    set_view_cache_dependencies
+    set_cache_controller
 
-      @view.render(partial: "test/cached_customer", locals: { cached_customer: Customer.new("david") })
-      assert_match(/Rendered test\/_cached_customer\.erb (.*) \[cache miss\]/, @logger.logged(:debug).last)
+    @view.render(partial: "test/cached_customer", locals: { cached_customer: Customer.new("david") })
+    assert_match(/Rendered test\/_cached_customer\.erb (.*) \[cache miss\]/, @logger.logged(:debug).last)
 
-      @view.render(partial: "test/cached_customer", locals: { cached_customer: Customer.new("david") })
-      assert_match(/Rendered test\/_cached_customer\.erb (.*) \[cache hit\]/, @logger.logged(:debug).last)
+    @view.render(partial: "test/cached_customer", locals: { cached_customer: Customer.new("david") })
+    assert_match(/Rendered test\/_cached_customer\.erb (.*) \[cache hit\]/, @logger.logged(:debug).last)
 
-      @view.render(partial: "test/cached_customer", locals: { cached_customer: Customer.new("Stan") })
-      assert_match(/Rendered test\/_cached_customer\.erb (.*) \[cache miss\]/, @logger.logged(:debug).last)
-    end
+    @view.render(partial: "test/cached_customer", locals: { cached_customer: Customer.new("Stan") })
+    assert_match(/Rendered test\/_cached_customer\.erb (.*) \[cache miss\]/, @logger.logged(:debug).last)
   end
 
   def test_render_collection_template
-    Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-      set_cache_controller
+    set_cache_controller
 
-      @view.render(partial: "test/customer", collection: [ Customer.new("david"), Customer.new("mary") ])
+    @view.render(partial: "test/customer", collection: [ Customer.new("david"), Customer.new("mary") ])
 
-      assert_equal 1, @logger.logged(:debug).size
-      assert_match(/Rendered collection of test\/_customer.erb \[2 times\]/, @logger.logged(:debug).last)
-    end
+    assert_equal 1, @logger.logged(:debug).size
+    assert_match(/Rendered collection of test\/_customer.erb \[2 times\]/, @logger.logged(:debug).last)
   end
 
   def test_render_collection_template_with_layout
-    Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-      set_cache_controller
+    set_cache_controller
 
-      @view.render(partial: "test/customer", layout: "layouts/yield_only", collection: [ Customer.new("david"), Customer.new("mary") ])
+    @view.render(partial: "test/customer", layout: "layouts/yield_only", collection: [ Customer.new("david"), Customer.new("mary") ])
 
-      assert_equal 1, @logger.logged(:debug).size
-      assert_match(/Rendered collection of test\/_customer.erb within layouts\/_yield_only \[2 times\]/, @logger.logged(:debug).last)
-    end
+    assert_equal 1, @logger.logged(:debug).size
+    assert_match(/Rendered collection of test\/_customer.erb within layouts\/_yield_only \[2 times\]/, @logger.logged(:debug).last)
   end
 
   def test_render_collection_with_implicit_path
-    Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-      set_cache_controller
+    set_cache_controller
 
-      @view.render([ Customer.new("david"), Customer.new("mary") ], greeting: "hi")
+    @view.render([ Customer.new("david"), Customer.new("mary") ], greeting: "hi")
 
-      assert_equal 1, @logger.logged(:debug).size
-      assert_match(/Rendered collection of customers\/_customer\.html\.erb \[2 times\]/, @logger.logged(:debug).last)
-    end
+    assert_equal 1, @logger.logged(:debug).size
+    assert_match(/Rendered collection of customers\/_customer\.html\.erb \[2 times\]/, @logger.logged(:debug).last)
   end
 
   def test_render_collection_template_without_path
-    Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-      set_cache_controller
+    set_cache_controller
 
-      @view.render([ GoodCustomer.new("david"), Customer.new("mary") ], greeting: "hi")
+    @view.render([ GoodCustomer.new("david"), Customer.new("mary") ], greeting: "hi")
 
-      assert_equal 1, @logger.logged(:debug).size
-      assert_match(/Rendered collection of templates/, @logger.logged(:debug).last)
-    end
+    assert_equal 1, @logger.logged(:debug).size
+    assert_match(/Rendered collection of templates/, @logger.logged(:debug).last)
   end
 
   def test_render_collection_with_cached_set
-    Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-      set_view_cache_dependencies
-      set_cache_controller
+    set_view_cache_dependencies
+    set_cache_controller
 
-      @view.render(partial: "customers/customer", collection: [ Customer.new("david"), Customer.new("mary") ], cached: true,
-        locals: { greeting: "hi" })
+    @view.render(partial: "customers/customer", collection: [ Customer.new("david"), Customer.new("mary") ], cached: true,
+      locals: { greeting: "hi" })
 
-      assert_equal 1, @logger.logged(:debug).size
-      assert_match(/Rendered collection of customers\/_customer\.html\.erb \[0 \/ 2 cache hits\]/, @logger.logged(:debug).last)
-    end
+    assert_equal 1, @logger.logged(:debug).size
+    assert_match(/Rendered collection of customers\/_customer\.html\.erb \[0 \/ 2 cache hits\]/, @logger.logged(:debug).last)
   end
 end

--- a/actionview/test/template/structured_event_subscriber_test.rb
+++ b/actionview/test/template/structured_event_subscriber_test.rb
@@ -19,304 +19,267 @@ module ActionView
       lookup_context = ActionView::LookupContext.new(view_paths, {}, ["test"])
       @view          = ActionView::Base.with_empty_template_cache.with_context(lookup_context)
 
-      unless Rails.respond_to?(:root)
-        @defined_root = true
-        Rails.define_singleton_method(:root) { :defined_root } # Minitest `stub` expects the method to be defined.
-      end
+      @previous_rails_root = StructuredEventSubscriber.rails_root
+
+      StructuredEventSubscriber.rails_root = "#{File.expand_path(FIXTURE_LOAD_PATH)}/".freeze
     end
 
     def teardown
       super
+      StructuredEventSubscriber.rails_root = @previous_rails_root
       ActionController::Base.view_paths.map(&:clear_cache)
-
-      # We need to undef `root`, RenderTestCases don't want this to be defined
-      Rails.instance_eval { undef :root } if defined?(@defined_root)
     end
 
     def test_render_template
-      Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-        with_debug_event_reporting do
-          assert_event_reported("action_view.render_start", payload: { identifier: "test/hello_world.erb", layout: nil }) do
-            event = assert_event_reported("action_view.render_template", payload: { identifier: "test/hello_world.erb", layout: nil }) do
-              @view.render(template: "test/hello_world")
-            end
-
-            assert(event[:payload][:gc_ms] >= 0)
-            assert(event[:payload][:duration_ms] >= 0)
+      with_debug_event_reporting do
+        assert_event_reported("action_view.render_start", payload: { identifier: "test/hello_world.erb", layout: nil }) do
+          event = assert_event_reported("action_view.render_template", payload: { identifier: "test/hello_world.erb", layout: nil }) do
+            @view.render(template: "test/hello_world")
           end
+
+          assert(event[:payload][:gc_ms] >= 0)
+          assert(event[:payload][:duration_ms] >= 0)
         end
       end
     end
 
     def test_render_template_with_layout
-      Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-        with_debug_event_reporting do
-          payload = { identifier: "test/hello_world.erb", layout: "layouts/yield" }
-          assert_event_reported("action_view.render_start", payload:) do
-            event = assert_event_reported("action_view.render_template", payload:) do
-              @view.render(template: "test/hello_world", layout: "layouts/yield")
-            end
-
-            assert(event[:payload][:gc_ms] >= 0)
-            assert(event[:payload][:duration_ms] >= 0)
+      with_debug_event_reporting do
+        payload = { identifier: "test/hello_world.erb", layout: "layouts/yield" }
+        assert_event_reported("action_view.render_start", payload:) do
+          event = assert_event_reported("action_view.render_template", payload:) do
+            @view.render(template: "test/hello_world", layout: "layouts/yield")
           end
+
+          assert(event[:payload][:gc_ms] >= 0)
+          assert(event[:payload][:duration_ms] >= 0)
         end
       end
     end
 
     def test_render_file_template
-      Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-        with_debug_event_reporting do
-          assert_event_reported("action_view.render_start", payload: { identifier: "test/hello_world.erb", layout: nil }) do
-            event = assert_event_reported("action_view.render_template", payload: { identifier: "test/hello_world.erb", layout: nil }) do
-              @view.render(file: "#{FIXTURE_LOAD_PATH}/test/hello_world.erb")
-            end
-
-            assert(event[:payload][:gc_ms] >= 0)
-            assert(event[:payload][:duration_ms] >= 0)
+      with_debug_event_reporting do
+        assert_event_reported("action_view.render_start", payload: { identifier: "test/hello_world.erb", layout: nil }) do
+          event = assert_event_reported("action_view.render_template", payload: { identifier: "test/hello_world.erb", layout: nil }) do
+            @view.render(file: "#{FIXTURE_LOAD_PATH}/test/hello_world.erb")
           end
+
+          assert(event[:payload][:gc_ms] >= 0)
+          assert(event[:payload][:duration_ms] >= 0)
         end
       end
     end
 
     def test_render_text_template
-      Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-        with_debug_event_reporting do
-          assert_event_reported("action_view.render_start", payload: { identifier: "text template", layout: nil }) do
-            event = assert_event_reported("action_view.render_template", payload: { identifier: "text template", layout: nil }) do
-              @view.render(plain: "TEXT")
-            end
-
-            assert(event[:payload][:gc_ms] >= 0)
-            assert(event[:payload][:duration_ms] >= 0)
+      with_debug_event_reporting do
+        assert_event_reported("action_view.render_start", payload: { identifier: "text template", layout: nil }) do
+          event = assert_event_reported("action_view.render_template", payload: { identifier: "text template", layout: nil }) do
+            @view.render(plain: "TEXT")
           end
+
+          assert(event[:payload][:gc_ms] >= 0)
+          assert(event[:payload][:duration_ms] >= 0)
         end
       end
     end
 
     def test_render_inline_template
-      Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-        with_debug_event_reporting do
-          assert_event_reported("action_view.render_start", payload: { identifier: "inline template", layout: nil }) do
-            event = assert_event_reported("action_view.render_template", payload: { identifier: "inline template", layout: nil }) do
-              @view.render(inline: "<%= 'TEXT' %>")
-            end
-
-            assert(event[:payload][:gc_ms] >= 0)
-            assert(event[:payload][:duration_ms] >= 0)
+      with_debug_event_reporting do
+        assert_event_reported("action_view.render_start", payload: { identifier: "inline template", layout: nil }) do
+          event = assert_event_reported("action_view.render_template", payload: { identifier: "inline template", layout: nil }) do
+            @view.render(inline: "<%= 'TEXT' %>")
           end
+
+          assert(event[:payload][:gc_ms] >= 0)
+          assert(event[:payload][:duration_ms] >= 0)
         end
       end
     end
 
     def test_render_partial_with_implicit_path
-      Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-        with_debug_event_reporting do
-          payload = { identifier: "customers/_customer.html.erb", layout: nil, cache_hit: nil }
-          event = assert_event_reported("action_view.render_partial", payload:) do
-            @view.render(Customer.new("david"), greeting: "hi")
-          end
-
-          assert(event[:payload][:gc_ms] >= 0)
-          assert(event[:payload][:duration_ms] >= 0)
+      with_debug_event_reporting do
+        payload = { identifier: "customers/_customer.html.erb", layout: nil, cache_hit: nil }
+        event = assert_event_reported("action_view.render_partial", payload:) do
+          @view.render(Customer.new("david"), greeting: "hi")
         end
+
+        assert(event[:payload][:gc_ms] >= 0)
+        assert(event[:payload][:duration_ms] >= 0)
       end
     end
 
     def test_render_partial_with_cache_is_missed
-      Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-        set_view_cache_dependencies
-        set_cache_controller
+      set_view_cache_dependencies
+      set_cache_controller
 
-        with_debug_event_reporting do
-          payload = { identifier: "test/_cached_customer.erb", layout: nil, cache_hit: :miss }
-          event = assert_event_reported("action_view.render_partial", payload:) do
-            @view.render(partial: "test/cached_customer", locals: { cached_customer: Customer.new("david") })
-          end
-
-          assert(event[:payload][:gc_ms] >= 0)
-          assert(event[:payload][:duration_ms] >= 0)
+      with_debug_event_reporting do
+        payload = { identifier: "test/_cached_customer.erb", layout: nil, cache_hit: :miss }
+        event = assert_event_reported("action_view.render_partial", payload:) do
+          @view.render(partial: "test/cached_customer", locals: { cached_customer: Customer.new("david") })
         end
+
+        assert(event[:payload][:gc_ms] >= 0)
+        assert(event[:payload][:duration_ms] >= 0)
       end
     end
 
     def test_render_partial_with_cache_is_hit
-      Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-        set_view_cache_dependencies
-        set_cache_controller
+      set_view_cache_dependencies
+      set_cache_controller
 
-        @view.render(partial: "test/cached_customer", locals: { cached_customer: Customer.new("david") })
+      @view.render(partial: "test/cached_customer", locals: { cached_customer: Customer.new("david") })
 
-        with_debug_event_reporting do
-          payload = { identifier: "test/_cached_customer.erb", layout: nil, cache_hit: :hit }
-          event = assert_event_reported("action_view.render_partial", payload:) do
-            # Second render should hit cache.
-            @view.render(partial: "test/cached_customer", locals: { cached_customer: Customer.new("david") })
-          end
-
-          assert(event[:payload][:gc_ms] >= 0)
-          assert(event[:payload][:duration_ms] >= 0)
+      with_debug_event_reporting do
+        payload = { identifier: "test/_cached_customer.erb", layout: nil, cache_hit: :hit }
+        event = assert_event_reported("action_view.render_partial", payload:) do
+          # Second render should hit cache.
+          @view.render(partial: "test/cached_customer", locals: { cached_customer: Customer.new("david") })
         end
+
+        assert(event[:payload][:gc_ms] >= 0)
+        assert(event[:payload][:duration_ms] >= 0)
       end
     end
 
     def test_render_partial_as_layout
-      Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-        set_view_cache_dependencies
-        set_cache_controller
+      set_view_cache_dependencies
+      set_cache_controller
 
-        with_debug_event_reporting do
-          event = assert_event_reported("action_view.render_partial", payload: { identifier: "layouts/_yield_only.erb", layout: nil }) do
-            @view.render(layout: "layouts/yield_only") { "hello" }
-          end
-
-          assert(event[:payload][:gc_ms] >= 0)
-          assert(event[:payload][:duration_ms] >= 0)
+      with_debug_event_reporting do
+        event = assert_event_reported("action_view.render_partial", payload: { identifier: "layouts/_yield_only.erb", layout: nil }) do
+          @view.render(layout: "layouts/yield_only") { "hello" }
         end
+
+        assert(event[:payload][:gc_ms] >= 0)
+        assert(event[:payload][:duration_ms] >= 0)
       end
     end
 
     def test_render_partial_with_layout
-      Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-        set_view_cache_dependencies
-        set_cache_controller
+      set_view_cache_dependencies
+      set_cache_controller
 
-        with_debug_event_reporting do
-          payload = { identifier: "test/_partial.html.erb", layout: "layouts/_yield_only" }
-          event = assert_event_reported("action_view.render_partial", payload:) do
-            @view.render(partial: "partial", layout: "layouts/yield_only")
-          end
-
-          assert(event[:payload][:gc_ms] >= 0)
-          assert(event[:payload][:duration_ms] >= 0)
+      with_debug_event_reporting do
+        payload = { identifier: "test/_partial.html.erb", layout: "layouts/_yield_only" }
+        event = assert_event_reported("action_view.render_partial", payload:) do
+          @view.render(partial: "partial", layout: "layouts/yield_only")
         end
+
+        assert(event[:payload][:gc_ms] >= 0)
+        assert(event[:payload][:duration_ms] >= 0)
       end
     end
 
     def test_render_uncached_outer_partial_with_inner_cached_partial_wont_mix_cache_hits_or_misses
-      Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-        set_view_cache_dependencies
-        set_cache_controller
+      set_view_cache_dependencies
+      set_cache_controller
 
-        with_debug_event_reporting do
-          event = assert_event_reported("action_view.render_partial", payload: { identifier: "test/_cached_customer.erb", layout: nil }) do
-            @view.render(partial: "test/nested_cached_customer", locals: { cached_customer: Customer.new("Stan") })
-          end
-
-          assert(event[:payload][:gc_ms] >= 0)
-          assert(event[:payload][:duration_ms] >= 0)
-
-          payload = { identifier: "test/_cached_customer.erb", layout: nil, cache_hit: :hit }
-          event = assert_event_reported("action_view.render_partial", payload:) do
-            # Second render hits the cache for the _cached_customer partial. Outer template's log shouldn't be affected.
-            @view.render(partial: "test/nested_cached_customer", locals: { cached_customer: Customer.new("Stan") })
-          end
-
-          assert(event[:payload][:gc_ms] >= 0)
-          assert(event[:payload][:duration_ms] >= 0)
+      with_debug_event_reporting do
+        event = assert_event_reported("action_view.render_partial", payload: { identifier: "test/_cached_customer.erb", layout: nil }) do
+          @view.render(partial: "test/nested_cached_customer", locals: { cached_customer: Customer.new("Stan") })
         end
+
+        assert(event[:payload][:gc_ms] >= 0)
+        assert(event[:payload][:duration_ms] >= 0)
+
+        payload = { identifier: "test/_cached_customer.erb", layout: nil, cache_hit: :hit }
+        event = assert_event_reported("action_view.render_partial", payload:) do
+          # Second render hits the cache for the _cached_customer partial. Outer template's log shouldn't be affected.
+          @view.render(partial: "test/nested_cached_customer", locals: { cached_customer: Customer.new("Stan") })
+        end
+
+        assert(event[:payload][:gc_ms] >= 0)
+        assert(event[:payload][:duration_ms] >= 0)
       end
     end
 
     def test_render_cached_outer_partial_with_cached_inner_partial
-      Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-        set_view_cache_dependencies
-        set_cache_controller
+      set_view_cache_dependencies
+      set_cache_controller
 
-        with_debug_event_reporting do
-          assert_event_reported("action_view.render_partial", payload: { identifier: "test/_cached_customer.erb", layout: nil }) do
-            assert_event_reported("action_view.render_partial", payload: { identifier: "test/_cached_nested_cached_customer.erb", layout: nil, cache_hit: :miss }) do
-              @view.render(partial: "test/cached_nested_cached_customer", locals: { cached_customer: Customer.new("Stan") })
-            end
+      with_debug_event_reporting do
+        assert_event_reported("action_view.render_partial", payload: { identifier: "test/_cached_customer.erb", layout: nil }) do
+          assert_event_reported("action_view.render_partial", payload: { identifier: "test/_cached_nested_cached_customer.erb", layout: nil, cache_hit: :miss }) do
+            @view.render(partial: "test/cached_nested_cached_customer", locals: { cached_customer: Customer.new("Stan") })
           end
+        end
 
-          # One render: inner partial skipped, because the outer has been cached.
-          assert_no_event_reported("action_view.render_partial", payload: { identifier: "test/_cached_customer.erb", layout: nil }) do
-            assert_event_reported("action_view.render_partial", payload: { identifier: "test/_cached_nested_cached_customer.erb", layout: nil, cache_hit: :hit }) do
-              @view.render(partial: "test/cached_nested_cached_customer", locals: { cached_customer: Customer.new("Stan") })
-            end
+        # One render: inner partial skipped, because the outer has been cached.
+        assert_no_event_reported("action_view.render_partial", payload: { identifier: "test/_cached_customer.erb", layout: nil }) do
+          assert_event_reported("action_view.render_partial", payload: { identifier: "test/_cached_nested_cached_customer.erb", layout: nil, cache_hit: :hit }) do
+            @view.render(partial: "test/cached_nested_cached_customer", locals: { cached_customer: Customer.new("Stan") })
           end
         end
       end
     end
 
     def test_render_partial_with_cache_hit_and_missed
-      Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-        set_view_cache_dependencies
-        set_cache_controller
+      set_view_cache_dependencies
+      set_cache_controller
 
-        with_debug_event_reporting do
-          assert_event_reported("action_view.render_partial", payload: { identifier: "test/_cached_customer.erb", layout: nil, cache_hit: :miss }) do
-            @view.render(partial: "test/cached_customer", locals: { cached_customer: Customer.new("david") })
-          end
-          assert_event_reported("action_view.render_partial", payload: { identifier: "test/_cached_customer.erb", layout: nil, cache_hit: :hit }) do
-            @view.render(partial: "test/cached_customer", locals: { cached_customer: Customer.new("david") })
-          end
+      with_debug_event_reporting do
+        assert_event_reported("action_view.render_partial", payload: { identifier: "test/_cached_customer.erb", layout: nil, cache_hit: :miss }) do
+          @view.render(partial: "test/cached_customer", locals: { cached_customer: Customer.new("david") })
+        end
+        assert_event_reported("action_view.render_partial", payload: { identifier: "test/_cached_customer.erb", layout: nil, cache_hit: :hit }) do
+          @view.render(partial: "test/cached_customer", locals: { cached_customer: Customer.new("david") })
+        end
 
-          assert_event_reported("action_view.render_partial", payload: { identifier: "test/_cached_customer.erb", layout: nil, cache_hit: :miss }) do
-            @view.render(partial: "test/cached_customer", locals: { cached_customer: Customer.new("Stan") })
-          end
+        assert_event_reported("action_view.render_partial", payload: { identifier: "test/_cached_customer.erb", layout: nil, cache_hit: :miss }) do
+          @view.render(partial: "test/cached_customer", locals: { cached_customer: Customer.new("Stan") })
         end
       end
     end
 
     def test_render_collection_template
-      Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-        set_cache_controller
+      set_cache_controller
 
-        with_debug_event_reporting do
-          event = assert_event_reported("action_view.render_collection", payload: { identifier: "test/_customer.erb", layout: nil, cache_hits: nil, count: 2 }) do
-            @view.render(partial: "test/customer", collection: [ Customer.new("david"), Customer.new("mary") ])
-          end
-
-          assert(event[:payload][:gc_ms] >= 0)
-          assert(event[:payload][:duration_ms] >= 0)
+      with_debug_event_reporting do
+        event = assert_event_reported("action_view.render_collection", payload: { identifier: "test/_customer.erb", layout: nil, cache_hits: nil, count: 2 }) do
+          @view.render(partial: "test/customer", collection: [ Customer.new("david"), Customer.new("mary") ])
         end
+
+        assert(event[:payload][:gc_ms] >= 0)
+        assert(event[:payload][:duration_ms] >= 0)
       end
     end
 
     def test_render_collection_template_with_layout
-      Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-        set_cache_controller
+      set_cache_controller
 
-        with_debug_event_reporting do
-          event = assert_event_reported("action_view.render_collection", payload: { identifier: "test/_customer.erb", layout: "layouts/_yield_only", cache_hits: nil, count: 2 }) do
-            @view.render(partial: "test/customer", layout: "layouts/yield_only", collection: [ Customer.new("david"), Customer.new("mary") ])
-          end
-
-          assert(event[:payload][:gc_ms] >= 0)
-          assert(event[:payload][:duration_ms] >= 0)
+      with_debug_event_reporting do
+        event = assert_event_reported("action_view.render_collection", payload: { identifier: "test/_customer.erb", layout: "layouts/_yield_only", cache_hits: nil, count: 2 }) do
+          @view.render(partial: "test/customer", layout: "layouts/yield_only", collection: [ Customer.new("david"), Customer.new("mary") ])
         end
+
+        assert(event[:payload][:gc_ms] >= 0)
+        assert(event[:payload][:duration_ms] >= 0)
       end
     end
 
     def test_render_collection_with_implicit_path
-      Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-        set_cache_controller
+      set_cache_controller
 
-        with_debug_event_reporting do
-          event = assert_event_reported("action_view.render_collection", payload: { identifier: "customers/_customer.html.erb", layout: nil, cache_hits: nil, count: 2 }) do
-            @view.render([ Customer.new("david"), Customer.new("mary") ], greeting: "hi")
-          end
-
-          assert(event[:payload][:gc_ms] >= 0)
-          assert(event[:payload][:duration_ms] >= 0)
+      with_debug_event_reporting do
+        event = assert_event_reported("action_view.render_collection", payload: { identifier: "customers/_customer.html.erb", layout: nil, cache_hits: nil, count: 2 }) do
+          @view.render([ Customer.new("david"), Customer.new("mary") ], greeting: "hi")
         end
+
+        assert(event[:payload][:gc_ms] >= 0)
+        assert(event[:payload][:duration_ms] >= 0)
       end
     end
 
     def test_render_collection_template_without_path
-      Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-        set_cache_controller
+      set_cache_controller
 
-        with_debug_event_reporting do
-          event = assert_event_reported("action_view.render_collection", payload: { identifier: "templates", layout: nil, cache_hits: nil, count: 2 }) do
-            @view.render([ GoodCustomer.new("david"), Customer.new("mary") ], greeting: "hi")
-          end
-
-          assert(event[:payload][:gc_ms] >= 0)
-          assert(event[:payload][:duration_ms] >= 0)
+      with_debug_event_reporting do
+        event = assert_event_reported("action_view.render_collection", payload: { identifier: "templates", layout: nil, cache_hits: nil, count: 2 }) do
+          @view.render([ GoodCustomer.new("david"), Customer.new("mary") ], greeting: "hi")
         end
+
+        assert(event[:payload][:gc_ms] >= 0)
+        assert(event[:payload][:duration_ms] >= 0)
       end
     end
 
@@ -325,14 +288,12 @@ module ActionView
       ActiveSupport.filter_parameters = [:identifier]
       ActiveSupport.event_reporter.reload_payload_filter
 
-      Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-        with_debug_event_reporting do
-          event = assert_event_reported("action_view.render_start", payload: { identifier: "test/hello_world.erb" }) do
-            @view.render(template: "test/hello_world")
-          end
-
-          assert_equal "test/hello_world.erb", event[:payload][:identifier]
+      with_debug_event_reporting do
+        event = assert_event_reported("action_view.render_start", payload: { identifier: "test/hello_world.erb" }) do
+          @view.render(template: "test/hello_world")
         end
+
+        assert_equal "test/hello_world.erb", event[:payload][:identifier]
       end
     ensure
       ActiveSupport.filter_parameters = old_filter_parameters
@@ -340,19 +301,17 @@ module ActionView
     end
 
     def test_render_collection_with_cached_set
-      Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-        set_view_cache_dependencies
-        set_cache_controller
+      set_view_cache_dependencies
+      set_cache_controller
 
-        with_debug_event_reporting do
-          event = assert_event_reported("action_view.render_collection", payload: { identifier: "customers/_customer.html.erb", layout: nil, cache_hits: 0, count: 2 }) do
-            @view.render(partial: "customers/customer", collection: [ Customer.new("david"), Customer.new("mary") ], cached: true,
-              locals: { greeting: "hi" })
-          end
-
-          assert(event[:payload][:gc_ms] >= 0)
-          assert(event[:payload][:duration_ms] >= 0)
+      with_debug_event_reporting do
+        event = assert_event_reported("action_view.render_collection", payload: { identifier: "customers/_customer.html.erb", layout: nil, cache_hits: 0, count: 2 }) do
+          @view.render(partial: "customers/customer", collection: [ Customer.new("david"), Customer.new("mary") ], cached: true,
+            locals: { greeting: "hi" })
         end
+
+        assert(event[:payload][:gc_ms] >= 0)
+        assert(event[:payload][:duration_ms] >= 0)
       end
     end
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because root assignment in `ActionView::StructuredEventSubscriber` and `ActionView::LogSubscriber` ractor safe.

### Detail

This Pull Request changes log subscribers to not lazily memoize `Rails.root`. Instead, roots are set at initialize time. Similar to https://github.com/rails/rails/pull/58467.

### Additional information

The application should be making the root ractor safe / frozen, so referencing the root ivar should work on non-main ractors. Initializers will run on the main ractor for the initial assignment.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
