### PR TITLE
Query predicate expressions for Active Record types, take 2

### DIFF
--- a/activemodel/lib/active_model/type/value.rb
+++ b/activemodel/lib/active_model/type/value.rb
@@ -114,47 +114,6 @@ module ActiveModel
         false
       end
 
-      # Returns true if the type customizes how attributes and values are
-      # rendered in hash-based +where+ predicates. When this method returns
-      # true, equality, array (+IN+), and range (+BETWEEN+) predicates are
-      # built by passing the attribute through Value#query_attribute and each
-      # value through Value#query_value. Returns +false+ by default. Types
-      # whose read-side SQL differs from what +cast+ and +serialize+ produce
-      # (e.g. a UUID stored as binary comparing as
-      # <tt>id = UUID_TO_BIN(?)</tt>) should override this method to return
-      # +true+.
-      def transforms_query_predicates?
-        false
-      end
-
-      # Returns the Arel node used for the attribute side of a +where+
-      # predicate. Only called when Value#transforms_query_predicates?
-      # returns +true+. The default implementation returns the attribute
-      # unchanged. Override this method to wrap the column reference, for
-      # example in a SQL function call.
-      #
-      # +attribute+ The Arel attribute for the column being compared.
-      def query_attribute(attribute)
-        attribute
-      end
-
-      # Returns the Arel node used for the value side of a +where+
-      # predicate. Only called when Value#transforms_query_predicates?
-      # returns +true+. The default implementation returns a bind parameter
-      # for +value+. Override this method to wrap the bind parameter, for
-      # example in a SQL function call.
-      #
-      # +attribute+ The Arel attribute for the column being compared.
-      #
-      # +value+ The value being compared against, before type casting.
-      #
-      # +predicate_builder+ The ActiveRecord::PredicateBuilder building the
-      # predicate. Call +predicate_builder.build_bind_attribute+ to create a
-      # bind parameter for +value+.
-      def query_value(attribute, value, predicate_builder:)
-        predicate_builder.build_bind_attribute(attribute.name, value, self)
-      end
-
       def map(value, &) # :nodoc:
         value
       end

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -134,51 +134,6 @@
 
     *Ryuta Kamizono*
 
-*   Add query predicate hooks for Active Model types.
-
-    Types can override `transforms_query_predicates?`, `query_attribute`, and
-    `query_value` to customize how hash `where` predicates are built while
-    preserving normal casting and serialization behavior.
-
-    For example, a UUID type stored in MySQL `binary(16)` can accept UUID
-    strings while rendering predicates as `id = UUID_TO_BIN(?)`:
-
-    ```ruby
-    def transforms_query_predicates?
-      true
-    end
-
-    def query_value(attribute, value, predicate_builder:)
-      Arel::Nodes::NamedFunction.new(
-        "UUID_TO_BIN",
-        [predicate_builder.build_bind_attribute(attribute.name, value, self)]
-      )
-    end
-    ```
-
-    `query_attribute` transforms the left-hand side of the predicate, so a text
-    type can compare through a normalized expression such as
-    `lower(name) = lower(?)`:
-
-    ```ruby
-    def transforms_query_predicates?
-      true
-    end
-
-    def query_attribute(attribute)
-      Arel::Nodes::NamedFunction.new("lower", [attribute])
-    end
-
-    def query_value(attribute, value, predicate_builder:)
-      Arel::Nodes::NamedFunction.new(
-        "lower",
-        [predicate_builder.build_bind_attribute(attribute.name, value, self)]
-      )
-    end
-    ```
-
-    *Kir Shatrov*, *Jean-Samuel Aubry-Guzzi*
-
 *   Fix `pluck` ignoring records assigned to a new record's association.
 
     ```ruby

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add query predicate expressions for Active Record types.
+
+    Types can include `ActiveRecord::Type::QueryPredicates` to define the SQL
+    expression through which query predicates compare stored attributes and
+    serialized query values. Ordering sorts through the same expression.
+
+    *Kir Shatrov*, *Jean-Samuel Aubry-Guzzi*, *Matthew Draper*
+
 *   Deprecate `ActiveRecord::Relation#uniq!`.
 
     The method was added in Rails 6.1 (#39358) as part of the migration path

--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -66,12 +66,12 @@ module ActiveRecord
           primary_key_foreign_key_pairs = primary_key.zip(foreign_key)
           primary_key_foreign_key_pairs.each do |join_key, foreign_key|
             value = transform_value(owner.read_attribute(foreign_key))
-            scope = apply_scope(scope, table, join_key, value)
+            scope = apply_scope(scope, reflection, table, join_key, value)
           end
 
           if reflection.type
             polymorphic_type = transform_value(owner.class.polymorphic_name)
-            scope = apply_scope(scope, table, reflection.type, polymorphic_type)
+            scope = apply_scope(scope, reflection, table, reflection.type, polymorphic_type)
           end
 
           scope
@@ -88,14 +88,18 @@ module ActiveRecord
           table = reflection.aliased_table
           foreign_table = next_reflection.aliased_table
 
+          predicate_builder = scope.predicate_builder
           primary_key_foreign_key_pairs = primary_key.zip(foreign_key)
           constraints = primary_key_foreign_key_pairs.map do |join_primary_key, foreign_key|
-            table[join_primary_key].eq(foreign_table[foreign_key])
+            join_primary_key_attribute = predicate_builder.predicate_attribute(table[join_primary_key])
+            foreign_key_attribute = predicate_builder.predicate_attribute(foreign_table[foreign_key])
+
+            join_primary_key_attribute.eq(foreign_key_attribute)
           end.inject(&:and)
 
           if reflection.type
             value = transform_value(next_reflection.klass.polymorphic_name)
-            scope = apply_scope(scope, table, reflection.type, value)
+            scope = apply_scope(scope, reflection, table, reflection.type, value)
           end
 
           scope.joins!(join(foreign_table, constraints))
@@ -162,11 +166,13 @@ module ActiveRecord
           scope
         end
 
-        def apply_scope(scope, table, key, value)
+        def apply_scope(scope, reflection, table, key, value)
           if scope.table == table
             scope.where!(key => value)
           else
-            scope.where!(table.name => { key => value })
+            scope.references_values |= [Arel.sql(table.name, retryable: true)]
+            predicate_builder = reflection.klass.predicate_builder.with(TableMetadata.new(reflection.klass, table))
+            scope.where!(predicate_builder[key, value])
           end
         end
 

--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -6,8 +6,14 @@ module ActiveRecord
   module AttributeMethods
     module TimeZoneConversion
       class TimeZoneConverter < ActiveSupport::Delegation::DelegateClass(Type::Value) # :nodoc:
+        include Type::QueryPredicates::Decorator
+
         def self.new(subtype)
           self === subtype ? subtype : super
+        end
+
+        def subtype
+          __getobj__
         end
 
         def deserialize(value)

--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -9,6 +9,10 @@ module ActiveRecord
     include ActiveModel::AttributeRegistration
     include ActiveModel::Attributes::Normalization
 
+    ActiveModel::Attributes::Normalization::NormalizedValueType.include(
+      Type::QueryPredicates::NormalizedValueTypeDecorator
+    )
+
     # = Active Record \Attributes
     module ClassMethods
       # :method: attribute

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -168,6 +168,8 @@ module ActiveRecord
     end
 
     class EnumType < Type::Value # :nodoc:
+      include Type::QueryPredicates::Decorator
+
       delegate :type, to: :subtype
 
       def initialize(name, mapping, subtype, raise_on_invalid_values: true)

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -246,8 +246,14 @@ module ActiveRecord
     # `nil` values to `lock_version`, and not result in `ActiveRecord::StaleObjectError`
     # during update record.
     class LockingType < ActiveSupport::Delegation::DelegateClass(Type::Value) # :nodoc:
+      include Type::QueryPredicates::Decorator
+
       def self.new(subtype)
         self === subtype ? subtype : super
+      end
+
+      def subtype
+        __getobj__
       end
 
       def deserialize(value)

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -214,7 +214,10 @@ module ActiveRecord
         primary_foreign_key_pairs = primary_key_column_names.zip(foreign_key_column_names)
 
         primary_foreign_key_pairs.each do |primary_key_column_name, foreign_key_column_name|
-          klass_scope.where!(table[primary_key_column_name].eq(foreign_table[foreign_key_column_name]))
+          primary_key_attribute = predicate_builder.predicate_attribute(table[primary_key_column_name])
+          foreign_key_attribute = predicate_builder.predicate_attribute(foreign_table[foreign_key_column_name])
+
+          klass_scope.where!(primary_key_attribute.eq(foreign_key_attribute))
         end
 
         if klass.finder_needs_type_condition?

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -106,8 +106,8 @@ module ActiveRecord
         value = value.read_attribute(reflection.association_primary_key) unless value.nil?
       end
 
-      attr = table[name]
-      bind = predicate_builder.build_bind_attribute(attr.name, value)
+      attr = predicate_builder.predicate_attribute(table[name])
+      bind = predicate_builder.build_bind_attribute(attr, value)
       yield attr, bind
     end
 
@@ -1456,14 +1456,14 @@ module ActiveRecord
             end
           else
             type = model.type_for_attribute(attr.name)
-            value = predicate_builder.build_bind_attribute(attr.name, type.cast(value))
+            value = predicate_builder.build_bind_attribute(attr, type.cast(value))
           end
           [attr, value]
         end
       end
 
       def _increment_attribute(attribute, value = 1)
-        bind = predicate_builder.build_bind_attribute(attribute.name, value.abs)
+        bind = predicate_builder.build_bind_attribute(attribute, value.abs)
         expr = table.coalesce(attribute, 0)
         expr = value < 0 ? expr - bind : expr + bind
         expr.expr

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -107,7 +107,7 @@ module ActiveRecord
       end
 
       attr = table[name]
-      bind = predicate_builder.build_bind_attribute(attr.name, value, model.type_for_attribute(attr.name))
+      bind = predicate_builder.build_bind_attribute(attr.name, value)
       yield attr, bind
     end
 
@@ -1456,14 +1456,14 @@ module ActiveRecord
             end
           else
             type = model.type_for_attribute(attr.name)
-            value = predicate_builder.build_bind_attribute(attr.name, type.cast(value), type)
+            value = predicate_builder.build_bind_attribute(attr.name, type.cast(value))
           end
           [attr, value]
         end
       end
 
       def _increment_attribute(attribute, value = 1)
-        bind = predicate_builder.build_bind_attribute(attribute.name, value.abs, model.type_for_attribute(attribute.name))
+        bind = predicate_builder.build_bind_attribute(attribute.name, value.abs)
         expr = table.coalesce(attribute, 0)
         expr = value < 0 ? expr - bind : expr + bind
         expr.expr

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -641,7 +641,7 @@ module ActiveRecord
           end
 
           if !_order_columns.empty?
-            return order(_order_columns.map { |column| table[column].asc })
+            return order(_order_columns.map { |column| predicate_builder.predicate_attribute(table[column]).asc })
           end
 
           if ActiveRecord.raise_on_missing_required_finder_order_columns

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -2,6 +2,7 @@
 
 module ActiveRecord
   class PredicateBuilder # :nodoc:
+    require "active_record/relation/predicate_builder/comparison"
     require "active_record/relation/predicate_builder/array_handler"
     require "active_record/relation/predicate_builder/basic_object_handler"
     require "active_record/relation/predicate_builder/range_handler"
@@ -44,6 +45,11 @@ module ActiveRecord
     #       )
     #     end
     #     ActiveRecord::PredicateBuilder.new("users").register_handler(MyCustomDateRange, handler)
+    #
+    # The column exposes its effective type through +type_caster+. Call
+    # <tt>fetch_attribute { |attribute| ... }</tt> to access the underlying
+    # logical Arel attribute when a type supplies a comparison expression. The
+    # handler is responsible for constructing its right-hand side.
     def register_handler(klass, handler)
       @handlers.unshift([klass, handler])
     end
@@ -54,16 +60,35 @@ module ActiveRecord
 
     def build(attribute, value, operator = nil)
       value = value.id if value.respond_to?(:id)
-      if operator ||= table.type(attribute.name).force_equality?(value) && :eq
-        bind = build_bind_attribute(attribute.name, value)
-        attribute.public_send(operator, bind)
+      type = attribute.type_caster
+      attribute = predicate_attribute(attribute, type)
+
+      if operator ||= type.force_equality?(value) && :eq
+        attribute.public_send(operator, predicate_value(attribute, value))
       else
         handler_for(value).call(attribute, value)
       end
     end
 
-    def build_bind_attribute(column_name, value)
-      Relation::QueryAttribute.new(column_name, value, table.type(column_name))
+    def predicate_attribute(attribute, type = attribute.type_caster)
+      if !attribute.is_a?(ComparisonAttribute) && Type::QueryPredicates.type?(type)
+        ComparisonAttribute.new(attribute, type)
+      else
+        attribute
+      end
+    end
+
+    def predicate_value(attribute, value)
+      if Arel.arel_node?(value)
+        attribute.is_a?(ComparisonAttribute) ? attribute.comparison_expression(value) : value
+      else
+        build_bind_attribute(attribute, value)
+      end
+    end
+
+    def build_bind_attribute(attribute, value)
+      bind = Relation::QueryAttribute.new(attribute.name, value, attribute.type_caster)
+      attribute.is_a?(ComparisonAttribute) ? ComparisonValue.new(bind) : bind
     end
 
     def resolve_arel_attribute(table_name, column_name, &block)

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -38,7 +38,7 @@ module ActiveRecord
     # for any value that <tt>===</tt> the class given. For example:
     #
     #     MyCustomDateRange = Struct.new(:start, :end)
-    #     handler = proc do |column, range, type|
+    #     handler = proc do |column, range|
     #       Arel::Nodes::Between.new(column,
     #         Arel::Nodes::And.new([range.start, range.end])
     #       )
@@ -53,51 +53,17 @@ module ActiveRecord
     end
 
     def build(attribute, value, operator = nil)
-      type = table.type(attribute.name)
-
-      predicate_for(attribute, value, operator, type)
-    end
-
-    def predicate_for(attribute, value, operator, type)
       value = value.id if value.respond_to?(:id)
-
-      if operator ||= type.force_equality?(value) && :eq
-        if type.transforms_query_predicates?
-          right = query_value(attribute, value, type)
-          left = right.nil? ? attribute : type.query_attribute(attribute)
-        else
-          right = build_bind_attribute(attribute.name, value, type)
-          left = attribute
-        end
-
-        left.public_send(operator, right)
+      if operator ||= table.type(attribute.name).force_equality?(value) && :eq
+        bind = build_bind_attribute(attribute.name, value)
+        attribute.public_send(operator, bind)
       else
-        handler_for(value).call(attribute, value, type)
+        handler_for(value).call(attribute, value)
       end
     end
 
-    def array_predicate_for(attribute, values, type, transformable)
-      if transformable
-        type.query_attribute(attribute).in(
-          values.map { |value| query_value(attribute, value, type) }
-        )
-      else
-        Arel::Nodes::HomogeneousIn.new(values, attribute, :in)
-      end
-    end
-
-    def range_predicate_for(attribute, range, type)
-      type.query_attribute(attribute).between(
-        RangeHandler::RangeWithBinds.new(
-          query_value(attribute, range.begin, type),
-          query_value(attribute, range.end, type),
-          range.exclude_end?
-        )
-      )
-    end
-
-    def build_bind_attribute(column_name, value, type)
-      Relation::QueryAttribute.new(column_name, value, type)
+    def build_bind_attribute(column_name, value)
+      Relation::QueryAttribute.new(column_name, value, table.type(column_name))
     end
 
     def resolve_arel_attribute(table_name, column_name, &block)
@@ -233,13 +199,6 @@ module ActiveRecord
 
       def handler_for(object)
         @handlers.detect { |klass, _| klass === object }.last
-      end
-
-      def query_value(attribute, value, type)
-        bind = build_bind_attribute(attribute.name, value, type)
-        return bind if bind.nil? || bind.infinite? || bind.unboundable?
-
-        type.query_value(attribute, value, predicate_builder: self)
       end
   end
 end

--- a/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
@@ -9,10 +9,9 @@ module ActiveRecord
         @predicate_builder = predicate_builder
       end
 
-      def call(attribute, value, type)
+      def call(attribute, value)
         return attribute.in([]) if value.empty?
 
-        transformable = type.transforms_query_predicates?
         values = value.map { |x| x.is_a?(Base) ? x.id : x }
         nils = values.compact!
         ranges = values.extract! { |v| v.is_a?(Range) }
@@ -20,8 +19,8 @@ module ActiveRecord
         values_predicate =
           case values.length
           when 0 then NullPredicate
-          when 1 then predicate_builder.predicate_for(attribute, values.first, nil, type)
-          else predicate_builder.array_predicate_for(attribute, values, type, transformable)
+          when 1 then predicate_builder.build(attribute, values.first)
+          else Arel::Nodes::HomogeneousIn.new(values, attribute, :in)
           end
 
         if nils
@@ -31,7 +30,7 @@ module ActiveRecord
         if ranges.empty?
           values_predicate
         else
-          array_predicates = ranges.map! { |range| predicate_builder.predicate_for(attribute, range, nil, type) }
+          array_predicates = ranges.map! { |range| predicate_builder.build(attribute, range) }
           values_predicate.or(
             Arel::Nodes::Grouping.new Arel::Nodes::Or.new(array_predicates)
           )

--- a/activerecord/lib/active_record/relation/predicate_builder/basic_object_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/basic_object_handler.rb
@@ -8,8 +8,8 @@ module ActiveRecord
       end
 
       def call(attribute, value)
-        bind = predicate_builder.build_bind_attribute(attribute.name, value)
-        attribute.eq(bind)
+        value = predicate_builder.predicate_value(attribute, value)
+        attribute.eq(value)
       end
 
       private

--- a/activerecord/lib/active_record/relation/predicate_builder/basic_object_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/basic_object_handler.rb
@@ -7,8 +7,9 @@ module ActiveRecord
         @predicate_builder = predicate_builder
       end
 
-      def call(attribute, value, type)
-        predicate_builder.predicate_for(attribute, value, :eq, type)
+      def call(attribute, value)
+        bind = predicate_builder.build_bind_attribute(attribute.name, value)
+        attribute.eq(bind)
       end
 
       private

--- a/activerecord/lib/active_record/relation/predicate_builder/comparison.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/comparison.rb
@@ -1,0 +1,62 @@
+# :markup: markdown
+# frozen_string_literal: true
+
+require "active_record/relation/query_attribute"
+
+module ActiveRecord
+  class PredicateBuilder
+    class ComparisonAttribute < Arel::Attributes::Attribute # :nodoc:
+      attr_reader :attribute, :expression, :type_caster
+
+      def initialize(attribute, type_caster)
+        super(attribute.relation, attribute.name)
+        @attribute = attribute
+        @type_caster = type_caster
+        @expression = comparison_expression(attribute)
+      end
+
+      def comparison_expression(expression)
+        type_caster.comparison_expression(expression)
+      end
+
+      delegate :able_to_type_cast?, :type_cast_for_database, to: :attribute
+
+      def fetch_attribute(&)
+        attribute.fetch_attribute(&)
+      end
+
+      def hash
+        [self.class, attribute, expression].hash
+      end
+
+      def ==(other)
+        self.class == other.class &&
+          attribute == other.attribute &&
+          expression == other.expression
+      end
+      alias eql? ==
+    end
+
+    class ComparisonValue < Arel::Nodes::NodeExpression # :nodoc:
+      attr_reader :expression, :query_attribute
+
+      def initialize(query_attribute)
+        @query_attribute = query_attribute
+        @expression = query_attribute.type.comparison_expression(query_attribute)
+      end
+
+      delegate :infinite?, :nil?, :unboundable?, :value_before_type_cast, to: :query_attribute
+
+      def hash
+        [self.class, expression, query_attribute].hash
+      end
+
+      def ==(other)
+        self.class == other.class &&
+          expression == other.expression &&
+          query_attribute == other.query_attribute
+      end
+      alias eql? ==
+    end
+  end
+end

--- a/activerecord/lib/active_record/relation/predicate_builder/range_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/range_handler.rb
@@ -10,8 +10,8 @@ module ActiveRecord
       end
 
       def call(attribute, value)
-        begin_bind = predicate_builder.build_bind_attribute(attribute.name, value.begin)
-        end_bind = predicate_builder.build_bind_attribute(attribute.name, value.end)
+        begin_bind = predicate_builder.build_bind_attribute(attribute, value.begin)
+        end_bind = predicate_builder.build_bind_attribute(attribute, value.end)
         attribute.between(RangeWithBinds.new(begin_bind, end_bind, value.exclude_end?))
       end
 

--- a/activerecord/lib/active_record/relation/predicate_builder/range_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/range_handler.rb
@@ -9,8 +9,10 @@ module ActiveRecord
         @predicate_builder = predicate_builder
       end
 
-      def call(attribute, value, type)
-        predicate_builder.range_predicate_for(attribute, value, type)
+      def call(attribute, value)
+        begin_bind = predicate_builder.build_bind_attribute(attribute.name, value.begin)
+        end_bind = predicate_builder.build_bind_attribute(attribute.name, value.end)
+        attribute.between(RangeWithBinds.new(begin_bind, end_bind, value.exclude_end?))
       end
 
       private

--- a/activerecord/lib/active_record/relation/predicate_builder/relation_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/relation_handler.rb
@@ -17,8 +17,23 @@ module ActiveRecord
           end
         end
 
-        attribute.in(value.arel)
+        query = value.arel
+        if attribute.is_a?(ComparisonAttribute)
+          query = query.clone
+          query.projections = query.projections.map { |projection| comparison_projection(attribute, projection) }
+        end
+
+        attribute.in(query)
       end
+
+      private
+        def comparison_projection(attribute, projection)
+          if projection.is_a?(Arel::Nodes::As)
+            Arel::Nodes::As.new(attribute.comparison_expression(projection.left), projection.right)
+          else
+            attribute.comparison_expression(projection)
+          end
+        end
     end
   end
 end

--- a/activerecord/lib/active_record/relation/predicate_builder/relation_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/relation_handler.rb
@@ -3,7 +3,7 @@
 module ActiveRecord
   class PredicateBuilder
     class RelationHandler # :nodoc:
-      def call(attribute, value, _type)
+      def call(attribute, value)
         if value.eager_loading?
           value = value.send(:apply_join_dependency)
         end

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -739,6 +739,9 @@ module ActiveRecord
 
         unless arel_column.is_a?(Arel::Nodes::SqlLiteral)
           values = cast_values_for_in_order_of(values, arel_column.type_caster)
+          if arel_column.is_a?(PredicateBuilder::ComparisonAttribute)
+            values = comparison_values_for_in_order_of(values, arel_column)
+          end
         end
         return spawn.none! if values.empty?
       end
@@ -2052,7 +2055,7 @@ module ActiveRecord
       def reverse_sql_order(order_query)
         if order_query.empty?
           if !_order_columns.empty?
-            return _order_columns.map { |column| table[column].desc }
+            return _order_columns.map { |column| predicate_builder.predicate_attribute(table[column]).desc }
           end
 
           raise IrreversibleOrderError, <<~MSG.squish
@@ -2195,12 +2198,18 @@ module ActiveRecord
       end
 
       def order_column(field)
-        arel_column(field) do |attr_name|
+        column = arel_column(field) do |attr_name|
           if attr_name == "count" && !group_values.empty?
             table[attr_name]
           else
             Arel.sql(model.adapter_class.quote_table_name(attr_name), retryable: true)
           end
+        end
+
+        if column.is_a?(Arel::Attributes::Attribute)
+          predicate_builder.predicate_attribute(column)
+        else
+          column
         end
       end
 
@@ -2307,6 +2316,18 @@ module ActiveRecord
         end
 
         values.reject { |v| v == bad_value || (v.is_a?(Array) && v.empty?) }
+      end
+
+      def comparison_values_for_in_order_of(values, column)
+        values.map do |value|
+          if value.is_a?(Array)
+            comparison_values_for_in_order_of(value, column)
+          elsif value.nil?
+            nil
+          else
+            column.comparison_expression(Arel::Nodes.build_quoted(value))
+          end
+        end
       end
 
       def arel_column_aliases_from_hash(fields)

--- a/activerecord/lib/active_record/table_metadata.rb
+++ b/activerecord/lib/active_record/table_metadata.rb
@@ -11,10 +11,6 @@ module ActiveRecord
       klass&.primary_key
     end
 
-    def type(column_name)
-      arel_table.type_for_attribute(column_name)
-    end
-
     def has_column?(column_name)
       klass&.columns_hash&.key?(column_name)
     end

--- a/activerecord/lib/active_record/type.rb
+++ b/activerecord/lib/active_record/type.rb
@@ -3,6 +3,7 @@
 require "active_model/type"
 
 require "active_record/type/internal/timezone"
+require "active_record/type/query_predicates"
 
 require "active_record/type/date"
 require "active_record/type/date_time"

--- a/activerecord/lib/active_record/type/query_predicates.rb
+++ b/activerecord/lib/active_record/type/query_predicates.rb
@@ -17,9 +17,11 @@ module ActiveRecord
     # symmetrically to the stored attribute and query value. Ruby values are
     # serialized first; Arel expressions are not. `IS NULL` tests apply to the
     # transformed attribute, and subquery projections are treated as stored
-    # values and transformed as well. The expression defines equality,
-    # ordering, and null semantics for the type. Type authors are responsible
-    # for ensuring those semantics are appropriate and supported by the database.
+    # values and transformed as well. Association join constraints compare two
+    # stored attributes. Each side is transformed through its own column's type.
+    # The expression defines equality, ordering, and null semantics for the type.
+    # Type authors are responsible for ensuring those semantics are appropriate
+    # and supported by the database.
     #
     # Ordering compares through the same expression: `order` on an attribute
     # sorts by the transformed value, as do `in_order_of` and batch cursors.

--- a/activerecord/lib/active_record/type/query_predicates.rb
+++ b/activerecord/lib/active_record/type/query_predicates.rb
@@ -1,0 +1,66 @@
+# :markup: markdown
+# frozen_string_literal: true
+
+module ActiveRecord
+  module Type
+    # Include this module in an attribute type to customize the SQL expression
+    # used to compare values of that type in Active Record predicates.
+    #
+    # For example, a text type can compare through the normalized expression
+    # used by a database expression index:
+    #
+    #     def comparison_expression(expression)
+    #       Arel::Nodes::NamedFunction.new("lower", [expression])
+    #     end
+    #
+    # Active Record compares values of the type by applying the expression
+    # symmetrically to the stored attribute and query value. Ruby values are
+    # serialized first; Arel expressions are not. `IS NULL` tests apply to the
+    # transformed attribute, and subquery projections are treated as stored
+    # values and transformed as well. The expression defines equality,
+    # ordering, and null semantics for the type. Type authors are responsible
+    # for ensuring those semantics are appropriate and supported by the database.
+    #
+    # Ordering compares through the same expression: `order` on an attribute
+    # sorts by the transformed value, as do `in_order_of` and batch cursors.
+    # Writes use `serialize` without applying the comparison expression;
+    # `group` and aggregate calculations use the stored attribute.
+    module QueryPredicates
+      def query_predicates? # :nodoc:
+        true
+      end
+
+      # Converts a stored attribute or serialized query value into the
+      # expression on which comparisons are performed.
+      def comparison_expression(expression)
+        expression
+      end
+
+      # Include in a representation-preserving type decorator that exposes its
+      # wrapped type as `subtype`.
+      module Decorator
+        include QueryPredicates
+
+        def query_predicates?
+          QueryPredicates.type?(subtype)
+        end
+
+        def comparison_expression(expression)
+          subtype.comparison_expression(expression)
+        end
+      end
+
+      module NormalizedValueTypeDecorator # :nodoc:
+        include Decorator
+
+        def subtype
+          cast_type
+        end
+      end
+
+      def self.type?(type) # :nodoc:
+        self === type && type.query_predicates?
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/type/serialized.rb
+++ b/activerecord/lib/active_record/type/serialized.rb
@@ -6,6 +6,7 @@ module ActiveRecord
       undef to_yaml if method_defined?(:to_yaml)
 
       include ActiveModel::Type::Helpers::Mutable
+      include QueryPredicates::Decorator
 
       attr_reader :subtype, :coder
 

--- a/activerecord/lib/arel/attributes/attribute.rb
+++ b/activerecord/lib/arel/attributes/attribute.rb
@@ -26,6 +26,10 @@ module Arel # :nodoc: all
       def able_to_type_cast?
         relation.able_to_type_cast?
       end
+
+      def fetch_attribute(&)
+        yield self
+      end
     end
   end
 

--- a/activerecord/lib/arel/nodes/binary.rb
+++ b/activerecord/lib/arel/nodes/binary.rb
@@ -32,9 +32,9 @@ module Arel # :nodoc: all
     module FetchAttribute
       def fetch_attribute(&)
         if left.is_a?(Arel::Attributes::Attribute)
-          yield left
+          left.fetch_attribute(&)
         elsif right.is_a?(Arel::Attributes::Attribute)
-          yield right
+          right.fetch_attribute(&)
         end
       end
     end

--- a/activerecord/lib/arel/nodes/homogeneous_in.rb
+++ b/activerecord/lib/arel/nodes/homogeneous_in.rb
@@ -53,7 +53,7 @@ module Arel # :nodoc: all
 
       def fetch_attribute(&block)
         if attribute
-          yield attribute
+          attribute.fetch_attribute(&block)
         else
           expr.fetch_attribute(&block)
         end

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -363,6 +363,12 @@ module Arel # :nodoc: all
 
           if values.empty?
             collector << @connection.quote(nil)
+          elsif o.attribute.respond_to?(:comparison_expression)
+            # Comparison values need SQL around each bind, so they cannot use
+            # the collector's bulk bind path.
+            binds = values.map(&o.proc_for_binds)
+            expressions = binds.map { |bind| o.attribute.comparison_expression(bind) }
+            collector = inject_join(expressions, collector, ", ")
           else
             collector.add_binds(values, o.proc_for_binds, &bind_block)
           end
@@ -772,6 +778,14 @@ module Arel # :nodoc: all
 
         def visit_ActiveModel_Attribute(o, collector)
           collector.add_bind(o, &bind_block)
+        end
+
+        def visit_ActiveRecord_PredicateBuilder_ComparisonAttribute(o, collector)
+          visit o.expression, collector
+        end
+
+        def visit_ActiveRecord_PredicateBuilder_ComparisonValue(o, collector)
+          visit o.expression, collector
         end
 
         def visit_Arel_Nodes_BindParam(o, collector)

--- a/activerecord/test/cases/relation/predicate_builder_test.rb
+++ b/activerecord/test/cases/relation/predicate_builder_test.rb
@@ -9,46 +9,11 @@ module ActiveRecord
   class PredicateBuilderTest < ActiveRecord::TestCase
     include ActiveSupport::Testing::RactorsAssertions
 
-    class UnaccentedString < ActiveRecord::Type::String
-      def transforms_query_predicates?
-        true
-      end
-
-      def query_attribute(attribute)
-        normalize(attribute)
-      end
-
-      def query_value(attribute, value, predicate_builder:)
-        normalize(predicate_builder.build_bind_attribute(attribute.name, value, self))
-      end
-
-      private
-        def normalize(node)
-          Arel::Nodes::NamedFunction.new(
-            "lower",
-            [Arel::Nodes::NamedFunction.new("custom_immutable_unaccent", [node])]
-          )
-        end
-    end
-
-    class UuidToBinString < ActiveRecord::Type::String
-      UUID_STRING = ActiveRecord::Type::String.new
-
-      def transforms_query_predicates?
-        true
-      end
-
-      def query_value(attribute, value, predicate_builder:)
-        bind = Relation::QueryAttribute.new(attribute.name, value, UUID_STRING)
-        Arel::Nodes::NamedFunction.new("UUID_TO_BIN", [bind])
-      end
-    end
-
     class RegexpPredicateBuilder < PredicateBuilder
       def register_handlers
         super
 
-        register_handler(Regexp, ActiveSupport::Ractors.shareable_proc do |column, value, _type|
+        register_handler(Regexp, ActiveSupport::Ractors.shareable_proc do |column, value|
           Arel::Nodes::InfixOperation.new("~", column, Arel::Nodes.build_quoted(value.source))
         end)
       end
@@ -95,70 +60,5 @@ module ActiveRecord
       assert_ractor_shareable Topic.predicate_builder
     end
 
-    def test_attribute_type_can_transform_query_attribute_and_value
-      topic = topic_model_with_title_type(UnaccentedString.new)
-      sql = topic.where(title: "CAFE").to_sql
-      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
-        "WHERE #{normalized_title} = #{normalized_value("CAFE")}"
-
-      assert_equal expected_sql, sql
-    end
-
-    def test_attribute_type_can_transform_array_query_values
-      topic = topic_model_with_title_type(UnaccentedString.new)
-      sql = topic.where(title: ["CAFE", "BAR"]).to_sql
-      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
-        "WHERE #{normalized_title} IN (#{normalized_value("CAFE")}, #{normalized_value("BAR")})"
-
-      assert_equal expected_sql, sql
-    end
-
-    def test_attribute_type_can_transform_range_query_values
-      topic = topic_model_with_title_type(UnaccentedString.new)
-      sql = topic.where(title: "A".."Z").to_sql
-      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
-        "WHERE #{normalized_title} BETWEEN #{normalized_value("A")} AND #{normalized_value("Z")}"
-
-      assert_equal expected_sql, sql
-    end
-
-    def test_attribute_type_can_transform_only_query_value
-      topic = topic_model_with_title_type(UuidToBinString.new)
-      uuid = "6ccd780c-baba-1026-9564-5b8c656024db"
-      sql = topic.where(title: uuid).to_sql
-      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
-        "WHERE #{quote_table_name("topics.title")} = UUID_TO_BIN('#{uuid}')"
-
-      assert_equal expected_sql, sql
-    end
-
-    def test_attribute_type_query_transform_keeps_nil_predicates_unwrapped
-      topic = topic_model_with_title_type(UnaccentedString.new)
-      sql = topic.where(title: nil).to_sql
-      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
-        "WHERE #{quote_table_name("topics.title")} IS NULL"
-
-      assert_equal expected_sql, sql
-    end
-
-    private
-      def quoted_topics
-        quote_table_name("topics")
-      end
-
-      def normalized_title
-        "lower(custom_immutable_unaccent(#{quote_table_name("topics.title")}))"
-      end
-
-      def normalized_value(value)
-        "lower(custom_immutable_unaccent(#{ActiveRecord::Base.lease_connection.quote(value)}))"
-      end
-
-      def topic_model_with_title_type(type)
-        Class.new(ActiveRecord::Base) do
-          self.table_name = "topics"
-          attribute :title, type
-        end
-      end
   end
 end

--- a/activerecord/test/cases/relation/predicate_builder_test.rb
+++ b/activerecord/test/cases/relation/predicate_builder_test.rb
@@ -8,6 +8,141 @@ require "active_support/core_ext/object/with"
 module ActiveRecord
   class PredicateBuilderTest < ActiveRecord::TestCase
     include ActiveSupport::Testing::RactorsAssertions
+    class UnaccentedString < ActiveRecord::Type::String
+      include ActiveRecord::Type::QueryPredicates
+
+      def comparison_expression(expression)
+        Arel::Nodes::NamedFunction.new(
+          "lower",
+          [Arel::Nodes::NamedFunction.new("custom_immutable_unaccent", [expression])]
+        )
+      end
+    end
+
+    class LowerString < ActiveRecord::Type::String
+      include ActiveRecord::Type::QueryPredicates
+
+      def comparison_expression(expression)
+        Arel::Nodes::NamedFunction.new("lower", [expression])
+      end
+    end
+
+    class TypeCastingAttribute < Arel::Attributes::Attribute
+      attr_reader :custom_type
+
+      def initialize(relation, name, custom_type)
+        super(relation, name)
+        @custom_type = custom_type
+      end
+
+      def type_caster
+        custom_type
+      end
+
+      def type_cast_for_database(value)
+        ["custom", value]
+      end
+    end
+
+    class TruncatedDateTime < ActiveRecord::Type::DateTime
+      include ActiveRecord::Type::QueryPredicates
+
+      def comparison_expression(expression)
+        Arel::Nodes::NamedFunction.new("date", [expression])
+      end
+    end
+
+    class FlooredBoundedInteger < ActiveRecord::Type::Integer
+      include ActiveRecord::Type::QueryPredicates
+
+      def comparison_expression(expression)
+        Arel::Nodes::NamedFunction.new("floor", [expression])
+      end
+    end
+
+    class FlooredFloat < ActiveRecord::Type::Float
+      include ActiveRecord::Type::QueryPredicates
+
+      def comparison_expression(expression)
+        Arel::Nodes::NamedFunction.new("floor", [expression])
+      end
+    end
+
+    class InvertedInteger < ActiveRecord::Type::Integer
+      include ActiveRecord::Type::QueryPredicates
+
+      def comparison_expression(expression)
+        Arel::Nodes::Grouping.new(Arel::Nodes::Subtraction.new(0, expression))
+      end
+    end
+
+    class InnerExpressionString < ActiveRecord::Type::String
+      include ActiveRecord::Type::QueryPredicates
+
+      def comparison_expression(expression)
+        Arel::Nodes::NamedFunction.new("inner_comparison", [expression])
+      end
+    end
+
+    class OuterExpressionDecorator < ActiveSupport::Delegation::DelegateClass(ActiveModel::Type::Value)
+      include ActiveRecord::Type::QueryPredicates::Decorator
+
+      def subtype
+        __getobj__
+      end
+
+      def comparison_expression(expression)
+        Arel::Nodes::NamedFunction.new("outer_comparison", [super])
+      end
+    end
+
+    OpaqueDecorator = ActiveSupport::Delegation::DelegateClass(ActiveModel::Type::Value)
+
+    class TrackingString < ActiveRecord::Type::String
+      include ActiveRecord::Type::QueryPredicates
+
+      attr_reader :expressions
+
+      def initialize
+        @expressions = []
+        super
+      end
+
+      def comparison_expression(expression)
+        expressions << expression
+        expression
+      end
+    end
+
+    class MutableSerializedType < ActiveRecord::Type::Value
+      include ActiveRecord::Type::QueryPredicates
+
+      attr_reader :serializations
+
+      def initialize
+        @serializations = 0
+        super
+      end
+
+      def serialize(value)
+        @serializations += 1
+        value[:value]
+      end
+
+      def serialized?
+        true
+      end
+    end
+
+    module PrefixCoder
+      def self.dump(value)
+        "coded:#{value}"
+      end
+
+      def self.load(value)
+        value&.delete_prefix("coded:")
+      end
+    end
 
     class RegexpPredicateBuilder < PredicateBuilder
       def register_handlers
@@ -15,6 +150,18 @@ module ActiveRecord
 
         register_handler(Regexp, ActiveSupport::Ractors.shareable_proc do |column, value|
           Arel::Nodes::InfixOperation.new("~", column, Arel::Nodes.build_quoted(value.source))
+        end)
+      end
+    end
+
+    class RawRegexpPredicateBuilder < PredicateBuilder
+      def register_handlers
+        super
+
+        register_handler(Regexp, ActiveSupport::Ractors.shareable_proc do |column, value|
+          raw_column = nil
+          column.fetch_attribute { |attribute| raw_column = attribute }
+          Arel::Nodes::InfixOperation.new("~", raw_column, Arel::Nodes.build_quoted(value.source))
         end)
       end
     end
@@ -60,5 +207,480 @@ module ActiveRecord
       assert_ractor_shareable Topic.predicate_builder
     end
 
+    def test_attribute_type_can_define_a_comparison_expression
+      topic = topic_model_with_title_type(UnaccentedString.new)
+      sql = topic.where(title: "CAFE").to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "WHERE #{normalized_title} = #{normalized_value("CAFE")}"
+
+      assert_equal expected_sql, sql
+    end
+
+    def test_comparison_expression_applies_to_sql_literal_values_without_serializing_them
+      topic = Class.new(ActiveRecord::Base) do
+        self.table_name = "topics"
+        attribute :replies_count, FlooredBoundedInteger.new
+      end
+      sql = topic.where(replies_count: Arel.sql(quote_table_name("topics.parent_id"))).to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "WHERE floor(#{quote_table_name("topics.replies_count")}) = floor(#{quote_table_name("topics.parent_id")})"
+
+      assert_equal expected_sql, sql
+    end
+
+    def test_comparison_attribute_preserves_custom_type_casting
+      type = LowerString.new
+      attribute = TypeCastingAttribute.new(Topic.arel_table, "title", type)
+      predicate = Topic.predicate_builder.build(attribute, "CAFE")
+
+      assert_same type, predicate.left.type_caster
+      assert_equal ["custom", "CAFE"], predicate.left.type_cast_for_database("CAFE")
+      assert_equal "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "WHERE lower(#{quote_table_name("topics.title")}) = lower('CAFE')", Topic.where(predicate).to_sql
+    end
+
+    def test_scalar_query_predicate_expressions_are_built_eagerly
+      type = TrackingString.new
+      topic = topic_model_with_title_type(type)
+      relation = topic.where(title: "CAFE")
+
+      assert_equal 2, type.expressions.size
+      relation.to_sql
+      assert_equal 2, type.expressions.size
+    end
+
+    def test_query_predicate_expression_decorators_stack
+      type = OuterExpressionDecorator.new(InnerExpressionString.new)
+      topic = topic_model_with_title_type(type)
+      sql = topic.where(title: "VALUE").to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "WHERE outer_comparison(inner_comparison(#{quote_table_name("topics.title")})) = " \
+        "outer_comparison(inner_comparison('VALUE'))"
+
+      assert_equal expected_sql, sql
+    end
+
+    def test_opaque_type_decorators_stop_query_predicate_composition
+      type = OpaqueDecorator.new(LowerString.new)
+      topic = topic_model_with_title_type(type)
+      sql = topic.where(title: "value").to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "WHERE #{quote_table_name("topics.title")} = 'value'"
+
+      assert_equal expected_sql, sql
+    end
+
+    def test_comparison_expression_composes_with_custom_predicate_handlers
+      topic = topic_model_with_title_type(UnaccentedString.new)
+      builder = RegexpPredicateBuilder.new(TableMetadata.new(topic, topic.arel_table))
+      topic.class_eval { @predicate_builder = builder }
+      sql = topic.where(title: /cafe/).to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "WHERE #{normalized_title} ~ 'cafe'"
+
+      assert_equal expected_sql, sql
+    end
+
+    def test_custom_predicate_handlers_can_access_the_raw_attribute_and_type
+      topic = topic_model_with_title_type(UnaccentedString.new)
+      builder = RawRegexpPredicateBuilder.new(TableMetadata.new(topic, topic.arel_table))
+      topic.class_eval { @predicate_builder = builder }
+      attribute = builder.predicate_attribute(topic.arel_table[:title])
+      sql = topic.where(title: /cafe/).to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "WHERE #{quote_table_name("topics.title")} ~ 'cafe'"
+
+      assert_equal expected_sql, sql
+      assert_instance_of UnaccentedString, attribute.type_caster
+    end
+
+    def test_attribute_type_comparison_expression_applies_to_array_values
+      topic = topic_model_with_title_type(UnaccentedString.new)
+      relation = topic.where(title: ["CAFE", "BAR"])
+      values = relation.where_values_hash
+
+      assert_instance_of Arel::Nodes::HomogeneousIn, relation.where_clause.ast
+      sql = relation.to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "WHERE #{normalized_title} IN (#{normalized_value("CAFE")}, #{normalized_value("BAR")})"
+
+      assert_equal expected_sql, sql
+      assert_equal values, relation.where_values_hash
+    end
+
+    def test_attribute_type_comparison_expression_executes_array_predicates
+      topic = topic_model_with_title_type(LowerString.new)
+      records = [topic.create!(title: "Array One"), topic.create!(title: "Array Two")]
+      topic.create!(title: "Other")
+
+      assert_equal records, topic.where(title: ["ARRAY ONE", "ARRAY TWO"]).order(:id).to_a
+    end
+
+    def test_attribute_type_comparison_expression_applies_to_range_bounds
+      topic = topic_model_with_title_type(UnaccentedString.new)
+      sql = topic.where(title: "A".."Z").to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "WHERE #{normalized_title} BETWEEN #{normalized_value("A")} AND #{normalized_value("Z")}"
+
+      assert_equal expected_sql, sql
+    end
+
+    def test_attribute_type_comparison_expression_applies_to_open_range_bounds
+      topic = topic_model_with_title_type(UnaccentedString.new)
+      sql = topic.where(title: .."M").to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "WHERE #{normalized_title} <= #{normalized_value("M")}"
+
+      assert_equal expected_sql, sql
+    end
+
+    def test_attribute_type_comparison_expression_applies_to_nil_in_arrays
+      topic = topic_model_with_title_type(UnaccentedString.new)
+      sql = topic.where(title: ["CAFE", nil]).to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "WHERE (#{normalized_title} = #{normalized_value("CAFE")} OR #{normalized_title} IS NULL)"
+
+      assert_equal expected_sql, sql
+    end
+
+    def test_attribute_type_comparison_expression_applies_to_explicit_operators
+      topic = topic_model_with_title_type(UnaccentedString.new)
+      predicate = topic.predicate_builder[:title, "M", :gt]
+      sql = topic.where(predicate).to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "WHERE #{normalized_title} > #{normalized_value("M")}"
+
+      assert_equal expected_sql, sql
+    end
+
+    def test_attribute_type_comparison_expression_applies_to_nil
+      topic = topic_model_with_title_type(UnaccentedString.new)
+      sql = topic.where(title: nil).to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "WHERE #{normalized_title} IS NULL"
+
+      assert_equal expected_sql, sql
+    end
+
+    def test_attribute_type_comparison_expression_applies_to_where_not
+      topic = topic_model_with_title_type(UnaccentedString.new)
+      sql = topic.where.not(title: "CAFE").to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "WHERE #{normalized_title} != #{normalized_value("CAFE")}"
+
+      assert_equal expected_sql, sql
+    end
+
+    def test_comparison_expression_preserves_unboundable_query_values
+      topic = Class.new(ActiveRecord::Base) do
+        self.table_name = "topics"
+        attribute :replies_count, FlooredBoundedInteger.new
+      end
+
+      assert_equal "SELECT #{quoted_topics}.* FROM #{quoted_topics} WHERE 1=0", topic.where(replies_count: 2**100).to_sql
+    end
+
+    def test_comparison_expression_preserves_infinite_range_bounds
+      topic = Class.new(ActiveRecord::Base) do
+        self.table_name = "topics"
+        attribute :replies_count, FlooredFloat.new
+      end
+      sql = topic.where(replies_count: 1.0..Float::INFINITY).to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "WHERE floor(#{quote_table_name("topics.replies_count")}) >= floor(1.0)"
+
+      assert_equal expected_sql, sql
+    end
+
+    def test_comparison_expression_preserves_statement_cache_binds
+      topic = topic_model_with_title_type(LowerString.new)
+      record = topic.create!(title: "Mixed Case")
+
+      assert_equal record, topic.find_by(title: "mixed case")
+      assert_equal record, topic.find_by(title: "MIXED CASE")
+    end
+
+    def test_comparison_expression_preserves_serialized_values
+      type = MutableSerializedType.new
+      topic = topic_model_with_title_type(type)
+      value = { value: "original" }
+      relation = topic.where(title: value)
+      value[:value] = "changed"
+
+      assert_match(/= 'original'/, relation.to_sql)
+      assert_equal 1, type.serializations
+    end
+
+    def test_comparison_attribute_preserves_where_clause_introspection
+      topic = topic_model_with_title_type(UnaccentedString.new)
+      relation = topic.where(title: "CAFE")
+
+      assert_equal({ "title" => "CAFE" }, relation.where_values_hash)
+      assert_no_match(/WHERE/, relation.unscope(where: :title).to_sql)
+      assert_no_match(/WHERE/, relation.unscope(where: topic.arel_table[:title]).to_sql)
+    end
+
+    def test_comparison_attribute_preserves_where_clause_introspection_for_array_predicates
+      topic = topic_model_with_title_type(UnaccentedString.new)
+      relation = topic.where(title: ["CAFE", "BAR"])
+
+      assert_equal({ "title" => ["CAFE", "BAR"] }, relation.where_values_hash)
+      assert_no_match(/WHERE/, relation.unscope(where: :title).to_sql)
+      assert_no_match(/WHERE/, relation.unscope(where: topic.arel_table[:title]).to_sql)
+    end
+
+    def test_comparison_attribute_preserves_where_clause_merge
+      topic = topic_model_with_title_type(UnaccentedString.new)
+      relation = topic.where.not(title: "CAFE").merge(topic.where.not(title: "BAR"))
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "WHERE #{normalized_title} != #{normalized_value("BAR")}"
+
+      assert_equal expected_sql, relation.to_sql
+    end
+
+    def test_comparison_attribute_preserves_scope_for_create
+      topic = topic_model_with_title_type(LowerString.new)
+      record = topic.where(title: "Mixed Case").first_or_create!
+
+      assert_equal "Mixed Case", record.title
+      assert_equal record, topic.find_by(title: "MIXED CASE")
+    end
+
+    def test_query_predicates_compose_with_time_zone_conversion
+      topic = Class.new(ActiveRecord::Base) do
+        self.table_name = "topics"
+        self.time_zone_aware_attributes = true
+        attribute :written_on, TruncatedDateTime.new
+      end
+      type = topic.type_for_attribute("written_on")
+      sql = topic.where(written_on: Time.utc(2024, 1, 2, 3, 4, 5)).to_sql
+
+      assert ActiveRecord::Type::QueryPredicates.type?(type)
+      assert_match(/date\(.+written_on.+\) = date\(/, sql)
+    end
+
+    def test_query_predicates_compose_with_optimistic_locking
+      topic = Class.new(ActiveRecord::Base) do
+        self.table_name = "topics"
+        self.locking_column = :replies_count
+        attribute :replies_count, FlooredBoundedInteger.new
+      end
+      type = topic.type_for_attribute("replies_count")
+      sql = topic.where(replies_count: 1).to_sql
+
+      assert ActiveRecord::Type::QueryPredicates.type?(type)
+      assert_match(/floor\(.+replies_count.+\) = floor\(/, sql)
+    end
+
+    def test_query_predicates_compose_with_type_decorators
+      topic = Class.new(ActiveRecord::Base) do
+        self.table_name = "topics"
+        attribute :title, LowerString.new
+        normalizes :title, with: ->(title) { title.strip }
+      end
+      sql = topic.where(title: " PADDED ").to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "WHERE lower(#{quote_table_name("topics.title")}) = lower('PADDED')"
+
+      assert_equal expected_sql, sql
+    end
+
+    def test_query_predicates_compose_with_enum_types
+      topic = Class.new(ActiveRecord::Base) do
+        self.table_name = "topics"
+        attribute :title, LowerString.new
+        enum :title, { draft: "PUBLISHED" }
+      end
+      sql = topic.where(title: :draft).to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "WHERE lower(#{quote_table_name("topics.title")}) = lower('PUBLISHED')"
+
+      assert_equal expected_sql, sql
+    end
+
+    def test_query_predicates_compose_with_serialized_types
+      type = ActiveRecord::Type::Serialized.new(LowerString.new, PrefixCoder)
+      topic = topic_model_with_title_type(type)
+      sql = topic.where(title: "VALUE").to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "WHERE lower(#{quote_table_name("topics.title")}) = lower('coded:VALUE')"
+
+      assert_equal expected_sql, sql
+    end
+
+    def test_query_predicates_compose_with_serialized_types_in_arrays
+      type = ActiveRecord::Type::Serialized.new(LowerString.new, PrefixCoder)
+      topic = topic_model_with_title_type(type)
+      sql = topic.where(title: ["ONE", "TWO"]).to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "WHERE lower(#{quote_table_name("topics.title")}) IN (lower('coded:ONE'), lower('coded:TWO'))"
+
+      assert_equal expected_sql, sql
+    end
+
+    def test_relation_query_values_are_comparison_expressions
+      topic = topic_model_with_title_type(UnaccentedString.new)
+      query = topic.select(:title)
+      query_sql = query.to_sql
+      sql = topic.where(title: query).to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "WHERE #{normalized_title} IN (SELECT #{normalized_title} FROM #{quoted_topics})"
+
+      assert_equal expected_sql, sql
+      assert_equal query_sql, query.to_sql
+    end
+
+    def test_relation_query_values_preserve_projection_aliases
+      topic = topic_model_with_title_type(UnaccentedString.new)
+      sql = topic.where(title: topic.select(title: :candidate_title)).to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "WHERE #{normalized_title} IN (SELECT #{normalized_title} AS #{ActiveRecord::Base.lease_connection.quote_column_name("candidate_title")} FROM #{quoted_topics})"
+
+      assert_equal expected_sql, sql
+    end
+
+    def test_relation_query_values_transform_sql_literal_projections
+      topic = topic_model_with_title_type(UnaccentedString.new)
+      projection = quote_table_name("topics.title")
+      sql = topic.where(title: topic.select(projection)).to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "WHERE #{normalized_title} IN (SELECT #{normalized_title} FROM #{quoted_topics})"
+
+      assert_equal expected_sql, sql
+    end
+
+    def test_order_uses_query_predicate_expressions
+      topic = topic_model_with_title_type(UnaccentedString.new)
+      sql = topic.order(:title).to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "ORDER BY #{normalized_title} ASC"
+
+      assert_equal expected_sql, sql
+    end
+
+    def test_order_directions_use_query_predicate_expressions
+      topic = topic_model_with_title_type(UnaccentedString.new)
+      sql = topic.order(title: :desc).to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "ORDER BY #{normalized_title} DESC"
+
+      assert_equal expected_sql, sql
+      assert_equal expected_sql, topic.order(:title).reverse_order.to_sql
+    end
+
+    def test_order_with_explicit_sql_uses_stored_attributes
+      topic = topic_model_with_title_type(UnaccentedString.new)
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} ORDER BY title"
+
+      assert_equal expected_sql, topic.order("title").to_sql
+      assert_equal "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "ORDER BY #{quote_table_name("topics.title")}", topic.order(topic.arel_table[:title]).to_sql
+    end
+
+    def test_order_executes_query_predicate_expressions
+      topic = Class.new(ActiveRecord::Base) do
+        self.table_name = "topics"
+        attribute :replies_count, InvertedInteger.new
+      end
+      topic.create!(title: "Inverted Order", replies_count: 1)
+      topic.create!(title: "Inverted Order", replies_count: 2)
+
+      assert_equal [2, 1], topic.where(title: "Inverted Order").order(:replies_count).pluck(:replies_count)
+    end
+
+    def test_implicit_order_uses_query_predicate_expressions
+      topic = Class.new(ActiveRecord::Base) do
+        self.table_name = "topics"
+        attribute :id, InvertedInteger.new
+      end
+      lower_id = topic.create!(title: "Implicit Order")
+      higher_id = topic.create!(title: "Implicit Order")
+      scope = topic.where(title: "Implicit Order")
+
+      assert_equal [higher_id, lower_id], [scope.first, scope.last]
+    end
+
+    def test_batch_cursors_use_query_predicate_expressions
+      topic = Class.new(ActiveRecord::Base) do
+        self.table_name = "topics"
+        attribute :id, InvertedInteger.new
+      end
+      records = 3.times.map { topic.create!(title: "Batched Order") }
+      batched_ids = topic.where(title: "Batched Order").find_each(batch_size: 2).map(&:id)
+
+      assert_equal records.reverse.map(&:id), batched_ids
+    end
+
+    def test_in_order_of_uses_query_predicate_expressions
+      topic = topic_model_with_title_type(LowerString.new)
+      alpha = topic.create!(title: "Alpha")
+      beta = topic.create!(title: "Beta")
+
+      assert_equal [beta, alpha], topic.in_order_of(:title, ["BETA", "ALPHA"]).to_a
+    end
+
+    def test_bind_attribute_uses_query_predicate_expressions
+      topic = topic_model_with_title_type(UnaccentedString.new)
+      relation = topic.all
+      predicate = relation.bind_attribute(:title, "CAFE") { |attribute, bind| attribute.eq(bind) }
+      sql = relation.where(predicate).to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "WHERE #{normalized_title} = #{normalized_value("CAFE")}"
+
+      assert_equal expected_sql, sql
+    end
+
+    def test_uniqueness_validation_uses_query_predicate_expressions
+      topic = topic_model_with_unique_lower_title
+      topic.create!(title: "Mixed Case")
+      duplicate = topic.new(title: "MIXED CASE")
+
+      assert_not_predicate duplicate, :valid?
+      assert_predicate duplicate.errors[:title], :present?
+    end
+
+    def test_case_sensitive_uniqueness_validation_uses_query_predicate_expressions
+      topic = topic_model_with_unique_lower_title(case_sensitive: true)
+      topic.create!(title: "Case Sensitive Expression")
+
+      assert_not_predicate topic.new(title: "CASE SENSITIVE EXPRESSION"), :valid?
+    end
+
+    def test_case_insensitive_uniqueness_validation_uses_query_predicate_expressions
+      topic = topic_model_with_unique_lower_title(case_sensitive: false)
+      topic.create!(title: "Case Insensitive Expression")
+
+      assert_not_predicate topic.new(title: "CASE INSENSITIVE EXPRESSION"), :valid?
+    end
+
+    private
+      def quoted_topics
+        quote_table_name("topics")
+      end
+
+      def normalized_title
+        "lower(custom_immutable_unaccent(#{quote_table_name("topics.title")}))"
+      end
+
+      def normalized_value(value)
+        "lower(custom_immutable_unaccent(#{ActiveRecord::Base.lease_connection.quote(value)}))"
+      end
+
+      def topic_model_with_title_type(type)
+        Class.new(ActiveRecord::Base) do
+          self.table_name = "topics"
+          attribute :title, type
+        end
+      end
+
+      def topic_model_with_unique_lower_title(case_sensitive: nil)
+        Class.new(ActiveRecord::Base) do
+          self.table_name = "topics"
+          attribute :title, LowerString.new
+          validates :title, uniqueness: { case_sensitive: case_sensitive }.compact
+
+          define_singleton_method(:name) { "NormalizedTopic" }
+        end
+      end
   end
 end

--- a/activerecord/test/cases/relation/predicate_builder_test.rb
+++ b/activerecord/test/cases/relation/predicate_builder_test.rb
@@ -27,6 +27,14 @@ module ActiveRecord
       end
     end
 
+    class UpperString < ActiveRecord::Type::String
+      include ActiveRecord::Type::QueryPredicates
+
+      def comparison_expression(expression)
+        Arel::Nodes::NamedFunction.new("upper", [expression])
+      end
+    end
+
     class TypeCastingAttribute < Arel::Attributes::Attribute
       attr_reader :custom_type
 
@@ -142,6 +150,22 @@ module ActiveRecord
       def self.load(value)
         value&.delete_prefix("coded:")
       end
+    end
+
+    class UpperNamedAuthor < ActiveRecord::Base
+      self.table_name = "authors"
+
+      attribute :name, UpperString.new
+    end
+
+    class MatchableAuthor < ActiveRecord::Base
+      self.table_name = "authors"
+
+      attribute :name, LowerString.new
+
+      has_many :matching_authors, class_name: "MatchableAuthor", primary_key: :name, foreign_key: :name
+      has_many :upper_matching_authors, class_name: "UpperNamedAuthor", primary_key: :name, foreign_key: :name
+      has_many :matches_of_matches, through: :matching_authors, source: :matching_authors
     end
 
     class RegexpPredicateBuilder < PredicateBuilder
@@ -547,6 +571,53 @@ module ActiveRecord
         "WHERE #{normalized_title} IN (SELECT #{normalized_title} FROM #{quoted_topics})"
 
       assert_equal expected_sql, sql
+    end
+
+    def test_association_join_constraints_use_query_predicate_expressions
+      sql = MatchableAuthor.joins(:matching_authors).to_sql
+      join_name = Regexp.escape(quote_table_name("matching_authors_authors.name"))
+      owner_name = Regexp.escape(quote_table_name("authors.name"))
+
+      assert_match %r{ON lower\(#{join_name}\) = lower\(#{owner_name}\)}, sql
+    end
+
+    def test_association_join_constraints_apply_each_columns_own_type
+      sql = MatchableAuthor.joins(:upper_matching_authors).to_sql
+      join_name = Regexp.escape(quote_table_name("upper_matching_authors_authors.name"))
+      owner_name = Regexp.escape(quote_table_name("authors.name"))
+
+      assert_match %r{ON upper\(#{join_name}\) = lower\(#{owner_name}\)}, sql
+    end
+
+    def test_association_join_constraints_execute_query_predicate_expressions
+      MatchableAuthor.create!(name: "CAFE")
+      MatchableAuthor.create!(name: "cafe")
+
+      assert_equal 4, MatchableAuthor.where(name: "cafe").joins(:matching_authors).count
+    end
+
+    def test_through_association_scopes_use_query_predicate_expressions
+      author = MatchableAuthor.create!(name: "Through Case")
+      sql = author.matches_of_matches.to_sql
+      middle_name = Regexp.escape(quote_table_name("matching_authors_matches_of_matches.name"))
+      owner_name = Regexp.escape(quote_table_name("authors.name"))
+
+      assert_match %r{ON lower\(#{owner_name}\) = lower\(#{middle_name}\)}, sql
+      assert_match %r{WHERE lower\(#{middle_name}\) = lower\('Through Case'\)}, sql
+    end
+
+    def test_through_association_scopes_execute_query_predicate_expressions
+      author = MatchableAuthor.create!(name: "Through Case")
+      MatchableAuthor.create!(name: "THROUGH CASE")
+
+      assert_equal 4, author.matches_of_matches.count
+    end
+
+    def test_through_association_scopes_preserve_aliased_table_references
+      author = MatchableAuthor.create!(name: "Through Case")
+      relation = author.matches_of_matches
+
+      assert_equal [Arel.sql("matching_authors_matches_of_matches", retryable: true)], relation.references_values
     end
 
     def test_order_uses_query_predicate_expressions


### PR DESCRIPTION
Replaces #58135 

This gives the same capability to (via a type) define an Arel expression to be used for comparisons, etc.

Notable differences:
* avoids adding AR / Arel specifics to Active Model
* applies transformations in more contexts (ordering, associations, for example)
* avoids defining e.g. specific Range handling in the base PredicateBuilder
* addresses #58407
* narrowly/correctly addresses #58410
