### PR TITLE
Run test:prepare in a subprocess when running bin/rails test

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Run the `test:prepare` task in a subprocess when `bin/rails test` is given no
+    path argument.
+
+    Prepare tasks that depend on `:environment`, such as the asset builds gems
+    like `tailwindcss-rails` enhance it with, booted the application inside the
+    test process before any test file was loaded. Coverage tools started from
+    `test_helper.rb` cannot see code loaded before they start, so `bin/rails test`
+    and `bin/rails test test/` reported different coverage for the same suite.
+
+    Fixes #58477.
+
+    *Lazizbek Ergashev*
+
 *   Show a Rails-flavored startup banner (a small logo, Rails/Ruby
     version, a rotating tip about console helpers like `app`/`reload!`, and
     `Rails.root`) when starting `bin/rails console`.

--- a/railties/lib/rails/commands/rake/rake_command.rb
+++ b/railties/lib/rails/commands/rake/rake_command.rb
@@ -16,6 +16,10 @@ module Rails
           end
         end
 
+        def task_defined?(task)
+          with_rake { |rake| !!rake.lookup(task) }
+        end
+
         def perform(task, args, config)
           with_rake(task, *args) do |rake|
             if unrecognized_task = (rake.top_level_tasks - ["default"]).find { |task| !rake.lookup(task[/[^\[]+/]) }

--- a/railties/lib/rails/commands/test/test_command.rb
+++ b/railties/lib/rails/commands/test/test_command.rb
@@ -70,9 +70,10 @@ module Rails
         EXACT_TEST_ARGUMENT_PATTERN = %r{^-n|^--name\b|^(?!/.+/$)[.\w]*[/\\]}
 
         def run_prepare_task
-          Rails::Command::RakeCommand.perform("test:prepare", [], {})
-        rescue UnrecognizedCommandError => error
-          raise unless error.name == "test:prepare"
+          return unless Rails::Command::RakeCommand.task_defined?("test:prepare")
+
+          # Run in a subprocess so tasks depending on :environment don't boot the app in the test process.
+          Kernel.system("rake", "test:prepare") || exit(false)
         end
     end
   end

--- a/railties/test/commands/test_test.rb
+++ b/railties/test/commands/test_test.rb
@@ -61,6 +61,21 @@ class Rails::Command::TestTest < ActiveSupport::TestCase
     end
   end
 
+  test "test command does not boot the app when running test:prepare task" do
+    app_file "Rakefile", <<~RUBY, "a"
+      Rake::Task["test:prepare"].enhance(["environment"])
+    RUBY
+
+    app_file "test/booted_test.rb", <<~'RUBY'
+      puts "Booted: #{!!Rails.application&.initialized?}"
+      require "test_helper"
+    RUBY
+
+    output = run_test_command("test")
+    assert_successful_run output
+    assert_match "Booted: false", output
+  end
+
   test "test command runs successfully when no tasks defined" do
     app_file "Rakefile", ""
     assert_successful_run run_test_command("test")


### PR DESCRIPTION
### Motivation / Background

Fixes #58477.

Without a path argument, `bin/rails test` invokes `test:prepare` in process before minitest loads the test files. Gems enhance that task with asset builds that depend on `:environment`, so the application boots inside the test process, ahead of anything `test_helper.rb` does.

Coverage tools cannot see code that was loaded before they start. SimpleCov is started at the top of `test_helper.rb`, as its README says to, and everything the boot already touched is then reported as uncovered. An initializer using `to_prepare` to reference an application constant, the pattern the autoloading guide prescribes, is enough to pull in `ApplicationController` and every file in `app/helpers`. So `bin/rails test` and `bin/rails test test/` disagree about the same suite, with no warning, because the path form matches `EXACT_TEST_ARGUMENT_PATTERN` and skips prepare altogether.

### Detail

`run_prepare_task` now runs the task in a subprocess, the way `maintain_test_schema!` already runs `db:test:prepare` in this same flow. The extra boot lands only on the invocation that has no path argument.

Whether the task exists is still decided in process, through the Rakefile that `RakeCommand` already loads, so an application with no `test:prepare` task keeps running its tests as before rather than failing on rake's unknown-task error. Loading the Rakefile does not initialize the application; only running `:environment` does.

### Additional information

simplecov-ruby/simplecov#1082 reports the same problem from the other side. It closed with a workaround, starting coverage in `bin/rails`, which conflicts with Bootsnap's compile cache.

Deferring the invoke until after the test files load, before `rails/test_help` synchronizes the schema, also fixes the coverage numbers and avoids the extra boot. It changes ordering for applications whose prepare tasks generate code needed at test load time, so the subprocess seemed safer.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.