### PR TITLE
Restore `unshareable_proc_action` with `ensure` in default scoping test

### DIFF
--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -736,21 +736,18 @@ class DefaultScopingTest < ActiveRecord::TestCase
   end
 
   def test_default_scopes_are_ractor_shareable
-    old = ActiveSupport::Ractors.unshareable_proc_action
-    ActiveSupport::Ractors.unshareable_proc_action = :raise
+    model = ActiveSupport::Ractors.with(unshareable_proc_action: :raise) do
+      Class.new(ActiveRecord::Base) do
+        def self.name = "ractor_safe_posts"
+        self.table_name = "posts"
 
-    model = Class.new(ActiveRecord::Base) do
-      def self.name = "ractor_safe_posts"
-      self.table_name = "posts"
+        default_scope -> { ractor_safe }
 
-      default_scope -> { ractor_safe }
-
-      def self.ractor_safe
-        where(type: "ractor_safe")
+        def self.ractor_safe
+          where(type: "ractor_safe")
+        end
       end
     end
-
-    ActiveSupport::Ractors.unshareable_proc_action = old
 
     select_sql = capture_sql { model.all.to_a }.first
 


### PR DESCRIPTION
### Motivation / Background

`DefaultScopingTest#test_default_scopes_are_ractor_shareable` mutates a global and restores it with a plain assignment:

```ruby
old = ActiveSupport::Ractors.unshareable_proc_action
ActiveSupport::Ractors.unshareable_proc_action = :raise

model = Class.new(ActiveRecord::Base) do
  # ...
  default_scope -> { ractor_safe }
  # ...
end

ActiveSupport::Ractors.unshareable_proc_action = old
```

Nothing guarantees that last line runs. The work in between is a `Class.new` block calling `default_scope`, which is precisely the code path `:raise` exists to exercise — so it is a plausible place to raise. When it does, `:raise` leaks into every subsequent test in the process, turning one failure into unrelated failures elsewhere and making the real cause hard to find.

Easy to show in isolation:

```
old pattern, after a raise: :raise  (leaked)
with(...),  after a raise: nil  (restored)
```

### Detail

Use `ActiveSupport::Ractors.with`, which restores in an `ensure`. That is already the idiom in `actionpack/test/dispatch/routing/route_set_test.rb`, `actionpack/test/controller/caching_test.rb` and `activesupport/test/callbacks_test.rb`, and the sibling tests in `activesupport/test/ractors_test.rb` and `actionpack/test/controller/new_base/middleware_test.rb` already use `ensure` — this test was the odd one out.

Wrapping only the model definition keeps the original scoping intact: `capture_sql` and both assertions still run with the setting the suite came in with, not with `:raise`.

Test-only change; no CHANGELOG entry.

### Checklist

- [x] `bundle exec ruby -Itest test/cases/scoping/default_scoping_test.rb` — 99 runs, 0 failures, 0 errors
- [x] `bundle exec rubocop` on the changed file — no offenses