### PR TITLE
Fix clearing PK-overlapping association keys when assigning nil

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,8 +1,10 @@
-*   Fix clearing a `belongs_to` association whose composite foreign key is a
-    subset of the referencing record's primary key.
+*   Fix clearing an association whose foreign key is a subset of the
+    referencing record's primary key. This affected `belongs_to` associations
+    with composite foreign keys, and `has_one` associations with either scalar
+    or composite foreign keys.
 
-    Previously, assigning `nil` preserved every foreign key column in this
-    case. Shared columns are now preserved only when the foreign key has
+    Previously, assigning `nil` preserved every foreign key column in these
+    cases. Shared columns are now preserved only when the foreign key has
     another column that can be nulled instead.
 
     *Matthew Draper*

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix clearing a `belongs_to` association whose composite foreign key is a
+    subset of the referencing record's primary key.
+
+    Previously, assigning `nil` preserved every foreign key column in this
+    case. Shared columns are now preserved only when the foreign key has
+    another column that can be nulled instead.
+
+    *Matthew Draper*
+
 *   `ActiveRecord::Relation#update` and `#update!` no longer escape the relation
     when given ids.
 

--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -147,8 +147,13 @@ module ActiveRecord
           return if !force && owner_key_values == target_key_values
 
           owner_pk = ActiveRecord::Key.for(owner.class.primary_key)
+
+          # Preserve shared primary key columns only if another foreign key
+          # column can be cleared to disassociate the record.
+          preserve_owner_pk = record.nil? && foreign_key.any? { |key| !owner_pk.include?(key) }
+
           foreign_key.each_with_index do |key, index|
-            next if record.nil? && owner_pk.include?(key)
+            next if preserve_owner_pk && owner_pk.include?(key)
             owner.write_attribute(key, target_key_values[index])
           end
         end

--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -118,8 +118,15 @@ module ActiveRecord
 
         def nullify_owner_attributes(record)
           primary_key = ActiveRecord::Key.for(record.class.primary_key)
-          ActiveRecord::Key.for(reflection.foreign_key).each do |foreign_key_column|
-            record.write_attribute(foreign_key_column, nil) unless primary_key.include?(foreign_key_column)
+          foreign_key = ActiveRecord::Key.for(reflection.foreign_key)
+
+          # Preserve shared primary key columns only if another foreign key
+          # column can be cleared to disassociate the record.
+          preserve_primary_key = foreign_key.any? { |key| !primary_key.include?(key) }
+
+          foreign_key.each do |foreign_key_column|
+            next if preserve_primary_key && primary_key.include?(foreign_key_column)
+            record.write_attribute(foreign_key_column, nil)
           end
           record.write_attribute(reflection.type, nil) if reflection.type.present?
         end

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -42,6 +42,18 @@ require "models/image"
 require "models/shipment"
 require "models/adjustment"
 require "models/dats"
+require "models/human"
+
+class BelongsToContainedKeyChapter < Cpk::Chapter
+  self.primary_key = [:author_id, :book_id, :id]
+
+  belongs_to :contained_book,
+    class_name: "Cpk::Book",
+    foreign_key: [:author_id, :book_id],
+    primary_key: [:author_id, :id],
+    optional: true,
+    inverse_of: false
+end
 
 class BelongsToAssociationsTest < ActiveRecord::TestCase
   fixtures :accounts, :companies, :developers, :projects, :topics,
@@ -505,6 +517,67 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal [1, 2], chapter.id
     assert_nil chapter.book_id
     assert_equal chapter.author_id, book.author_id
+  end
+
+  def test_clearing_belongs_to_nullifies_composite_foreign_key_that_is_a_subset_of_primary_key
+    chapter = BelongsToContainedKeyChapter.new(author_id: 1, book_id: 2)
+    chapter.write_attribute(:id, 3)
+
+    chapter.contained_book = nil
+
+    assert_nil chapter.author_id
+    assert_nil chapter.book_id
+    assert_equal 3, chapter.read_attribute(:id)
+  end
+
+  def test_clearing_belongs_to_nullifies_foreign_key_contained_in_composite_pk
+    order_tag = Cpk::OrderTag.new(order_id: 1, tag_id: 2)
+
+    assert_equal 2, order_tag.tag_id
+
+    order_tag.tag = nil
+
+    assert_nil order_tag.tag_id
+  end
+
+  def test_clearing_polymorphic_belongs_to_nullifies_both_columns_contained_in_composite_pk
+    face_class = Class.new(ActiveRecord::Base) do
+      self.table_name = "faces"
+      self.primary_key = [:polymorphic_human_type, :polymorphic_human_id, :id]
+
+      belongs_to :polymorphic_human, polymorphic: true, optional: true
+    end
+
+    human = Human.new(id: 1, name: "Sonny")
+    face = face_class.new(polymorphic_human: human)
+
+    assert_equal "Human", face.polymorphic_human_type
+    assert_equal 1, face.polymorphic_human_id
+
+    face.polymorphic_human = nil
+
+    assert_nil face.polymorphic_human_type
+    assert_nil face.polymorphic_human_id
+  end
+
+  def test_clearing_polymorphic_belongs_to_nullifies_id_when_only_id_is_in_composite_pk
+    face_class = Class.new(ActiveRecord::Base) do
+      self.table_name = "faces"
+      self.primary_key = [:polymorphic_human_id, :id]
+
+      belongs_to :polymorphic_human, polymorphic: true, optional: true
+    end
+
+    human = Human.new(id: 1, name: "Sonny")
+    face = face_class.new(polymorphic_human: human)
+
+    assert_equal "Human", face.polymorphic_human_type
+    assert_equal 1, face.polymorphic_human_id
+
+    face.polymorphic_human = nil
+
+    assert_nil face.polymorphic_human_type
+    assert_nil face.polymorphic_human_id
   end
 
   def test_should_reload_association_on_model_with_query_constraints_when_foreign_key_changes

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -34,6 +34,16 @@ class HasOneStaleTypeOwner < ActiveRecord::Base
   has_one :stale_type_child, class_name: "HasOneStaleTypeChild", as: :poly_human_without_inverse
 end
 
+class HasOneContainedKeyChild < ActiveRecord::Base
+  self.table_name = "faces"
+  self.primary_key = [:poly_human_without_inverse_id, :human_id]
+end
+
+class HasOneContainedKeyOwner < ActiveRecord::Base
+  self.table_name = "humans"
+  has_one :contained_key_child, class_name: "HasOneContainedKeyChild", as: :poly_human_without_inverse
+end
+
 class HasOneAssociationsTest < ActiveRecord::TestCase
   self.use_transactional_tests = false unless supports_savepoints?
   fixtures :accounts, :companies, :developers, :projects, :developers_projects,
@@ -164,6 +174,23 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     assert_nil child.poly_human_without_inverse_type
   end
 
+  def test_clearing_polymorphic_has_one_nullifies_id_contained_in_composite_pk
+    owner = HasOneContainedKeyOwner.create!
+    child = HasOneContainedKeyChild.create!(
+      human_id: 1,
+      poly_human_without_inverse_id: owner.id,
+      poly_human_without_inverse_type: "HasOneContainedKeyOwner"
+    )
+
+    assert_equal child, owner.contained_key_child
+
+    owner.contained_key_child = nil
+
+    child = HasOneContainedKeyChild.find_by!(id: child.read_attribute(:id))
+    assert_nil child.poly_human_without_inverse_id
+    assert_nil child.poly_human_without_inverse_type
+  end
+
   def test_nullification_on_destroyed_association
     developer = Developer.create!(name: "Someone")
     ship = Ship.create!(name: "Planet Caravan", developer: developer)
@@ -181,6 +208,17 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
 
     assert_nil book.order_id
     assert_nil book.shop_id
+  end
+
+  def test_nullification_on_cpk_association_with_pk_column
+    chapter = Cpk::Chapter.create!(id: [1, 2])
+    other_chapter = Cpk::Chapter.create!(id: [1, 4])
+    book = Cpk::NullifiedBook.create!(id: [1, 3], chapter: chapter)
+
+    book.chapter = other_chapter
+
+    assert_nil chapter.book_id
+    assert_equal 1, chapter.author_id
   end
 
   def test_has_one_for_new_record_owner_with_composite_primary_key_present


### PR DESCRIPTION
Follow-up to #58368 

When `nil` is assigned to a singular association, we intentionally avoid clearing foreign key columns that are also part of the referencing model's primary key, assuming they're part of a common shard key or similar. (#55332)

However, that's only a reasonable assumption/behaviour if there's also another FK component that that rule still allows us to clear: keeping _all_ parts of the FK would mean we lose the set-to-nil operation entirely.

This PR implements that latter distinction.

This has been a broken edge case for fully-PK-overlapping FKs for a while, but the unification in #58368 made it also apply to the potentially-less-rare case where a single-column FK is part/all of the referencing record's PK.

(It also revealed a specific misbehaviour for polymorphic `belongs_to`, where `…_type` would be cleared while its corresponding `…_id` was retained. We now do a better job of keeping things together; I've added specific tests to demonstrate that.)