### PR TITLE
Honour `all_queries` default scopes in internal queries

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Apply `all_queries: true` default scopes consistently across counter caches,
+    uniqueness validations, fixture lookups, and record reloads, while those
+    operations continue to bypass ordinary default scopes.
+
+    *Andrew Novoselac* and *Matthew Draper*
+
 *   Fix clearing an association whose foreign key is a subset of the
     referencing record's primary key. This affected `belongs_to` associations
     with composite foreign keys, and `has_one` associations with either scalar

--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -128,7 +128,7 @@ module ActiveRecord
 
         def update_counters_via_scope(klass, values, by)
           primary_key = ActiveRecord::Key.for(primary_key(klass))
-          scope = klass.unscoped.where!(primary_key.where_hash(values))
+          scope = klass.all_queries_scope.where!(primary_key.where_hash(values))
           scope.update_counters(reflection.counter_cache_column => by, touch: reflection.options[:touch])
         end
 

--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -61,7 +61,7 @@ module ActiveRecord
           counter_name = reflection.counter_cache_column
 
           counts =
-            unscoped
+            all_queries_scope
               .joins(counter_association)
               .where(primary_key => ids)
               .group(primary_key)
@@ -84,7 +84,7 @@ module ActiveRecord
         end
 
         updates.each do |id, record_updates|
-          unscoped.where(primary_key => [id]).update_all(record_updates)
+          all_queries_scope.where(primary_key => [id]).update_all(record_updates)
         end
 
         true
@@ -134,7 +134,7 @@ module ActiveRecord
       def update_counters(id, counters)
         pk = primary_key_definition
         id = [id] if pk.composite? && id.is_a?(Array) && !pk.expects_multiple_ids?(id)
-        unscoped.where!(primary_key => id).update_counters(counters)
+        all_queries_scope.where!(primary_key => id).update_counters(counters)
       end
 
       # Increment a numeric field by one, via a direct SQL update.

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -845,7 +845,7 @@ module ActiveRecord
 
     def find
       raise FixtureClassNotFound, "No class attached to find." unless model_class
-      object = model_class.unscoped do
+      object = model_class.all_queries_scope.scoping do
         pk_clauses = fixture.slice(*Array(model_class.primary_key))
         model_class.find_by!(pk_clauses)
       end

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -650,7 +650,7 @@ module ActiveRecord
       change = public_send(attribute) - (public_send(:"#{attribute}_in_database") || 0)
       counters = { attribute => change, touch: touch }
 
-      self.class.unscoped.where!(_query_constraints_hash).update_counters(counters)
+      self.class.all_queries_scope.where!(_query_constraints_hash).update_counters(counters)
       public_send(:"clear_#{attribute}_change")
       self
     end
@@ -832,15 +832,10 @@ module ActiveRecord
       def _find_record(options)
         all_queries = options ? options[:all_queries] : nil
         base = if all_queries
-          self.class.default_scoped(all_queries: true)
+          self.class.all_queries_scope
         else
           self.class.all
         end
-
-        if all_queries && (current_scope = self.class.global_current_scope)
-          base = base.merge!(current_scope)
-        end
-
         base = base.preload(strict_loaded_associations)
 
         if options && options[:lock]

--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -19,7 +19,17 @@ module ActiveRecord
         #
         # You can define a scope that applies to all finders using
         # {default_scope}[rdoc-ref:Scoping::Default::ClassMethods#default_scope].
-        def all(all_queries: nil)
+        def all(all_queries: (all_queries_not_set = true))
+          if all_queries_not_set
+            all_queries = nil
+          else
+            ActiveRecord.deprecator.warn(
+              "The `all_queries` keyword argument to `ActiveRecord::Base.all` is deprecated and will be removed in Rails 9.0."
+            )
+          end
+
+          return all_queries_scope if all_queries
+
           scope = current_scope
 
           if scope
@@ -44,6 +54,20 @@ module ActiveRecord
         # Returns a scope for the model with default scopes.
         def default_scoped(scope = relation, all_queries: nil)
           build_default_scope(scope, all_queries: all_queries) || scope
+        end
+
+        def all_queries_scope # :nodoc:
+          scope = if default_scopes?(all_queries: true)
+            default_scoped(all_queries: true)
+          else
+            relation
+          end
+
+          if current_scope = global_current_scope
+            scope = scope.merge!(current_scope)
+          end
+
+          scope
         end
 
         def default_extensions # :nodoc:

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -114,7 +114,7 @@ module ActiveRecord
       end
 
       def build_relation(klass, attribute, value)
-        relation = klass.unscoped
+        relation = klass.all_queries_scope
         comparison = relation.bind_attribute(attribute, value) do |attr, bind|
           return relation.none! if bind.unboundable?
 

--- a/activerecord/test/cases/counter_cache_test.rb
+++ b/activerecord/test/cases/counter_cache_test.rb
@@ -18,6 +18,8 @@ require "models/friendship"
 require "models/subscriber"
 require "models/subscription"
 require "models/book"
+require "models/scoped_counter_cache_topic"
+require "models/scoped_counter_cache_child"
 require "models/cpk"
 require "active_support/core_ext/enumerable"
 require "active_support/testing/ractors_assertions"
@@ -39,6 +41,25 @@ class CounterCacheTest < ActiveRecord::TestCase
 
   setup do
     @topic = Topic.find(1)
+  end
+
+  test "update counters uses only all-query default scopes" do
+    assert_difference -> { @topic.reload.replies_count } do
+      ScopedCounterCacheTopic.update_counters(@topic.id, replies_count: 1)
+    end
+  end
+
+  test "reset counters uses only all-query default scopes" do
+    @topic.update_columns(replies_count: 0)
+    ScopedCounterCacheTopic.reset_counters(@topic.id, :replies)
+
+    assert_equal 1, @topic.reload.replies_count
+  end
+
+  test "belongs_to counter cache uses only all-query default scopes" do
+    assert_difference -> { @topic.reload.replies_count } do
+      ScopedCounterCacheChild.create!(title: "Counter cache child", parent_id: @topic.id, approved: true)
+    end
   end
 
   test "increment counter" do

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -507,6 +507,23 @@ class FixturesTest < ActiveRecord::TestCase
     assert_kind_of Topic, topics["first"].find
   end
 
+  def test_fixture_find_uses_only_all_query_default_scopes
+    topic_class = Class.new(ActiveRecord::Base) do
+      self.table_name = "topics"
+      self.inheritance_column = :_type_disabled
+
+      default_scope -> { where(approved: true) }
+      default_scope -> { where(id: 1) }, all_queries: true
+    end
+
+    ActiveRecord::FixtureSet.reset_cache
+    topics = ActiveRecord::FixtureSet.create_fixtures(fixture_paths, "topics", "topics" => topic_class).first
+
+    assert_kind_of topic_class, topics["first"].find
+  ensure
+    ActiveRecord::FixtureSet.reset_cache
+  end
+
   def test_complete_instantiation
     assert_equal "The First Topic", @first.title
   end

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -116,6 +116,62 @@ class DefaultScopingTest < ActiveRecord::TestCase
     assert_match(/firm_id/, update_sql)
   end
 
+  def test_all_without_all_queries_is_not_deprecated
+    assert_not_deprecated(ActiveRecord.deprecator) do
+      DeveloperWithDefaultMentorScopeAllQueries.all
+    end
+  end
+
+  def test_all_with_explicit_nil_all_queries_is_deprecated
+    klass = DeveloperWithIncludedMentorDefaultScopeNotAllQueriesAndDefaultScopeFirmWithAllQueries
+
+    wheres = assert_deprecated(/The `all_queries` keyword argument to `ActiveRecord::Base\.all` is deprecated/, ActiveRecord.deprecator) do
+      klass.all(all_queries: nil).where_values_hash
+    end
+
+    assert_includes wheres, "mentor_id"
+    assert_includes wheres, "firm_id"
+  end
+
+  def test_all_with_false_all_queries_is_deprecated
+    klass = DeveloperWithIncludedMentorDefaultScopeNotAllQueriesAndDefaultScopeFirmWithAllQueries
+
+    wheres = assert_deprecated(/The `all_queries` keyword argument to `ActiveRecord::Base\.all` is deprecated/, ActiveRecord.deprecator) do
+      klass.all(all_queries: false).where_values_hash
+    end
+
+    assert_not_includes wheres, "mentor_id"
+    assert_not_includes wheres, "firm_id"
+  end
+
+  def test_all_with_all_queries_ignores_non_global_current_scope
+    klass = DeveloperWithIncludedMentorDefaultScopeNotAllQueriesAndDefaultScopeFirmWithAllQueries
+
+    wheres = assert_deprecated(/The `all_queries` keyword argument to `ActiveRecord::Base\.all` is deprecated/, ActiveRecord.deprecator) do
+      klass.where(salary: 80_000).scoping do
+        klass.all(all_queries: true).where_values_hash
+      end
+    end
+
+    assert_not_includes wheres, "mentor_id"
+    assert_includes wheres, "firm_id"
+    assert_not_includes wheres, "salary"
+  end
+
+  def test_all_with_all_queries_includes_global_current_scope
+    klass = DeveloperWithIncludedMentorDefaultScopeNotAllQueriesAndDefaultScopeFirmWithAllQueries
+
+    wheres = assert_deprecated(/The `all_queries` keyword argument to `ActiveRecord::Base\.all` is deprecated/, ActiveRecord.deprecator) do
+      klass.unscoped.where(salary: 80_000).scoping(all_queries: true) do
+        klass.all(all_queries: true).where_values_hash
+      end
+    end
+
+    assert_not_includes wheres, "mentor_id"
+    assert_includes wheres, "firm_id"
+    assert_includes wheres, "salary"
+  end
+
   def test_default_scope_runs_on_create
     Mentor.create!
     create_sql = capture_sql { DeveloperwithDefaultMentorScopeNot.create!(name: "Eileen") }.second
@@ -203,6 +259,20 @@ class DefaultScopingTest < ActiveRecord::TestCase
     update_sql = capture_sql { dev.update_columns(name: "Not Nikita") }.first
 
     assert_no_match(/AND$/, update_sql)
+  end
+
+  def test_default_scope_doesnt_run_on_increment
+    dev = DeveloperwithDefaultMentorScopeNot.create!(name: "Eileen")
+    update_sql = capture_sql { dev.increment!(:salary) }.first
+
+    assert_no_match(/mentor_id/, update_sql)
+  end
+
+  def test_default_scope_with_all_queries_runs_on_increment
+    dev = DeveloperWithDefaultMentorScopeAllQueries.create!(name: "Eileen")
+    update_sql = capture_sql { dev.increment!(:salary) }.first
+
+    assert_match(/mentor_id/, update_sql)
   end
 
   def test_default_scope_doesnt_run_on_destroy

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -117,6 +117,23 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     assert_predicate t3, :valid?
   end
 
+  def test_validate_uniqueness_uses_only_all_query_default_scopes
+    topic_class = Class.new(ActiveRecord::Base) do
+      self.table_name = "topics"
+      self.inheritance_column = :_type_disabled
+
+      default_scope -> { where(approved: true) }
+      default_scope -> { where(parent_id: 1) }, all_queries: true
+
+      validates_uniqueness_of :title
+    end
+
+    Topic.create!(title: "Scoped uniqueness", parent_id: 1, approved: false)
+    topic = topic_class.new(title: "Scoped uniqueness", parent_id: 1, approved: false)
+
+    assert_not_predicate topic, :valid?
+  end
+
   def test_validate_uniqueness_with_alias_attribute
     Topic.alias_attribute :new_title, :title
     Topic.validates_uniqueness_of(:new_title)

--- a/activerecord/test/models/scoped_counter_cache_child.rb
+++ b/activerecord/test/models/scoped_counter_cache_child.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ScopedCounterCacheChild < ActiveRecord::Base
+  self.table_name = "topics"
+  self.inheritance_column = :_type_disabled
+
+  belongs_to :parent, class_name: "ScopedCounterCacheTopic", foreign_key: "parent_id", counter_cache: "replies_count"
+end

--- a/activerecord/test/models/scoped_counter_cache_topic.rb
+++ b/activerecord/test/models/scoped_counter_cache_topic.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ScopedCounterCacheTopic < ActiveRecord::Base
+  self.table_name = "topics"
+  self.inheritance_column = :_type_disabled
+
+  has_many :replies, foreign_key: "parent_id", class_name: "Reply"
+
+  default_scope -> { where(approved: true) }
+  default_scope -> { where(id: 1) }, all_queries: true
+end


### PR DESCRIPTION
### Motivation / Background

Apply `all_queries` default scopes to internal queries, like uniqueness validations, fixture loading, and counter caches.

Extracted from: https://github.com/rails/rails/pull/57123

> We also audited places that call unscope but should be respecting all-queries scopes. We added the all_queries_scopes method to uniqueness validations, fixture loading and updating/reseting counter caches.

### Detail

Introduces an `all_queries_scope` method to build an internal query scope. It applies:
  - Default scopes with all_queries: true.
  - The current scope from scoping(all_queries: true).

It excludes ordinary default scopes.

### Additional information

There are ongoing discussions on whether the durable scopes change will be landed, so these changes should be shipped separately.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
