### PR TITLE
Fix the `CollectionProxy#delete_all` documentation return value

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -394,7 +394,8 @@ module ActiveRecord
 
       # Deletes all the records from the collection according to the strategy
       # specified by the +:dependent+ option. If no +:dependent+ option is given,
-      # then it will follow the default strategy.
+      # then it will follow the default strategy. Returns the number of deleted
+      # records.
       #
       # For <tt>has_many :through</tt> associations, the default deletion strategy is
       # +:delete_all+.
@@ -415,11 +416,6 @@ module ActiveRecord
       #   #    ]
       #
       #   person.pets.delete_all
-      #   # => [
-      #   #       #<Pet id: 1, name: "Fancy-Fancy", person_id: 1>,
-      #   #       #<Pet id: 2, name: "Spook", person_id: 1>,
-      #   #       #<Pet id: 3, name: "Choo-Choo", person_id: 1>
-      #   #    ]
       #
       #   person.pets.size # => 0
       #   person.pets      # => []


### PR DESCRIPTION
`CollectionProxy#delete_all` returns the number of deleted records, but the example for the default `:nullify` strategy shows it returning an array of the records themselves:

```ruby
person.pets.delete_all
# => [
#       #<Pet id: 1, name: "Fancy-Fancy", person_id: 1>,
#       #<Pet id: 2, name: "Spook", person_id: 1>,
#       #<Pet id: 3, name: "Choo-Choo", person_id: 1>
#    ]
```

The test suite asserts the count for this exact strategy:

```ruby
# activerecord/test/cases/associations/has_many_associations_test.rb
assert_equal count, firm.dependent_clients_of_firm.delete_all(:nullify)
```

Three deletion strategies are documented on this method, and `:nullify` is the only one that still shows an array. The equivalent lines were removed from the `:destroy` and `:delete_all` examples in 9534006c47 and 02d3a25361.

9534006c47 also dropped the "Returns an array with the deleted records." sentence from the prose, but the correct return value was not added back. This restores it so the summary now reads the same way as the neighbouring `#delete` and `#destroy`, which both document theirs:

```ruby
# #delete
# ... then it will follow the default strategy. Returns an array with the
# deleted records.

# #delete_all (this change)
# ... then it will follow the default strategy. Returns the number of deleted
# records.
```

`delete_all` is the only one of the four deletion methods on `CollectionProxy` that does not return records, which is what made the stale example misleading in the first place (see #14546).