### PR TITLE
Read the schema cache's primary keys and indexes for many tables at once

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -390,8 +390,19 @@ module ActiveRecord
       end
 
       def add_all(pool) # :nodoc:
-        pool.with_connection do
-          tables_to_cache(pool).each do |table|
+        pool.with_connection do |connection|
+          tables = tables_to_cache(pool)
+
+          connection.primary_keys(tables).each do |table, primary_keys|
+            primary_key = primary_keys.size > 1 ? primary_keys : primary_keys.first
+            @primary_keys[deep_deduplicate(table)] = deep_deduplicate(primary_key)
+          end
+
+          connection.indexes(tables).each do |table, indexes|
+            @indexes[deep_deduplicate(table)] = deep_deduplicate(indexes)
+          end
+
+          tables.each do |table|
             add(pool, table)
           end
 

--- a/activerecord/test/cases/connection_adapters/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
@@ -35,6 +35,10 @@ module ActiveRecord
         end
       end
 
+      def add_all_to_new_cache
+        SchemaCache.new.tap { |cache| cache.add_all(@pool) }
+      end
+
       def deduplicable_classes
         klasses = [
           ActiveRecord::ConnectionAdapters::SqlTypeMetadata,
@@ -152,6 +156,21 @@ module ActiveRecord
 
       def test_indexes_for_non_existent_table
         assert_equal [], @cache.indexes("omgponies")
+      end
+
+      def test_add_all_caches_a_table_without_a_primary_key
+        assert_nil add_all_to_new_cache.primary_keys(@pool, "courses_professors")
+      end
+
+      def test_add_all_caches_a_composite_primary_key
+        @connection.create_table(:schema_cache_composite_pks, primary_key: [:one, :two], force: true) do |t|
+          t.integer :one
+          t.integer :two
+        end
+
+        assert_equal ["one", "two"], add_all_to_new_cache.primary_keys(@pool, "schema_cache_composite_pks")
+      ensure
+        @connection.drop_table(:schema_cache_composite_pks, if_exists: true)
       end
 
       def test_clearing


### PR DESCRIPTION
Follow-up to #58421, which taught the schema readers to answer for a list of tables. The schema cache was not changed at the time and still reads one table at a time.

`SchemaCache#add_all` walked every table calling `#add`, which reads that table's primary key, columns and indexes. Primary keys and indexes are two of the readers #58421 batched, so a cache dump paid one statement per table for each of them unnecessarily.

`add_all` now asks for both once for the whole list, then walks the tables only for their columns.

## Effect

MySQL 8.0, 204 tables, counted by statement rather than wall clock:

| | statements |
|---|---|
| before | 615 |
| after | **209** |

That is 204 column reads plus two catalog queries, down from 204 of each of three kinds. Columns are deliberately untouched — they dominate what is left, and I understand batching them is being worked on separately.

Adapters with no catalog to read many tables from, such as SQLite, loop internally and issue the same number of statements as before. They still get the single-call path, just no reduction.

## The cache it writes is unchanged

Since #58421 a single table is read through the same query as a list of one, so neither the values nor their order depend on how many tables were asked for. Verified by building a cache both ways and comparing every instance variable — `@columns`, `@columns_hash`, `@primary_keys`, `@data_sources`, `@indexes`, `@version` — described down to the attributes of each `Column` and `IndexDefinition`, since neither defines value equality. Identical on sqlite3, trilogy, mysql2 and postgresql.

Index order in particular is unaffected. It is worth being explicit because it is the natural thing to worry about: unlike `schema.rb`, the cache serialises the array as it received it. But `SchemaCache#indexes` calls `connection.indexes(table_name)`, which #58421 already routed through the same catalog query, so cached order settled then and this change cannot move it. Confirmed directly — with indexes defined in the order `zzz, aaa, mmm, bbb`, MySQL's per-table path already returns them alphabetically.

## Notes for review

- `add_all` stores a single primary key column as a string and a composite key as an array, matching what `SchemaStatements#primary_key` returns to `#add` today, rather than the array the list reader answers with. The two tests cover both shapes.
- The prefetch is unconditional, which is safe because `add_all`'s only caller is `SchemaReflection#dump_to`, and that always runs on a fresh cache. `#add` is untouched and still memoises per table, so repeated calls for one table cost nothing extra.
- An empty database reads nothing and does not error; #58421's `test_an_empty_list_reads_nothing` covers the reader side of that.

Full suites pass with no failures: sqlite3 (9,713 runs), trilogy (9,863), postgresql (10,592).
