### PR TITLE
Track fixture connection pools as they are pinned

### DIFF
--- a/activerecord/lib/active_record/test_fixtures.rb
+++ b/activerecord/lib/active_record/test_fixtures.rb
@@ -193,13 +193,16 @@ module ActiveRecord
         setup_shared_connection_pool
 
         # Begin transactions for connections already established
-        @fixture_connection_pools = ActiveRecord::Base.connection_handler.connection_pool_list(:writing)
+        pools = ActiveRecord::Base.connection_handler.connection_pool_list(:writing)
 
         # Filter to pools that want to use transactions
-        @fixture_connection_pools.select! { |pool| transactional_tests_for_pool?(pool) }
+        pools.select! { |pool| transactional_tests_for_pool?(pool) }
 
-        @fixture_connection_pools.each do |pool|
+        # Record each pool as it is pinned. Teardown raises for a pool it is
+        # asked to unpin that never was, which buries whatever stopped it.
+        pools.each do |pool|
           pool.pin_connection!(lock_threads)
+          @fixture_connection_pools << pool
           pool.lease_connection
         end
 
@@ -216,8 +219,8 @@ module ActiveRecord
               # Don't begin a transaction if we've already done so, or are not using them for this pool
               if !@fixture_connection_pools.include?(pool) && transactional_tests_for_pool?(pool)
                 pool.pin_connection!(lock_threads)
-                pool.lease_connection
                 @fixture_connection_pools << pool
+                pool.lease_connection
               end
             end
           end

--- a/activerecord/test/cases/test_fixtures_test.rb
+++ b/activerecord/test/cases/test_fixtures_test.rb
@@ -35,6 +35,35 @@ class TestFixturesTest < ActiveRecord::TestCase
   end
 
   unless in_memory_db?
+    def test_teardown_does_not_mask_a_failure_to_pin_a_pool
+      klass = Class.new(Minitest::Test) do
+        include ActiveRecord::TestFixtures
+
+        def test_run; end
+      end
+
+      ActiveSupport::Notifications.unsubscribe(@connection_subscriber)
+      @connection_subscriber = nil
+
+      # A pool that can never hand out a connection, so pinning it really fails.
+      db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+      exhausted = db_config.configuration_hash.merge(pool: 0, checkout_timeout: 0.001)
+
+      old_handler = ActiveRecord::Base.connection_handler
+      ActiveRecord::Base.connection_handler = ActiveRecord::ConnectionAdapters::ConnectionHandler.new
+      ActiveRecord::Base.establish_connection(exhausted)
+
+      messages = klass.new("test_run").run.failures.map(&:message)
+
+      assert messages.any? { |message| message.include?("ConnectionTimeoutError") },
+        "expected the failure that stopped the pool being pinned, got: #{messages.inspect}"
+      assert messages.none? { |message| message.include?("isn't a pinned connection") },
+        "teardown reported an unpinned pool instead of the failure that caused it: #{messages.inspect}"
+    ensure
+      ActiveRecord::Base.connection_handler = old_handler
+      clean_up_connection_handler
+    end
+
     def test_doesnt_rely_on_active_support_test_case_specific_methods
       tmp_dir = Dir.mktmpdir
       File.write(File.join(tmp_dir, "zines.yml"), <<~YML)


### PR DESCRIPTION
Noticed while looking at a CI failure on #58488: https://buildkite.com/rails/rails/builds/132580/canvas?sid=01a003b0-2bbb-48e4-a035-0c11ab41d350&tab=output#01a003b0-2c3d-4101-b01f-bb970c27f0f7/L11465

```
ReloadModelsTest#test_has_one_with_reload:
RuntimeError: There isn't a pinned connection 651992
    connection_pool.rb:384:in 'unpin_connection!'
    test_fixtures.rb:230:in 'Array#map'
    test_fixtures.rb:230:in 'teardown_transactional_fixtures'
    test_fixtures.rb:166:in 'teardown_fixtures'
    test_fixtures.rb:17:in 'after_teardown'
```

That error is not the failure. It is teardown tripping over the bookkeeping left behind by a failure in setup.

## What happens

`setup_transactional_fixtures` collected every pool it was about to pin *before* pinning any of them:

```ruby
@fixture_connection_pools = connection_handler.connection_pool_list(:writing)
@fixture_connection_pools.select! { |pool| transactional_tests_for_pool?(pool) }

@fixture_connection_pools.each do |pool|
  pool.pin_connection!(lock_threads)   # if this raises...
  pool.lease_connection
end
```

So when `pin_connection!` raises, the pool it choked on is still in the list. Teardown asks it to unpin, `unpin_connection!` raises because there is nothing pinned, and that is the error above.

The real failure is still reported alongside it — but the pinned-connection error reads like a bug in the connection pool rather than a consequence of setup, which is misleading enough to have cost me a wrong first guess.

It also stops teardown reaching this:

```ruby
unless @fixture_connection_pools.map(&:unpin_connection!).all?
  @@already_loaded_fixtures.clear
end
```

`unpin_connection!` returns whether the transaction was still clean. Raising part way through skips the `all?`, so a database another pool had left committed or rolled back keeps its cached fixtures.

## The change

Record each pool once it has been pinned. The pools teardown unpins are exactly the pools that were pinned, which is what the old code intended.

The notification subscriber that pins pools established mid-test had the same ordering the other way round — it recorded a pool *after* leasing rather than after pinning:

```ruby
pool.pin_connection!(lock_threads)
pool.lease_connection      # if this raises, the pool is pinned but untracked
@fixture_connection_pools << pool
```

A pool pinned but never tracked is never unpinned, and that one does leave damage. Its depth never returns to zero, so `unpin_connection!`'s `@pinned_connection = nil if @pinned_connections_depth.zero?` never fires:

```
test 1 pinned, untracked     pinned=true  depth=1 open_transactions=1
test 2 setup                 pinned=true  depth=2 open_transactions=2
test 2 teardown              pinned=true  depth=1 open_transactions=1
test 3 setup                 pinned=true  depth=2 open_transactions=2
test 3 teardown              pinned=true  depth=1 open_transactions=1
```

The connection is never checked back into the pool, an outer transaction stays open for the rest of the process, and `lock_thread` stays set on it.

## What this does not fix

The failure underneath the CI error is `SQLite3::BusyException: database is locked` on `PRAGMA journal_mode='wal'`, raised from `pin_connection!`. After this change that is what gets reported, which is more useful, but the test can still fail.

`SQLite3Adapter#configure_connection` applies every entry in `DEFAULT_PRAGMAS` to each new connection, `journal_mode: :wal` among them. Setting it is free once the database is already in WAL, but the transition needs an exclusive lock, and any other connection holding any lock — a read lock is enough — makes it fail after waiting out `timeout`:

| database state | other connection holds | result |
|---|---|---|
| already `wal` | exclusive lock | ok, immediately |
| not yet `wal` | exclusive lock | `BusyException` |
| not yet `wal` | read lock | `BusyException` |
| not yet `wal` | nothing | ok |

`ReloadModelsTest` includes `ActiveSupport::Testing::Isolation`, so it forks against the shared fixture databases, which is presumably how two connections end up in that window. I have not been able to reproduce that part reliably and have left it alone; happy to open a separate issue about the pragma if that seems worth pursuing.

## Test

The new test drives a pool that genuinely cannot be pinned — `pool: 0` with a short `checkout_timeout`, so `pin_connection!` raises `ConnectionTimeoutError` — and asserts teardown reports that rather than the missing pin. It fails on sqlite3, trilogy and postgresql without the change and passes with it.

Full suites pass: sqlite3 (9,711 runs), trilogy (9,861), postgresql (10,593).