### PR TITLE
Fix deadlock in ConnectionPool#checkout when pinned connection is replaced

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Fix a deadlock in `ConnectionPool#checkout` when the pinned connection is
+    replaced concurrently.
+
+    When using transactional tests, the pinned connection is unpinned at the end
+    of an example and a new one is pinned at the start of the next. If another
+    thread was in `checkout` during that window, it could lock the old connection
+    and then verify the *new* pinned connection while holding the old one's lock,
+    causing an ABBA deadlock with a thread checking out the new connection.
+
+    `checkout` now captures the pinned connection once and only verifies it if it
+    is still the pinned connection after acquiring the locks, retrying otherwise.
+
+    *VANDENBOGAERDE Nicolas*
+
 *   Support dumping `schema_migrations` in `db/schema.rb`.
 
     When the new `ActiveRecord.dump_schema_migrations` flag is true, `:ruby`

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -636,26 +636,25 @@ module ActiveRecord
       # Raises:
       # - ActiveRecord::ConnectionTimeoutError no connection can be obtained from the pool.
       def checkout(checkout_timeout = @checkout_timeout)
-        return checkout_and_verify(acquire_connection(checkout_timeout)) unless @pinned_connection
+        while (connection = @pinned_connection)
+          connection.lock.synchronize do
+            synchronize do
+              if @pinned_connection.equal?(connection)
+                connection.verify
 
-        @pinned_connection.lock.synchronize do
-          synchronize do
-            # The pinned connection may have been cleaned up before we synchronized, so check if it is still present
-            if @pinned_connection
-              @pinned_connection.verify
+                # Any leased connection must be in @connections otherwise
+                # some methods like #connected? won't behave correctly
+                unless @connections.include?(connection)
+                  @connections << connection
+                end
 
-              # Any leased connection must be in @connections otherwise
-              # some methods like #connected? won't behave correctly
-              unless @connections.include?(@pinned_connection)
-                @connections << @pinned_connection
+                return connection
               end
-
-              @pinned_connection
-            else
-              checkout_and_verify(acquire_connection(checkout_timeout))
             end
           end
         end
+
+        checkout_and_verify(acquire_connection(checkout_timeout))
       end
 
       # Check-in a database connection back into the pool, indicating that you

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -1356,6 +1356,68 @@ module ActiveRecord
         end
       end
 
+      def test_checkout_retries_when_pinned_connection_is_replaced
+        connection_a = @pool.checkout
+        connection_b = @pool.checkout
+        connection_a.lock_thread = Thread.current
+        connection_b.lock_thread = Thread.current
+
+        checkout_started = Concurrent::CountDownLatch.new
+        continue_checkout = Concurrent::CountDownLatch.new
+        connection_b_locked = Concurrent::CountDownLatch.new
+        connection_b_lock_attempted = Concurrent::CountDownLatch.new
+
+        connection_a_lock = connection_a.lock
+        connection_a_lock_wrapper = Object.new
+        connection_a_lock_wrapper.define_singleton_method(:synchronize) do |&block|
+          checkout_started.count_down
+          raise "checkout did not continue" unless continue_checkout.wait(1)
+          connection_a_lock.synchronize(&block)
+        end
+        connection_a.instance_variable_set(:@lock, connection_a_lock_wrapper)
+
+        connection_b_lock = connection_b.lock
+        checkout_thread = nil
+        connection_b_lock_wrapper = Object.new
+        connection_b_lock_wrapper.define_singleton_method(:synchronize) do |&block|
+          connection_b_lock_attempted.count_down if Thread.current.equal?(checkout_thread)
+          connection_b_lock.synchronize(&block)
+        end
+        connection_b.instance_variable_set(:@lock, connection_b_lock_wrapper)
+
+        @pool.instance_variable_set(:@pinned_connection, connection_a)
+        checkout_thread = Thread.new { @pool.checkout }
+
+        assert checkout_started.wait(1)
+        @pool.instance_variable_set(:@pinned_connection, connection_b)
+
+        pool_thread = Thread.new do
+          connection_b.lock.synchronize do
+            connection_b_locked.count_down
+            continue_checkout.count_down
+            raise "checkout did not attempt the replacement connection" unless connection_b_lock_attempted.wait(1)
+            @pool.synchronize { }
+          end
+        end
+
+        assert connection_b_locked.wait(1)
+        assert pool_thread.join(1), "pool lock could not be acquired while holding the replacement connection lock"
+        assert checkout_thread.join(1), "checkout did not complete"
+        assert_same connection_b, checkout_thread.value
+        pool_thread.value
+      ensure
+        continue_checkout&.count_down
+        [pool_thread, checkout_thread].compact.each do |thread|
+          thread.kill
+          thread.join
+        end
+        @pool.instance_variable_set(:@pinned_connection, nil)
+        [connection_a, connection_b].compact.each do |connection|
+          connection.lock_thread = nil
+          @pool.checkin(connection) if connection.in_use?
+        end
+      end
+
       def test_disconnect_and_clear_reloadable_connections_are_able_to_preempt_other_waiting_threads
         with_single_connection_pool(checkout_timeout: 1.0) do |pool|
           [:disconnect, :disconnect!, :clear_reloadable_connections, :clear_reloadable_connections!].each do |group_action_method|


### PR DESCRIPTION
### Motivation / Background

Fixes #58478.

In transactional system tests, the pool pins a connection per example. When another thread (for example an in-process Action Cable worker) calls `checkout` while one example unpins connection A and the next pins connection B, `ConnectionPool#checkout` could lock A and then verify B while still holding A's lock. That inverted the lock order against a thread checking out B and caused a permanent ABBA deadlock.

### Detail

This pull request changes `ConnectionPool#checkout` so it captures the pinned connection once and only verifies/returns it if it is still the pinned connection after acquiring the locks. If the pin was removed or replaced concurrently, both locks are released and checkout retries against the new state. That keeps a single lock order: connection lock → pool monitor, only for the connection being returned.

It also adds a regression test that forces the A → B replacement window and verifies checkout completes with the replacement connection instead of deadlocking.

### Additional information

This builds on #54052, which only handled the pinned connection becoming `nil`. The bug here is the remaining case where the pin is replaced with a different connection between reading `@pinned_connection` and verifying it.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
