### PR TITLE
Fix `Relation` documentation return values

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -981,24 +981,25 @@ module ActiveRecord
     # This method can be passed attribute names and an optional time argument.
     # If attribute names are passed, they are updated along with +updated_at+/+updated_on+ attributes.
     # If no time argument is passed, the current time is used as default.
+    # Returns the number of rows affected.
     #
     # ==== Examples
     #
     #   # Touch all records
-    #   Person.all.touch_all
-    #   # => "UPDATE \"people\" SET \"updated_at\" = '2018-01-04 22:55:23.132670'"
+    #   Person.all.touch_all # => 42
     #
     #   # Touch multiple records with a custom attribute
-    #   Person.all.touch_all(:created_at)
-    #   # => "UPDATE \"people\" SET \"updated_at\" = '2018-01-04 22:55:23.132670', \"created_at\" = '2018-01-04 22:55:23.132670'"
+    #   Person.all.touch_all(:created_at) # => 42
     #
     #   # Touch multiple records with a specified time
-    #   Person.all.touch_all(time: Time.new(2020, 5, 16, 0, 0, 0))
-    #   # => "UPDATE \"people\" SET \"updated_at\" = '2020-05-16 00:00:00'"
+    #   Person.all.touch_all(time: Time.new(2020, 5, 16, 0, 0, 0)) # => 42
     #
     #   # Touch records with scope
-    #   Person.where(name: 'David').touch_all
-    #   # => "UPDATE \"people\" SET \"updated_at\" = '2018-01-04 22:55:23.132670' WHERE \"people\".\"name\" = 'David'"
+    #   Person.where(name: 'David').touch_all # => 1
+    #
+    # The first example above generates an SQL statement like:
+    #
+    #   UPDATE "people" SET "updated_at" = '2018-01-04 22:55:23.132670'
     def touch_all(*names, time: nil)
       update_all model.touch_attributes_with_time(*names, time: time)
     end

--- a/activerecord/test/cases/relation/update_all_test.rb
+++ b/activerecord/test/cases/relation/update_all_test.rb
@@ -276,7 +276,8 @@ class UpdateAllTest < ActiveRecord::TestCase
     david_previously_updated_at = david.updated_at
     jamis = developers(:jamis)
     jamis_previously_updated_at = jamis.updated_at
-    Developer.where(name: "David").touch_all
+
+    assert_equal 1, Developer.where(name: "David").touch_all
 
     assert_not_equal david_previously_updated_at, david.reload.updated_at
     assert_equal jamis_previously_updated_at, jamis.reload.updated_at


### PR DESCRIPTION
`touch_all` returns the number of rows affected (it delegates to `update_all`), but all four examples show it returning the UPDATE statement as a string.

In the `create` documentation, the result of `users.create(name: 'fxn')` is attached to an extra argument-less `users.create` call, which would instead create a record with the scoped name.