### PR TITLE
Keep execution context balanced when nesting is enabled mid-execution

### DIFF
--- a/activesupport/lib/active_support/execution_context.rb
+++ b/activesupport/lib/active_support/execution_context.rb
@@ -27,6 +27,10 @@ module ActiveSupport
         self
       end
 
+      def nested?
+        !@stack.empty?
+      end
+
       def flush
         @stack = Array.new(@stack.size) { {} }
         @store = {}
@@ -95,8 +99,9 @@ module ActiveSupport
       end
 
       def pop
-        if @nestable
-          record.pop
+        context = IsolatedExecutionState[:active_support_execution_context]
+        if context&.nested?
+          context.pop
         else
           clear
         end

--- a/activesupport/test/execution_context_test.rb
+++ b/activesupport/test/execution_context_test.rb
@@ -50,6 +50,27 @@ class ExecutionContextTest < ActiveSupport::TestCase
     end
   end
 
+  test "#pop after nestable is enabled does not corrupt execution context" do
+    ActiveSupport::ExecutionContext.with(nestable: false) do
+      # simulate executor hooks from active_support/railtie.rb
+      executor = Class.new(ActiveSupport::Executor)
+
+      executor.to_run do
+        ActiveSupport::ExecutionContext.push
+      end
+      executor.to_complete do
+        ActiveSupport::ExecutionContext.pop
+      end
+      executor.wrap do
+        # simulate the active_support_test_case load hook from active_support/railtie.rb
+        ActiveSupport::ExecutionContext.nestable = true
+      end
+
+      assert_equal({}, ActiveSupport::ExecutionContext.to_h)
+      assert_equal({}, ActiveSupport::ExecutionContext.current_attributes_instances)
+    end
+  end
+
   test "#set coerce keys to symbol" do
     ActiveSupport::ExecutionContext.set("foo" => "bar") do
       assert_equal "bar", ActiveSupport::ExecutionContext.to_h[:foo]


### PR DESCRIPTION
### Motivation / Background

Fixes #58492.

`ActiveSupport::ExecutionContext.push` saves the current frame on the stack when `nestable` is true, and clears the context when it is false. `pop` made the same decision by reading the flag a second time. If the flag is enabled between the two, `pop` takes the nested branch against an empty stack, `@stack.pop` returns `nil`, and the store becomes `nil` instead of a Hash.

Rails triggers this on its own. Requiring `action_dispatch/testing/integration` inside a running executor loads `ActiveSupport::TestCase`, and the Active Support railtie load hook then sets `nestable = true`. When the next executor completes, `ExecutionContext.to_h` returns `nil`, so `ActiveSupport::ErrorReporter#report` raises `undefined method 'merge' for nil` and whatever error was being reported survives only as the cause.

PR #56863 hit the same corruption, but its reproduction relied on `rspec-rails` flipping the flag. This one needs nothing outside Rails:

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(false) do
  source "https://rubygems.org"
  gem "rails", github: "rails/rails", branch: "main"
end

require "active_support/railtie"
require "action_controller/railtie"
require "rack/mock"
require "tmpdir"

class ReproductionApp < Rails::Application
  config.load_defaults 8.1
  config.root = Dir.mktmpdir("rails-execution-context-repro")
  config.eager_load = false
  config.logger = Logger.new(nil)
  config.hosts.clear
  config.secret_key_base = "reproduction-secret-key-base"

  routes.append do
    get "/up", to: ->(_env) { [200, { "content-type" => "text/plain" }, ["ok"]] }
  end
end

ReproductionApp.initialize!

ReproductionApp.executor.wrap(source: "application.runner.railties") do
  require "action_dispatch/testing/integration"

  env = Rack::MockRequest.env_for("/up", "HTTP_HOST" => "example.org")
  status, _headers, body = ReproductionApp.call(env)
  body.close if body.respond_to?(:close)

  raise "original runner error after HTTP #{status}"
end
```

Expected: `RuntimeError: original runner error after HTTP 200`. Actual: `NoMethodError: undefined method 'merge' for nil` out of the error reporter.

### Detail

`pop` now restores a frame only when `push` actually saved one, and clears otherwise, so the pair stays balanced whenever the flag changes underneath it. This isn't defaulting the store to an empty Hash to hide a missing pop, which is what was rejected in #56863: the push and the pop here are balanced, they just took structurally different branches.

The non-nestable path is unchanged. `push` still clears, so the stack is empty when the matching `pop` runs and the context is still fully dropped at the end of a request or job.

### Additional information

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
