### PR TITLE
Read the columns of many tables in one query

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,6 +1,6 @@
 *   Let the schema readers answer for many tables at once.
 
-    `indexes`, `primary_keys`, `foreign_keys`, `check_constraints`,
+    `columns`, `indexes`, `primary_keys`, `foreign_keys`, `check_constraints`,
     `exclusion_constraints` and `unique_constraints` now accept a list of tables and
     answer for all of them at once:
 
@@ -10,16 +10,17 @@
     ```
 
     Adapters that can read a kind of metadata for many tables in one query do so, a
-    schema at a time; SQLite, which has no catalog to read them from, reads table by
-    table, so every adapter answers.
+    schema at a time: MySQL and MariaDB read columns from
+    `information_schema.columns`, and PostgreSQL filters the queries it already used
+    by a list of tables. SQLite reads table by table, so every adapter answers.
 
     Schema dumping asked about each table separately, which meant the number of
-    round trips grew with the size of the schema: primary keys, indexes, foreign
-    keys and constraints each cost one statement per table, and MySQL spent another
-    `SHOW TABLE STATUS` per table just to read a collation. It now reads each kind
-    in one query for the tables it is about to dump. On a schema with a few thousand
-    tables that removes about 70% of the statements a dump issues, and the output is
-    unchanged.
+    round trips grew with the size of the schema: columns, primary keys, indexes,
+    foreign keys and constraints each cost one statement per table, and MySQL spent
+    another `SHOW TABLE STATUS` per table just to read a collation. It now reads each
+    kind in one query for the tables it is about to dump. On a schema with a few
+    thousand tables that removes about 70% of the statements a dump issues, and the
+    output is unchanged.
 
     An empty list reads nothing, without querying. A blank table name no longer
     raises `ArgumentError`: MySQL was the only adapter that did, and only from

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -105,13 +105,14 @@ module ActiveRecord
         indexes(table_name).any? { |i| i.defined_for?(column_name, **options) }
       end
 
-      # Returns an array of +Column+ objects for the table specified by +table_name+.
+      # Returns an array of +Column+ objects for the given table, or a Hash of them
+      # keyed by table name when given an Array of tables.
       def columns(table_name)
-        table_name = table_name.to_s
-        definitions = column_definitions(table_name)
-        definitions.map do |field|
-          new_column_from_field(table_name, field, definitions)
+        result = fetch_column_definitions(Array(table_name).map(&:to_s)).to_h do |table, definitions|
+          [table, definitions.map { |field| new_column_from_field(table, field, definitions) }]
         end
+
+        table_name.is_a?(Array) ? result : result[table_name.to_s]
       end
 
       # Checks to see if a column exists in a given table.
@@ -1720,6 +1721,10 @@ module ActiveRecord
       end
 
       private
+        def fetch_column_definitions(tables)
+          tables.index_with { |table| column_definitions(table) }
+        end
+
         def quoted_table_names(table_names)
           table_names.map { |name| quoted_scope(name)[:name] }.join(", ")
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -46,6 +46,12 @@ module ActiveRecord
         json:        { name: "json" },
       }
 
+      # Escape sequences MariaDB writes into the column defaults it reports.
+      MARIADB_DEFAULT_ESCAPES = {
+        "0" => "\0", "b" => "\b", "n" => "\n", "r" => "\r", "t" => "\t",
+        "Z" => "\x1A", "'" => "'", '"' => '"', "\\" => "\\"
+      }.freeze
+
       class StatementPool < ConnectionAdapters::StatementPool # :nodoc:
         private
           def dealloc(stmt)
@@ -1057,6 +1063,54 @@ module ActiveRecord
           update_fields_for_mariadb(table_name, fields) if mariadb?
 
           fields
+        end
+
+        def fetch_column_definitions(tables)
+          fetch_by_schema(tables) do |schema, group|
+            by_name = query_all(<<~SQL).group_by { |row| row["Table"] }
+              SELECT table_name AS 'Table', column_name AS 'Field', column_type AS 'Type',
+                     column_default AS 'Default', is_nullable AS 'Null', extra AS 'Extra',
+                     collation_name AS 'Collation', column_comment AS 'Comment'
+              FROM information_schema.columns
+              WHERE table_schema = #{schema}
+                AND table_name IN (#{quoted_table_names(group)})
+              ORDER BY table_name, ordinal_position
+            SQL
+
+            group.index_with do |table|
+              fields = rows_for(by_name, table)
+
+              next column_definitions(table) if fields.empty?
+
+              fields.each { |field| unquote_mariadb_default(field) } if mariadb?
+
+              fields
+            end
+          end
+        end
+
+        # MariaDB reports a default as the SQL literal that produced it, where
+        # `SHOW FULL FIELDS` reports the value: a literal comes back quoted, and a
+        # newline inside one is written `\n`. Put them back into the form
+        # #new_column_from_field reads.
+        def unquote_mariadb_default(field)
+          default = field["Default"]
+          return if default.nil?
+
+          if default == "NULL"
+            # A column declared DEFAULT NULL, which has no default at all.
+            field["Default"] = nil
+          elsif !default.start_with?("'")
+            # An expression rather than a value. A bare `(1 + 1)` is left alone,
+            # which is what reading the table directly reports too.
+            if /[a-zA-Z_]\w*\(/.match?(default) && !/\ACURRENT_TIMESTAMP/i.match?(default)
+              field["Extra"] = "DEFAULT_GENERATED"
+            end
+          elsif !/\A(?:tiny|medium|long)?(?:text|blob)\b/.match?(field["Type"])
+            # Text and blob defaults stay quoted; #new_column_from_field unquotes those.
+            field["Default"] = default[1...-1].gsub("''", "'")
+              .gsub(/\\(.)/) { MARIADB_DEFAULT_ESCAPES.fetch($1, "\\#{$1}") }
+          end
         end
 
         def update_fields_for_mariadb(table_name, fields)

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1275,6 +1275,40 @@ module ActiveRecord
           SQL
         end
 
+        def fetch_column_definitions(tables)
+          fetch_by_schema(tables) do |schema, group|
+            rows = query_rows(<<~SQL)
+              SELECT a.attname, format_type(a.atttypid, a.atttypmod),
+                     pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod,
+                     c.collname, col_description(a.attrelid, a.attnum) AS comment,
+                     #{supports_identity_columns? ? 'attidentity' : quote('')} AS identity,
+                     #{supports_virtual_columns? ? 'attgenerated' : quote('')} as attgenerated,
+                     r.relname
+              FROM (
+                SELECT DISTINCT ON (cls.relname) cls.oid, cls.relname
+                FROM pg_class cls
+                JOIN pg_namespace n ON n.oid = cls.relnamespace
+                WHERE n.nspname = #{schema}
+                  AND cls.relname IN (#{quoted_table_names(group)})
+                ORDER BY cls.relname, array_position(current_schemas(false), n.nspname)
+              ) r
+              JOIN pg_attribute a ON a.attrelid = r.oid
+              LEFT JOIN pg_attrdef d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
+              LEFT JOIN pg_type t ON a.atttypid = t.oid
+              LEFT JOIN pg_collation c ON a.attcollation = c.oid AND a.attcollation <> t.typcollation
+              WHERE a.attnum > 0 AND NOT a.attisdropped
+              ORDER BY r.relname, a.attnum
+            SQL
+            by_name = rows.group_by(&:last)
+
+            group.index_with do |table|
+              fields = rows_for(by_name, table)
+
+              fields.empty? ? column_definitions(table) : fields
+            end
+          end
+        end
+
         def arel_visitor
           Arel::Visitors::PostgreSQL.new(self)
         end

--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -393,9 +393,15 @@ module ActiveRecord
         pool.with_connection do |connection|
           tables = tables_to_cache(pool)
 
+          tables.each { |table| @data_sources[deep_deduplicate(table)] = true }
+
           connection.primary_keys(tables).each do |table, primary_keys|
             primary_key = primary_keys.size > 1 ? primary_keys : primary_keys.first
             @primary_keys[deep_deduplicate(table)] = deep_deduplicate(primary_key)
+          end
+
+          connection.columns(tables).each do |table, columns|
+            @columns[deep_deduplicate(table)] = deep_deduplicate(columns)
           end
 
           connection.indexes(tables).each do |table, indexes|

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -152,6 +152,7 @@ module ActiveRecord
       end
 
       def read_schema_metadata(tables)
+        @columns = @connection.columns(tables)
         @primary_keys = @connection.primary_keys(tables)
         @indexes = @connection.indexes(tables)
         @foreign_keys = @connection.foreign_keys(tables) if @connection.supports_foreign_keys?
@@ -187,7 +188,7 @@ module ActiveRecord
       end
 
       def table(table, stream)
-        columns = @connection.columns(table)
+        columns = @columns[table]
         begin
           self.table_name = table
 

--- a/activerecord/test/cases/connection_adapters/schema_statements_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_statements_test.rb
@@ -8,7 +8,7 @@ module ActiveRecord
       self.use_transactional_tests = false
 
       WHOLE_SCHEMA_READERS = %i[
-        indexes primary_keys foreign_keys
+        columns indexes primary_keys foreign_keys
         check_constraints exclusion_constraints unique_constraints
       ].freeze
 
@@ -87,6 +87,16 @@ module ActiveRecord
             attributes(listed.fetch(qualified)),
             "#{reader} disagreed about #{qualified}"
           assert_not_empty listed.fetch(qualified), "#{reader} found nothing for #{qualified}"
+        end
+      end
+
+      def test_a_list_reads_columns_in_the_same_order_as_one_table
+        tables = @connection.tables.sort.first(5)
+        listed = @connection.columns(tables)
+
+        tables.each do |table|
+          assert_equal @connection.columns(table).map(&:name), listed.fetch(table).map(&:name),
+            "columns for #{table} came back in a different order"
         end
       end
 


### PR DESCRIPTION
Follow-up to #58421 and #58488. `columns` was the last of the schema readers that still read one table at a time, so dumping the schema cache paid a statement per table for it.

It now takes a list of tables as well as a single one:

```ruby
connection.columns(:users)            # => [Column, ...]
connection.columns([:users, :posts])  # => { "users" => [...], "posts" => [...] }
```

## Effect

Dumping the schema cache for 250 tables, measured before and after on the same tree:

| | statements | time |
|---|---|---|
| before | 255 | 124.6 ms |
| after | **6** | **44.0 ms** |

Six statements for the whole dump: the table list, one read each for primary keys, columns and indexes, and two for the schema version — whether `schema_migrations` exists, then its versions.

That last count was seven until this push. `add_all` read the table list twice: once at the top, and again from `data_source_exists?` when it walked the tables to fill `columns_hash`. It now seeds `@data_sources` from the list it already has, which is one statement fewer and the same dumped cache byte for byte on PostgreSQL, MySQL and SQLite.

Columns were the last read in the cache dump that scaled with the number of tables. `schema.rb` dumps still read `table_options` per table, which I would rather do separately.

## Per adapter

- **MySQL and MariaDB** read `information_schema.columns`, which reports the same fields `SHOW FULL FIELDS` does, under the same names.
- **PostgreSQL** filters the `pg_attribute` query it already used by a list of tables instead of one.
- **SQLite** reads table by table, through the default implementation, so every adapter answers for a list.

Measured on MySQL 5.6 and 5.7 as well, where `information_schema` predates the data dictionary and is slower per query. One query still wins: 31 tables took 15.1 ms per table versus 1.8 ms for one query on 5.6, and 19.1 ms versus 2.4 ms on 5.7. So there is no version floor on the bulk read.

## MariaDB defaults

MariaDB reports a default as the SQL literal that produced it, where `SHOW FULL FIELDS` reports the value:

```
declared 'a\nb'    catalog: backslash, n     SHOW: a newline
declared 'a\tb'    catalog: a tab            SHOW: a tab
declared 'a\\b'    catalog: two backslashes  SHOW: one
declared 'a\%b'    catalog: backslash kept   SHOW: backslash kept
```

Those literals are unquoted so the rows match either way. Two other differences fall out of the same thing: a column declared `DEFAULT NULL` reads back as the word `NULL`, and a quoted default is a value rather than an expression — which is what `update_fields_for_mariadb` reads `SHOW CREATE TABLE` to work out. The catalog answers it without that read, so MariaDB gets slightly better information than it did.

## The same Column objects

`Column#==` skips `PostgreSQL::Column`'s `serial`, `identity` and `generated`, so I compared instance variables rather than trusting it. Every column built from the bulk read matches the one built from the per-table read, on every instance variable:

| | tables | columns |
|---|---|---|
| MySQL 8.0.46 | 21 | 76 |
| MariaDB 11.8.8 | 4 | 60 |
| MySQL 5.7.44 | 31 | 110 |
| MySQL 5.6.51 | 31 | 108 |
| PostgreSQL 17 | 21 | 73 |

Covering the shapes a plain schema does not have: expression defaults, a string that looks like a function call, `ON UPDATE CURRENT_TIMESTAMP`, STORED and VIRTUAL generated columns, doubled and escaped quotes, backslashes, `\%`, `\_`, NUL, Ctrl-Z, an empty string, `bit`, enum, a comment containing a comma, a latin1 column in a utf8mb4 table, and on PostgreSQL bigserial, both identity forms, an array default and an explicit collation.

Schema-qualified names keep the name they were given, and the same bare name in two schemas in one call reads from the right one:

```
public.things  -> ["id", "pub_col"]
other.things   -> ["id", "other_col"]
```

A table the catalog reports nothing for either does not exist or is not one the connection can see, so it is read by name and reports that the way it did before.

## Tests

`columns` joins `WHOLE_SCHEMA_READERS` in `schema_statements_test.rb`, which covers reading exactly the tables given, agreeing with a single read, not scaling with the number of tables, reading nothing for an empty list, and keying a qualified name by the name it was given. One test is new: column order is part of the answer, unlike the other readers, and the shared comparison sorts.

The MariaDB handling is covered by existing tests. I checked by breaking each branch and running the suite against MariaDB: removing the `DEFAULT NULL` case fails 11 tests, removing the expression marking fails 3, removing the escape table fails `test_add_column_newline_default`, and removing the doubled-quote handling fails `defaults_test`. The one branch nothing catches is keeping text and blob defaults quoted for `new_column_from_field` to unquote, because that only differs from unquoting them here when a text default contains an escape, and no test has one. That behaviour is unchanged from before, so I left it explained by a comment rather than pinning it with a test that asserts the value.

Full suites pass: sqlite3, mysql2, trilogy, postgresql, and MariaDB 11.8. MariaDB has four pre-existing errors in `ConcurrentTransactionTest` and `CreateOrFindByWithinTransactions` that are identical without this change.

MariaDB, 5.6 and 5.7 were checked against single containers rather than in CI, so those are worth a second look by someone with that in their matrix.
