### PR TITLE
Fix typo Rails Guide: Active Record Encryption 3.7 Fixtures [ci skip]

### DIFF
--- a/guides/source/active_record_encryption.md
+++ b/guides/source/active_record_encryption.md
@@ -393,7 +393,7 @@ options configured.
 
 ### Fixtures
 
-To allow your tests can use plain text values in the YAML fixture files for
+To allow your tests to use plain text values in the YAML fixture files for
 encrypted attributes, you can configure fixtures to be automatically encrypted
 by adding this configuration to your `config/environments/test.rb` file:
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request fixes a minor grammatical typo in the Active Record Encryption guide. Specifically in chapter 3.7, Fixtures. The typo occurs in the first sentence of that chapter.

### Detail

In `guides/source/active_record_encryption.md`, the phrase `"To allow your tests can use plain text values..."` has been corrected to `"To allow your tests to use plain text values..."`.

### Additional information

Documentation-only change. Included `[ci skip]` in the commit and PR title to bypass unnecessary CI builds.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.