### PR TITLE
Read the table options of many tables at once, and batch the SQLite readers

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -36,9 +36,9 @@
 
 *   Let the schema readers answer for many tables at once.
 
-    `columns`, `indexes`, `primary_keys`, `foreign_keys`, `check_constraints`,
-    `exclusion_constraints` and `unique_constraints` now accept a list of tables and
-    answer for all of them at once:
+    `columns`, `indexes`, `primary_keys`, `foreign_keys`, `table_options`,
+    `check_constraints`, `exclusion_constraints` and `unique_constraints` now accept
+    a list of tables and answer for all of them at once:
 
     ```ruby
     connection.indexes(:users)            # => [IndexDefinition, ...]
@@ -47,8 +47,10 @@
 
     Adapters that can read a kind of metadata for many tables in one query do so, a
     schema at a time: MySQL and MariaDB read columns from
-    `information_schema.columns`, and PostgreSQL filters the queries it already used
-    by a list of tables. SQLite reads table by table, so every adapter answers.
+    `information_schema.columns`, PostgreSQL filters the queries it already used by a
+    list of tables, and SQLite joins the table valued form of its pragmas to a list of
+    names. Only `table_options` on MySQL and MariaDB is still read a table at a time,
+    because `SHOW CREATE TABLE` is the only place they report it.
 
     Schema dumping asked about each table separately, which meant the number of
     round trips grew with the size of the schema: columns, primary keys, indexes,

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -16,8 +16,11 @@ module ActiveRecord
         {}
       end
 
+      # Returns the options the given table was created with, or a Hash of them
+      # keyed by table name when given an Array of tables.
       def table_options(table_name)
-        nil
+        result = fetch_table_options(Array(table_name).map(&:to_s))
+        table_name.is_a?(Array) ? result : result[table_name.to_s]
       end
 
       # Returns the table comment that's stored in database metadata.
@@ -1721,6 +1724,10 @@ module ActiveRecord
       end
 
       private
+        def fetch_table_options(tables)
+          tables.index_with(nil)
+        end
+
         def fetch_column_definitions(tables)
           tables.index_with { |table| column_definitions(table) }
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -526,35 +526,6 @@ module ActiveRecord
         table_name.is_a?(Array) ? result : result[table_name.to_s]
       end
 
-      def table_options(table_name) # :nodoc:
-        create_table_info = create_table_info(table_name)
-
-        # strip create_definitions and partition_options
-        # Be aware that `create_table_info` might not include any table options due to `NO_TABLE_OPTIONS` sql mode.
-        raw_table_options = create_table_info.sub(/\A.*\n\) ?/m, "").sub(/\n\/\*!.*\*\/\n\z/m, "").strip
-
-        return if raw_table_options.empty?
-
-        table_options = {}
-
-        if / DEFAULT CHARSET=(?<charset>\w+)(?: COLLATE=(?<collation>\w+))?/ =~ raw_table_options
-          raw_table_options = $` + $' # before part + after part
-          table_options[:charset] = charset
-          table_options[:collation] = collation if collation
-        end
-
-        # strip AUTO_INCREMENT
-        raw_table_options.sub!(/(ENGINE=\w+)(?: AUTO_INCREMENT=\d+)/, '\1')
-
-        # strip COMMENT
-        if raw_table_options.sub!(/ COMMENT='.+'/, "")
-          table_options[:comment] = table_comment(table_name)
-        end
-
-        table_options[:options] = raw_table_options unless raw_table_options == "ENGINE=InnoDB"
-        table_options
-      end
-
       # SHOW VARIABLES LIKE 'name'
       def show_variable(name)
         query_value("SELECT @@#{name}")
@@ -750,6 +721,39 @@ module ActiveRecord
       EMULATE_BOOLEANS_TRUE = { emulate_booleans: true }.freeze
 
       private
+        # `SHOW CREATE TABLE` is the only place MySQL reports a table's options, and
+        # it reads one table at a time.
+        def fetch_table_options(tables)
+          tables.index_with { |table| build_table_options(table, create_table_info(table)) }
+        end
+
+        def build_table_options(table_name, create_table_info)
+          # strip create_definitions and partition_options
+          # Be aware that `create_table_info` might not include any table options due to `NO_TABLE_OPTIONS` sql mode.
+          raw_table_options = create_table_info.sub(/\A.*\n\) ?/m, "").sub(/\n\/\*!.*\*\/\n\z/m, "").strip
+
+          return if raw_table_options.empty?
+
+          table_options = {}
+
+          if / DEFAULT CHARSET=(?<charset>\w+)(?: COLLATE=(?<collation>\w+))?/ =~ raw_table_options
+            raw_table_options = $` + $' # before part + after part
+            table_options[:charset] = charset
+            table_options[:collation] = collation if collation
+          end
+
+          # strip AUTO_INCREMENT
+          raw_table_options.sub!(/(ENGINE=\w+)(?: AUTO_INCREMENT=\d+)/, '\1')
+
+          # strip COMMENT
+          if raw_table_options.sub!(/ COMMENT='.+'/, "")
+            table_options[:comment] = table_comment(table_name)
+          end
+
+          table_options[:options] = raw_table_options unless raw_table_options == "ENGINE=InnoDB"
+          table_options
+        end
+
         def fetch_table_collations(tables)
           fetch_by_schema(tables) do |schema, group|
             by_name = query_all(<<~SQL).to_h { |row| [row["table"], row["collation"]] }

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -100,26 +100,6 @@ module ActiveRecord
           table_name.is_a?(Array) ? result : result[table_name.to_s]
         end
 
-        def table_options(table_name) # :nodoc:
-          options = {}
-
-          comment = table_comment(table_name)
-
-          options[:comment] = comment if comment
-
-          inherited_table_names = inherited_table_names(table_name).presence
-
-          options[:options] = "INHERITS (#{inherited_table_names.join(", ")})" if inherited_table_names
-
-          if !options[:options] && supports_native_partitioning?
-            partition_definition = table_partition_definition(table_name)
-
-            options[:options] = "PARTITION BY #{partition_definition}" if partition_definition
-          end
-
-          options
-        end
-
         # Returns a comment stored in database for given table
         def table_comment(table_name) # :nodoc:
           scope = quoted_scope(table_name, type: "BASE TABLE")
@@ -133,37 +113,6 @@ module ActiveRecord
                 AND n.nspname = #{scope[:schema]}
             SQL
           end
-        end
-
-        # Returns the partition definition of a given table
-        def table_partition_definition(table_name) # :nodoc:
-          scope = quoted_scope(table_name, type: "BASE TABLE")
-
-          query_value(<<~SQL)
-            SELECT pg_catalog.pg_get_partkeydef(c.oid)
-            FROM pg_catalog.pg_class c
-              LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
-            WHERE c.relname = #{scope[:name]}
-              AND c.relkind IN (#{scope[:type]})
-              AND n.nspname = #{scope[:schema]}
-          SQL
-        end
-
-        # Returns the inherited table name of a given table
-        def inherited_table_names(table_name) # :nodoc:
-          scope = quoted_scope(table_name, type: "BASE TABLE")
-
-          query_values(<<~SQL)
-            SELECT parent.relname
-            FROM pg_catalog.pg_inherits i
-              JOIN pg_catalog.pg_class child ON i.inhrelid = child.oid
-              JOIN pg_catalog.pg_class parent ON i.inhparent = parent.oid
-              LEFT JOIN pg_namespace n ON n.oid = child.relnamespace
-            WHERE child.relname = #{scope[:name]}
-              AND child.relkind IN (#{scope[:type]})
-              AND n.nspname = #{scope[:schema]}
-            ORDER BY i.inhseqno
-          SQL
         end
 
         # Returns the current database name.
@@ -1019,6 +968,50 @@ module ActiveRecord
 
               group.index_with { |table| build_indexes(table, rows_for(by_name, table)) }
             end
+          end
+
+          def fetch_table_options(tables)
+            fetch_by_schema(tables) do |schema, group|
+              # A table comes back once per parent it inherits from, and once if it
+              # inherits from nothing.
+              by_name = query_all(<<~SQL).group_by { |row| row["table_name"] }
+                SELECT t.relname AS table_name, t.comment, t.partition_key, parent.relname AS parent
+                FROM (
+                  SELECT DISTINCT ON (c.relname) c.oid, c.relname,
+                         pg_catalog.obj_description(c.oid, 'pg_class') AS comment,
+                         #{supports_native_partitioning? ? "pg_catalog.pg_get_partkeydef(c.oid)" : "NULL"} AS partition_key
+                  FROM pg_class c
+                  JOIN pg_namespace n ON n.oid = c.relnamespace
+                  WHERE n.nspname = #{schema}
+                    AND c.relname IN (#{quoted_table_names(group)})
+                    AND c.relkind IN ('r', 'p')
+                  ORDER BY c.relname, array_position(current_schemas(false), n.nspname)
+                ) t
+                LEFT JOIN pg_inherits i ON i.inhrelid = t.oid
+                LEFT JOIN pg_class parent ON i.inhparent = parent.oid
+                ORDER BY t.relname, i.inhseqno
+              SQL
+
+              group.index_with { |table| build_table_options(rows_for(by_name, table)) }
+            end
+          end
+
+          def build_table_options(rows)
+            options = {}
+            first = rows.first
+            return options unless first
+
+            options[:comment] = first["comment"] if first["comment"]
+
+            parents = rows.filter_map { |row| row["parent"] }
+
+            if parents.any?
+              options[:options] = "INHERITS (#{parents.join(", ")})"
+            elsif first["partition_key"]
+              options[:options] = "PARTITION BY #{first["partition_key"]}"
+            end
+
+            options
           end
 
           def fetch_primary_keys(tables)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_dumper.rb
@@ -5,6 +5,16 @@ module ActiveRecord
     module SQLite3
       class SchemaDumper < ConnectionAdapters::SchemaDumper # :nodoc:
         private
+          def read_schema_metadata(tables)
+            super
+
+            @table_sqls = @connection.query_all(<<~SQL, "SCHEMA").to_h { |row| [row["name"], row["sql"]] }
+              SELECT name, sql FROM sqlite_master WHERE type = 'table'
+              UNION ALL
+              SELECT name, sql FROM sqlite_temp_master WHERE type = 'table'
+            SQL
+          end
+
           def virtual_tables(stream)
             virtual_tables = @connection.virtual_tables.reject { |name, _| ignored?(name) }
             if virtual_tables.any?
@@ -29,13 +39,7 @@ module ActiveRecord
           def primary_key_has_autoincrement?
             return false unless table_name
 
-            table_sql = @connection.query_value(<<~SQL, "SCHEMA")
-              SELECT sql FROM sqlite_master WHERE name = #{@connection.quote(table_name)} AND type = 'table'
-              UNION ALL
-              SELECT sql FROM sqlite_temp_master WHERE name = #{@connection.quote(table_name)} AND type = 'table'
-            SQL
-
-            table_sql.to_s.match?(/\bAUTOINCREMENT\b/i)
+            @table_sqls[table_name].to_s.match?(/\bAUTOINCREMENT\b/i)
           end
 
           def prepare_column_options(column)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
@@ -69,69 +69,92 @@ module ActiveRecord
         end
 
         private
+          # sqlite_master lists the permanent objects in the database and
+          # sqlite_temp_master the temporary ones.
+          MASTER_CTE = <<~SQL
+            WITH master AS (
+              SELECT name, type, sql FROM sqlite_master
+              UNION ALL
+              SELECT name, type, sql FROM sqlite_temp_master
+            )
+          SQL
+
           def fetch_indexes(tables)
+            return {} if tables.empty?
+
+            rows = query_all(<<~SQL).group_by { |row| row["table_name"] }
+              #{MASTER_CTE}
+              SELECT m.name AS table_name, i.name, i."unique"
+              FROM master m
+              JOIN pragma_index_list(m.name) i
+              WHERE m.type = 'table'
+                AND m.name IN (#{quoted_table_names(tables)})
+                AND i.name NOT GLOB 'sqlite_*'
+            SQL
+
+            details = index_details(rows.each_value.flat_map { |group| group.map { |row| row["name"] } })
+
             tables.index_with do |table_name|
-              query_all("PRAGMA index_list(#{quote_table_name(table_name)})").filter_map do |row|
-                # Indexes SQLite creates implicitly for internal use start with "sqlite_".
-                # See https://www.sqlite.org/fileformat2.html#intschema
-                next if row["name"].start_with?("sqlite_")
+              rows.fetch(table_name, []).map do |row|
+                index_sql, columns = details[row["name"]] || [nil, []]
 
-                index_sql = query_value(<<~SQL)
-                  SELECT sql
-                  FROM sqlite_master
-                  WHERE name = #{quote(row['name'])} AND type = 'index'
-                  UNION ALL
-                  SELECT sql
-                  FROM sqlite_temp_master
-                  WHERE name = #{quote(row['name'])} AND type = 'index'
-                SQL
-
-                /\bON\b\s*"?(\w+?)"?\s*\((?<expressions>.+?)\)(?:\s*WHERE\b\s*(?<where>.+?))?(?:\s*\/\*.*\*\/)?\s*\z/im =~ index_sql
-
-                columns = query_all("PRAGMA index_info(#{quote(row['name'])})").map do |col|
-                  col["name"]
-                end
-
-                where = where.sub(/\s*\/\*.*\*\/\z/, "") if where
-                orders = {}
-
-                if columns.any?(&:nil?) # index created with an expression
-                  columns = expressions
-                else
-                  # Add info on sort order for columns (only desc order is explicitly specified,
-                  # asc is the default)
-                  if index_sql # index_sql can be null in case of primary key indexes
-                    index_sql.scan(/"(\w+)" DESC/).flatten.each { |order_column|
-                      orders[order_column] = :desc
-                    }
-                  end
-                end
-
-                IndexDefinition.new(
-                  table_name,
-                  row["name"],
-                  row["unique"] != 0,
-                  columns,
-                  where: where,
-                  orders: orders
-                )
+                build_index(table_name, row, index_sql, columns)
               end
             end
           end
 
-          def fetch_check_constraints(tables)
-            tables.index_with do |table_name|
-              table_sql = query_value(<<-SQL)
-                SELECT sql
-                FROM sqlite_master
-                WHERE name = #{quote(table_name)} AND type = 'table'
-                UNION ALL
-                SELECT sql
-                FROM sqlite_temp_master
-                WHERE name = #{quote(table_name)} AND type = 'table'
-              SQL
+          # The statement an index was created with says whether it is partial and how
+          # its columns are ordered, and repeats once per column of the index.
+          def index_details(names)
+            return {} if names.empty?
 
-              table_sql.to_s.scan(/CONSTRAINT\s+(?<name>\w+)\s+CHECK\s+\((?<expression>(:?[^()]|\(\g<expression>\))+)\)/i).map do |name, expression|
+            query_all(<<~SQL).group_by { |row| row["index_name"] }
+              #{MASTER_CTE}
+              SELECT m.name AS index_name, m.sql, i.name
+              FROM master m
+              JOIN pragma_index_info(m.name) i
+              WHERE m.type = 'index'
+                AND m.name IN (#{names.map { |name| quote(name) }.join(", ")})
+              ORDER BY m.name, i.seqno
+            SQL
+              .transform_values { |group| [group.first["sql"], group.map { |row| row["name"] }] }
+          end
+
+          def build_index(table_name, row, index_sql, columns)
+            /\bON\b\s*"?(\w+?)"?\s*\((?<expressions>.+?)\)(?:\s*WHERE\b\s*(?<where>.+?))?(?:\s*\/\*.*\*\/)?\s*\z/im =~ index_sql
+
+            where = where.sub(/\s*\/\*.*\*\/\z/, "") if where
+            orders = {}
+
+            if columns.any?(&:nil?) # index created with an expression
+              columns = expressions
+            else
+              # Add info on sort order for columns (only desc order is explicitly specified,
+              # asc is the default)
+              if index_sql # index_sql can be null in case of primary key indexes
+                index_sql.scan(/"(\w+)" DESC/).flatten.each { |order_column|
+                  orders[order_column] = :desc
+                }
+              end
+            end
+
+            IndexDefinition.new(
+              table_name,
+              row["name"],
+              row["unique"] != 0,
+              columns,
+              where: where,
+              orders: orders
+            )
+          end
+
+          def fetch_check_constraints(tables)
+            structures = table_structures(tables)
+
+            tables.index_with do |table_name|
+              create_table_sql, = structures[table_name]
+
+              create_table_sql.to_s.scan(/CONSTRAINT\s+(?<name>\w+)\s+CHECK\s+\((?<expression>(:?[^()]|\(\g<expression>\))+)\)/i).map do |name, expression|
                 CheckConstraintDefinition.new(table_name, expression, name: name)
               end
             end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -529,52 +529,90 @@ module ActiveRecord
       EXTENDED_TYPE_MAPS = Concurrent::Map.new
 
       private
-        def fetch_primary_keys(tables)
+        def fetch_column_definitions(tables)
+          structures = table_structures(tables)
+
           tables.index_with do |table|
-            pks = table_structure(table).select { |f| f["pk"] > 0 }
+            create_table_sql, structure = structure_for(structures, table)
+
+            build_table_structure(structure, split_table_structure_sql(create_table_sql, structure.map { |column| column["name"] }))
+          end
+        end
+
+        def fetch_primary_keys(tables)
+          structures = table_structures(tables)
+
+          tables.index_with do |table|
+            _, structure = structure_for(structures, table)
+            pks = structure.select { |f| f["pk"] > 0 }
             pks.sort_by { |f| f["pk"] }.map { |f| f["name"] }
           end
         end
 
+        def structure_for(structures, table)
+          structures.fetch(table) do
+            raise ActiveRecord::StatementInvalid.new("Could not find table '#{table}'", connection_pool: @pool)
+          end
+        end
+
         def fetch_foreign_keys(tables)
+          return {} if tables.empty?
+
+          # SQLite returns 1 row for each column of composite foreign keys.
+          fk_infos = query_all(<<~SQL).group_by { |row| row["table_name"] }
+            #{MASTER_CTE}
+            SELECT m.name AS table_name, fk.id, fk.seq, fk."table", fk."from", fk."to", fk.on_update, fk.on_delete
+            FROM master m
+            JOIN pragma_foreign_key_list(m.name) fk
+            WHERE m.type = 'table'
+              AND m.name IN (#{quoted_table_names(tables)})
+          SQL
+
+          structures = table_structures(tables)
+
           tables.index_with do |table_name|
-            # SQLite returns 1 row for each column of composite foreign keys.
-            fk_info = query_all("PRAGMA foreign_key_list(#{quote(table_name)})")
-            # Deferred or immediate foreign keys and the constraint name can only be
-            # seen in the CREATE TABLE sql.
-            fk_defs = table_structure_sql(table_name)
-                        .select do |column_string|
-                          column_string.start_with?("CONSTRAINT") &&
-                          column_string.include?("FOREIGN KEY")
-                        end
-                        .to_h do |fk_string|
-                          _, from, table, to = fk_string.match(FK_REGEX).to_a
-                          _, mode = fk_string.match(DEFERRABLE_REGEX).to_a
-                          _, name = fk_string.match(FK_NAME_REGEX).to_a
-                          deferred = mode&.downcase&.to_sym || false
-                          [[table, from, to], { deferrable: deferred, name: name }]
-                        end
+            create_table_sql, structure = structures[table_name] || [nil, []]
+            column_strings = split_table_structure_sql(create_table_sql, structure.map { |column| column["name"] })
 
-            grouped_fk = fk_info.group_by { |row| row["id"] }.values.each { |group| group.sort_by! { |row| row["seq"] } }
-            grouped_fk.map do |group|
-              row = group.first
-              fk_def = fk_defs[[row["table"], row["from"], row["to"]]]
-              options = {
-                on_delete: extract_foreign_key_action(row["on_delete"]),
-                on_update: extract_foreign_key_action(row["on_update"]),
-                deferrable: fk_def && fk_def[:deferrable],
-                name: fk_def && fk_def[:name],
-              }
+            build_foreign_keys(table_name, fk_infos.fetch(table_name, []), column_strings)
+          end
+        end
 
-              if group.one?
-                options[:column] = row["from"]
-                options[:primary_key] = row["to"]
-              else
-                options[:column] = group.map { |row| row["from"] }
-                options[:primary_key] = group.map { |row| row["to"] }
-              end
-              ForeignKeyDefinition.new(table_name, row["table"], options)
+        def build_foreign_keys(table_name, fk_info, column_strings)
+          # Deferred or immediate foreign keys and the constraint name can only be
+          # seen in the CREATE TABLE sql.
+          fk_defs = column_strings
+                      .select do |column_string|
+                        column_string.start_with?("CONSTRAINT") &&
+                        column_string.include?("FOREIGN KEY")
+                      end
+                      .to_h do |fk_string|
+                        _, from, table, to = fk_string.match(FK_REGEX).to_a
+                        _, mode = fk_string.match(DEFERRABLE_REGEX).to_a
+                        _, name = fk_string.match(FK_NAME_REGEX).to_a
+                        deferred = mode&.downcase&.to_sym || false
+                        [[table, from, to], { deferrable: deferred, name: name }]
+                      end
+
+          grouped_fk = fk_info.group_by { |row| row["id"] }.values.each { |group| group.sort_by! { |row| row["seq"] } }
+          grouped_fk.map do |group|
+            row = group.first
+            fk_def = fk_defs[[row["table"], row["from"], row["to"]]]
+            options = {
+              on_delete: extract_foreign_key_action(row["on_delete"]),
+              on_update: extract_foreign_key_action(row["on_update"]),
+              deferrable: fk_def && fk_def[:deferrable],
+              name: fk_def && fk_def[:name],
+            }
+
+            if group.one?
+              options[:column] = row["from"]
+              options[:primary_key] = row["to"]
+            else
+              options[:column] = group.map { |row| row["from"] }
+              options[:primary_key] = group.map { |row| row["to"] }
             end
+            ForeignKeyDefinition.new(table_name, row["table"], options)
           end
         end
 
@@ -800,11 +838,15 @@ module ActiveRecord
         GENERATED_ALWAYS_AS_REGEX = /.*"(\w+)".+GENERATED ALWAYS AS \((.+)\) (?:STORED|VIRTUAL)/i
 
         def table_structure_with_collation(table_name, basic_structure)
+          column_strings = table_structure_sql(table_name, basic_structure.map { |column| column["name"] })
+
+          build_table_structure(basic_structure, column_strings)
+        end
+
+        def build_table_structure(basic_structure, column_strings)
           collation_hash = {}
           auto_increments = {}
           generated_columns = {}
-
-          column_strings = table_structure_sql(table_name, basic_structure.map { |column| column["name"] })
 
           if column_strings.any?
             column_strings.each do |column_string|
@@ -853,32 +895,66 @@ module ActiveRecord
             WHERE type = 'table' AND name = #{quote(table_name)}
           SQL
 
-          # Result will have following sample string
-          # CREATE TABLE "users" ("id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-          #                       "password_digest" varchar COLLATE "NOCASE",
-          #                       "o_id" integer,
-          #                       CONSTRAINT "fk_rails_78146ddd2e" FOREIGN KEY ("o_id") REFERENCES "os" ("id"));
-          result = query_value(sql)
+          split_table_structure_sql(query_value(sql), column_names)
+        end
 
-          return [] unless result
+        # The sql is the statement the table was created with, and will have the
+        # following sample form
+        # CREATE TABLE "users" ("id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+        #                       "password_digest" varchar COLLATE "NOCASE",
+        #                       "o_id" integer,
+        #                       CONSTRAINT "fk_rails_78146ddd2e" FOREIGN KEY ("o_id") REFERENCES "os" ("id"));
+        def split_table_structure_sql(sql, column_names)
+          return [] unless sql
 
           # Splitting with left parentheses and discarding the first part will return all
           # columns separated with comma(,).
-          result.partition(UNQUOTED_OPEN_PARENS_REGEX)
-                .last
-                .sub(FINAL_CLOSE_PARENS_REGEX, "")
-                # column definitions can have a comma in them, so split on commas followed
-                # by a space and a column name in quotes or followed by the keyword CONSTRAINT
-                .split(/,(?=\s(?:CONSTRAINT|"(?:#{Regexp.union(column_names).source})"))/i)
-                .map(&:strip)
+          sql.partition(UNQUOTED_OPEN_PARENS_REGEX)
+             .last
+             .sub(FINAL_CLOSE_PARENS_REGEX, "")
+             # column definitions can have a comma in them, so split on commas followed
+             # by a space and a column name in quotes or followed by the keyword CONSTRAINT
+             .split(/,(?=\s(?:CONSTRAINT|"(?:#{Regexp.union(column_names).source})"))/i)
+             .map(&:strip)
         end
 
         def table_info(table_name)
-          if supports_virtual_columns?
-            query_all("PRAGMA table_xinfo(#{quote_table_name(table_name)})")
-          else
-            query_all("PRAGMA table_info(#{quote_table_name(table_name)})")
-          end
+          query_all("PRAGMA #{table_info_pragma}(#{quote_table_name(table_name)})")
+        end
+
+        # Only table_xinfo reports hidden columns, which is how a generated column is
+        # reported.
+        def table_info_pragma
+          supports_virtual_columns? ? "table_xinfo" : "table_info"
+        end
+
+        # The pragmas are table valued functions as well as statements, so they can be
+        # joined to a list of names and read for many tables at once.
+        # See https://www.sqlite.org/pragma.html#pragfunc
+        #
+        # The statement a table was created with comes along because the collation,
+        # auto increment and generated columns are only named there. It repeats once
+        # per column, so it is read from the first row. A view has a statement too,
+        # but it describes the query rather than any columns.
+        def table_structures(tables)
+          return {} if tables.empty?
+
+          fields = ["name", "type", "notnull", "dflt_value", "pk"]
+          fields << "hidden" if supports_virtual_columns?
+
+          query_all(<<~SQL).group_by { |row| row["table_name"] }
+            #{MASTER_CTE}
+            SELECT m.name AS table_name, CASE WHEN m.type = 'table' THEN m.sql END AS create_table_sql,
+                   #{fields.map { |field| "t.#{quote_column_name(field)}" }.join(", ")}
+            FROM master m
+            JOIN pragma_#{table_info_pragma}(m.name) t
+            WHERE m.type IN ('table', 'view')
+              AND m.name IN (#{quoted_table_names(tables)})
+            ORDER BY m.name, t.cid
+          SQL
+            .transform_values do |group|
+              [group.first["create_table_sql"], group.map { |row| row.except("table_name", "create_table_sql") }]
+            end
         end
 
         def arel_visitor

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -153,6 +153,7 @@ module ActiveRecord
 
       def read_schema_metadata(tables)
         @columns = @connection.columns(tables)
+        @table_options = @connection.table_options(tables)
         @primary_keys = @connection.primary_keys(tables)
         @indexes = @connection.indexes(tables)
         @foreign_keys = @connection.foreign_keys(tables) if @connection.supports_foreign_keys?
@@ -217,7 +218,7 @@ module ActiveRecord
             tbl.print ", id: false"
           end
 
-          table_options = @connection.table_options(table)
+          table_options = @table_options[table]
           if table_options.present?
             tbl.print ", #{format_options(table_options)}"
           end

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -482,6 +482,19 @@ class SchemaTest < ActiveRecord::PostgreSQLTestCase
     end
   end
 
+  def test_table_options_for_a_name_in_two_schemas_reads_the_first_on_the_search_path
+    @connection.execute "COMMENT ON TABLE #{SCHEMA_NAME}.#{TABLE_NAME} IS 'in schema one'"
+    @connection.execute "COMMENT ON TABLE #{SCHEMA2_NAME}.#{TABLE_NAME} IS 'in schema two'"
+
+    with_schema_search_path("#{SCHEMA_NAME}, #{SCHEMA2_NAME}") do
+      assert_equal({ comment: "in schema one" }, @connection.table_options(TABLE_NAME))
+    end
+
+    with_schema_search_path("#{SCHEMA2_NAME}, #{SCHEMA_NAME}") do
+      assert_equal({ comment: "in schema two" }, @connection.table_options(TABLE_NAME))
+    end
+  end
+
   def test_pk_and_sequence_for_with_schema_specified
     pg_name = ActiveRecord::ConnectionAdapters::PostgreSQL::Name
     [
@@ -992,6 +1005,18 @@ class SchemaCreateTableOptionsTest < ActiveRecord::PostgreSQLTestCase
     output = dump_table_schema "trains"
 
     assert_match("options: \"#{options}\"", output)
+  end
+
+  def test_table_options_are_only_read_for_base_tables
+    @connection.create_table "trains" do |t|
+      t.string :name
+    end
+    @connection.execute "CREATE VIEW train_names AS SELECT name FROM trains"
+    @connection.execute "COMMENT ON VIEW train_names IS 'not a table'"
+
+    assert_empty @connection.table_options("train_names")
+  ensure
+    @connection.execute "DROP VIEW IF EXISTS train_names"
   end
 
   def test_inherited_table_options_is_dumped

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -4,11 +4,13 @@ require "cases/helper"
 require "models/owner"
 require "tempfile"
 require "support/ddl_helper"
+require "support/schema_dumping_helper"
 
 module ActiveRecord
   module ConnectionAdapters
     class SQLite3AdapterTest < ActiveRecord::SQLite3TestCase
       include DdlHelper
+      include SchemaDumpingHelper
 
       self.use_transactional_tests = false
 
@@ -515,12 +517,24 @@ module ActiveRecord
           name = "foo"
 
           tables_query = ["SELECT name FROM pragma_table_list WHERE schema <> 'temp' AND name NOT IN ('sqlite_sequence', 'sqlite_schema') AND type IN ('table','view')", "SCHEMA", []]
-          pragma_query = ["PRAGMA table_xinfo(\"ex\")", "SCHEMA", []]
-          schema_query = ["SELECT sql FROM (SELECT * FROM sqlite_master UNION ALL SELECT * FROM sqlite_temp_master) WHERE type = 'table' AND name = 'ex'", "SCHEMA", []]
+          structure_query = [<<~SQL.squish, "SCHEMA", []]
+            WITH master AS (
+              SELECT name, type, sql FROM sqlite_master
+              UNION ALL
+              SELECT name, type, sql FROM sqlite_temp_master
+            )
+            SELECT m.name AS table_name, CASE WHEN m.type = 'table' THEN m.sql END AS create_table_sql,
+                   t."name", t."type", t."notnull", t."dflt_value", t."pk", t."hidden"
+            FROM master m
+            JOIN pragma_table_xinfo(m.name) t
+            WHERE m.type IN ('table', 'view')
+              AND m.name IN ('ex')
+            ORDER BY m.name, t.cid
+          SQL
           modified_insert_query = [(sql + ' RETURNING "id"'), name, []]
 
           # First insert after with_example_table has reset the schema cache
-          assert_logged [tables_query, pragma_query, schema_query, modified_insert_query] do
+          assert_logged [tables_query, structure_query, modified_insert_query] do
             @conn.insert(sql, name)
           end
 
@@ -673,9 +687,38 @@ module ActiveRecord
         end
       end
 
+      def test_autoincrement_primary_key_is_dumped_as_the_default
+        connection = ActiveRecord::Base.lease_connection
+        connection.create_table :autoincrement_pks, force: true
+        connection.drop_table :integer_pks, if_exists: true
+        connection.execute("CREATE TABLE integer_pks (id integer PRIMARY KEY NOT NULL)")
+
+        output = dump_table_schema("autoincrement_pks", "integer_pks")
+
+        assert_match %r{create_table "autoincrement_pks", force: :cascade}, output
+        assert_match %r{create_table "integer_pks", id: :integer, default: nil, force: :cascade}, output
+      ensure
+        connection.drop_table :autoincrement_pks, if_exists: true
+        connection.drop_table :integer_pks, if_exists: true
+      end
+
       def test_indexes_logs
         with_example_table do
-          assert_logged [["PRAGMA index_list(\"ex\")", "SCHEMA", []]] do
+          index_list_query = [<<~SQL.squish, "SCHEMA", []]
+            WITH master AS (
+              SELECT name, type, sql FROM sqlite_master
+              UNION ALL
+              SELECT name, type, sql FROM sqlite_temp_master
+            )
+            SELECT m.name AS table_name, i.name, i."unique"
+            FROM master m
+            JOIN pragma_index_list(m.name) i
+            WHERE m.type = 'table'
+              AND m.name IN ('ex')
+              AND i.name NOT GLOB 'sqlite_*'
+          SQL
+
+          assert_logged [index_list_query] do
             @conn.indexes("ex")
           end
         end

--- a/activerecord/test/cases/connection_adapters/schema_statements_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_statements_test.rb
@@ -8,7 +8,7 @@ module ActiveRecord
       self.use_transactional_tests = false
 
       WHOLE_SCHEMA_READERS = %i[
-        columns indexes primary_keys foreign_keys
+        columns indexes primary_keys foreign_keys table_options
         check_constraints exclusion_constraints unique_constraints
       ].freeze
 
@@ -32,9 +32,15 @@ module ActiveRecord
           listed = @connection.public_send(reader, tables)
 
           tables.each do |table|
-            assert_equal attributes(@connection.public_send(reader, table)),
-              attributes(listed.fetch(table)),
-              "#{reader} disagreed about #{table}"
+            one = attributes(@connection.public_send(reader, table))
+            many = attributes(listed.fetch(table))
+
+            # An adapter with nothing to report for a reader answers nil for every table.
+            if one.nil?
+              assert_nil many, "#{reader} disagreed about #{table}"
+            else
+              assert_equal one, many, "#{reader} disagreed about #{table}"
+            end
           end
         end
       end
@@ -138,7 +144,7 @@ module ActiveRecord
           case value
           when Array
             value.all?(String) ? value : value.map { |element| attributes(element) }.sort_by(&:to_s)
-          when String, nil then value
+          when Hash, String, nil then value
           else value.instance_variables.sort.index_with { |ivar| value.instance_variable_get(ivar) }
           end
         end


### PR DESCRIPTION
Follow-up to #58421, #58488 and #58494. Two things: `table_options` gains a list form, and SQLite starts actually batching the list form it already accepted.

## table_options

`SchemaStatements#table_options` now takes a list of tables and returns a hash keyed by table name, like the other readers:

```ruby
connection.table_options(:measurements)            # => { options: "PARTITION BY LIST (city_id)" }
connection.table_options([:measurements, :posts])  # => { "measurements" => {...}, "posts" => {} }
```

PostgreSQL used three queries per table to answer it: one for the table comment, one for the tables it inherits from, and one for its partition key. A single query now covers all three for every table.

## SQLite

SQLite accepted a list already but answered it a table at a time. Its pragmas are table valued functions as well as statements, so they can be joined to a list of names — available since 3.16, against the 3.35 Rails requires:

```sql
WITH master AS (
  SELECT name, type, sql FROM sqlite_master
  UNION ALL
  SELECT name, type, sql FROM sqlite_temp_master
)
SELECT m.name AS table_name, CASE WHEN m.type = 'table' THEN m.sql END AS create_table_sql, t.*
FROM master m
JOIN pragma_table_xinfo(m.name) t
WHERE m.type IN ('table', 'view') AND m.name IN (...)
ORDER BY m.name, t.cid
```

The statement each table was created with rides along with its columns, because the collation, auto increment and generated columns are only named there.

| reader | before | after |
|---|---|---|
| columns | 506 | **1** |
| primary keys | 506 | **1** |
| indexes | 435 | **2** |
| foreign keys | 759 | **2** |
| check constraints | 253 | **1** |
| `primary_key_has_autoincrement?` | 440 | **1** |

## Effect

Dumping the Active Record test schema, measured before and after on the same tree:

| adapter | tables | statements | time (best of 5) |
|---|---|---|---|
| PostgreSQL 17 | 274 | 836 → **24** | 107.8 → **36.2 ms** |
| SQLite 3.47 | 255 | 2907 → **12** | 97.8 → **25.8 ms** |
| MySQL 8.0.46 | 258 | 266 → 266 | 65.0 → 60.6 ms |

A synthetic PostgreSQL schema of plain tables, to show the shape:

| tables | statements | time |
|---|---|---|
| 250 | 768 → **19** | 126.3 → **48.5 ms** |
| 1000 | 3018 → **19** | 435.5 → **125.7 ms** |

The statement count no longer moves with the number of tables on PostgreSQL or SQLite.

Dump output is byte for byte identical on PostgreSQL, SQLite, MySQL 8.0.46 and MariaDB 11.8.8. Because the dumper sorts index and foreign key statements, an identical dump would not reveal a change in the order a reader returns things, so I also compared `columns`, `indexes`, `primary_keys`, `foreign_keys` and `check_constraints` for every table against the previous implementation, including every `Column` instance variable: 48,096 lines, identical.

## MySQL and MariaDB still read table options one table at a time

`SHOW CREATE TABLE` is the only place they report the options a table was created with, and `information_schema` cannot stand in for it.

Whether the tablespace comment is printed depends on the table having been rebuilt, not on where it currently lives, and nothing readable records that. With `innodb_file_per_table` off, two tables differing only by an `OPTIMIZE TABLE`:

```
np_created   flag=33   space=0  →  ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
np_rebuilt   flag=161  space=0  →  /*!50100 TABLESPACE `innodb_system` */ ENGINE=InnoDB DEFAULT CHARSET=...
```

Same engine, row format, collation, `create_options`, `innodb_tables.space` and `innodb_tablespaces` row. The flag differs here, but it tracks the shared tablespace rather than the printed clause: with `innodb_file_per_table` off every InnoDB table has it set, and predicting the clause from it adds a spurious `TABLESPACE` to 231 of the 258 tables in the test schema.

## Tests

`table_options` joins `WHOLE_SCHEMA_READERS`, which covers reading exactly the tables given, agreeing with a single read, not scaling with the number of tables, reading nothing for an empty list, and keying a qualified name by the name it was given.

Three tests are new, all found by mutation testing:

- PostgreSQL: the same bare table name in two schemas resolves down the search path, and options are read only for base tables so a commented view reports nothing.
- SQLite: an autoincrement primary key dumps as the default and a plain integer one does not. `SQLite3::SchemaDumper#primary_key_has_autoincrement?` had no coverage at all — forcing it false changes 440 lines of dump output with the whole suite still green, and it is a method this PR refactors.

Three mutations still survive deliberately: a partition that is itself partitioned reports `INHERITS` and drops its own partition key, which is unchanged from before rather than pinned; deleting `ORDER BY i.seqno` and `ORDER BY i.inhseqno` is caught only when the order is reversed, because both servers already return those rows ordered; and `supports_native_partitioning?` is hardcoded true on the PostgreSQL adapter, so its other arm is unreachable.

Full suites pass on postgresql, trilogy and sqlite3, plus MariaDB 11.8.8.

## Two readers removed

`inherited_table_names` and `table_partition_definition` no longer have callers inside Rails; the batched query answers both. Removed, per @byroot: `:nodoc:` makes them private API regardless of visibility.

