### PR TITLE
Add unit tests for NullAnalyzer and ImageProcessingTransformer

### DIFF
--- a/activestorage/test/analyzer/null_analyzer_test.rb
+++ b/activestorage/test/analyzer/null_analyzer_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "database/setup"
+
+require "active_storage/analyzer/null_analyzer"
+
+class ActiveStorage::Analyzer::NullAnalyzerTest < ActiveSupport::TestCase
+  test "accepts any blob" do
+    blob = create_blob
+
+    assert ActiveStorage::Analyzer::NullAnalyzer.accept?(blob)
+  end
+
+  test "accepts image blobs" do
+    blob = create_file_blob
+
+    assert ActiveStorage::Analyzer::NullAnalyzer.accept?(blob)
+  end
+
+  test "does not analyze later" do
+    assert_equal false, ActiveStorage::Analyzer::NullAnalyzer.analyze_later?
+  end
+
+  test "returns empty metadata" do
+    blob = create_blob
+    analyzer = ActiveStorage::Analyzer::NullAnalyzer.new(blob)
+
+    assert_equal({}, analyzer.metadata)
+  end
+end

--- a/activestorage/test/transformers/image_processing_transformer_test.rb
+++ b/activestorage/test/transformers/image_processing_transformer_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+require "active_storage/transformers/image_magick"
+
+class ActiveStorage::Transformers::ImageProcessingTransformerTest < ActiveSupport::TestCase
+  setup do
+    @transformer_class = ActiveStorage::Transformers::ImageMagick
+  end
+
+  test "combine_options raises ArgumentError" do
+    transformer = @transformer_class.new(combine_options: { resize: "100x100" })
+
+    assert_raises(ArgumentError, match: /combine_options/) do
+      transformer.send(:operations)
+    end
+  end
+
+  test "combine_options with a string key raises ArgumentError" do
+    transformer = @transformer_class.new("combine_options" => { resize: "100x100" })
+
+    assert_raises(ArgumentError, match: /combine_options/) do
+      transformer.send(:operations)
+    end
+  end
+
+  test "blank transformation arguments are omitted from operations" do
+    transformer = @transformer_class.new(resize_to_limit: [100, 100], colourspace: "")
+
+    assert_equal [[:resize_to_limit, [100, 100]]], transformer.send(:operations)
+  end
+
+  test "nil transformation arguments are omitted from operations" do
+    transformer = @transformer_class.new(resize_to_limit: [100, 100], rotate: nil)
+
+    assert_equal [[:resize_to_limit, [100, 100]]], transformer.send(:operations)
+  end
+
+  test "supported transformations are included in operations" do
+    transformer = @transformer_class.new(resize_to_limit: [100, 100], colourspace: "b-w")
+
+    operations = transformer.send(:operations)
+
+    assert_equal 2, operations.size
+    assert_includes operations, [:resize_to_limit, [100, 100]]
+    assert_includes operations, [:colourspace, "b-w"]
+  end
+
+  test "unsupported transformation methods raise UnsupportedImageProcessingMethod" do
+    transformer = @transformer_class.new(system: "touch /tmp/dangerous")
+
+    assert_raises(ActiveStorage::Transformers::ImageProcessingTransformer::UnsupportedImageProcessingMethod) do
+      transformer.send(:operations)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Add unit test coverage for `ActiveStorage::Analyzer::NullAnalyzer` and `ActiveStorage::Transformers::ImageProcessingTransformer`.

These classes had little or no dedicated test coverage. The new tests exercise fallback analyzer behavior and variant transformation validation without running full image processing or controller integration flows.

## Changes

### `activestorage/test/analyzer/null_analyzer_test.rb`

- `NullAnalyzer.accept?` returns true for text and image blobs
- `NullAnalyzer.analyze_later?` is false
- `NullAnalyzer#metadata` returns an empty hash

### `activestorage/test/transformers/image_processing_transformer_test.rb`

- `:combine_options` / `"combine_options"` raises `ArgumentError` (explicitly unsupported)
- Blank and nil transformation arguments are omitted from `operations`
- Supported transformations (`resize_to_limit`, `colourspace`) are included
- Unsupported methods raise `UnsupportedImageProcessingMethod`

No production code changes.

## Test plan

- [x] `cd activestorage && bin/test test/analyzer/null_analyzer_test.rb test/transformers/image_processing_transformer_test.rb`
- [x] 10 runs, 18 assertions, 0 failures

## Checklist

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. *(N/A — tests only, no behavior change.)*
