### PR TITLE
Fix stale has_many target during dependent destroy

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -28,18 +28,20 @@ module ActiveRecord
           load_target_for_dependent_destroy.each { |t| t.destroyed_by_association = reflection }
           destroy_all
         when :destroy_async
-          load_target.each do |t|
+          persisted_target = load_persisted_target_for_dependent_destroy
+
+          target.each do |t|
             t.destroyed_by_association = reflection
           end
 
-          unless target.empty?
-            association_class = target.first.class
+          unless persisted_target.empty?
+            association_class = persisted_target.first.class
             if association_class.query_constraints_list
               primary_key_column = association_class.query_constraints_list
-              ids = target.collect { |assoc| primary_key_column.map { |col| assoc.public_send(col) } }
+              ids = persisted_target.collect { |assoc| primary_key_column.map { |col| assoc.public_send(col) } }
             else
               primary_key_column = association_class.primary_key
-              ids = target.collect { |assoc| assoc.public_send(primary_key_column) }
+              ids = persisted_target.collect { |assoc| assoc.public_send(primary_key_column) }
             end
 
             ids.each_slice(owner.class.destroy_association_async_batch_size || ids.size) do |ids_batch|
@@ -70,11 +72,21 @@ module ActiveRecord
         def load_target_for_dependent_destroy
           return load_target if owner.new_record?
 
+          load_persisted_target_for_dependent_destroy
+          target
+        end
+
+        # Return fresh database records for async identifiers while separately
+        # merging them into the target to retain unsaved and changed state.
+        def load_persisted_target_for_dependent_destroy
+          return load_target.select(&:persisted?) if owner.new_record?
+
           persisted = reflection.klass.uncached do
             skip_strict_loading { find_target }
           end
 
-          self.target = merge_target_lists(persisted, target)
+          self.target = merge_target_lists(persisted.dup, target)
+          persisted
         end
 
         # Returns the number of records in this collection.

--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -25,7 +25,7 @@ module ActiveRecord
 
         when :destroy
           # No point in executing the counter update since we're going to destroy the parent anyway
-          load_target.each { |t| t.destroyed_by_association = reflection }
+          load_target_for_dependent_destroy.each { |t| t.destroyed_by_association = reflection }
           destroy_all
         when :destroy_async
           load_target.each do |t|
@@ -64,6 +64,19 @@ module ActiveRecord
       end
 
       private
+        # Persisted records may have been added without updating a loaded target.
+        # Re-read the association so dependent destruction uses the database as
+        # its source of truth, while retaining unsaved and changed target records.
+        def load_target_for_dependent_destroy
+          return load_target if owner.new_record?
+
+          persisted = reflection.klass.uncached do
+            skip_strict_loading { find_target }
+          end
+
+          self.target = merge_target_lists(persisted, target)
+        end
+
         # Returns the number of records in this collection.
         #
         # If the association has a counter cache it gets that value. Otherwise

--- a/activerecord/test/activejob/destroy_association_async_test.rb
+++ b/activerecord/test/activejob/destroy_association_async_test.rb
@@ -31,6 +31,10 @@ require "models/cpk/chapter_destroy_async"
 class DestroyAssociationAsyncTest < ActiveRecord::TestCase
   include ActiveJob::TestHelper
 
+  setup do
+    EssayDestroyAsync.destroyed_ids.clear
+  end
+
   test "destroying a record destroys the has_many :through records using a job" do
     tag = Tag.create!(name: "Der be treasure")
     tag2 = Tag.create!(name: "Der be rum")
@@ -272,6 +276,145 @@ class DestroyAssociationAsyncTest < ActiveRecord::TestCase
     BookDestroyAsync.delete_all
   end
 
+  test "has_many destroys records created after an empty association was loaded" do
+    book = BookDestroyAsync.create!(name: "Stale target")
+    assert_empty book.essays.load
+
+    essays = 2.times.map { |index| EssayDestroyAsync.create!(name: "Essay #{index}", book_id: book.id) }
+    assert_empty book.essays
+
+    assert_enqueues_destroy_association(essays.map(&:id)) do
+      book.destroy
+    end
+
+    perform_enqueued_jobs only: ActiveRecord::DestroyAssociationAsyncJob
+
+    assert_empty EssayDestroyAsync.where(id: essays.map(&:id))
+    assert_equal essays.map(&:id), EssayDestroyAsync.destroyed_ids
+  ensure
+    EssayDestroyAsync.delete_all
+    BookDestroyAsync.delete_all
+  end
+
+  test "has_many merges records created after a non-empty association was loaded" do
+    book = BookDestroyAsync.create!(name: "Partially stale target")
+    loaded_essay = EssayDestroyAsync.create!(name: "Loaded", book_id: book.id)
+    assert_equal [loaded_essay], book.essays.load
+    added_essay = EssayDestroyAsync.create!(name: "Added later", book_id: book.id)
+    assert_equal [loaded_essay], book.essays
+    essays = [loaded_essay, added_essay]
+
+    assert_enqueues_destroy_association(essays.map(&:id)) do
+      book.destroy
+    end
+
+    perform_enqueued_jobs only: ActiveRecord::DestroyAssociationAsyncJob
+
+    assert_empty EssayDestroyAsync.where(id: essays.map(&:id))
+    assert_equal essays.map(&:id), EssayDestroyAsync.destroyed_ids
+  ensure
+    EssayDestroyAsync.delete_all
+    BookDestroyAsync.delete_all
+  end
+
+  test "has_many uses persisted identifiers while preserving changed target records" do
+    book = BookDestroyAsync.create!(name: "Changed target")
+    essay = EssayDestroyAsync.create!(name: "Persisted", book_id: book.id)
+    loaded_essay = book.essays.load.first
+    loaded_essay.name = "Changed in memory"
+
+    assert_enqueues_destroy_association([essay.id]) do
+      book.destroy
+    end
+
+    assert_same loaded_essay, book.essays.target.first
+    assert_equal "Changed in memory", book.essays.target.first.name
+
+    perform_enqueued_jobs only: ActiveRecord::DestroyAssociationAsyncJob
+
+    assert_not EssayDestroyAsync.exists?(essay.id)
+    assert_equal [essay.id], EssayDestroyAsync.destroyed_ids
+  ensure
+    EssayDestroyAsync.delete_all
+    BookDestroyAsync.delete_all
+  end
+
+  test "has_many destroys records from an unloaded association" do
+    book = BookDestroyAsync.create!(name: "Unloaded target")
+    essays = 2.times.map { |index| EssayDestroyAsync.create!(name: "Essay #{index}", book_id: book.id) }
+    assert_not_predicate book.essays, :loaded?
+
+    assert_enqueues_destroy_association(essays.map(&:id)) do
+      book.destroy
+    end
+
+    perform_enqueued_jobs only: ActiveRecord::DestroyAssociationAsyncJob
+
+    assert_empty EssayDestroyAsync.where(id: essays.map(&:id))
+    assert_equal essays.map(&:id), EssayDestroyAsync.destroyed_ids
+  ensure
+    EssayDestroyAsync.delete_all
+    BookDestroyAsync.delete_all
+  end
+
+  test "has_many destroys records created through the association" do
+    book = BookDestroyAsync.create!(name: "Association-created target")
+    essays = 2.times.map { |index| book.essays.create!(name: "Essay #{index}") }
+
+    assert_enqueues_destroy_association(essays.map(&:id)) do
+      book.destroy
+    end
+
+    perform_enqueued_jobs only: ActiveRecord::DestroyAssociationAsyncJob
+
+    assert_empty EssayDestroyAsync.where(id: essays.map(&:id))
+    assert_equal essays.map(&:id), EssayDestroyAsync.destroyed_ids
+  ensure
+    EssayDestroyAsync.delete_all
+    BookDestroyAsync.delete_all
+  end
+
+  test "has_many does not enqueue unsaved target records" do
+    book = BookDestroyAsync.create!(name: "Mixed target")
+    unsaved_essay = book.essays.build(name: "Unsaved")
+    persisted_essay = EssayDestroyAsync.create!(name: "Persisted", book_id: book.id)
+
+    assert_enqueues_destroy_association([persisted_essay.id]) do
+      book.destroy
+    end
+
+    assert_not_predicate unsaved_essay, :persisted?
+    assert_not_predicate unsaved_essay, :destroyed?
+
+    perform_enqueued_jobs only: ActiveRecord::DestroyAssociationAsyncJob
+
+    assert_not EssayDestroyAsync.exists?(persisted_essay.id)
+    assert_equal [persisted_essay.id], EssayDestroyAsync.destroyed_ids
+  ensure
+    EssayDestroyAsync.delete_all
+    BookDestroyAsync.delete_all
+  end
+
+  test "scoped has_many only destroys records in the association scope" do
+    book = BookDestroyAsyncWithScopedEssays.create!(name: "Scoped target")
+    assert_empty book.essays.load
+    included = EssayDestroyAsync.create!(name: "In scope", book_id: book.id)
+    excluded = EssayDestroyAsync.create!(name: "Out of scope", book_id: book.id)
+
+    assert_enqueues_destroy_association([included.id]) do
+      book.destroy
+    end
+
+    perform_enqueued_jobs only: ActiveRecord::DestroyAssociationAsyncJob
+
+    assert_not EssayDestroyAsync.exists?(included.id)
+    assert EssayDestroyAsync.exists?(excluded.id)
+    assert_equal [included.id], EssayDestroyAsync.destroyed_ids
+  ensure
+    EssayDestroyAsync.delete_all
+    BookDestroyAsyncWithScopedEssays.delete_all
+  end
+
   test "has_many with STI parent class destroys all children class records" do
     book = BookDestroyAsync.create!
     LongEssayDestroyAsync.create!(book: book)
@@ -438,4 +581,13 @@ class DestroyAssociationAsyncTest < ActiveRecord::TestCase
     Tag.delete_all
     BookDestroyAsync.delete_all
   end
+
+  private
+    def assert_enqueues_destroy_association(ids, &block)
+      job_args = ->(args) { args.first[:association_ids] == ids }
+
+      assert_enqueued_jobs 1, only: ActiveRecord::DestroyAssociationAsyncJob do
+        assert_enqueued_with(job: ActiveRecord::DestroyAssociationAsyncJob, args: job_args, &block)
+      end
+    end
 end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -126,6 +126,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def setup
     Client.destroyed_client_ids.clear
+    Client.destroyed_ids.clear
   end
 
   def test_sti_subselect_count
@@ -1958,6 +1959,94 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal 3, firm.clients.size
     firm.destroy
     assert_empty Client.all.merge!(where: "firm_id=#{firm.id}").to_a
+  end
+
+  def test_dependence_destroys_records_created_after_an_empty_association_was_loaded
+    firm = StaleDependentFirm.create!(name: "Stale target")
+    assert_empty firm.dependent_clients.load
+
+    clients = 2.times.map { |index| Client.create!(name: "Client #{index}", firm: companies(:first_firm), firm_id: firm.id) }
+    assert_equal clients, Client.where(firm_id: firm.id).order(:id).to_a
+    assert_empty firm.dependent_clients
+
+    firm.destroy!
+
+    assert_empty Client.where(firm_id: firm.id)
+    assert_equal clients.map(&:id), Client.destroyed_ids
+  end
+
+  def test_dependence_merges_records_created_after_a_non_empty_association_was_loaded
+    firm = StaleDependentFirm.create!(name: "Partially stale target")
+    loaded_client = Client.create!(name: "Loaded", firm: companies(:first_firm), firm_id: firm.id)
+    assert_equal [loaded_client], firm.dependent_clients.load
+    added_client = Client.create!(name: "Added later", firm: companies(:first_firm), firm_id: firm.id)
+    assert_equal [loaded_client], firm.dependent_clients
+
+    firm.destroy!
+
+    clients = [loaded_client, added_client]
+    assert_empty Client.where(firm_id: firm.id)
+    assert_equal clients.map(&:id), Client.destroyed_ids
+    expected_removals = clients.map { |client| [:before, client.id] } + clients.map { |client| [:after, client.id] }
+    assert_equal expected_removals, firm.dependent_client_removals
+  end
+
+  def test_dependence_destroys_each_record_once_when_association_is_loaded
+    firm = StaleDependentFirm.create!(name: "Loaded target")
+    clients = 2.times.map { |index| Client.create!(name: "Client #{index}", firm: companies(:first_firm), firm_id: firm.id) }
+    assert_equal clients, firm.dependent_clients.load
+
+    firm.destroy!
+
+    assert_empty Client.where(firm_id: firm.id)
+    assert_equal clients.map(&:id), Client.destroyed_ids
+  end
+
+  def test_dependence_destroys_each_record_once_when_association_is_unloaded
+    firm = StaleDependentFirm.create!(name: "Unloaded target")
+    clients = 2.times.map { |index| Client.create!(name: "Client #{index}", firm: companies(:first_firm), firm_id: firm.id) }
+    assert_not_predicate firm.dependent_clients, :loaded?
+
+    firm.destroy!
+
+    assert_empty Client.where(firm_id: firm.id)
+    assert_equal clients.map(&:id), Client.destroyed_ids
+  end
+
+  def test_dependence_destroys_each_record_once_when_created_through_association
+    firm = StaleDependentFirm.create!(name: "Association-created target")
+    clients = 2.times.map { |index| firm.dependent_clients.create!(name: "Client #{index}", firm: companies(:first_firm)) }
+
+    firm.destroy!
+
+    assert_empty Client.where(firm_id: firm.id)
+    assert_equal clients.map(&:id), Client.destroyed_ids
+  end
+
+  def test_dependence_preserves_unsaved_target_members_while_loading_persisted_records
+    firm = StaleDependentFirm.create!(name: "Mixed target")
+    unsaved_client = firm.dependent_clients.build(name: "Unsaved", firm: companies(:first_firm))
+    persisted_client = Client.create!(name: "Persisted", firm: companies(:first_firm), firm_id: firm.id)
+
+    firm.destroy!
+
+    assert_not_predicate unsaved_client, :destroyed?
+    assert_not_predicate unsaved_client, :persisted?
+    assert_not Client.exists?(persisted_client.id)
+    assert_equal [persisted_client.id], Client.destroyed_ids
+  end
+
+  def test_dependence_destroys_only_records_in_the_association_scope
+    firm = ScopedDependentFirm.create!(name: "Scoped target")
+    assert_empty firm.dependent_clients.load
+    included = Client.create!(name: "BigShot Inc.", firm: companies(:first_firm), firm_id: firm.id)
+    excluded = Client.create!(name: "SmallTime Inc.", firm: companies(:first_firm), firm_id: firm.id)
+
+    firm.destroy!
+
+    assert_not Client.exists?(included.id)
+    assert Client.exists?(excluded.id)
+    assert_equal [included.id], Client.destroyed_ids
   end
 
   def test_dependence_for_associations_with_hash_condition

--- a/activerecord/test/models/book_destroy_async.rb
+++ b/activerecord/test/models/book_destroy_async.rb
@@ -22,3 +22,10 @@ class BookDestroyAsyncWithScopedTags < ActiveRecord::Base
   has_many :taggings, as: :taggable, class_name: "Tagging"
   has_many :tags, -> { where name: "Der be rum" }, through: :taggings, dependent: :destroy_async
 end
+
+class BookDestroyAsyncWithScopedEssays < ActiveRecord::Base
+  self.table_name = "books"
+
+  has_many :essays, -> { where(name: "In scope") }, dependent: :destroy_async,
+    class_name: "EssayDestroyAsync", foreign_key: "book_id"
+end

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -137,6 +137,28 @@ class Agency < Firm
   accepts_nested_attributes_for :projects
 end
 
+class StaleDependentFirm < Company
+  has_many :dependent_clients, -> { order(:id) }, foreign_key: "firm_id", class_name: "Client", dependent: :destroy,
+    before_remove: :log_dependent_client_before_remove, after_remove: :log_dependent_client_after_remove
+
+  def dependent_client_removals
+    @dependent_client_removals ||= []
+  end
+
+  private
+    def log_dependent_client_before_remove(client)
+      dependent_client_removals << [:before, client.id]
+    end
+
+    def log_dependent_client_after_remove(client)
+      dependent_client_removals << [:after, client.id]
+    end
+end
+
+class ScopedDependentFirm < Company
+  has_many :dependent_clients, -> { where(name: "BigShot Inc.") }, foreign_key: "firm_id", class_name: "Client", dependent: :destroy
+end
+
 class Client < Company
   belongs_to :firm, foreign_key: "client_of", inverse_of: :client
   belongs_to :firm_with_basic_id, class_name: "Firm", foreign_key: "firm_id"
@@ -188,7 +210,12 @@ class Client < Company
     @destroyed_client_ids ||= Hash.new { |h, k| h[k] = [] }
   end
 
+  def self.destroyed_ids
+    @destroyed_ids ||= []
+  end
+
   before_destroy do |client|
+    Client.destroyed_ids << client.id
     if client.firm
       Client.destroyed_client_ids[client.firm.id] << client.id
     end

--- a/activerecord/test/models/essay_destroy_async.rb
+++ b/activerecord/test/models/essay_destroy_async.rb
@@ -4,6 +4,12 @@ class EssayDestroyAsync < ActiveRecord::Base
   self.table_name = "essays"
   belongs_to :book, dependent: :destroy_async, class_name: "BookDestroyAsync"
   belongs_to :writer, polymorphic: true, dependent: :destroy_async
+
+  def self.destroyed_ids
+    @destroyed_ids ||= []
+  end
+
+  before_destroy { |essay| EssayDestroyAsync.destroyed_ids << essay.id }
 end
 
 class LongEssayDestroyAsync < EssayDestroyAsync


### PR DESCRIPTION
### Motivation / Background

Fixes #48968.

A loaded `has_many` association can become stale if dependent records are created outside the association.

With `dependent: :destroy`, Rails could trust that stale target and leave persisted children behind when the owner was destroyed.

The same problem also affected `dependent: :destroy_async`. A stale target could cause Rails to enqueue no job, or enqueue an incomplete set of child IDs.

### Detail

This Pull Request refreshes persisted association membership before both synchronous and asynchronous dependent destruction.

The database is used as the source of truth for persisted membership. The refreshed records are merged with the existing in-memory target so changed and unsaved records are preserved.

For `dependent: :destroy`, Rails continues through the normal destroy path and callbacks.

For `dependent: :destroy_async`, Rails queues the complete persisted ID set from the refreshed association. Unsaved records are not queued.

The change remains scoped to dependent destruction.

### Tests

Tests cover:

- stale empty and stale non-empty targets for `dependent: :destroy`;
- stale empty and stale non-empty targets for `dependent: :destroy_async`;
- exact-once child destruction;
- exact-once `before_remove` and `after_remove` callbacks for synchronous destruction;
- loaded, unloaded, changed-loaded, and association-created records;
- unsaved in-memory target records;
- scoped associations;
- async batching;
- custom primary keys;
- composite and query constraints;
- commit and rollback behavior.

### Verification

The exact submitted commit was independently verified with [FalseGreen](https://falsegreen.com/) against a frozen verification contract.

- stale cached associations cannot leave persisted dependents behind for `dependent: :destroy` or `dependent: :destroy_async`;
- stale async targets enqueue the complete persisted ID set without duplicates;
- child destruction remains exact-once;
- unsaved target members are preserved and never become async `nil` identifiers;
- association scopes remain authoritative;
- existing async batching, key, constraint, commit, and rollback behavior remains green;
- the complete `has_many` association test file passes;
- the complete `destroy_association_async` test file passes;
- all Active Record association tests pass under SQLite memory;
- RuboCop reports no offenses in the changed production and test files;
- 12/12 verification criteria passed;
- verified source: `f107130810c402d5286d60de579b9fdfaf2b9bd0`.

The verification is scoped to these criteria and does not claim broader correctness of Active Record.

Assisted-by: Codex

### Additional information

The complete Active Record SQLite suite is not part of the independent verification gate because the host run exposed unrelated order-dependent connection-pool failures and an environment missing the EST timezone definition.

The focused `has_many`, async destruction, and Active Record association test perimeters all pass.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.