### PR TITLE
Add an API to allow plugins to extend application code safely and fast

### DIFF
--- a/guides/source/autoloading_and_reloading_constants.md
+++ b/guides/source/autoloading_and_reloading_constants.md
@@ -687,6 +687,20 @@ Rails.autoloaders.main
 Rails.autoloaders.once
 ```
 
+If you want to configure an autoloaded constant, but the configuration does not
+depend on whether the constant is reloadable, register the callback with
+`Rails.autoloaders.any`:
+
+```ruby
+Rails.autoloaders.any.on_load("MyGateway") do |gateway|
+  gateway.endpoint = "https://my-gateway.example.com"
+end
+```
+
+The callback runs according to the semantics of the autoloader that manages the
+constant. In particular, it runs again when a reloadable constant is loaded
+after a reload. Code in the callback has to be safe under either policy.
+
 The predicate
 
 ```ruby

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add `Rails.autoloaders.any.on_load` to configure an autoloaded constant
+    without knowing whether the `main` or `once` autoloader manages it.
+
+    *Nicolas Vandenbogaerde*
+
 *   Validate subcommand in `rails plugin` command.
 
     `rails plugin foo bar` silently ignored the invalid subcommand "foo"

--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -145,6 +145,17 @@ module Rails
     #
     # This autoloader manages constants that are autoloaded, but not reloaded.
     #
+    # If the code being configured works regardless of whether its target is
+    # reloadable, you can register an +on_load+ callback with either autoloader:
+    #
+    #   Rails.autoloaders.any.on_load("MyGateway") do
+    #     MyGateway.endpoint = "https://my-gateway.example.com"
+    #   end
+    #
+    # The callback runs according to the semantics of the autoloader that
+    # manages the constant. In particular, it runs again when a reloadable
+    # constant is loaded after a reload.
+    #
     # You can use these objects to customize their behavior, defining custom
     # root namespaces, collapsing directories, configuring callbacks, etc.
     #

--- a/railties/lib/rails/autoloaders.rb
+++ b/railties/lib/rails/autoloaders.rb
@@ -6,9 +6,19 @@ module Rails
   class Autoloaders # :nodoc:
     require_relative "autoloaders/inflector"
 
+    class Any # :nodoc:
+      def initialize(autoloaders)
+        @autoloaders = autoloaders
+      end
+
+      def on_load(...)
+        @autoloaders.each { |autoloader| autoloader.on_load(...) }
+      end
+    end
+
     include Enumerable
 
-    attr_reader :main, :once
+    attr_reader :main, :once, :any
 
     def initialize
       # This `require` delays loading the library on purpose.
@@ -28,6 +38,8 @@ module Rails
       @once = Zeitwerk::Loader.new
       @once.tag = "rails.once"
       @once.inflector = Inflector
+
+      @any = Any.new([@main, @once])
     end
 
     def each

--- a/railties/test/application/zeitwerk_integration_test.rb
+++ b/railties/test/application/zeitwerk_integration_test.rb
@@ -27,7 +27,44 @@ class ZeitwerkIntegrationTest < ActiveSupport::TestCase
     assert_predicate Rails.autoloaders, :zeitwerk_enabled?
     assert_instance_of Zeitwerk::Loader, Rails.autoloaders.main
     assert_instance_of Zeitwerk::Loader, Rails.autoloaders.once
+    assert_instance_of Rails::Autoloaders::Any, Rails.autoloaders.any
     assert_equal [Rails.autoloaders.main, Rails.autoloaders.once], Rails.autoloaders.to_a
+  end
+
+  test "autoloaders.any runs on_load callbacks for the autoloader managing the constant" do
+    app_file "app/models/user.rb", "class User; end"
+    app_file "extras/money.rb", "class Money; end"
+    add_to_config 'config.autoload_once_paths << "#{Rails.root}/extras"'
+    add_to_config <<~'RUBY'
+      Rails.autoloaders.any.on_load("User") do |user|
+        $autoloaders_any_loaded << user
+      end
+      Rails.autoloaders.any.on_load("Money") do |money|
+        $autoloaders_any_loaded << money
+      end
+    RUBY
+
+    $autoloaders_any_loaded = []
+    boot
+
+    assert_empty $autoloaders_any_loaded
+
+    user = User
+    assert_equal [user], $autoloaders_any_loaded
+
+    money = Money
+    assert_equal [user, money], $autoloaders_any_loaded
+
+    Rails.application.reloader.reload!
+
+    assert_same money, Money
+    assert_equal [user, money], $autoloaders_any_loaded
+
+    reloaded_user = User
+    assert_not_same user, reloaded_user
+    assert_equal [user, money, reloaded_user], $autoloaders_any_loaded
+  ensure
+    $autoloaders_any_loaded = nil
   end
 
   test "autoloaders inflect with Active Support" do

--- a/railties/test/autoloaders_test.rb
+++ b/railties/test/autoloaders_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "active_support/testing/autorun"
+require "rails/autoloaders"
+
+class AutoloadersTest < ActiveSupport::TestCase
+  class Loader
+    attr_reader :on_load_calls
+
+    def initialize
+      @on_load_calls = []
+    end
+
+    def on_load(*args, &block)
+      @on_load_calls << [args, block]
+    end
+  end
+
+  setup do
+    @main = Loader.new
+    @once = Loader.new
+    @any = Rails::Autoloaders::Any.new([@main, @once])
+  end
+
+  test "any forwards on_load callbacks to all autoloaders" do
+    callback = proc { }
+
+    @any.on_load("User", &callback)
+
+    [@main, @once].each do |autoloader|
+      args, block = autoloader.on_load_calls.first
+      assert_equal ["User"], args
+      assert_same callback, block
+    end
+  end
+
+  test "any forwards on_load callbacks without a constant path" do
+    callback = proc { }
+
+    @any.on_load(&callback)
+
+    [@main, @once].each do |autoloader|
+      args, block = autoloader.on_load_calls.first
+      assert_empty args
+      assert_same callback, block
+    end
+  end
+
+  test "any only exposes callbacks supported across autoloaders" do
+    assert_respond_to @any, :on_load
+    assert_not_respond_to @any, :on_unload
+    assert_not_respond_to @any, :collapse
+    assert_not_respond_to @any, :ignore
+  end
+end


### PR DESCRIPTION
### Motivation / Background

Plugins sometimes need to extend application constants without eagerly loading them during boot. Zeitwerk's `on_load` callback supports this, but plugin authors may not know whether an application configured the target constant through the `main` or `once` autoloader.

This makes integrations choose an autoloader they cannot reliably know, or register the callback manually with both loaders.

Fix #57449.

### Detail

This Pull Request adds `Rails.autoloaders.any.on_load`, a focused proxy that registers an `on_load` callback with both Rails autoloaders while preserving the semantics of the loader that manages the constant.

The callback remains lazy and runs again when a reloadable constant is loaded after a reload. The proxy intentionally exposes only `on_load`, since APIs such as `on_unload`, `ignore`, and `collapse` require choosing a specific autoloader.

It also adds API and guide documentation, a Railties changelog entry, unit tests for delegation and the restricted API, and integration coverage for `main`, `once`, lazy loading, and reloading.

### Additional information

The related Railties unit, Zeitwerk checker, inflector, and integration tests pass: 32 tests and 109 assertions.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
