### PR TITLE
Remove trailing whitespace from Action Controller guide

### DIFF
--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -1138,7 +1138,7 @@ class ApplicationController < ActionController::Base
 end
 ```
 
-This is not the recommended way to implement this particular action callback, 
+This is not the recommended way to implement this particular action callback,
 but in simpler cases, it might be useful.
 
 Specifically for `around_action`, the block also yields the `action`:
@@ -1147,7 +1147,7 @@ Specifically for `around_action`, the block also yields the `action`:
 around_action { |_controller, action| time(&action) }
 ```
 
-Note that the `controller` is also passed to the block, but it can often 
+Note that the `controller` is also passed to the block, but it can often
 be ignored because the block is already executed in that controller's scope.
 
 The second way is to specify a class (or any object that responds to the


### PR DESCRIPTION
### Motivation / Background

`main` is currently red on `buildkite/rails`.

Two lines added by #58229 (merged as 65cfb20082) end with a single trailing space, which trips `MD009 Trailing spaces` in `rake guides:lint:mdl`. These are the only mdl violations across all 76 files in `guides/source`, so the guides lint step fails for every build until they are removed.

```
$ cd guides && mdl $(ls source/*.md | grep -v '_release_notes.md')
source/action_controller_overview.md:1141: MD009 Trailing spaces
source/action_controller_overview.md:1150: MD009 Trailing spaces
```

The build on #58229 was already failing before merge (https://buildkite.com/rails/rails/builds/131424), but the `[ci skip]` title meant the lint failure was easy to miss.

### Detail

This Pull Request strips the trailing space from the two affected lines in `guides/source/action_controller_overview.md`.

Both lines have exactly one trailing space, so this is a lint-only fix: two or more trailing spaces would be a Markdown hard line break, one is not, and the rendered guide is unchanged.

After the change, `mdl` reports no violations across the linted guides.

> [!NOTE]
> Follow-up to #58229. No content changes — whitespace only.