### PR TITLE
Honor query predicate transform flag for ranges

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -87,12 +87,17 @@ module ActiveRecord
     end
 
     def range_predicate_for(attribute, range, type)
-      type.query_attribute(attribute).between(
-        RangeHandler::RangeWithBinds.new(
-          query_value(attribute, range.begin, type),
-          query_value(attribute, range.end, type),
-          range.exclude_end?
-        )
+      if type.transforms_query_predicates?
+        begin_value = query_value(attribute, range.begin, type)
+        end_value = query_value(attribute, range.end, type)
+        attribute = type.query_attribute(attribute)
+      else
+        begin_value = build_bind_attribute(attribute.name, range.begin, type)
+        end_value = build_bind_attribute(attribute.name, range.end, type)
+      end
+
+      attribute.between(
+        RangeHandler::RangeWithBinds.new(begin_value, end_value, range.exclude_end?)
       )
     end
 

--- a/activerecord/test/cases/relation/predicate_builder_test.rb
+++ b/activerecord/test/cases/relation/predicate_builder_test.rb
@@ -31,6 +31,12 @@ module ActiveRecord
         end
     end
 
+    class DisabledUnaccentedString < UnaccentedString
+      def transforms_query_predicates?
+        false
+      end
+    end
+
     class UuidToBinString < ActiveRecord::Type::String
       UUID_STRING = ActiveRecord::Type::String.new
 
@@ -122,6 +128,15 @@ module ActiveRecord
       assert_equal expected_sql, sql
     end
 
+    def test_attribute_type_does_not_transform_range_query_values_when_disabled
+      topic = topic_model_with_title_type(DisabledUnaccentedString.new)
+      sql = topic.where(title: "A".."Z").to_sql
+      expected_sql = "SELECT #{quoted_topics}.* FROM #{quoted_topics} " \
+        "WHERE #{quote_table_name("topics.title")} BETWEEN #{quoted_value("A")} AND #{quoted_value("Z")}"
+
+      assert_equal expected_sql, sql
+    end
+
     def test_attribute_type_can_transform_only_query_value
       topic = topic_model_with_title_type(UuidToBinString.new)
       uuid = "6ccd780c-baba-1026-9564-5b8c656024db"
@@ -151,7 +166,11 @@ module ActiveRecord
       end
 
       def normalized_value(value)
-        "lower(custom_immutable_unaccent(#{ActiveRecord::Base.lease_connection.quote(value)}))"
+        "lower(custom_immutable_unaccent(#{quoted_value(value)}))"
+      end
+
+      def quoted_value(value)
+        ActiveRecord::Base.lease_connection.quote(value)
       end
 
       def topic_model_with_title_type(type)


### PR DESCRIPTION
## Summary

Follow-up to #58135.

That PR introduced `transforms_query_predicates?` as the opt-in gate for query predicate transformations. Its equality and array paths respect the flag, while the newly added range path invokes `query_attribute` and `query_value` regardless of its value.

If the flag exists, it should be respected consistently by every predicate shape; otherwise, we should remove it and always use the transformation path.

This adds the missing fast path for ranges when `transforms_query_predicates?` is false and adds regression coverage for the disabled case.


## Benchmark

This is a microbenchmark of query construction and SQL compilation only. It does not include a database round trip.

Environment: Ruby 4.0.6, `benchmark-ips` 2.15.1, SQLite in-memory, Apple M3 Pro.

### Building a range predicate

```text
Comparison:
          fast path:   101733.2 i/s
transformation path:    85259.1 i/s - 1.19x slower
 ```

 ### Building and compiling SQL

 ```text
Comparison:
          fast path:    34053.5 i/s
transformation path:    30112.5 i/s - 1.13x slower
 ```

 <details>
 <summary>Benchmark source</summary>

 ```ruby
 require "cases/helper"
 require "benchmark/ips"

 class AlwaysTransformRangeString < ActiveRecord::Type::String
   def transforms_query_predicates?
     true
   end
 end

 def predicate_model(type)
   Class.new(ActiveRecord::Base) do
     self.table_name = "topics"
     attribute :title, type
   end
 end

 fast_model = predicate_model(ActiveRecord::Type::String.new)
 transform_model = predicate_model(AlwaysTransformRangeString.new)
 range = ("A".freeze.."Z".freeze).freeze

 puts "Building a range predicate"

 Benchmark.ips do |x|
   x.config(time: 10, warmup: 3)

   x.report("fast path") do
     fast_model.where(title: range)
   end

   x.report("transformation path") do
     transform_model.where(title: range)
   end

   x.compare!
 end

 puts "Building and compiling SQL"

 Benchmark.ips do |x|
   x.config(time: 10, warmup: 3)

   x.report("fast path") do
     fast_model.where(title: range).to_sql
   end

   x.report("transformation path") do
     transform_model.where(title: range).to_sql
   end

   x.compare!
 end
 ```
 </details>