### PR TITLE
Use class_eval for flash types

### DIFF
--- a/actionpack/lib/action_controller/metal/flash.rb
+++ b/actionpack/lib/action_controller/metal/flash.rb
@@ -35,10 +35,11 @@ module ActionController # :nodoc:
         types.each do |type|
           next if _flash_types.include?(type)
 
-          define_method(type) do
-            request.flash[type]
-          end
-          private type
+          class_eval <<~RUBY, __FILE__, __LINE__ + 1
+            private def #{type}
+              request.flash[:#{type}]
+            end
+          RUBY
           helper_method(type) if respond_to?(:helper_method)
 
           self._flash_types = (_flash_types | [type]).freeze

--- a/actionpack/test/controller/flash_test.rb
+++ b/actionpack/test/controller/flash_test.rb
@@ -251,6 +251,14 @@ class FlashTest < ActionController::TestCase
 
   def test_flash_types_are_ractor_safe
     assert_ractor_shareable TestController._flash_types
+
+    assert_nothing_raised do
+      on_ractor do
+        c = TestController.new
+        c.set_request! ActionDispatch::Request.new({})
+        c.send(:alert)
+      end
+    end
   end
 end
 


### PR DESCRIPTION
The define_method block cannot be used in non-main Ractors