### PR TITLE
Adds locals when rendering ActionText attachments

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Support rendering ActionText with locals
+
+        <%= render @post.body, turbo_frame: :_top %>
+
+    Attachment partials can then read them from `local_assigns`:
+
+        <%# app/views/users/_user.html.erb %>
+        <%= link_to user.name, user, data: { turbo_frame: local_assigns[:turbo_frame] } %>
+
+    *Chris Oliver*
+
 *   Dispatch all Active Storage `direct-upload:`-prefixed events
 
     Add support for `direct-upload:before-blob-request` and `direct-upload:before-storage-request`.

--- a/actiontext/app/helpers/action_text/content_helper.rb
+++ b/actiontext/app/helpers/action_text/content_helper.rb
@@ -11,9 +11,13 @@ module ActionText
     mattr_accessor(:allowed_attributes)
     mattr_accessor(:scrubber)
 
-    def render_action_text_content(content)
+    def render_rich_text(rich_text, locals: {})
+      render_action_text_content(rich_text.body, locals: locals)
+    end
+
+    def render_action_text_content(content, locals: {})
       self.prefix_partial_path_with_controller_namespace = false
-      sanitize_action_text_content(render_action_text_attachments(content))
+      sanitize_action_text_content(render_action_text_attachments(content, locals: locals))
     end
 
     def sanitize_content_attachment(content_attachment)
@@ -34,17 +38,17 @@ module ActionText
       ).html_safe
     end
 
-    def render_action_text_attachments(content)
+    def render_action_text_attachments(content, locals: {})
       content.render_attachments do |attachment|
         unless attachment.in?(content.gallery_attachments)
           attachment.node.tap do |node|
-            node.inner_html = render_action_text_attachment attachment, locals: { in_gallery: false }
+            node.inner_html = render_action_text_attachment attachment, locals: locals.with_defaults(in_gallery: false)
           end
         end
       end.render_attachment_galleries do |attachment_gallery|
         render(layout: attachment_gallery, object: attachment_gallery) do
           attachment_gallery.attachments.map do |attachment|
-            attachment.node.inner_html = render_action_text_attachment attachment, locals: { in_gallery: true }
+            attachment.node.inner_html = render_action_text_attachment attachment, locals: locals.with_defaults(in_gallery: true)
             attachment.to_html
           end.join.html_safe
         end.chomp

--- a/actiontext/app/helpers/action_text/content_helper.rb
+++ b/actiontext/app/helpers/action_text/content_helper.rb
@@ -11,10 +11,6 @@ module ActionText
     mattr_accessor(:allowed_attributes)
     mattr_accessor(:scrubber)
 
-    def render_rich_text(rich_text, locals: {})
-      render_action_text_content(rich_text.body, locals: locals)
-    end
-
     def render_action_text_content(content, locals: {})
       self.prefix_partial_path_with_controller_namespace = false
       sanitize_action_text_content(render_action_text_attachments(content, locals: locals))

--- a/actiontext/app/models/action_text/rich_text.rb
+++ b/actiontext/app/models/action_text/rich_text.rb
@@ -40,7 +40,7 @@ module ActionText
     cattr_accessor :editor, instance_accessor: false
 
     serialize :body, coder: ActionText::Content
-    delegate :to_s, :nil?, to: :body
+    delegate :render_in, :to_s, :nil?, to: :body
 
     ##
     # :method: record

--- a/actiontext/app/views/action_text/contents/_content.html.erb
+++ b/actiontext/app/views/action_text/contents/_content.html.erb
@@ -1,1 +1,1 @@
-<%= render_action_text_content(content) %>
+<%= render_action_text_content(content, locals: local_assigns.excluding(:content)) %>

--- a/actiontext/lib/action_text/attachables/content_attachment.rb
+++ b/actiontext/lib/action_text/attachables/content_attachment.rb
@@ -26,7 +26,7 @@ module ActionText
       end
 
       def to_html
-        @to_html ||= content_instance.render(content_instance)
+        @to_html ||= content_instance.render(partial: content_instance.to_partial_path, object: content_instance)
       end
 
       def to_s

--- a/actiontext/lib/action_text/attachments/conversion.rb
+++ b/actiontext/lib/action_text/attachments/conversion.rb
@@ -34,7 +34,7 @@ module ActionText
               attachable.try(:to_editor_content_attachment_partial_path) ||
               ActionText.deprecator.silence { attachable.try(:to_trix_content_attachment_partial_path) }
             )
-            ActionText::Content.render(partial: partial_path, formats: :html, object: self, as: model_name.element)
+            ActionText::Content.render(partial: partial_path, formats: :html, object: self, as: model_name.element, locals: { in_editor: true })
           end
         end
     end

--- a/actiontext/lib/action_text/content.rb
+++ b/actiontext/lib/action_text/content.rb
@@ -170,8 +170,8 @@ module ActionText
       fragment.to_html
     end
 
-    def to_rendered_html_with_layout
-      render layout: "action_text/contents/content", partial: to_partial_path, formats: :html, locals: { content: self }
+    def to_rendered_html_with_layout(locals: {})
+      render layout: "action_text/contents/content", partial: to_partial_path, formats: :html, locals: locals.merge(content: self)
     end
 
     def to_partial_path
@@ -187,6 +187,22 @@ module ActionText
     #     content.to_s # => "<div>safeunsafe</div>"
     def to_s
       to_rendered_html_with_layout
+    end
+
+    # Safely transforms Content into an HTML String, passing any +locals+ through to the partials used to render attachments.
+    #
+    #     @post.body.render_in(view_context, locals: { turbo_frame: "_top" }
+    #
+    # In a view, locals can be passed the same way as when rendering a partial:
+    #
+    #     <%= render @post.body, turbo_frame: "_top" %>
+    #
+    # Attachment partials can then read them from +local_assigns+:
+    #
+    #     <%# app/views/users/_user.html.erb %>
+    #     <%= link_to user.name, user, data: { turbo_frame: local_assigns[:turbo_frame] } %>
+    def render_in(view_context, locals: {}, **options)
+      to_rendered_html_with_layout(locals: locals)
     end
 
     def as_json(*)

--- a/actiontext/test/dummy/app/views/people/_attachable.html.erb
+++ b/actiontext/test/dummy/app/views/people/_attachable.html.erb
@@ -1,1 +1,1 @@
-<span class="mentioned-person"><%= person.name %></span>
+<span class="mentioned-person"><%= person.name %><%= " (#{local_assigns[:role]})" if local_assigns[:role] %></span>

--- a/actiontext/test/unit/content_test.rb
+++ b/actiontext/test/unit/content_test.rb
@@ -151,6 +151,24 @@ class ActionText::ContentTest < ActiveSupport::TestCase
     assert_not defined?(::ApplicationController)
   end
 
+  test "renders via render_in" do
+    html = "<h1>Hello world</h1>"
+    rendered = content_from_html(html).render_in(ActionController::Base.new.view_context)
+
+    assert_includes rendered, html
+    assert_match %r/\A#{Regexp.escape '<div class="trix-content">'}/, rendered
+  end
+
+  test "render_in passes locals through to attachment partials" do
+    alice = people(:alice)
+    html = %Q(<action-text-attachment sgid="#{alice.attachable_sgid}"></action-text-attachment>)
+
+    ActionText::Content.with_renderer MessagesController.renderer do
+      rendered = content_from_html(html).render_in(ActionController::Base.new.view_context, locals: { role: "admin" })
+      assert_includes rendered, "Alice (admin)"
+    end
+  end
+
   test "does basic sanitization" do
     html = "<div onclick='action()'>safe<script>unsafe</script></div>"
     rendered = content_from_html(html).to_rendered_html_with_layout


### PR DESCRIPTION
### Motivation / Background

ActionText attachments may need additional context from where they're rendered. Right now, there is no way to reference the context which the ActionText::Content is rendered in so it can't really be dynamic.

I ran into this initially rendering ActionText::Content in an admin area where I wanted attachments to render different URLs than the customer facing version.

Another case was rendering some ActionText::Content inside and outside Turbo Frames. When inside, I need to ensure the links in ActionText are rendered with `data-turbo-frame="_top"` and I really need the context to be passed in.

### Detail

Allows users to render ActionText::Content with locals passed along to attachments.

```erb
<%= render post.body, locals: {turbo_frame: :_top} %>
```

These locals are passed along to attachment partials.

@jorgemanrubia would you find this helpful?

### Additional Information

I also added a default local `in_editor: true` for `to_editor_html` like `in_gallery: true` for images.

It's common practice to use the same partial for both the regular and editor HTML. You could use this to make links disabled in the editor (a user accidentally clicking a link in the editor could lose their writing) for example:

```erb
<%= link_to_if !local_assigns[:in_editor], post.title, post %>
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
