### PR TITLE
Escape ordinary routing redirect params as segments

### DIFF
--- a/actionpack/lib/action_dispatch/routing/redirection.rb
+++ b/actionpack/lib/action_dispatch/routing/redirection.rb
@@ -83,8 +83,30 @@ module ActionDispatch
           params.transform_values { |v| Journey::Router::Utils.escape_fragment(v) }
         end
 
-        def escape_path(params)
-          params.transform_values { |v| Journey::Router::Utils.escape_path(v) }
+        # Ordinary dynamic segments use segment escaping so a decoded slash
+        # cannot pass into the interpolated path. Wildcard (*path) params and
+        # :controller keep path escaping, matching Journey URL generation.
+        def escape_route_params(params, request)
+          path_keys = path_escaped_param_names(request)
+
+          params.each_with_object({}) do |(key, value), escaped|
+            escaped[key] = if path_keys.include?(key.to_sym)
+              Journey::Router::Utils.escape_path(value)
+            else
+              Journey::Router::Utils.escape_segment(value)
+            end
+          end
+        end
+
+        def path_escaped_param_names(request)
+          names = [:controller]
+          spec = request.get_header("action_dispatch.route")&.path&.spec
+          return names unless spec
+
+          spec.each do |node|
+            names << node.name.to_sym if node.star?
+          end
+          names
         end
     end
 
@@ -93,9 +115,9 @@ module ActionDispatch
 
       def path(params, request)
         if block.match(URL_PARTS)
-          path     = interpolation_required?($1, params) ? $1 % escape_path(params)     : $1
-          query    = interpolation_required?($2, params) ? $2 % escape(params)          : $2
-          fragment = interpolation_required?($3, params) ? $3 % escape_fragment(params) : $3
+          path     = interpolation_required?($1, params) ? $1 % escape_route_params(params, request) : $1
+          query    = interpolation_required?($2, params) ? $2 % escape(params)                       : $2
+          fragment = interpolation_required?($3, params) ? $3 % escape_fragment(params)              : $3
 
           "#{path}#{query}#{fragment}"
         else
@@ -126,7 +148,7 @@ module ActionDispatch
         }.merge! options
 
         if !params.empty? && url_options[:path].match(/%\{\w*\}/)
-          url_options[:path] = (url_options[:path] % escape_path(params))
+          url_options[:path] = (url_options[:path] % escape_route_params(params, request))
         end
 
         unless options[:host] || options[:domain]

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -4549,6 +4549,10 @@ class TestRedirectInterpolation < ActionDispatch::IntegrationTest
       get "/foo/:id" => redirect("/foo/bar/%{id}")
       get "/bar/:id" => redirect(path: "/foo/bar/%{id}")
       get "/baz/:id" => redirect("/baz?id=%{id}&foo=?&bar=1#id-%{id}")
+      get "/leading/:name" => redirect("/%{name}/account")
+      get "/glob/*path" => redirect("/files/%{path}")
+      get "/mix/:locale/*rest" => redirect("/%{locale}/%{rest}")
+      get "/opt/:id" => redirect(path: "/%{id}/next")
       get "/foo/bar/:id" => ok
       get "/baz" => ok
     end
@@ -4573,6 +4577,27 @@ class TestRedirectInterpolation < ActionDispatch::IntegrationTest
 
     get "/baz/1%201"
     verify_redirect "http://www.example.com/baz?id=1+1&foo=?&bar=1#id-1%201"
+  end
+
+  test "path redirect interpolates ordinary params with segment escaping" do
+    get "/leading/%2Fevil%2Eexample"
+    verify_redirect "http://www.example.com/%2Fevil.example/account"
+
+    get "/opt/%2Fevil%2Eexample"
+    verify_redirect "http://www.example.com/%2Fevil.example/next"
+  end
+
+  test "path redirect interpolates wildcard params with path escaping" do
+    get "/glob/a/b/c"
+    verify_redirect "http://www.example.com/files/a/b/c"
+  end
+
+  test "path redirect mixes segment and path escaping" do
+    get "/mix/en/a/b"
+    verify_redirect "http://www.example.com/en/a/b"
+
+    get "/mix/%2Fevil%2Eexample/a/b"
+    verify_redirect "http://www.example.com/%2Fevil.example/a/b"
   end
 
 private


### PR DESCRIPTION
### Motivation

`redirect("/%{param}")` interpolates path parameters with `Journey::Router::Utils.escape_path`, which leaves `/` unescaped. Journey matches against the still-encoded path, so `%2F` is a legal dynamic segment, then decodes it to `/` before interpolation. A leading-segment template becomes a protocol-relative URL.

Wildcard params are supposed to contain slashes. Ordinary segments are not.

### Change

When interpolating into a routing redirect path:

- ordinary dynamic segments use `escape_segment` (a decoded `/` becomes `%2F`)
- wildcard (`*path`) params and `:controller` keep `escape_path`, matching Journey URL generation (`FormatBuilder`)

`redirect(path: "/%{id}")` uses the same helper.

An application that interpolates a wildcard at the start of a path-only template (`redirect("/%{path}")`) can still produce `//…`. That is the same as writing a glob into a path. This PR does not collapse leading slashes.

### Tests

`TestRedirectInterpolation` covers:

- `%2F` in a leading ordinary segment stays on the request host
- the same for `redirect(path:)`
- a glob still interpolates slashes (`/files/a/b/c`)
- mixed `:locale/*rest` uses both escapers
