### PR TITLE
docs: add RDoc singleton-method directives for ActiveRecord::Core

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -69,12 +69,14 @@ module ActiveRecord
       #     #<ActiveRecord::DatabaseConfigurations::HashConfig:0x00007fd1acbdea90 @env_name="production",
       #       @name="primary", @config={adapter: "sqlite3", database: "storage/production.sqlite3"}>
       #   ]>
+      # :singleton-method: configurations=
       def self.configurations=(config)
         @@configurations = ActiveRecord::DatabaseConfigurations.new(config)
       end
       self.configurations = {}
 
       # Returns a fully resolved ActiveRecord::DatabaseConfigurations object.
+      # :singleton-method: configurations
       def self.configurations
         @@configurations
       end

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -10,6 +10,38 @@ module ActiveRecord
     extend ActiveSupport::Concern
     include ActiveModel::Access
 
+    ##
+    # :singleton-method: configurations=
+    # :call-seq: configurations=(config)
+    #
+    # Contains the database configuration - as is typically stored in config/database.yml -
+    # as an ActiveRecord::DatabaseConfigurations object.
+    #
+    # For example, the following database.yml...
+    #
+    #   development:
+    #     adapter: sqlite3
+    #     database: storage/development.sqlite3
+    #
+    #   production:
+    #     adapter: sqlite3
+    #     database: storage/production.sqlite3
+    #
+    # ...would result in ActiveRecord::Base.configurations to look like this:
+    #
+    #   #<ActiveRecord::DatabaseConfigurations:0x00007fd1acbdf800 @configurations=[
+    #     #<ActiveRecord::DatabaseConfigurations::HashConfig:0x00007fd1acbded10 @env_name="development",
+    #       @name="primary", @config={adapter: "sqlite3", database: "storage/development.sqlite3"}>,
+    #     #<ActiveRecord::DatabaseConfigurations::HashConfig:0x00007fd1acbdea90 @env_name="production",
+    #       @name="primary", @config={adapter: "sqlite3", database: "storage/production.sqlite3"}>
+    #   ]>
+
+    ##
+    # :singleton-method: configurations
+    # :call-seq: configurations
+    #
+    # Returns a fully resolved ActiveRecord::DatabaseConfigurations object.
+
     included do
       @arel_table = Arel::Table.new(klass: self)
 
@@ -47,36 +79,11 @@ module ActiveRecord
       # destroyed will be split into multiple background jobs.
       class_attribute :destroy_association_async_batch_size, instance_writer: false, instance_predicate: false, default: nil
 
-      ##
-      # Contains the database configuration - as is typically stored in config/database.yml -
-      # as an ActiveRecord::DatabaseConfigurations object.
-      #
-      # For example, the following database.yml...
-      #
-      #   development:
-      #     adapter: sqlite3
-      #     database: storage/development.sqlite3
-      #
-      #   production:
-      #     adapter: sqlite3
-      #     database: storage/production.sqlite3
-      #
-      # ...would result in ActiveRecord::Base.configurations to look like this:
-      #
-      #   #<ActiveRecord::DatabaseConfigurations:0x00007fd1acbdf800 @configurations=[
-      #     #<ActiveRecord::DatabaseConfigurations::HashConfig:0x00007fd1acbded10 @env_name="development",
-      #       @name="primary", @config={adapter: "sqlite3", database: "storage/development.sqlite3"}>,
-      #     #<ActiveRecord::DatabaseConfigurations::HashConfig:0x00007fd1acbdea90 @env_name="production",
-      #       @name="primary", @config={adapter: "sqlite3", database: "storage/production.sqlite3"}>
-      #   ]>
-      # :singleton-method: configurations=
       def self.configurations=(config)
         @@configurations = ActiveRecord::DatabaseConfigurations.new(config)
       end
       self.configurations = {}
 
-      # Returns a fully resolved ActiveRecord::DatabaseConfigurations object.
-      # :singleton-method: configurations
       def self.configurations
         @@configurations
       end


### PR DESCRIPTION
### Motivation / Background

This PR adds `# :singleton-method:` directives to ActiveRecord::Core for configurations= and configurations inside the included do block. The change is documentation-only: it does not alter runtime behavior, but restores proper method visibility in RDoc for these public APIs.


This pull request has been created due to discussion in the following RDoc thread:
https://github.com/ruby/rdoc/pull/1753

### Detail

This is just a documentation change, ActiveRecord::Core#configuration are not visibile in the documentation. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
