### PR TITLE
Freeze the Response default_headers at the end of the boot process

### DIFF
--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -88,7 +88,7 @@ module ActionDispatch
 
       ActiveSupport.on_load(:action_dispatch_response) do
         self.default_charset = app.config.action_dispatch.default_charset || app.config.encoding
-        self.default_headers = app.config.action_dispatch.default_headers
+        self.default_headers = ActiveSupport::Ractors.make_shareable(app.config.action_dispatch.default_headers)
       end
 
       ActionDispatch::ExceptionWrapper.rescue_responses = ActionDispatch::ExceptionWrapper.rescue_responses.merge(config.action_dispatch.rescue_responses)


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I want to be able to access the response default headers in a Ractor.

### Detail

Regardless of Ractor it will also prevents app from mutating the response headers at runtime which can cause some unexpected and hard to troubleshoot behaviour.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
