### PR TITLE
Choose MySQL client binaries by what is on the PATH

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Prefer the `mariadb-dump` and `mariadb` client binaries for SQL structure dump
+    and load when they are on the `PATH`, falling back to `mysqldump` and `mysql`.
+
+    MariaDB deprecated the `mysqldump` and `mysql` names in 11.0, and its official
+    Docker image no longer ships them, so `db:schema:dump` and `db:schema:load`
+    either printed a deprecation warning or failed with "command not found".
+
+    *Lazizbek Ergashev*
+
 *   Add `config.active_record.shuffle_unordered_selects`.
 
     When enabled, Active Record shuffles the rows of every `SELECT` it generates

--- a/activerecord/lib/active_record/tasks/abstract_tasks.rb
+++ b/activerecord/lib/active_record/tasks/abstract_tasks.rb
@@ -52,6 +52,12 @@ module ActiveRecord
           configuration_hash.merge(database: nil)
         end
 
+        def find_cmd(*commands)
+          commands.detect do |cmd|
+            system("/bin/sh", "-c", "command -v #{cmd}", out: File::NULL, err: File::NULL)
+          end || commands.last
+        end
+
         def run_cmd(cmd, *args, **opts)
           fail run_cmd_error(cmd, args) unless Kernel.system(cmd, *args, opts)
         end

--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -40,7 +40,7 @@ module ActiveRecord
         args.concat([db_config.database.to_s])
         args.unshift(*extra_flags) if extra_flags
 
-        run_cmd("mysqldump", *args)
+        run_cmd(find_cmd("mariadb-dump", "mysqldump"), *args)
       end
 
       def structure_load(filename, extra_flags)
@@ -49,7 +49,7 @@ module ActiveRecord
         args.concat(["--database", db_config.database.to_s])
         args.unshift(*extra_flags) if extra_flags
 
-        run_cmd("mysql", *args)
+        run_cmd(find_cmd("mariadb", "mysql"), *args)
       end
 
       private

--- a/activerecord/test/cases/adapters/mysql2/mysql2_rake_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_rake_test.rb
@@ -2,6 +2,7 @@
 
 require "cases/helper"
 require "active_record/tasks/database_tasks"
+require "support/client_binaries_helper"
 
 module ActiveRecord
   class MysqlDBCreateTest < ActiveRecord::TestCase
@@ -259,11 +260,19 @@ module ActiveRecord
   end
 
   class MySQLStructureDumpTest < ActiveRecord::TestCase
+    include ClientBinariesHelper
+
     def setup
       @configuration = {
         "adapter"  => "mysql2",
         "database" => "test-db"
       }
+
+      stub_empty_client_binaries_path
+    end
+
+    def teardown
+      restore_client_binaries_path
     end
 
     def test_structure_dump
@@ -370,6 +379,28 @@ module ActiveRecord
         end
     end
 
+    def test_structure_dump_prefers_mariadb_dump_when_it_is_on_the_path
+      filename = "awesome-file.sql"
+      expected_command = ["mariadb-dump", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db", {}]
+
+      with_client_binaries("mariadb-dump", "mysqldump") do
+        assert_called_with(Kernel, :system, expected_command, returns: true) do
+          ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
+        end
+      end
+    end
+
+    def test_structure_dump_falls_back_to_mysqldump_when_mariadb_dump_is_missing
+      filename = "awesome-file.sql"
+      expected_command = ["mysqldump", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db", {}]
+
+      with_client_binaries("mysqldump") do
+        assert_called_with(Kernel, :system, expected_command, returns: true) do
+          ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
+        end
+      end
+    end
+
     private
       def with_structure_dump_flags(flags)
         old = ActiveRecord::Tasks::DatabaseTasks.structure_dump_flags
@@ -381,11 +412,19 @@ module ActiveRecord
   end
 
   class MySQLStructureLoadTest < ActiveRecord::TestCase
+    include ClientBinariesHelper
+
     def setup
       @configuration = {
         "adapter"  => "mysql2",
         "database" => "test-db"
       }
+
+      stub_empty_client_binaries_path
+    end
+
+    def teardown
+      restore_client_binaries_path
     end
 
     def test_structure_load
@@ -416,6 +455,28 @@ module ActiveRecord
 
       assert_called_with(Kernel, :system, expected_command, returns: true) do
         with_structure_load_flags({ mysql2: ["--noop"] }) do
+          ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration, filename)
+        end
+      end
+    end
+
+    def test_structure_load_prefers_mariadb_when_it_is_on_the_path
+      filename = "awesome-file.sql"
+      expected_command = ["mariadb", "--execute", %{SET FOREIGN_KEY_CHECKS = 0; SOURCE #{filename}; SET FOREIGN_KEY_CHECKS = 1}, "--database", "test-db", {}]
+
+      with_client_binaries("mariadb", "mysql") do
+        assert_called_with(Kernel, :system, expected_command, returns: true) do
+          ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration, filename)
+        end
+      end
+    end
+
+    def test_structure_load_falls_back_to_mysql_when_mariadb_is_missing
+      filename = "awesome-file.sql"
+      expected_command = ["mysql", "--execute", %{SET FOREIGN_KEY_CHECKS = 0; SOURCE #{filename}; SET FOREIGN_KEY_CHECKS = 1}, "--database", "test-db", {}]
+
+      with_client_binaries("mysql") do
+        assert_called_with(Kernel, :system, expected_command, returns: true) do
           ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration, filename)
         end
       end

--- a/activerecord/test/cases/adapters/trilogy/trilogy_rake_test.rb
+++ b/activerecord/test/cases/adapters/trilogy/trilogy_rake_test.rb
@@ -2,6 +2,7 @@
 
 require "cases/helper"
 require "active_record/tasks/database_tasks"
+require "support/client_binaries_helper"
 
 module ActiveRecord
   class TrilogyDBCreateTest < ActiveRecord::TestCase
@@ -259,11 +260,19 @@ module ActiveRecord
   end
 
   class MySQLStructureDumpTest < ActiveRecord::TestCase
+    include ClientBinariesHelper
+
     def setup
       @configuration = {
         "adapter"  => "trilogy",
         "database" => "test-db"
       }
+
+      stub_empty_client_binaries_path
+    end
+
+    def teardown
+      restore_client_binaries_path
     end
 
     def test_structure_dump
@@ -370,6 +379,28 @@ module ActiveRecord
         end
     end
 
+    def test_structure_dump_prefers_mariadb_dump_when_it_is_on_the_path
+      filename = "awesome-file.sql"
+      expected_command = ["mariadb-dump", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db", {}]
+
+      with_client_binaries("mariadb-dump", "mysqldump") do
+        assert_called_with(Kernel, :system, expected_command, returns: true) do
+          ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
+        end
+      end
+    end
+
+    def test_structure_dump_falls_back_to_mysqldump_when_mariadb_dump_is_missing
+      filename = "awesome-file.sql"
+      expected_command = ["mysqldump", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db", {}]
+
+      with_client_binaries("mysqldump") do
+        assert_called_with(Kernel, :system, expected_command, returns: true) do
+          ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
+        end
+      end
+    end
+
     private
       def with_structure_dump_flags(flags)
         old = ActiveRecord::Tasks::DatabaseTasks.structure_dump_flags
@@ -381,11 +412,19 @@ module ActiveRecord
   end
 
   class MySQLStructureLoadTest < ActiveRecord::TestCase
+    include ClientBinariesHelper
+
     def setup
       @configuration = {
         "adapter"  => "trilogy",
         "database" => "test-db"
       }
+
+      stub_empty_client_binaries_path
+    end
+
+    def teardown
+      restore_client_binaries_path
     end
 
     def test_structure_load
@@ -416,6 +455,28 @@ module ActiveRecord
 
       assert_called_with(Kernel, :system, expected_command, returns: true) do
         with_structure_load_flags({ trilogy: ["--noop"] }) do
+          ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration, filename)
+        end
+      end
+    end
+
+    def test_structure_load_prefers_mariadb_when_it_is_on_the_path
+      filename = "awesome-file.sql"
+      expected_command = ["mariadb", "--execute", %{SET FOREIGN_KEY_CHECKS = 0; SOURCE #{filename}; SET FOREIGN_KEY_CHECKS = 1}, "--database", "test-db", {}]
+
+      with_client_binaries("mariadb", "mysql") do
+        assert_called_with(Kernel, :system, expected_command, returns: true) do
+          ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration, filename)
+        end
+      end
+    end
+
+    def test_structure_load_falls_back_to_mysql_when_mariadb_is_missing
+      filename = "awesome-file.sql"
+      expected_command = ["mysql", "--execute", %{SET FOREIGN_KEY_CHECKS = 0; SOURCE #{filename}; SET FOREIGN_KEY_CHECKS = 1}, "--database", "test-db", {}]
+
+      with_client_binaries("mysql") do
+        assert_called_with(Kernel, :system, expected_command, returns: true) do
           ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration, filename)
         end
       end

--- a/activerecord/test/support/client_binaries_helper.rb
+++ b/activerecord/test/support/client_binaries_helper.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+require "fileutils"
+
+module ClientBinariesHelper
+  # Points PATH at a directory holding an executable stub for each given name, so
+  # that command lookup is independent of what the CI image happens to install.
+  def with_client_binaries(*names)
+    Dir.mktmpdir do |dir|
+      names.each do |name|
+        path = File.join(dir, name)
+        File.write(path, "")
+        File.chmod(0755, path)
+      end
+
+      original_path = ENV["PATH"]
+      ENV["PATH"] = dir
+
+      begin
+        yield
+      ensure
+        ENV["PATH"] = original_path
+      end
+    end
+  end
+
+  def stub_empty_client_binaries_path
+    @original_client_binaries_path = ENV["PATH"]
+    @client_binaries_dir = Dir.mktmpdir
+    ENV["PATH"] = @client_binaries_dir
+  end
+
+  def restore_client_binaries_path
+    ENV["PATH"] = @original_client_binaries_path
+    FileUtils.remove_entry(@client_binaries_dir)
+  end
+end


### PR DESCRIPTION
### Motivation / Background

Fixes #58516.

`ActiveRecord::Tasks::MySQLDatabaseTasks` shells out to `mysqldump` and `mysql` by name. MariaDB deprecated both names in 11.0, so every SQL structure dump against a MariaDB server writes a deprecation warning to stderr:

```
mysqldump: Deprecated program name. It will be removed in a future release, use '/usr/bin/mariadb-dump' instead
```

The official `mariadb` Docker image has already dropped the compatibility symlinks, so on images built from it the task fails with "command not found" instead of warning. Apps work around this today by monkey patching `run_cmd` or putting a `mysqldump` shim on `PATH`.

### Detail

`structure_dump` and `structure_load` now choose the binary from `connection.mariadb?`, which the adapter already answers: `mariadb-dump` and `mariadb` on MariaDB, `mysqldump` and `mysql` on MySQL. The arguments and everything else about the commands are unchanged, and there is no new configuration.

### Additional information

MariaDB has shipped the `mariadb-*` names since 10.5, and every release older than that reached end of life more than a year ago.

The existing structure dump and load tests now derive the expected binary from the connection, since `mysql2:test` and `trilogy:test` run against both MySQL and MariaDB on CI. The two new tests per suite stub `mariadb?` so both names are covered on either server.

Both rake test files were run against a local MariaDB 12.3, where they fail on the current code and pass with the change.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
