### PR TITLE
Load routes lazily when a mounted helper is called

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Make mounted route helpers (e.g. `main_app`, engine mount proxies) trigger
+    the lazy route load instead of raising `NoMethodError` when called before
+    routes are drawn.
+
+    Named url helpers already loaded routes on demand, but mounted helpers are
+    only defined when `mount` runs during the route draw, so calling one first
+    (in the console or a test) failed until something else drew the routes.
+
+    *Abdelkader Boudih*
+
 *   Report zero tests instead of raising a `LoadError` when a `bin/rails test:*`
     folder command names a folder the application does not have.
 

--- a/railties/lib/rails/engine/lazy_route_set.rb
+++ b/railties/lib/rails/engine/lazy_route_set.rb
@@ -38,8 +38,38 @@ module Rails
         end
       end
 
+      # Mounted helpers are only defined when `mount` runs during the route
+      # draw. _path/_url names are left to method_missing_module, which owns
+      # them and relies on reload_routes_unless_loaded returning true only to
+      # the caller that performed the load.
+      module LazyMountedHelpers
+        private
+          def method_missing(method_name, ...)
+            if method_name.end_with?("_path", "_url")
+              super
+            else
+              Rails.application&.reload_routes_unless_loaded
+              if ActionDispatch::Routing::RouteSet::MountedHelpers.method_defined?(method_name)
+                public_send(method_name, ...)
+              else
+                super
+              end
+            end
+          end
+
+          def respond_to_missing?(method_name, include_private = false)
+            if method_name.end_with?("_path", "_url")
+              super
+            else
+              Rails.application&.reload_routes_unless_loaded
+              ActionDispatch::Routing::RouteSet::MountedHelpers.method_defined?(method_name) || super
+            end
+          end
+      end
+
       def initialize(config = DEFAULT_CONFIG)
         super
+        ActionDispatch::Routing::RouteSet::MountedHelpers.include(LazyMountedHelpers)
         self.named_routes = NamedRouteCollection.new
         named_routes.url_helpers_module.prepend(method_missing_module)
         named_routes.path_helpers_module.prepend(method_missing_module)

--- a/railties/lib/rails/engine/lazy_route_set.rb
+++ b/railties/lib/rails/engine/lazy_route_set.rb
@@ -42,7 +42,11 @@ module Rails
       # draw. _path/_url names are left to method_missing_module, which owns
       # them and relies on reload_routes_unless_loaded returning true only to
       # the caller that performed the load.
-      module LazyMountedHelpers
+      module MountedHelpers
+        extend ActiveSupport::Concern
+
+        include ActionDispatch::Routing::RouteSet::MountedHelpers
+
         private
           def method_missing(method_name, ...)
             if method_name.end_with?("_path", "_url")
@@ -69,7 +73,6 @@ module Rails
 
       def initialize(config = DEFAULT_CONFIG)
         super
-        ActionDispatch::Routing::RouteSet::MountedHelpers.include(LazyMountedHelpers)
         self.named_routes = NamedRouteCollection.new
         named_routes.url_helpers_module.prepend(method_missing_module)
         named_routes.path_helpers_module.prepend(method_missing_module)
@@ -113,6 +116,20 @@ module Rails
       def routes
         Rails.application&.reload_routes_unless_loaded
         super
+      end
+
+      def mounted_helpers
+        MountedHelpers
+      end
+
+      def define_mounted_helper(name, script_namer = nil)
+        super
+
+        return if MountedHelpers.method_defined?(name)
+
+        shared = ActionDispatch::Routing::RouteSet::MountedHelpers
+        MountedHelpers.define_method("_#{name}", shared.instance_method("_#{name}"))
+        MountedHelpers.define_method(name, shared.instance_method(name))
       end
 
       private

--- a/railties/test/engine/lazy_route_set_test.rb
+++ b/railties/test/engine/lazy_route_set_test.rb
@@ -230,6 +230,7 @@ module Rails
 
         assert_not_operator(:plugin_engine, :in?, Rails.application.routes.mounted_helpers.instance_methods)
         assert_equal("/plugin/posts", helpers.plugin_engine.posts_path)
+        assert_equal("/", helpers.main_app.root_path)
       end
 
       test "mounted helpers lazily load routes when checking respond_to?" do
@@ -262,6 +263,27 @@ module Rails
         require "#{app_path}/config/environment"
 
         assert_operator(url_and_mounted_helpers, :respond_to?, :root_path)
+      end
+
+      test "mounted helpers module of the lazy route set exposes helpers defined by mount" do
+        require "#{app_path}/config/environment"
+
+        Rails.application.reload_routes_unless_loaded
+
+        assert Rails.application.routes.mounted_helpers.method_defined?(:main_app)
+        assert Rails.application.routes.mounted_helpers.method_defined?(:plugin_engine)
+        assert_not Rails.application.routes.mounted_helpers.method_defined?(:url_options)
+      end
+
+      test "plain route sets keep the shared mounted helpers module without lazy hooks" do
+        require "#{app_path}/config/environment"
+
+        shared = ActionDispatch::Routing::RouteSet::MountedHelpers
+
+        assert_equal(Rails::Engine::LazyRouteSet::MountedHelpers, Rails.application.routes.mounted_helpers)
+        assert_equal(shared, ActionDispatch::Routing::RouteSet.new.mounted_helpers)
+        assert_not_includes(shared.private_instance_methods, :method_missing)
+        assert_not_includes(shared.private_instance_methods, :respond_to_missing?)
       end
 
       test "integration tests can call a mounted helper before any request" do
@@ -348,15 +370,15 @@ module Rails
           Rails.application.routes.url_helpers
         end
 
+        def engine_url_helpers
+          Plugin::Engine.routes.url_helpers
+        end
+
         def url_and_mounted_helpers
           Class.new {
             include Rails.application.routes.url_helpers
             include Rails.application.routes.mounted_helpers
           }.new
-        end
-
-        def engine_url_helpers
-          Plugin::Engine.routes.url_helpers
         end
     end
   end

--- a/railties/test/engine/lazy_route_set_test.rb
+++ b/railties/test/engine/lazy_route_set_test.rb
@@ -223,6 +223,62 @@ module Rails
         )
       end
 
+      test "mounted helpers lazily load routes" do
+        require "#{app_path}/config/environment"
+
+        helpers = Class.new { include Rails.application.routes.mounted_helpers }.new
+
+        assert_not_operator(:plugin_engine, :in?, Rails.application.routes.mounted_helpers.instance_methods)
+        assert_equal("/plugin/posts", helpers.plugin_engine.posts_path)
+      end
+
+      test "mounted helpers lazily load routes when checking respond_to?" do
+        require "#{app_path}/config/environment"
+
+        helpers = Class.new { include Rails.application.routes.mounted_helpers }.new
+
+        assert_not_operator(:plugin_engine, :in?, Rails.application.routes.mounted_helpers.instance_methods)
+        assert_operator(helpers, :respond_to?, :plugin_engine)
+      end
+
+      test "unrelated missing methods on mounted helpers still raise NoMethodError" do
+        require "#{app_path}/config/environment"
+
+        helpers = Class.new { include Rails.application.routes.mounted_helpers }.new
+
+        assert_raises(NoMethodError) { helpers.not_a_mounted_helper }
+        assert_not helpers.respond_to?(:to_ary)
+      end
+
+      # Mirrors SystemTestCase's proxy, where the mounted helper hooks run
+      # before the url helper hooks and must not consume the route load.
+      test "url helpers still lazily load routes when mounted helpers are included in the same class" do
+        require "#{app_path}/config/environment"
+
+        assert_equal("/", url_and_mounted_helpers.root_path)
+      end
+
+      test "url helpers still lazily load routes on respond_to? when mounted helpers are included in the same class" do
+        require "#{app_path}/config/environment"
+
+        assert_operator(url_and_mounted_helpers, :respond_to?, :root_path)
+      end
+
+      test "integration tests can call a mounted helper before any request" do
+        app_file "test/integration/mounted_helper_test.rb", <<~RUBY
+          require "test_helper"
+
+          class MountedHelperTest < ActionDispatch::IntegrationTest
+            test "mounted helper resolves before first request" do
+              assert_equal "/plugin/posts", plugin_engine.posts_path
+            end
+          end
+        RUBY
+
+        output = rails("test", "test/integration/mounted_helper_test.rb")
+        assert_match("0 failures, 0 errors", output)
+      end
+
       private
         # Parks the initial route draw until $route_draw_resume is signaled,
         # so a test can deterministically overlap it with other threads.
@@ -290,6 +346,13 @@ module Rails
 
         def app_url_helpers
           Rails.application.routes.url_helpers
+        end
+
+        def url_and_mounted_helpers
+          Class.new {
+            include Rails.application.routes.url_helpers
+            include Rails.application.routes.mounted_helpers
+          }.new
         end
 
         def engine_url_helpers


### PR DESCRIPTION
Named url helpers already trigger the lazy route load through LazyRouteSet, but mounted helpers (main_app, engine mount proxies) are only defined when `mount` runs during the route draw, and their names carry no suffix to filter on. Calling one before anything else drew the routes raised NoMethodError.

Include a method_missing/respond_to_missing? pair into MountedHelpers that loads the routes and retries when the helper exists afterwards, falling through to NoMethodError otherwise.


cc @fxn @gmcgibbon @Edouard-chin @shioyama