### PR TITLE
Freeze the route polymorphic cache

### DIFF
--- a/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
+++ b/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb
@@ -357,6 +357,7 @@ module ActionDispatch
               CACHE[:url][action]  = build action, "url"
               CACHE[:path][action] = build action, "path"
             end
+            ActiveSupport::Ractors.make_shareable(CACHE)
         end
     end
   end

--- a/actionpack/test/dispatch/routing/custom_url_helpers_test.rb
+++ b/actionpack/test/dispatch/routing/custom_url_helpers_test.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require "abstract_unit"
+require "active_support/testing/ractors_assertions"
 
 class TestCustomUrlHelpers < ActionDispatch::IntegrationTest
+  include ActiveSupport::Testing::RactorsAssertions
+
   class Linkable
     attr_reader :id
 
@@ -299,6 +302,18 @@ class TestCustomUrlHelpers < ActionDispatch::IntegrationTest
 
     assert_equal "http://www.example.com/manufacturers/apple", polymorphic_url(@manufacturer)
     assert_equal "http://www.example.com/manufacturers/apple", Routes.url_helpers.polymorphic_url(@manufacturer)
+  end
+
+  def test_polymorphic_cache_is_ractor_shareable
+    assert_ractor_shareable(ActionDispatch::Routing::PolymorphicRoutes::HelperMethodBuilder::CACHE)
+
+    Model.model_name
+
+    values = on_ractor do
+      ActionDispatch::Routing::PolymorphicRoutes::HelperMethodBuilder.url.handle_class(Model)
+    end
+
+    assert_equal("test_custom_url_helpers_models_url", values[0])
   end
 
   def test_url_helpers_module_can_be_included_directly_in_an_active_support_concern


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because generating polymorphic url in a Ractor isn't possible. This codepath is hit for instance when a user call `link_to(record)` and the Ractor isolation error will look like.

```
can not access non-shareable objects in constant 

ActionDispatch::Routing::PolymorphicRoutes::HelperMethodBuilder::CACHE by non-main Ractor.
```

### Detail

This cache is used to store the 3 main url helper for a resource so that the string `edit_photo_path`, `new_photo_path`, `photos_path` are computed eagerly when `url_for(record)` is called.

This cache may get hit on other other action names that aren't standard, but the resulted value aren't stored, so freezing the cache as soon as the module is loaded is safe.

https://github.com/rails/rails/blob/caf984cb256eb57bc36db76e87b909255d227f9f/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb#L190

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc/ @skipkayhil @gmcgibbon 