### PR TITLE
Fix Callbacks only made shareable in :raise mode

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -1019,16 +1019,16 @@ module ActiveSupport
           end
         end
 
+        def freeze # :nodoc:
+          descendants.prepend(self).each do |target|
+            target.__callbacks =
+              Ractors.make_shareable(target.__callbacks)
+          end
+        end
+
         protected
           def get_callbacks(name) # :nodoc:
             __callbacks[name.to_sym]
-          end
-
-          def freeze # :nodoc:
-            descendants.prepend(self).each do |target|
-              target.__callbacks =
-                Ractors.make_shareable(target.__callbacks)
-            end
           end
 
           def set_callbacks(name, callbacks) # :nodoc:
@@ -1039,13 +1039,8 @@ module ActiveSupport
               alias_method("_run_#{name}_callbacks", "_run_#{name}_callbacks!")
             end
             callback_sets[name] = callbacks
-            ractor_shareable = Ractors.unshareable_proc_action == :raise ||
-              (!__callbacks.empty? && Ractors.shareable?(__callbacks))
-            self.__callbacks = if ractor_shareable
-              Ractors.make_shareable(callback_sets)
-            else
-              callback_sets
-            end
+
+            self.__callbacks = Ractors.try_make_shareable(callback_sets)
           end
       end
   end

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -55,15 +55,15 @@ module ActiveSupport
         ActiveSupport.event_reporter.clear_context
       end
 
-      app.executor.to_run do
+      app.executor.to_run(&ActiveSupport::Ractors.shareable_proc do
         ActiveSupport::ExecutionContext.push
-      end
+      end)
 
-      app.executor.to_complete do
+      app.executor.to_complete(&ActiveSupport::Ractors.shareable_proc do
         ActiveSupport::CurrentAttributes.clear_all
         ActiveSupport::ExecutionContext.pop
         ActiveSupport.event_reporter.clear_context
-      end
+      end)
 
       ActiveSupport.on_load(:active_support_test_case) do
         if app.config.active_support.executor_around_test_case

--- a/activesupport/test/callbacks_test.rb
+++ b/activesupport/test/callbacks_test.rb
@@ -603,38 +603,40 @@ module CallbacksTest
 
     if RUBY_VERSION >= "4.0"
       def test_callbacks_are_ractor_shareable
-        ActiveSupport::Ractors.with(unshareable_proc_action: :raise) do
-          klass = Class.new do
-            include ActiveSupport::Callbacks
+        [:raise, :warn].each do |unshareable_proc_action|
+          ActiveSupport::Ractors.with(unshareable_proc_action:) do
+            klass = Class.new do
+              include ActiveSupport::Callbacks
 
-            define_callbacks :save, terminator: ->(_target, result_lambda) { result_lambda.call == false }
+              define_callbacks :save, terminator: ->(_target, result_lambda) { result_lambda.call == false }
 
-            set_callback :save, :before, -> { events << :before }, if: -> { true }
-            set_callback :save, :around, ->(_record, block) {
-              events << :around_before
-              block.call
-              events << :around_after
-            }
-            set_callback :save, :after, ->(record) { record.events << :after }, unless: -> { false }
+              set_callback :save, :before, -> { events << :before }, if: -> { true }
+              set_callback :save, :around, ->(_record, block) {
+                events << :around_before
+                block.call
+                events << :around_after
+              }
+              set_callback :save, :after, ->(record) { record.events << :after }, unless: -> { false }
 
-            attr_reader :events
+              attr_reader :events
 
-            def initialize
-              @events = []
+              def initialize
+                @events = []
+              end
+
+              def save
+                run_callbacks(:save) { events << :save }
+              end
             end
 
-            def save
-              run_callbacks(:save) { events << :save }
-            end
+            assert_ractor_shareable klass
+
+            assert_equal [:before, :around_before, :save, :after, :around_after], Ractor.new(klass) { |callback_class|
+              record = callback_class.new
+              record.save
+              record.events
+            }.value
           end
-
-          assert_ractor_shareable klass
-
-          assert_equal [:before, :around_before, :save, :after, :around_after], Ractor.new(klass) { |callback_class|
-            record = callback_class.new
-            record.save
-            record.events
-          }.value
         end
       end
 


### PR DESCRIPTION
Previously, if `Ractors.unshareable_proc_action` was set to `:warn`, `Callbacks` would not attempt to make themselves shareable.

While working on this change, I also found that:
- `ActiveSupport::Callbacks` made `freeze` a protected method, so that's fixed now
- two block based executor callbacks needed to be made explicitly shareable for the application's executor to work inside a Ractor