### PR TITLE
Fix comparison of time attributes assigned from another time zone

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Fix `time` attributes comparing in the wrong order after being assigned a
+    `Time` from another time zone.
+
+    Casting pinned the date to 2000-01-01 after converting the value to
+    `Time.zone`, throwing away the day the conversion had moved it to. Two times
+    that ended up on either side of a day boundary then compared the wrong way
+    around. Values read back from the database are still pinned, so assigning
+    the same time twice keeps leaving the attribute unchanged.
+
+    *Lazizbek Ergashev*
+
 *   Apply `all_queries: true` default scopes consistently across counter caches,
     uniqueness validations, fixture lookups, and record reloads, while those
     operations continue to bypass ordinary default scopes.

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -4,8 +4,13 @@
     Casting pinned the date to 2000-01-01 after converting the value to
     `Time.zone`, throwing away the day the conversion had moved it to. Two times
     that ended up on either side of a day boundary then compared the wrong way
-    around. Values read back from the database are still pinned, so assigning
-    the same time twice keeps leaving the attribute unchanged.
+    around.
+
+    Casting leaves the date alone again, and time attributes are compared by
+    their time of day instead, so assigning the same time twice still leaves
+    the attribute unchanged.
+
+    Fixes #58523.
 
     *Lazizbek Ergashev*
 

--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -21,11 +21,7 @@ module ActiveRecord
             set_time_zone_without_conversion(super)
           elsif value.respond_to?(:in_time_zone)
             begin
-              result = super(__getobj__.user_input_in_time_zone(value)) || super
-              if result && type == :time
-                result = result.change(year: 2000, month: 1, day: 1)
-              end
-              result
+              super(__getobj__.user_input_in_time_zone(value)) || super
             rescue ArgumentError
               nil
             end

--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -36,6 +36,14 @@ module ActiveRecord
           other.is_a?(self.class) && __getobj__ == other.__getobj__
         end
 
+        def changed?(old_value, new_value, new_value_before_type_cast)
+          if type == :time && old_value.acts_like?(:time) && new_value.acts_like?(:time)
+            fixed_date(old_value) != fixed_date(new_value)
+          else
+            super
+          end
+        end
+
         private
           def convert_time_to_time_zone(value)
             return if value.nil?
@@ -43,7 +51,7 @@ module ActiveRecord
             if value.acts_like?(:time)
               converted = value.in_time_zone
               if type == :time && converted
-                converted = converted.change(year: 2000, month: 1, day: 1)
+                converted = fixed_date(converted)
               end
               converted
             elsif value.respond_to?(:infinite?) && value.infinite?
@@ -51,6 +59,10 @@ module ActiveRecord
             else
               map(value) { |v| convert_time_to_time_zone(v) }
             end
+          end
+
+          def fixed_date(value)
+            value.change(year: 2000, month: 1, day: 1)
           end
 
           def set_time_zone_without_conversion(value)

--- a/activerecord/test/cases/attribute_methods/time_zone_converter_test.rb
+++ b/activerecord/test/cases/attribute_methods/time_zone_converter_test.rb
@@ -42,22 +42,6 @@ module ActiveRecord
           Time.zone = old_time_zone
         end
 
-        def test_time_attributes_keep_their_relative_order_when_converted
-          old_time_zone = Time.zone
-
-          Time.zone = "UTC"
-
-          subtype = ActiveRecord::Type::Time.new
-          converter = ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter.new(subtype)
-
-          from = ::Time.new(2000, 1, 1, 1, 0, 0, "+02:00")
-          to = ::Time.new(2000, 1, 1, 23, 0, 0, "+02:00")
-
-          assert_operator converter.cast(from), :<, converter.cast(to)
-        ensure
-          Time.zone = old_time_zone
-        end
-
         def test_time_attribute_dirty_tracking_with_fixed_date
           old_time_zone = Time.zone
           old_default_timezone = ActiveRecord.default_timezone
@@ -75,6 +59,47 @@ module ActiveRecord
           topic = timezone_aware_topic.create!(bonus_time: "08:00")
           topic.reload
           topic.bonus_time = "08:00"
+          assert_not_predicate topic, :bonus_time_changed?
+        ensure
+          Time.zone = old_time_zone
+          ActiveRecord.default_timezone = old_default_timezone
+        end
+
+        def test_time_attribute_comparison_across_time_zones
+          old_time_zone = Time.zone
+
+          Time.zone = "UTC"
+
+          subtype = ActiveRecord::Type::Time.new
+          converter = ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter.new(subtype)
+
+          from = Time.new(2000, 1, 1, 1, 0, 0, "+02:00")
+          to = Time.new(2000, 1, 1, 23, 0, 0, "+02:00")
+
+          assert_operator converter.cast(from), :<, converter.cast(to)
+        ensure
+          Time.zone = old_time_zone
+        end
+
+        def test_time_attribute_dirty_tracking_across_time_zones
+          old_time_zone = Time.zone
+          old_default_timezone = ActiveRecord.default_timezone
+
+          Time.zone = "Tokyo"
+          ActiveRecord.default_timezone = :utc
+
+          timezone_aware_topic = Class.new(ActiveRecord::Base) do
+            self.table_name = "topics"
+            self.time_zone_aware_attributes = true
+            self.time_zone_aware_types = [:datetime, :time]
+            attribute :bonus_time, :time
+          end
+
+          bonus_time = Time.utc(2000, 1, 1, 20, 0)
+
+          topic = timezone_aware_topic.create!(bonus_time: bonus_time)
+          topic.reload
+          topic.bonus_time = bonus_time
           assert_not_predicate topic, :bonus_time_changed?
         ensure
           Time.zone = old_time_zone

--- a/activerecord/test/cases/attribute_methods/time_zone_converter_test.rb
+++ b/activerecord/test/cases/attribute_methods/time_zone_converter_test.rb
@@ -42,6 +42,22 @@ module ActiveRecord
           Time.zone = old_time_zone
         end
 
+        def test_time_attributes_keep_their_relative_order_when_converted
+          old_time_zone = Time.zone
+
+          Time.zone = "UTC"
+
+          subtype = ActiveRecord::Type::Time.new
+          converter = ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter.new(subtype)
+
+          from = ::Time.new(2000, 1, 1, 1, 0, 0, "+02:00")
+          to = ::Time.new(2000, 1, 1, 23, 0, 0, "+02:00")
+
+          assert_operator converter.cast(from), :<, converter.cast(to)
+        ensure
+          Time.zone = old_time_zone
+        end
+
         def test_time_attribute_dirty_tracking_with_fixed_date
           old_time_zone = Time.zone
           old_default_timezone = ActiveRecord.default_timezone


### PR DESCRIPTION
### Motivation / Background

Fixes #58523.

Two `time` attributes assigned from a zone other than `Time.zone` can compare in the wrong order on 8.1. In the reported case an app running in UTC assigns 1am and 11pm from a `+02:00` zone and gets back `2000-01-01 23:00` and `2000-01-01 21:00`, so a validation checking that one comes before the other fails. It worked on 8.0.

The cause is #55298: casting now pins the date to 2000-01-01 *after* the value has been converted into `Time.zone`, which throws away the day the conversion moved it to.

### Detail

Casting leaves the date alone again. Reading still pins it, since that is where the mismatch in #55118 came from: the database stores the time of day alone, so a value loaded back from it can land on a different day than the same time assigned by hand.

That on its own would trade one false-dirty case for another, so dirty tracking no longer depends on both sides carrying the same date. A `time` column stores the time of day and nothing else, and two values that differ only by date serialize identically, so `TimeZoneConverter#changed?` compares them that way. This covers the cases the date pinning never did, such as assigning a `Time` in another zone or a string with an explicit offset, both of which report no change on 8.0 and on this branch but would be marked as changed by the first commit alone.

The test added with #55298 still passes. Two more cover the ordering and the dirty tracking.

One thing this does not change: a `time` column has nowhere to keep the day a conversion crossed, so two times reloaded from the database can still compare the other way around when `Time.zone` is UTC. That is true on 8.0 as well.

### Additional information

The regression came in with #55298, first released in 8.1.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
