### PR TITLE
Deprecate `ActiveRecord::Relation#uniq!`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Deprecate `ActiveRecord::Relation#uniq!`.
+
+    The method was added in Rails 6.1 (#39358) as part of the migration path
+    toward Rails 7.0's default deduplication of multi-value query methods.
+    Deduplication has been applied automatically since Rails 7.0, so
+    `uniq!` no longer has a purpose and will be removed in Rails 9.0.
+
+    *Ryuta Kamizono*
+
 *   Apply `all_queries: true` default scopes consistently across counter caches,
     uniqueness validations, fixture lookups, and record reloads, while those
     operations continue to bypass ordinary default scopes.

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1613,8 +1613,14 @@ module ActiveRecord
       self
     end
 
-    # Deduplicate multiple values.
-    def uniq!(name)
+    def uniq!(name) # :nodoc:
+      ActiveRecord.deprecator.warn(<<~MSG.squish)
+        `ActiveRecord::Relation#uniq!` is deprecated and will be removed in
+        Rails 9.0. It was added in Rails 6.1 as part of the migration path
+        toward Rails 7.0's default deduplication of multi-value query
+        methods, which is no longer necessary now that deduplication is
+        applied automatically.
+      MSG
       if values = @values[name]
         values.uniq! if values.is_a?(Array) && !values.empty?
       end

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -230,7 +230,10 @@ class CalculationsTest < ActiveRecord::TestCase
       9 => 53
     }
     assert_equal expected, accounts.sum(:credit_limit)
-    assert_equal expected, accounts.merge!(accounts).uniq!(:group).sum(:credit_limit)
+    result = assert_deprecated(/`ActiveRecord::Relation#uniq!` is deprecated/, ActiveRecord.deprecator) do
+      accounts.merge!(accounts).uniq!(:group).sum(:credit_limit)
+    end
+    assert_equal expected, result
 
     expected = {
       nil => 50,

--- a/activerecord/test/cases/relation/merging_test.rb
+++ b/activerecord/test/cases/relation/merging_test.rb
@@ -303,7 +303,9 @@ class RelationMergingTest < ActiveRecord::TestCase
   def test_merging_duplicated_annotations
     posts = Post.annotate("foo")
     assert_queries_match(%r{FROM #{Regexp.escape(Post.quoted_table_name)} /\* foo \*/\z}) do
-      posts.merge(posts).uniq!(:annotate).to_a
+      assert_deprecated(/`ActiveRecord::Relation#uniq!` is deprecated/, ActiveRecord.deprecator) do
+        posts.merge(posts).uniq!(:annotate).to_a
+      end
     end
 
     assert_queries_match(%r{FROM #{Regexp.escape(Post.quoted_table_name)} /\* foo \*/\z}) do


### PR DESCRIPTION
`Relation#uniq!` was introduced in #39358 as part of the migration path toward Rails 7.0's default deduplication of multi-value query methods. That deduplication has been applied automatically since Rails 7.0, so this method no longer has a purpose. Deprecate it now so it can be removed in Rails 9.0.

Closes #56338.
