### PR TITLE
Remove `true:` / `false:` options from `ImmutableString` API doc

### DIFF
--- a/activemodel/lib/active_model/type/immutable_string.rb
+++ b/activemodel/lib/active_model/type/immutable_string.rb
@@ -21,19 +21,7 @@ module ActiveModel
     #
     # Values are coerced to strings using their +to_s+ method. Boolean values
     # are treated differently, however: +true+ will be cast to <tt>"t"</tt> and
-    # +false+ will be cast to <tt>"f"</tt>. These strings can be customized when
-    # declaring an attribute:
-    #
-    #   class Person
-    #     include ActiveModel::Attributes
-    #
-    #     attribute :active, :immutable_string, true: "aye", false: "nay"
-    #   end
-    #
-    #   person = Person.new
-    #   person.active = true
-    #
-    #   person.active # => "aye"
+    # +false+ will be cast to <tt>"f"</tt>.
     class ImmutableString < Value
       include Helpers::Immutable
 


### PR DESCRIPTION
These options were added in #39599 to keep the boolean serialization asymmetry of the mysql2 / trilogy adapters (`"1"` / `"0"` instead of `"t"` / `"f"`) on the string type without adding an `ImmutableMysqlString`-like class, so they are for internal use only and are not intended for public use. #44306 documented them in the API doc, but since the options are not part of the public API (and I'd rather remove them entirely eventually), remove them from the API doc.
