### PR TITLE
`activerecord`: make sure SQLite tests do not rely on implicit SELECT order

### DIFF
--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2395,20 +2395,20 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_predicate firm.clients, :loaded?
 
     author = Author.create!(name: "Carl")
-    third  = topics(:third)
-    fourth = topics(:fourth).becomes(Topic)
 
     new_topic = author.topics_without_type.build
 
     assert_not_predicate author.topics_without_type, :loaded?
 
-    assert_queries_count(1) do
-      if current_adapter?(:Mysql2Adapter, :TrilogyAdapter, :SQLite3Adapter)
-        assert_equal fourth, author.topics_without_type.first
-        assert_equal third, author.topics_without_type.second
+    queries = capture_sql do
+      assert_queries_count(1) do
+        author.topics_without_type.first
+        author.topics_without_type.second
+        assert_equal new_topic, author.topics_without_type.last
       end
-      assert_equal new_topic, author.topics_without_type.last
     end
+
+    assert_no_match(/ORDER BY|LIMIT/, queries.sole)
 
     assert_predicate author.topics_without_type, :loaded?
   end


### PR DESCRIPTION
### Motivation / Background

follow-up to https://github.com/rails/rails/pull/58267

### Detail

MySQL, Trilogy and SQLite used to return relation records in that specific order because they used to follow the `(author_name, title)` index access path (postgresql did not).

The test is now deterministic and it does not rely on this side effect anymore.

### Additional information

Failing test:

```shell
Failure:
HasManyAssociationsTest#test_calling_first_nth_or_last_on_existing_record_with_build_should_load_association [test/cases/associations/has_many_associations_test.rb:2405]:
--- expected
+++ actual
@@ -1 +1 @@
-#<Topic id: 4, title: "The Fourth Topic of the day", author_name: "Carl", author_email_address: nil, written_on: "2006-07-15 14:28:00.009900000 +0000", bonus_time: nil, last_read: nil, content: "Why not?", important: nil, binary_content: nil, approved: true, replies_count: 0, unique_replies_count: 0, parent_id: 3, parent_title: nil, type: "Reply", group: nil, created_at: "2026-08-20 12:11:05.217708000 +0000", updated_at: "2026-08-20 12:11:05.217708000 +0000">
+#<Topic id: 3, title: "The Third Topic of the day", author_name: "Carl">
```

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
