### PR TITLE
`activerecord`: prevent tests from relying on unspecified `SELECT` order

### DIFF
--- a/activerecord/test/config.example.yml
+++ b/activerecord/test/config.example.yml
@@ -85,15 +85,23 @@ connections:
       database: <%= FIXTURES_ROOT %>/fixture_database.sqlite3
       timeout:  5000
       strict:   true
+      pragmas:
+        reverse_unordered_selects: true
     arunit2:
       database: <%= FIXTURES_ROOT %>/fixture_database_2.sqlite3
       timeout:  5000
       strict:   true
+      pragmas:
+        reverse_unordered_selects: true
 
   sqlite3_mem:
     arunit:
       adapter: sqlite3
       database: ':memory:'
+      pragmas:
+        reverse_unordered_selects: true
     arunit2:
       adapter: sqlite3
       database: ':memory:'
+      pragmas:
+        reverse_unordered_selects: true


### PR DESCRIPTION
I've fixed some flaky tests

- https://github.com/rails/rails/pull/58267
- https://github.com/rails/rails/pull/58527

and a bug

- https://github.com/rails/rails/pull/58177

related to this assumption, and as Byroot [mentioned](https://github.com/rails/rails/pull/58267#issuecomment-5113975701) it makes sense to prevent this issue in future.

I'm proposing to run the test suite with `reverse_unordered_selects` pragma enabled (ref: https://sqlite.org/pragma.html#pragma_reverse_unordered_selects).

While it does not cover all the specs (some are e.g. PG-specific or skip SQLite adapter), it covers most of them.

FYI @byroot 

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
