### PR TITLE
Make url helpers ractor safe

### DIFF
--- a/actionpack/lib/action_dispatch/journey/path/pattern.rb
+++ b/actionpack/lib/action_dispatch/journey/path/pattern.rb
@@ -36,9 +36,17 @@ module ActionDispatch
 
         def eager_load!
           required_names
+          optional_names
+          requirements_for_missing_keys_check
           offsets
           to_regexp
-          @ast = nil
+          @ast = nil if @ast
+        end
+
+        def freeze
+          eager_load!
+
+          super
         end
 
         def requirements_anchored?

--- a/actionpack/lib/action_dispatch/journey/route.rb
+++ b/actionpack/lib/action_dispatch/journey/route.rb
@@ -101,8 +101,15 @@ module ActionDispatch
       def eager_load!
         path.eager_load!
         parts
+        required_parts
         required_defaults
         nil
+      end
+
+      def freeze
+        eager_load!
+
+        super
       end
 
       # Needed for `bin/rails routes`. Picks up succinctly defined requirements for a

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -187,11 +187,13 @@ module ActionDispatch
 
         class UrlHelper
           def self.create(route, options, route_name)
-            if optimize_helper?(route)
+            helper = if optimize_helper?(route)
               OptimizedUrlHelper.new(route, options, route_name)
             else
               new(route, options, route_name)
             end
+
+            ActiveSupport::Ractors.try_make_shareable(helper)
           end
 
           def self.optimize_helper?(route)
@@ -331,7 +333,7 @@ module ActionDispatch
           #     foo_url(bar, baz, bang, sort_by: 'baz')
           #
           def define_url_helper(mod, name, helper, url_strategy)
-            mod.define_method(name) do |*args|
+            mod.define_method(name, ActiveSupport::Ractors.try_shareable_proc { |*args|
               last = args.last
               options = \
                 case last
@@ -341,7 +343,7 @@ module ActionDispatch
                   args.pop.to_h
                 end
               helper.call(self, name, args, options, url_strategy)
-            end
+            })
           end
       end
 

--- a/actionpack/test/dispatch/routing/route_set_test.rb
+++ b/actionpack/test/dispatch/routing/route_set_test.rb
@@ -2,10 +2,13 @@
 
 require "abstract_unit"
 require "active_support/core_ext/object/with"
+require "active_support/testing/ractors_assertions"
 
 module ActionDispatch
   module Routing
     class RouteSetTest < ActiveSupport::TestCase
+      include ActiveSupport::Testing::RactorsAssertions
+
       class SimpleApp
         def initialize(response)
           @response = response
@@ -242,6 +245,17 @@ module ActionDispatch
               end
             end
           end
+        end
+
+        test "generated url_helpers are ractor shareable" do
+          assert_nothing_raised do
+            ActiveSupport::Ractors.with(unshareable_proc_action: :raise) do
+              draw { resources :posts }
+            end
+          end
+
+          assert_ractor_shareable(@set.named_routes.get(:post))
+          assert_ractor_shareable(@set.named_routes.get(:posts))
         end
       end
 

--- a/actionpack/test/journey/route_test.rb
+++ b/actionpack/test/journey/route_test.rb
@@ -110,6 +110,20 @@ module ActionDispatch
 
         assert_equal specific, found
       end
+
+      if RUBY_VERSION >= "4.0"
+        def test_route_instance_is_ractor_shareable
+          path  = path_from_string "/messages/:id(.:format)"
+          route = Route.new(name: "name", path: path, defaults: { controller: "messages", action: "show" })
+
+          assert_nothing_raised { Ractor.make_shareable(route) }
+          assert Ractor.shareable?(route)
+
+          assert_equal "/messages/1", route.format(id: 1)
+          assert_equal [:id], route.required_parts
+          assert_nothing_raised { route.eager_load! }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Motivation / Background

I'd like to be able to call url helper inside a Ractor. For instance calling `<%= edit_post_path %>` inside a view will trigger a bunch of Ractor isolation error (unshareable proc, access to outer variable, ivar memoization).

### Detail

> [!NOTE]
>
> This patch is **one of the puzzle piece** to solve the problem. 

By itself, it's still not possible to call a url helper, due to other isolation issues on the RouteSet object itself. I'd like to tackle this separately.

### Additional information

This commit allows to **generate** url helpers that are Ractor safe. Previously, it would cause a Ractor isolation error, because of two problems:

1. `define_method` was passed a unshareable proc
2. To fix 1. and make the proc shareable, some objects in the dependency graph such as `Route` also would need to made shareable.

The changes are quite similar to the others we already did where we freeze the graph and make sure to eager load some data to prevent memoization from happening inside a worker ractor.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc/ @gmcgibbon @skipkayhil 
