### PR TITLE
Make ActiveModel::Conversion._to_partial_path ractor safe

### DIFF
--- a/activemodel/lib/active_model/conversion.rb
+++ b/activemodel/lib/active_model/conversion.rb
@@ -108,12 +108,14 @@ module ActiveModel
       # Provide a class level cache for #to_partial_path. This is an
       # internal method and should not be accessed directly.
       def _to_partial_path # :nodoc:
-        @_to_partial_path ||= if respond_to?(:model_name)
-          "#{model_name.collection}/#{model_name.element}".freeze
-        else
-          element = ActiveSupport::Inflector.underscore(ActiveSupport::Inflector.demodulize(name))
-          collection = ActiveSupport::Inflector.tableize(name)
-          "#{collection}/#{element}".freeze
+        @_to_partial_path || ActiveSupport::Ractors.on_main(self) do
+          @_to_partial_path ||= if respond_to?(:model_name)
+            "#{model_name.collection}/#{model_name.element}".freeze
+          else
+            element = ActiveSupport::Inflector.underscore(ActiveSupport::Inflector.demodulize(name))
+            collection = ActiveSupport::Inflector.tableize(name)
+            "#{collection}/#{element}".freeze
+          end
         end
       end
     end

--- a/activemodel/test/cases/conversion_test.rb
+++ b/activemodel/test/cases/conversion_test.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
 require "cases/helper"
+require "active_support/testing/ractors_assertions"
 require "models/contact"
 require "models/helicopter"
 
 class ConversionTest < ActiveModel::TestCase
+  include ActiveSupport::Testing::RactorsAssertions
+
   test "to_model default implementation returns self" do
     contact = Contact.new
     assert_equal contact, contact.to_model
@@ -60,6 +63,18 @@ class ConversionTest < ActiveModel::TestCase
 
   test "to_partial_path handles non-standard model_name" do
     assert_equal "attack_helicopters/ah-64", Helicopter::Apache.new.to_partial_path
+  end
+
+  test "to_partial_path initializes its cache on the main Ractor" do
+    model_class = Class.new do
+      include ActiveModel::Conversion
+
+      def self.name
+        "RactorModel"
+      end
+    end
+
+    assert_equal "ractor_models/ractor_model", on_ractor(model_class) { |klass| klass.new.to_partial_path }
   end
 
   test "to_partial_path on a model implementing .model_name returns a frozen string" do


### PR DESCRIPTION
### Motivation / Background

ActiveModel::Conversion lazily caches a model's partial path in a class instance variable. 
When the cache is first initialized from a non-main Ractor, Ruby raises `Ractor::IsolationError`.

### Detail

The PR delegates initializing the cache to the main Ractor while preserving the direct cache-hit path for previously computed partial paths.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
