### PR TITLE
Avoid quadratic lookups when attaching to a collection

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Avoid quadratic lookups when replacing records common to a collection association.
+
+    *David Paluy*
+
 *   Deprecate `ActiveRecord::Relation#uniq!`.
 
     The method was added in Rails 6.1 (#39358) as part of the migration path

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -422,9 +422,11 @@ module ActiveRecord
 
         def replace_common_records_in_memory(new_target, original_target)
           common_records = intersection(new_target, original_target)
+          target_indexes = {}
+          @target.each_with_index { |record, index| target_indexes[record] ||= index }
           common_records.each do |record|
             skip_callbacks = true
-            replace_on_target(record, skip_callbacks, replace: true)
+            replace_on_target(record, skip_callbacks, replace: true, index: target_indexes[record])
           end
         end
 
@@ -447,9 +449,9 @@ module ActiveRecord
           records
         end
 
-        def replace_on_target(record, skip_callbacks, replace:, inversing: false)
+        def replace_on_target(record, skip_callbacks, replace:, inversing: false, index: nil)
           if replace && (!record.new_record? || @replaced_or_added_targets.include?(record))
-            index = @target.index(record)
+            index ||= @target.index(record)
           end
 
           catch(:abort) do

--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Avoid quadratic attachment lookups when adding to a `has_many_attached` collection.
+
+    *David Paluy*
+
 *   Allow ffmpeg and ffprobe input arguments to be configured.
 
     Two new configuration parameters are introduced.

--- a/activestorage/lib/active_storage/attached/changes/create_many.rb
+++ b/activestorage/lib/active_storage/attached/changes/create_many.rb
@@ -35,11 +35,16 @@ module ActiveStorage
 
     private
       def subchanges
-        @subchanges ||= attachables.collect { |attachable| build_subchange_from(attachable) }
+        @subchanges ||= begin
+          attachments_by_blob = record.public_send("#{name}_attachments").each_with_object({}) do |attachment, index|
+            index[attachment.blob_id] ||= attachment
+          end
+          attachables.collect { |attachable| build_subchange_from(attachable, attachments_by_blob) }
+        end
       end
 
-      def build_subchange_from(attachable)
-        ActiveStorage::Attached::Changes::CreateOneOfMany.new(name, record, attachable)
+      def build_subchange_from(attachable, attachments_by_blob)
+        ActiveStorage::Attached::Changes::CreateOneOfMany.new(name, record, attachable, attachments_by_blob)
       end
 
       def subchanges_without_blobs

--- a/activestorage/lib/active_storage/attached/changes/create_one_of_many.rb
+++ b/activestorage/lib/active_storage/attached/changes/create_one_of_many.rb
@@ -2,10 +2,15 @@
 
 module ActiveStorage
   class Attached::Changes::CreateOneOfMany < Attached::Changes::CreateOne # :nodoc:
+    def initialize(name, record, attachable, attachments_by_blob)
+      @attachments_by_blob = attachments_by_blob
+      super(name, record, attachable)
+    end
+
     private
       def find_attachment
         if blob.persisted?
-          record.public_send("#{name}_attachments").detect { |attachment| attachment.blob_id == blob.id }
+          @attachments_by_blob[blob.id]
         else
           blob.attachments.find { |attachment| attachment.record == record }
         end


### PR DESCRIPTION
## Motivation

Appending one attachment to a large `has_many_attached` collection performs two repeated linear scans:

- `CollectionAssociation#replace_common_records_in_memory` calls `Array#index` once for every common record.
- `CreateOneOfMany#find_attachment` scans the attachment association once for every existing blob.

At 1,000 existing attachments, those scans dominate `attach`.

## Changes

- Build a local first-index lookup while replacing common collection records.
- Build a local first-attachment lookup while constructing an Active Storage `CreateMany` change.

Both lookups live only for the current operation. This avoids the persistent `@target_index_map` and its invalidation invariants discussed in #46652.

## Benchmark

The script seeds existing blob and attachment rows, then reports the median of three calls that attach an existing blob. Times are seconds on Ruby 4.0.3 with SQLite.

| Existing attachments | Before | After | Improvement |
| ---: | ---: | ---: | ---: |
| 250 | 0.024387 | 0.007457 | 3.27x |
| 500 | 0.084327 | 0.016791 | 5.02x |
| 1,000 | 0.300122 | 0.043184 | 6.95x |

<details>
<summary>Benchmark script</summary>

```ruby
# frozen_string_literal: true

ENV["RAILS_ENV"] = "test"

require_relative "activestorage/test/dummy/config/environment"
require_relative "activestorage/test/database/setup"

class User < ActiveRecord::Base
  has_many_attached :highlights
end

sizes = [250, 500, 1_000]

ActiveStorage::Attachment.delete_all
ActiveStorage::Blob.delete_all
User.delete_all

puts "size\tseconds"

sizes.each do |size|
  user = User.create!(name: "Benchmark")
  now = Time.current

  ActiveStorage::Blob.insert_all! Array.new(size + 3) { |index|
    {
      key: SecureRandom.base58(28),
      filename: "file-#{index}.txt",
      content_type: "text/plain",
      metadata: { identified: true },
      service_name: "local",
      byte_size: 1,
      checksum: "dGVzdA==",
      created_at: now
    }
  }

  blobs = ActiveStorage::Blob.order(:id).last(size + 3)
  ActiveStorage::Attachment.insert_all! blobs.first(size).map { |blob|
    {
      name: "highlights",
      record_type: "User",
      record_id: user.id,
      blob_id: blob.id,
      created_at: now
    }
  }

  user.reload
  measurements = blobs.last(3).map do |blob|
    started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
    user.highlights.attach(blob)
    Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
  end

  puts "#{size}\t#{format("%.6f", measurements.sort[1])}"

  ActiveStorage::Attachment.delete_all
  ActiveStorage::Blob.delete_all
  User.delete_all
end
```

</details>

## Verification

- `cd activerecord && bin/test test/cases/associations/has_many_associations_test.rb` — 328 runs, 1,056 assertions, 0 failures, 0 errors
- `cd activestorage && bin/test test/models/attached/many_test.rb -i /attach/` — 64 runs, 330 assertions, 0 failures, 0 errors
- `bundle exec rubocop activerecord/lib/active_record/associations/collection_association.rb activestorage/lib/active_storage/attached/changes/create_many.rb activestorage/lib/active_storage/attached/changes/create_one_of_many.rb` — 3 files inspected, no offenses

Fixes #50848.

Related prior approach: #46652.
