### PR TITLE
Add enumerable to AttributeMethodPatternSet

### DIFF
--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -496,6 +496,8 @@ module ActiveModel
         end
 
         class AttributeMethodPatternSet # :nodoc:
+          include Enumerable
+
           def initialize(patterns)
             @patterns = patterns.freeze
             @affixed = patterns.reject { |pattern| pattern.prefix.empty? && pattern.suffix.empty? }.freeze

--- a/activemodel/test/cases/attribute_methods_test.rb
+++ b/activemodel/test/cases/attribute_methods_test.rb
@@ -113,6 +113,13 @@ class AttributeMethodsTest < ActiveModel::TestCase
                      ModelWithAttributes2.public_send(:attribute_method_patterns)
   end
 
+  test "attribute method patterns are enumerable and respond to map" do
+    patterns = ModelWithAttributes2.attribute_method_patterns
+
+    assert_kind_of Enumerable, patterns
+    assert_equal ["foo", "foo_test", "foo_kw"], patterns.map { |pattern| pattern.method_name("foo") }
+  end
+
   test "#define_attribute_method generates attribute method" do
     ModelWithAttributes.define_attribute_method(:foo)
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because https://github.com/rails/rails/pull/58462 made `attribute_method_patterns` not enumerable. This isn't technically a regression because this is private API, but it seems like adding enumerable here was intended as it has an `each` method and replaces an array.

### Detail

This Pull Request changes Active Model's `attribute_method_patterns `. Previous implementation was an array which was enumerable, so AttributeMethodPatternSet should be too.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
