### PR TITLE
Fix the `Relation#create` documentation example

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -145,7 +145,7 @@ module ActiveRecord
     #   users.create # => #<User id: 3, name: "Oscar", ...>
     #
     #   users.create(name: 'fxn')
-    #   users.create # => #<User id: 4, name: "fxn", ...>
+    #   # => #<User id: 4, name: "fxn", ...>
     #
     #   users.create { |user| user.name = 'tenderlove' }
     #   # => #<User id: 5, name: "tenderlove", ...>


### PR DESCRIPTION
The `Relation#create` examples show the result of `users.create(name: 'fxn')` attached to an extra argument-less `users.create` call:

```ruby
users = User.where(name: 'Oscar')
users.create # => #<User id: 3, name: "Oscar", ...>

users.create(name: 'fxn')
users.create # => #<User id: 4, name: "fxn", ...>
```

An argument-less `create` on a scoped relation takes the scoped attributes, so that second call would create a record named `"Oscar"`, not `"fxn"` — exactly what the first example two lines above already demonstrates, and what `relations_test.rb:1357-1359` asserts.

The stray call was carried over from the first example when the block was introduced in 5edbeb0a87 (2012). The two examples that follow (`tenderlove` and the validation one) already present the result on its own line, so this conforms the remaining one to them.