### PR TITLE
Fix async `ActiveRecord::StatementCache` execution with out-of-range bind values

### DIFF
--- a/activerecord/lib/active_record/statement_cache.rb
+++ b/activerecord/lib/active_record/statement_cache.rb
@@ -156,7 +156,7 @@ module ActiveRecord
         @model.find_by_sql(sql, bind_values, preparable: true, allow_retry: @query_builder.retryable, &block)
       end
     rescue ::RangeError
-      async ? Promise.wrap([]) : []
+      async ? Promise::Complete.new([]) : []
     end
 
     def self.unsupported_value?(value)

--- a/activerecord/test/cases/statement_cache_test.rb
+++ b/activerecord/test/cases/statement_cache_test.rb
@@ -112,6 +112,29 @@ module ActiveRecord
       assert_not_equal book, other_book
     end
 
+    def test_out_of_range_bind_value_returns_an_empty_result
+      cache = Book.lease_connection.unprepared_statement do
+        StatementCache.create(Book.lease_connection) do |params|
+          Book.where(id: params.bind)
+        end
+      end
+
+      assert_equal [], cache.execute([2 << 63], Book.lease_connection)
+    end
+
+    def test_out_of_range_bind_value_returns_an_empty_result_when_async
+      cache = Book.lease_connection.unprepared_statement do
+        StatementCache.create(Book.lease_connection) do |params|
+          Book.where(id: params.bind)
+        end
+      end
+
+      promise = cache.execute([2 << 63], Book.lease_connection, async: true)
+
+      assert promise.is_a?(ActiveRecord::Promise)
+      assert_equal [], promise.value
+    end
+
     def test_find_by_does_not_use_statement_cache_if_table_name_is_changed
       liquid = Liquid.create(name: "salty")
 


### PR DESCRIPTION
The `Promise.wrap` method does not exist; we should use `Promise::Complete.new` instead.

```
Error:
ActiveRecord::StatementCacheTest#test_out_of_range_bind_value_returns_an_empty_result_when_async:
NoMethodError: undefined method 'wrap' for class ActiveRecord::Promise
    lib/active_record/statement_cache.rb:159:in 'ActiveRecord::StatementCache#execute'
    test/cases/statement_cache_test.rb:132:in 'ActiveRecord::StatementCacheTest#test_out_of_range_bind_value_returns_an_empty_result_when_async'

bin/test test/cases/statement_cache_test.rb:125
```
Seems to be introduced in https://github.com/rails/rails/pull/52807 (cc @byroot)

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
