### PR TITLE
Fix the documented return type of AVG calculations

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -195,8 +195,9 @@ module ActiveRecord
     #
     # There are two basic forms of output:
     #
-    # * Single aggregate value: The single value is type cast to Integer for COUNT, Float
-    #   for AVG, and the given column's type for everything else.
+    # * Single aggregate value: The single value is type cast to Integer for COUNT,
+    #   BigDecimal for AVG of integer and decimal columns, and the given column's type
+    #   for everything else.
     #
     # * Grouped values: This returns an ordered hash of the values and groups them. It
     #   takes either a column name, or the name of a belongs_to association.


### PR DESCRIPTION
`ActiveRecord::Calculations` documents the type of a single aggregate value as:

> The single value is type cast to Integer for COUNT, **Float for AVG**, and the given column's type for everything else.

`average` returns a `BigDecimal` for integer and decimal columns. `Float` comes back only for float columns, which the "given column's type" case already covers.

The test names in `activerecord/test/cases/calculations_test.rb` spell the behaviour out:

```ruby
def test_should_return_decimal_average_of_integer_field
  value = Account.average(:id)
  assert_instance_of BigDecimal, value
end

def test_should_return_decimal_average_if_db_returns_such
  NumericData.create!([{ bank_balance: 37.50 }, { bank_balance: 37.45 }])
  assert_instance_of BigDecimal, NumericData.average(:bank_balance)
end

def test_should_return_float_average_if_db_returns_such
  NumericData.create!(temperature: 37.5)
  assert_instance_of Float, NumericData.average(:temperature)
end
```

Measured on `main` with SQLite, PostgreSQL and MySQL, which agree:

| column type | `average` |
| --- | --- |
| integer | `BigDecimal` |
| decimal | `BigDecimal` |
| float | `Float` |

>[!NOTE]
>
>#### Documentation only.