### PR TITLE
Fix the Active Record Store dirty tracking documentation example

### DIFF
--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -45,7 +45,7 @@ module ActiveRecord
   #     store :settings, accessors: [ :login_retry ], suffix: :config
   #   end
   #
-  #   u = User.new(color: 'black', homepage: '37signals.com', parent_name: 'Mary', partner_name: 'Lily')
+  #   u = User.create!(color: 'black', homepage: '37signals.com', parent_name: 'Mary', partner_name: 'Lily')
   #   u.color                          # Accessor stored attribute
   #   u.parent_name                    # Accessor stored attribute with prefix
   #   u.partner_name                   # Accessor stored attribute with custom prefix


### PR DESCRIPTION
The dirty tracking block in the `ActiveRecord::Store` documentation shows the values of a **persisted** record, but the example object it operates on is built with `User.new` and never saved:

```ruby
u = User.new(color: 'black', homepage: '37signals.com', parent_name: 'Mary', partner_name: 'Lily')
...
# Dirty tracking
u.color = 'green'
u.color_changed? # => true
u.color_was # => 'black'
u.color_change # => ['black', 'green']
```

For an unsaved record there is no previous store to compare against, so the actual values are `nil` and `[nil, 'green']`.

The test suite asserts exactly this. `activerecord/test/cases/store_test.rb` has one test for each case:

```ruby
test "new record and no accessors changes" do
  user = Admin::User.new
  ...
  user.color = "red"
  assert_predicate user, :color_changed?
  assert_nil user.color_was
  assert_equal "red", user.color_change[1]
end
```

while the tests built on the persisted `@john` (`Admin::User.create!`) assert the documented values:

```ruby
test "updating the store populates the accessor changed array correctly" do
  @john.color = "red"
  assert_equal "black", @john.color_was
  assert_equal "black", @john.color_change[0]
  assert_equal "red", @john.color_change[1]
end
```

Verified against `main`:

```
u = User.new(...)     -> color_was = nil,     color_change = [nil, "green"]
u = User.create!(...) -> color_was = "black", color_change = ["black", "green"]
```

Creating the record makes every `# =>` in the example hold, and the rest of the block (the accessors, the string/symbol equivalence, `stored_attributes`) is unaffected.

> [!NOTE]
> Documentation only.
