### PR TITLE
Avoid needless Array#flatten calls

### DIFF
--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -25,7 +25,9 @@ module ActiveRecord
         owner = association.owner
         chain = get_chain(reflection, association, scope.alias_tracker)
 
-        scope.extending! reflection.extensions
+        extensions = reflection.extensions
+        scope.extending!(extensions) unless extensions.empty?
+
         scope = add_constraints(scope, owner, chain)
         scope.default_order!(reflection.options[:default_order]) if reflection.options[:default_order].present?
         scope.limit!(1) unless reflection.collection?

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -731,8 +731,15 @@ module ActiveRecord
         seed + [self]
       end
 
+      FROZEN_EMPTY_ARRAY = [].freeze
+      private_constant :FROZEN_EMPTY_ARRAY
+
       def extensions
-        Array(options[:extend])
+        if options[:extend]
+          Array(options[:extend])
+        else
+          FROZEN_EMPTY_ARRAY
+        end
       end
 
       def deprecated?


### PR DESCRIPTION
`extending!` uses the classic `*args -> args.flatten` pattern, which is a bit wasteful when most of the time it's called with a single positional empty array.

When `Array#flatten` encounter a nested Array, it has to allocate an expensive identity Hash to handle recursion, migth as well avoid that.
