### PR TITLE
[Docs][ci skip] Clarify that dynamic finder method are mildly deprecated

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -493,7 +493,7 @@ the Composite Primary Keys guide for the `find_by(id:)` behavior.
 
 #### Dynamic Finder Methods
 
-NOTE: Dynamic attribute-based finders are a mildly deprecated.
+NOTE: Dynamic finder methods are a mildly deprecated.
 
 For every field (also known as an attribute) you define in your table, Active
 Record dynamically provides a finder method. If you have a field called

--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -493,6 +493,8 @@ the Composite Primary Keys guide for the `find_by(id:)` behavior.
 
 #### Dynamic Finder Methods
 
+NOTE: Dynamic attribute-based finders are a mildly deprecated.
+
 For every field (also known as an attribute) you define in your table, Active
 Record dynamically provides a finder method. If you have a field called
 `first_name` on your `Customer` model for example, you get the
@@ -502,9 +504,6 @@ Record dynamically provides a finder method. If you have a field called
 store(dev)> Customer.find_by_first_name("Bhumi")
 => #<Customer id: 25, first_name: "Bhumi">
 ```
-
-If you also have a `locked` field on the `Customer` model, you also get a
-`find_by_locked` method.
 
 You can specify an exclamation point (`!`) on the end of the dynamic finders to
 get them to raise an `ActiveRecord::RecordNotFound` error if they do not return


### PR DESCRIPTION
1. Added note about the mild deprecation of dynamic attribute-based finders in Active Record. This is to match the [comment in the source code](https://github.com/rails/rails/blob/2a2db1e8d6d104ee0611efcae7eb023af65cff34/activerecord/lib/active_record/base.rb#L170).
2. Removed the tiny example that used a column named "locked". I think that example was unnecessarily confusing because the term "lock" has a lot of strong connotations that are unrelated to dynamic finder methods. Since these are basically deprecated, I thought to not replace the example and just make this section shorter.

