### PR TITLE
Strip user-supplied `<action-text-markdown>` while canonicalizing

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -47,6 +47,10 @@
         message = Message.create!(content: "<h1>Hello</h1><p>This is <strong>bold</strong></p>")
         message.content.to_markdown # => "# Hello\n\nThis is **bold**"
 
+    The `<action-text-markdown>` element is reserved for Action Text's own use and is
+    removed from rich text content, so Markdown typed inside one is escaped like any
+    other text.
+
     *Mike Dalessio*
 
 *   Make `ActionText::Attachable#read_attribute_for_serialization` public.

--- a/actiontext/lib/action_text/content.rb
+++ b/actiontext/lib/action_text/content.rb
@@ -148,9 +148,7 @@ module ActionText
     # browsers without additional sanitization.
     def to_markdown(attachment_links: false)
       render_attachments(with_full_attributes: false) { |attachment|
-        ActionText::HtmlConversion.create_element("action-text-markdown").tap do |node|
-          node.content = attachment.to_markdown(attachment_links: attachment_links)
-        end
+        ActionText::MarkdownConversion.render_attachment(attachment, attachment_links: attachment_links)
       }.fragment.to_markdown
     end
 

--- a/actiontext/lib/action_text/content.rb
+++ b/actiontext/lib/action_text/content.rb
@@ -33,6 +33,7 @@ module ActionText
       def fragment_by_canonicalizing_content(content)
         fragment = ActionText::Attachment.fragment_by_canonicalizing_attachments(content)
         fragment = ActionText::AttachmentGallery.fragment_by_canonicalizing_attachment_galleries(fragment)
+        fragment = ActionText::MarkdownConversion.fragment_by_unwrapping_raw_markdown_tags(fragment)
         fragment
       end
     end

--- a/actiontext/lib/action_text/content.rb
+++ b/actiontext/lib/action_text/content.rb
@@ -140,7 +140,7 @@ module ActionText
     #     content = ActionText::Content.new("<p>Hello <strong>world</strong></p>")
     #     content.to_markdown # => "Hello **world**"
     #
-    # When +attachment_links+ is true, ActiveStorage blob attachments generate Markdown links with
+    # When `attachment_links` is true, ActiveStorage blob attachments generate Markdown links with
     # URLs. This requires a rendering context (e.g., controller or mailer action) and will raise if
     # URL generation fails.
     #

--- a/actiontext/lib/action_text/fragment.rb
+++ b/actiontext/lib/action_text/fragment.rb
@@ -51,6 +51,8 @@ module ActionText
       @plain_text ||= PlainTextConversion.node_to_plain_text(source)
     end
 
+    # NOTE: this does not canonicalize, so it is not safe for untrusted content. See the
+    # note on ActionText::MarkdownConversion.node_to_markdown.
     def to_markdown
       @markdown ||= MarkdownConversion.node_to_markdown(source)
     end

--- a/actiontext/lib/action_text/markdown_conversion.rb
+++ b/actiontext/lib/action_text/markdown_conversion.rb
@@ -18,7 +18,7 @@ module ActionText
   module MarkdownConversion
     extend self
 
-    # Converts a Nokogiri HTML +node+ into a Markdown string.
+    # Converts a Nokogiri HTML `node` into a Markdown string.
     #
     #     node = Nokogiri::HTML4.fragment("<p>Hello <strong>world</strong></p>")
     #     MarkdownConversion.node_to_markdown(node) # => "Hello **world**"
@@ -28,21 +28,21 @@ module ActionText
       end.strip
     end
 
-    # Returns a Markdown link: +[title](url)+.
+    # Returns a Markdown link: `[title](url)`.
     #
-    # Escapes metacharacters in +title+, and percent-encodes characters in +url+ that would break
+    # Escapes metacharacters in `title`, and percent-encodes characters in `url` that would break
     # the link syntax.
     #
     #     MarkdownConversion.markdown_link("photo", "https://example.com/photo_(large).png")
     #     # => "[photo](https://example.com/photo_%28large%29.png)"
     #
-    # Pass <tt>image: true</tt> to produce an image link (+![title](url)+).
+    # Pass `image: true` to produce an image link (`![title](url)`).
     #
     #     MarkdownConversion.markdown_link("photo", "https://example.com/photo.png", image: true)
     #     # => "![photo](https://example.com/photo.png)"
     #
-    # If the URI scheme is not allowed (per +Rails::HTML::Sanitizer.allowed_uri?+), returns the
-    # escaped title wrapped in escaped brackets (+\[title\]+).
+    # If the URI scheme is not allowed (per `Rails::HTML::Sanitizer.allowed_uri?`), returns the
+    # escaped title wrapped in escaped brackets (`\[title\]`).
     #
     #     MarkdownConversion.markdown_link("click", "javascript:alert(1)")
     #     # => "\\[click\\]"
@@ -54,7 +54,7 @@ module ActionText
       end
     end
 
-    # Backslash-escapes CommonMark metacharacters in +text+ so they are treated
+    # Backslash-escapes CommonMark metacharacters in `text` so they are treated
     # as literal characters by Markdown renderers.
     #
     #     MarkdownConversion.escape_markdown_text("**Important**")

--- a/actiontext/lib/action_text/markdown_conversion.rb
+++ b/actiontext/lib/action_text/markdown_conversion.rb
@@ -18,6 +18,8 @@ module ActionText
   module MarkdownConversion
     extend self
 
+    RAW_MARKDOWN_TAG_NAME = "action-text-markdown" # :nodoc:
+
     # Converts a Nokogiri HTML `node` into a Markdown string.
     #
     #     node = Nokogiri::HTML4.fragment("<p>Hello <strong>world</strong></p>")
@@ -26,6 +28,15 @@ module ActionText
       BottomUpReducer.new(node).reduce do |n, child_values|
         markdown_for_node(n, child_values)
       end.strip
+    end
+
+    # Returns an element holding `attachment`'s Markdown, for `ActionText::Content#to_markdown` to
+    # substitute in place of the attachment. #node_to_markdown emits the element's text verbatim
+    # rather than escaping it as ordinary Markdown source.
+    def render_attachment(attachment, attachment_links: false)
+      ActionText::HtmlConversion.create_element(RAW_MARKDOWN_TAG_NAME).tap do |node|
+        node.content = attachment.to_markdown(attachment_links: attachment_links)
+      end
     end
 
     # Returns a Markdown link: `[title](url)`.
@@ -77,12 +88,11 @@ module ActionText
         | \A\+(?=\s|\z)       # leading plus before space: list item
         | \A\d+\K\.(?=\s|\z)  # leading "1." with trailing space: ordered list item (only the dot is matched)
       /x
-      SKIP_ESCAPING_PARENTS = %w[ action-text-markdown code pre ].freeze
-      INLINE_ELEMENTS = %w[
-        action-text-markdown
+      SKIP_ESCAPING_PARENTS = [ RAW_MARKDOWN_TAG_NAME, "code", "pre" ].freeze
+      INLINE_ELEMENTS = [ RAW_MARKDOWN_TAG_NAME, *%w[
         a abbr b bdi bdo cite code data del dfn em i kbd mark q
         rp rt ruby s samp small span strong sub sup time u var
-      ].freeze
+      ] ].freeze
       LEADING_PRETTY_PRINT_WHITESPACE = /\A\s*\n\s*/
       TRAILING_PRETTY_PRINT_WHITESPACE = /\s*\n\s*\z/
       private_constant :BOLD_TAGS, :ITALIC_TAGS, :LIST_BULLET, :LIST_INDENT, :ENCODE_HREF_CHARS,

--- a/actiontext/lib/action_text/markdown_conversion.rb
+++ b/actiontext/lib/action_text/markdown_conversion.rb
@@ -24,10 +24,29 @@ module ActionText
     #
     #     node = Nokogiri::HTML4.fragment("<p>Hello <strong>world</strong></p>")
     #     MarkdownConversion.node_to_markdown(node) # => "Hello **world**"
+    #
+    # NOTE: text inside `<action-text-markdown>` elements is emitted without escaping, so this
+    # method is not safe for untrusted content. Convert user-supplied markup through
+    # ActionText::Content, which strips those elements while canonicalizing.
     def node_to_markdown(node)
       BottomUpReducer.new(node).reduce do |n, child_values|
         markdown_for_node(n, child_values)
       end.strip
+    end
+
+    # Returns a copy of `fragment` with `<action-text-markdown>` elements replaced by their
+    # children, leaving the text to be escaped like any other.
+    #
+    # #render_attachment wraps already-rendered Markdown in that element so #node_to_markdown
+    # emits it without escaping. Only Action Text may do that, so ActionText::Content unwraps
+    # the element while canonicalizing: anything carrying it at that point came from outside
+    # the framework.
+    def fragment_by_unwrapping_raw_markdown_tags(fragment)
+      ActionText::Fragment.wrap(fragment).update do |source|
+        source.css(RAW_MARKDOWN_TAG_NAME).each do |node|
+          node.replace(node.children)
+        end
+      end
     end
 
     # Returns an element holding `attachment`'s Markdown, for `ActionText::Content#to_markdown` to

--- a/actiontext/test/integration/markdown_sanitization_test.rb
+++ b/actiontext/test/integration/markdown_sanitization_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ActionText::MarkdownSanitizationTest < ActionDispatch::IntegrationTest
+  PAYLOAD     = "[click](javascript:alert(1))"
+  WITH_MARKER = "<action-text-markdown>#{PAYLOAD}</action-text-markdown>".freeze
+  ESCAPED     = "\\[click\\](javascript:alert(1))"
+
+  test "a submitted body is stored without the raw Markdown tag it arrived with" do
+    post messages_path, params: { message: { subject: "x", content: WITH_MARKER } }
+
+    assert_equal PAYLOAD, Message.last.rich_text_content.read_attribute_before_type_cast(:body)
+  end
+
+  test "wrapping the payload in the raw Markdown tag grants it no privilege" do
+    assert_equal markdown_for(PAYLOAD), markdown_for(WITH_MARKER)
+  end
+
+  test "a body persisted with the raw Markdown tag is stripped when it is loaded" do
+    post messages_path, params: { message: { subject: "x", content: PAYLOAD } }
+    rich_text = Message.last.rich_text_content
+    rich_text.update_column(:body, ActionText::Content.new(WITH_MARKER, canonicalize: false))
+
+    assert_equal ESCAPED, rich_text.reload.body.to_markdown
+  end
+
+  private
+    def markdown_for(content)
+      post messages_path, params: { message: { subject: "x", content: content } }
+      Message.last.tap(&:reload).content.to_markdown
+    end
+end

--- a/actiontext/test/unit/markdown_conversion_test.rb
+++ b/actiontext/test/unit/markdown_conversion_test.rb
@@ -3,6 +3,7 @@
 require "test_helper"
 
 class ActionText::MarkdownConversionTest < ActiveSupport::TestCase
+  RAW_MARKDOWN_TAG = ActionText::MarkdownConversion::RAW_MARKDOWN_TAG_NAME
   test "escape_markdown_text escapes metacharacters" do
     assert_equal '\\*\\*bold\\*\\* and \\[link\\](url)', ActionText::MarkdownConversion.escape_markdown_text("**bold** and [link](url)")
   end
@@ -1079,6 +1080,64 @@ class ActionText::MarkdownConversionTest < ActiveSupport::TestCase
     blob.destroy!
 
     assert_converted_to("☒", html)
+  end
+
+  # --- User-supplied <action-text-markdown> tests ---
+
+  test "user-supplied action-text-markdown does not bypass URI scheme validation" do
+    assert_converted_to "\\[click\\](javascript:alert(1))",
+      "<action-text-markdown>[click](javascript:alert(1))</action-text-markdown>"
+  end
+
+  test "user-supplied action-text-markdown has its text escaped" do
+    assert_converted_to "\\*\\*bold\\*\\*", "<action-text-markdown>**bold**</action-text-markdown>"
+  end
+
+  test "user-supplied action-text-markdown keeps its element children" do
+    assert_converted_to "**bold**", "<action-text-markdown><strong>bold</strong></action-text-markdown>"
+  end
+
+  test "nested user-supplied action-text-markdown is neutralized at every level" do
+    assert_converted_to "\\[click\\](javascript:alert(1))",
+      "<action-text-markdown><action-text-markdown>[click](javascript:alert(1))</action-text-markdown></action-text-markdown>"
+  end
+
+  test "user-supplied action-text-markdown does not disturb attachment markdown in the same content" do
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+    html = "<action-text-markdown>[click](javascript:alert(1))</action-text-markdown>" +
+      %Q(<action-text-attachment sgid="#{blob.attachable_sgid}" caption="Captioned"></action-text-attachment>)
+
+    with_controller_renderer do |controller|
+      url = controller.url_for(blob)
+      assert_converted_to "\\[click\\](javascript:alert(1))![Captioned](#{url})", html, attachment_links: true
+    end
+  end
+
+  test "canonicalizing unwraps every raw Markdown tag it finds" do
+    content = ActionText::Content.new("<action-text-markdown>[click](javascript:alert(1))</action-text-markdown>")
+
+    assert_equal "[click](javascript:alert(1))", content.to_html
+    assert_empty content.fragment.find_all(RAW_MARKDOWN_TAG),
+      "canonicalizing must leave no raw Markdown tag behind, whatever the source of the content"
+  end
+
+  test "render_attachments does not canonicalize away the raw Markdown tags it adds" do
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+    content = ActionText::Content.new(%Q(<action-text-attachment sgid="#{blob.attachable_sgid}"></action-text-attachment>))
+
+    rendered = content.render_attachments(with_full_attributes: false) do |attachment|
+      ActionText::MarkdownConversion.render_attachment(attachment)
+    end
+
+    assert_equal 1, rendered.fragment.find_all(RAW_MARKDOWN_TAG).size,
+      "#to_markdown adds raw Markdown tags after canonicalizing, so render_attachments must " \
+      "build its result with canonicalize: false or the tags it just added are unwrapped again"
+  end
+
+  test "to_markdown is repeatable for content holding user-supplied action-text-markdown" do
+    content = ActionText::Content.new("<action-text-markdown>[click](javascript:alert(1))</action-text-markdown>")
+
+    assert_equal content.to_markdown, content.to_markdown
   end
 
   # --- Fragment and Rich Text tests ---


### PR DESCRIPTION
### Motivation / Background

`ActionText::Content#to_markdown` wraps each rendered attachment's Markdown in an `<action-text-markdown>` element so that `MarkdownConversion` emits the text verbatim instead of escaping it. The converter had no way to tell that element apart from one a user typed into a rich text body, so a body containing a literal `<action-text-markdown>` had its contents emitted as Markdown source, bypassing the URI scheme check in `MarkdownConversion#markdown_link`:

```ruby
ActionText::Content.new("<action-text-markdown>[click](javascript:alert(1))</action-text-markdown>").to_markdown
# before => "[click](javascript:alert(1))"
# after  => "\\[click\\](javascript:alert(1))"
```

Reported to the Rails HackerOne program as https://hackerone.com/reports/3727743. `to_markdown` has not shipped in a released version of Rails, so no released version is affected and this is not being handled as a security release.

### Detail

Three commits:

1. **`doc: use Markdown markup in Action Text Markdown docs`** — `content.rb` and `markdown_conversion.rb` declare `# :markup: markdown` but their doc comments used RDoc's `+text+` and `<tt>` markup, which renders literally under that directive. No code change.
2. **`Move Markdown attachment rendering into MarkdownConversion`** — extracts the wrapper `Content#to_markdown` built inline into `MarkdownConversion.render_attachment`, alongside a shared `RAW_MARKDOWN_TAG_NAME` that the two private constants matching the same literal now use. No behavior change.
3. **`Strip user-supplied <action-text-markdown> while canonicalizing`** — the fix.

The fix unwraps the element in `Content.fragment_by_canonicalizing_content`. That is the right seam because it already exists to normalize markup arriving from outside the framework and it runs once per `Content`, including for every body loaded from the database. The trusted markers are added afterwards, by `render_attachments`, which builds its result with `canonicalize: false` — so the ordering that makes this correct is structural rather than something a future caller has to remember. A test asserts that ordering by name, rather than leaving it to the attachment tests that would incidentally fail.

`Fragment#to_markdown` and `MarkdownConversion.node_to_markdown` neither canonicalize nor render attachments. They are documented as unsafe for untrusted content and point at the safe path.

### Additional information

**Performance.** The fix adds a third pass over the fragment during canonicalization, which every `Content` construction pays — including every rich text load from the database, since `ActionText::Serialization.load` is `Content.new`. Measured on `Content.fragment_by_canonicalizing_content` with a 20-paragraph body containing no markers, best-of-15 rounds of 1000 iterations, three separate runs:

| | run 1 | run 2 | run 3 |
|---|---|---|---|
| before | 1758 i/s | 1702 i/s | 1687 i/s |
| after | 1393 i/s | 1372 i/s | 1367 i/s |
| | -20.8% | -19.4% | -19.0% |

In absolute terms the whole operation stays under a millisecond. Skipping `Fragment#update`'s dup when nothing matches recovers roughly four of those twenty points and costs an API wrinkle, so it is not done here.

**Alternative considered.** Stripping at `to_markdown` time instead would be nearly free, since `to_markdown` already walks the tree. It was rejected because the marker would then survive in `Content#to_html`, and every future consumer of the element would need its own strip. Canonicalization keeps the invariant in one place.

**CHANGELOG.** No new entry — `to_markdown` is itself unreleased. The existing entry is amended to note that `<action-text-markdown>` is reserved for Action Text's own use.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
