### PR TITLE
[ci skip] Remove `:https` from Content Security Policy examples

### DIFF
--- a/actionpack/lib/action_controller/metal/content_security_policy.rb
+++ b/actionpack/lib/action_controller/metal/content_security_policy.rb
@@ -28,7 +28,7 @@ module ActionController # :nodoc:
       #
       #     class PostsController < ApplicationController
       #       content_security_policy(only: :index) do |policy|
-      #         policy.default_src :self, :https
+      #         policy.default_src :self
       #       end
       #     end
       #

--- a/actionpack/lib/action_dispatch/http/content_security_policy.rb
+++ b/actionpack/lib/action_dispatch/http/content_security_policy.rb
@@ -15,12 +15,12 @@ module ActionDispatch # :nodoc:
   # Example global policy:
   #
   #     Rails.application.config.content_security_policy do |policy|
-  #       policy.default_src :self, :https
-  #       policy.font_src    :self, :https, :data
-  #       policy.img_src     :self, :https, :data
+  #       policy.default_src :self
+  #       policy.font_src    :self, :data
+  #       policy.img_src     :self, :data
   #       policy.object_src  :none
-  #       policy.script_src  :self, :https
-  #       policy.style_src   :self, :https
+  #       policy.script_src  :self
+  #       policy.style_src   :self
   #
   #       # Specify URI for violation reports
   #       policy.report_uri "/csp-violation-report-endpoint"

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -1453,12 +1453,12 @@ Define the security policy in the appropriate initializer:
 ```ruby
 # config/initializers/content_security_policy.rb
 Rails.application.config.content_security_policy do |policy|
-  policy.default_src :self, :https
-  policy.font_src    :self, :https, :data
-  policy.img_src     :self, :https, :data
+  policy.default_src :self
+  policy.font_src    :self, :data
+  policy.img_src     :self, :data
   policy.object_src  :none
-  policy.script_src  :self, :https
-  policy.style_src   :self, :https
+  policy.script_src  :self
+  policy.style_src   :self
   # Specify URI for violation reports
   policy.report_uri "/csp-violation-report-endpoint"
 end
@@ -1535,7 +1535,7 @@ of existing code.
 ```ruby
 # config/initializers/content_security_policy.rb
 Rails.application.config.content_security_policy do |policy|
-  policy.script_src :self, :https
+  policy.script_src :self
 end
 
 Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/content_security_policy.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/content_security_policy.rb.tt
@@ -6,12 +6,12 @@
 
 # Rails.application.configure do
 #   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
+#     policy.default_src :self
+#     policy.font_src    :self, :data
+#     policy.img_src     :self, :data
 #     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
+#     policy.script_src  :self
+#     policy.style_src   :self
 #     # Specify URI for violation reports
 #     # policy.report_uri "/csp-violation-report-endpoint"
 #   end


### PR DESCRIPTION
### Motivation / Background

The Rails documentation and generated templates for Content Security Policy frequently suggest adding the `:https` source expression to CSP directives. This does not require resources to be fetched over HTTPS; instead, it permits resources from all HTTPS origins. As a result, resources can be loaded from any HTTPS origin without that origin being explicitly allowlisted.

I initially misunderstood this behavior myself and had to confirm it experimentally, which made me concerned that the examples could lead other application developers to unintentionally weaken their CSPs.

### Detail

This pull request removes `:https` from the CSP template that Rails automatically generates. It also removes `:https` from the CSP examples in YARD documentation and the Rails security guide.

### Additional information

The idea for this PR originates in [this Rails discussion](https://discuss.rubyonrails.org/t/improper-defaults-in-generated-content-security-policy/91534).

There are several other locations in the Rails codebase that contain `:https` in CSP examples. I think most of these are in unit tests or commented-out CSPs in test dummy apps, so I have left these as-is.

This PR only changes commented-out code in the CSP generator template and CSP documentation examples, so I have marked it `[ci skip]`. If the generator template change warrants running CI despite the lack of executable code changes, I'm happy to remove the `[ci skip]` marker.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
