### PR TITLE
Don't touch the connection in MySQL's `fetch_indexes` for an empty list

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -81,6 +81,8 @@ module ActiveRecord
 
         private
           def fetch_indexes(tables)
+            return {} if tables.empty?
+
             # MariaDB has no EXPRESSION column, and neither it nor MySQL before
             # 8.0.13 reports index visibility the same way, so ask for what the
             # server has.


### PR DESCRIPTION
`fetch_indexes` builds `optional_columns` before it looks at `tables`, and `supports_expression_index?` asks for `database_version`, so `indexes([])` opens the connection just to read nothing. Return early like the SQLite reader already does.

This fails `SchemaStatementsTest#test_an_empty_list_reads_nothing` whenever it runs right after a test that re-establishes the connection, which CI hits often:

https://buildkite.com/rails/rails/builds/132802/canvas?sid=01a0320e-c18f-4c26-b4d3-84069b6971fb&tab=output#01a0320e-c1f8-4cab-b837-86aa84688c4b/L11493
