### PR TITLE
Fix typo in Reflection initializer

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -532,7 +532,7 @@ module ActiveRecord
         @association_foreign_key = nil
         @association_primary_key = nil
         @extensions = options[:extend] ? Array(options[:extend]) : FROZEN_EMPTY_ARRAY
-        @extensions = @extensions.dup.freeze unless @extension.frozen?
+        @extensions = @extensions.dup.freeze unless @extensions.frozen?
 
         if options[:query_constraints]
           raise ConfigurationError, <<~MSG.squish


### PR DESCRIPTION
`@extension` (singular) is undefined, and `nil.frozen?` is always true, causing unnecessary `dup` calls.

Typo was introduced yesterday in #58541.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
