### PR TITLE
url_for: use Hash splat to append keys

### DIFF
--- a/actionpack/lib/action_controller/metal/url_for.rb
+++ b/actionpack/lib/action_controller/metal/url_for.rb
@@ -39,24 +39,22 @@ module ActionController
         host: request.host,
         port: request.optional_port,
         protocol: request.protocol,
-        _recall: request.path_parameters
-      }.merge!(super).freeze
+        _recall: request.path_parameters,
+        **super,
+      }.freeze
 
       if (same_origin = _routes.equal?(request.routes)) ||
          (script_name = request.engine_script_name(_routes)) ||
          (original_script_name = request.original_script_name)
 
-        options = @_url_options.dup
         if original_script_name
-          options[:original_script_name] = original_script_name
+          { **@_url_options, original_script_name: original_script_name }.freeze
         else
           if same_origin
-            options[:script_name] = request.script_name.empty? ? "" : request.script_name.dup
-          else
-            options[:script_name] = script_name
+            script_name = request.script_name.empty? ? "" : request.script_name.dup
           end
+          { **@_url_options, script_name: script_name }.freeze
         end
-        options.freeze
       else
         @_url_options
       end


### PR DESCRIPTION
The pattern of duping a Hash to later append a key to it isn't ideal because if the original Hash was full, its copy will be too and it will need to be reallocated on insertion.

By using the `{ **base, new_key: 1 }` pattern, we allow Ruby to directly allocate a hash of the right size, at least on Ruby 4.1 (it is neutral on older rubies).

Ref: https://github.com/ruby/ruby/pull/18344

This callsite has been identified as a common source of such reallocations in the ruby-bench suite (lobsters and shipit).
