### PR TITLE
`activerecord`: add an option to shuffle unordered `SELECT` results

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,26 @@
+*   Add `config.active_record.shuffle_unordered_selects`.
+
+    When enabled, Active Record shuffles the rows of every `SELECT` it generates
+    that has no `ORDER BY` clause. The order of such a query is not specified, so
+    this surfaces code and tests that accidentally depend on the order a given
+    database happens to return today. Queries written as raw SQL strings are left
+    untouched.
+
+    This is best effort: the shuffle applies where Active Record still has the
+    Arel to recognise the query by, which leaves out association loading, `find`
+    and `find_by`, since those are served from a precompiled SQL string by
+    `ActiveRecord::StatementCache`. Rows are shuffled after the database returns
+    them, so queries ending in `LIMIT 1` (`take`, `pick`, `has_one`) are
+    unaffected, and a query that has an `ORDER BY` is never shuffled even when
+    that ordering is not a total order.
+
+    Intended for the test or development environments. Disabled by default.
+
+        # config/environments/test.rb
+        config.active_record.shuffle_unordered_selects = true
+
+    *viralpraxis*
+
 *   Add `config.active_record.schema_ignored_tables` to exclude tables from both the
     schema cache and the schema file.
 

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -396,6 +396,25 @@ module ActiveRecord
   singleton_class.attr_accessor :raise_on_missing_required_finder_order_columns
   self.raise_on_missing_required_finder_order_columns = false
 
+  ##
+  # :singleton-method: shuffle_unordered_selects
+  # Shuffles the rows of every +SELECT+ Active Record generates that has no
+  # +ORDER BY+ clause.
+  #
+  # The order of such a query is not specified, and databases are free to
+  # return its rows in any order. Enabling this option makes that explicit, so
+  # code (and tests) that accidentally rely on the order a given database
+  # happens to return today fails loudly instead of breaking later.
+  #
+  # It is meant to be enabled in the test or development environments only.
+  #
+  # Rows are shuffled after the database has returned them, so queries built from
+  # raw SQL strings are left untouched (Active Record cannot tell whether they are
+  # ordered), and queries ending in +LIMIT 1+ are unaffected because the database
+  # has already picked the row.
+  singleton_class.attr_accessor :shuffle_unordered_selects
+  self.shuffle_unordered_selects = false
+
   singleton_class.attr_accessor :application_record_class
   self.application_record_class = nil
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -266,7 +266,8 @@ module ActiveRecord
             result = lookup_sql_cache(sql, name, binds) || super(sql, name, binds, preparable: preparable, async: async, allow_retry: allow_retry)
             FutureResult.wrap(result)
           else
-            cache_sql(sql, name, binds) { super(sql, name, binds, preparable: preparable, async: async, allow_retry: allow_retry) }
+            result = cache_sql(sql, name, binds) { super(sql, name, binds, preparable: preparable, async: async, allow_retry: allow_retry) }
+            result.shuffle_rows(arel)
           end
         else
           super

--- a/activerecord/lib/active_record/connection_adapters/query_intent.rb
+++ b/activerecord/lib/active_record/connection_adapters/query_intent.rb
@@ -110,6 +110,16 @@ module ActiveRecord
         @retry_budget = nil
       end
 
+      def self.unordered_select?(arel)
+        ast = arel.respond_to?(:ast) ? arel.ast : arel
+
+        Arel::Nodes::SelectStatement === ast && ast.orders.empty?
+      end
+
+      def self.shuffle_rows?(arel)
+        ActiveRecord.shuffle_unordered_selects && unordered_select?(arel)
+      end
+
       # Returns a hash representation of the QueryIntent for debugging/introspection
       def to_h
         {
@@ -332,7 +342,7 @@ module ActiveRecord
         raise "Cannot call cast_result after affected_rows has been called" if defined?(@affected_rows)
 
         ensure_result
-        @cast_result ||= adapter.send(:cast_result, @raw_result)
+        @cast_result ||= adapter.send(:cast_result, @raw_result).shuffle_rows(@arel)
       end
 
       def affected_rows

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -37,6 +37,7 @@ module ActiveRecord
     config.active_record.cache_query_log_tags = false
     config.active_record.query_log_tags_prepend_comment = false
     config.active_record.raise_on_assign_to_attr_readonly = false
+    config.active_record.shuffle_unordered_selects = false
     config.active_record.belongs_to_required_validates_foreign_key = true
     config.active_record.generate_secure_token_on = :create
     config.active_record.use_legacy_signed_id_verifier = :generate_and_verify

--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -215,7 +215,20 @@ module ActiveRecord
 
     def initialize_copy(other)
       @rows = rows.dup
-      @hash_rows    = nil
+      @hash_rows = nil
+      @indexed_rows = nil
+    end
+
+    def shuffle_rows(arel) # :nodoc:
+      return self if rows.size < 2
+      return self unless ConnectionAdapters::QueryIntent.shuffle_rows?(arel)
+
+      dup.shuffle!
+    end
+
+    def shuffle! # :nodoc:
+      @rows = @rows.shuffle
+      self
     end
 
     def freeze # :nodoc:

--- a/activerecord/test/cases/result_test.rb
+++ b/activerecord/test/cases/result_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "cases/helper"
+require "active_support/core_ext/object/with"
 
 module ActiveRecord
   class ResultTest < ActiveRecord::TestCase
@@ -165,5 +166,87 @@ module ActiveRecord
         result.column_types["col2"].deserialize("test value")
       end
     end
+
+    test "shuffle_rows returns a copy with the rows reordered" do
+      rows = 10.times.map { |i| ["row #{i}"] }
+      result = ActiveRecord::Result.new(["col_1"], rows.map(&:dup))
+
+      shuffled = with_shuffle { 10.times.map { result.shuffle_rows(unordered_arel).rows }.uniq }
+
+      assert_operator shuffled.size, :>, 1
+      shuffled.each { |r| assert_equal rows.sort, r.sort }
+    end
+
+    test "shuffle_rows leaves the receiver untouched" do
+      rows = 10.times.map { |i| ["row #{i}"] }
+      result = ActiveRecord::Result.new(["col_1"], rows)
+      original = result.rows.dup
+
+      with_shuffle { 5.times { result.shuffle_rows(unordered_arel) } }
+
+      assert_equal original, result.rows
+      assert_equal original, rows, "the array handed to the constructor must not be mutated"
+    end
+
+    test "shuffle_rows returns the receiver when there is nothing to reorder" do
+      one_row = ActiveRecord::Result.new(["col_1"], [["a"]])
+
+      with_shuffle do
+        assert_same one_row, one_row.shuffle_rows(unordered_arel)
+        empty = ActiveRecord::Result.empty
+        assert_same empty, empty.shuffle_rows(unordered_arel)
+      end
+    end
+
+    test "shuffle_rows returns the receiver for an ordered query" do
+      result = ActiveRecord::Result.new(["col_1"], [["a"], ["b"], ["c"]])
+
+      with_shuffle { assert_same result, result.shuffle_rows(ordered_arel) }
+    end
+
+    test "shuffle_rows returns the receiver for raw SQL" do
+      result = ActiveRecord::Result.new(["col_1"], [["a"], ["b"], ["c"]])
+
+      with_shuffle { assert_same result, result.shuffle_rows("SELECT * FROM posts") }
+    end
+
+    test "shuffle_rows returns the receiver when the option is disabled" do
+      result = ActiveRecord::Result.new(["col_1"], [["a"], ["b"], ["c"]])
+
+      with_shuffle(false) { assert_same result, result.shuffle_rows(unordered_arel) }
+    end
+
+    test "shuffle_rows works on a frozen result whose caches are already warm" do
+      result = ActiveRecord::Result.new(["col_1"], [["a"], ["b"], ["c"]]).freeze
+
+      shuffled = with_shuffle { result.shuffle_rows(unordered_arel) }
+
+      assert_not_predicate shuffled, :frozen?
+      assert_equal [["a"], ["b"], ["c"]], shuffled.rows.sort
+      assert_equal shuffled.rows.map(&:first), shuffled.indexed_rows.map { |row| row["col_1"] }
+      assert_equal [["a"], ["b"], ["c"]], result.rows
+    end
+
+    test "shuffle! reorders in place and returns self" do
+      rows = 10.times.map { |i| ["row #{i}"] }
+      result = ActiveRecord::Result.new(["col_1"], rows.map(&:dup))
+
+      assert_same result, result.shuffle!
+      assert_equal rows.sort, result.rows.sort
+    end
+
+private
+  def unordered_arel
+    Arel::SelectManager.new(Arel::Table.new(name: :posts)).project(Arel.star)
+  end
+
+  def ordered_arel
+    table = Arel::Table.new(name: :posts)
+    Arel::SelectManager.new(table).project(Arel.star).order(table[:id])
+  end
+
+  def with_shuffle(value = true, &block)
+    ActiveRecord.with(shuffle_unordered_selects: value, &block)
+  end
   end
 end

--- a/activerecord/test/cases/shuffle_unordered_selects_test.rb
+++ b/activerecord/test/cases/shuffle_unordered_selects_test.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "active_support/core_ext/object/with"
+require "models/author"
+require "models/post"
+require "models/comment"
+
+class ShuffleUnorderedSelectsTest < ActiveRecord::TestCase
+  fixtures :authors, :author_addresses, :posts, :comments
+
+  SAMPLES = 10
+
+  test "unordered relations are shuffled" do
+    natural = with_shuffle(false) { Post.all.map(&:id) }
+    orders = with_shuffle(true) { sample { Post.all.map(&:id) } }
+
+    assert_operator orders.size, :>, 1
+    orders.each { |ids| assert_equal natural.sort, ids.sort }
+  end
+
+  test "unordered pluck is shuffled" do
+    natural = with_shuffle(false) { Post.pluck(:id) }
+    orders = with_shuffle(true) { sample { Post.pluck(:id) } }
+
+    assert_operator orders.size, :>, 1
+    orders.each { |ids| assert_equal natural.sort, ids.sort }
+  end
+
+  test "eager loaded associations are shuffled" do
+    id = authors(:david).id
+    natural = with_shuffle(false) { Author.eager_load(:posts).find(id).posts.map(&:id) }
+    orders = with_shuffle(true) { sample { Author.eager_load(:posts).find(id).posts.map(&:id) } }
+
+    assert_operator orders.size, :>, 1
+    orders.each { |ids| assert_equal natural.sort, ids.sort }
+  end
+
+  test "asynchronous queries are shuffled" do
+    natural = with_shuffle(false) { Post.pluck(:id) }
+    orders = with_shuffle(true) { sample { Post.async_pluck(:id).value } }
+
+    assert_operator orders.size, :>, 1
+    orders.each { |ids| assert_equal natural.sort, ids.sort }
+  end
+
+  test "ordered relations are left alone" do
+    natural = with_shuffle(false) { Post.order(:id).map(&:id) }
+
+    assert_equal [natural], with_shuffle(true) { sample { Post.order(:id).map(&:id) } }
+  end
+
+  test "raw SQL is left alone" do
+    sql = Post.all.to_sql
+    natural = with_shuffle(false) { Post.find_by_sql(sql).map(&:id) }
+
+    assert_equal [natural], with_shuffle(true) { sample { Post.find_by_sql(sql).map(&:id) } }
+  end
+
+  test "order dependent finders are unaffected" do
+    with_shuffle(true) do
+      assert_equal Post.order(:id).first, Post.first
+      assert_equal Post.order(:id).last, Post.last
+    end
+  end
+
+  test "counts are unaffected" do
+    count = with_shuffle(false) { Post.count }
+
+    assert_equal count, with_shuffle(true) { Post.count }
+  end
+
+  test "exists? is unaffected" do
+    with_shuffle(true) do
+      assert_predicate Post, :exists?
+      assert_not_predicate Post.where(id: -1), :exists?
+    end
+  end
+
+  test "associations loaded through the statement cache are not shuffled" do
+    author = authors(:david)
+    natural = with_shuffle(false) { author.posts.reload.map(&:id) }
+
+    assert_equal [natural], with_shuffle(true) { sample { author.posts.reload.map(&:id) } }
+  end
+
+  test "queries running under the query cache are shuffled" do
+    natural = with_shuffle(false) { Post.all.map(&:id) }
+
+    with_shuffle(true) do
+      Post.cache do
+        assert_not_equal natural, Post.all.map(&:id)
+        assert_equal natural.sort, Post.all.map(&:id).sort
+      end
+    end
+  end
+
+  test "a cached query is shuffled again on every read" do
+    natural = with_shuffle(false) { Post.pluck(:id) }
+
+    with_shuffle(true) do
+      Post.cache do
+        orders = sample { Post.pluck(:id) }
+
+        assert_operator orders.size, :>, 1
+        orders.each { |ids| assert_equal natural.sort, ids.sort }
+      end
+    end
+  end
+
+  test "raw SQL sharing a cache entry with a generated query is left alone" do
+    sql = Post.all.to_sql
+    natural = with_shuffle(false) { Post.find_by_sql(sql).map(&:id) }
+
+    with_shuffle(true) do
+      Post.cache do
+        assert_not_equal natural, Post.all.map(&:id)
+        assert_equal natural, Post.find_by_sql(sql).map(&:id)
+      end
+    end
+
+    with_shuffle(true) do
+      Post.cache do
+        assert_equal natural, Post.find_by_sql(sql).map(&:id)
+        assert_not_equal natural, Post.all.map(&:id)
+      end
+    end
+  end
+
+  private
+    def with_shuffle(value, &block)
+      ActiveRecord.with(shuffle_unordered_selects: value, &block)
+    end
+
+    def sample(&block)
+      SAMPLES.times.map(&block).uniq
+    end
+end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2004,6 +2004,42 @@ The default value depends on the `config.load_defaults` target version:
 | (original)            | `false`              |
 | 8.1                   | `true`               |
 
+#### `config.active_record.shuffle_unordered_selects`
+
+Shuffles the rows of every `SELECT` Active Record generates that has no `ORDER BY` clause.
+
+The order of such a query is not specified: the database is free to return the rows in any order, and that
+order can change when an index is added, when the data grows, or when the query planner changes its mind.
+Enabling this option makes the lack of order explicit, so code and tests that accidentally depend on the
+order a particular database happens to return today fail immediately instead of breaking later.
+
+```ruby
+# config/environments/test.rb
+config.active_record.shuffle_unordered_selects = true
+```
+
+The order is fully random and drawn again on every execution, so a query cannot accidentally settle into an
+order that an assertion keeps passing against.
+
+The option is best effort, and two things bound what it can surface.
+
+The first is that Active Record has to recognise the query, which it does from the Arel it built. A query that
+reaches it as already-compiled SQL is left alone: SQL you wrote yourself, and association loading, `find` and
+`find_by`, which are served from a precompiled statement by `ActiveRecord::StatementCache`. Relations, `pluck`,
+calculations and eager loading are covered, inside a query cache block or out.
+
+The second is that rows are shuffled after the database has returned them, so the option cannot change *which*
+rows come back. Queries ending in `LIMIT 1` are unaffected — `find`, `find_by`, `take`, `pick`, `exists?`,
+`has_one` and `belongs_to` — which makes this weaker than SQLite's `reverse_unordered_selects` pragma. A query
+with an `ORDER BY` is never shuffled even when that ordering is not a total order, so ties on a non-unique
+column stay hidden. And the SQL in your log is the SQL that was sent, so replaying it by hand will not
+reproduce the order your application saw.
+
+This is a development aid intended for the test or development environments, and it is never enabled by
+`config.load_defaults`.
+
+The default value is `false`.
+
 ### Configuring Action Controller
 
 `config.action_controller` includes a number of configuration settings:


### PR DESCRIPTION
Follows up on order-dependence fixes in
- https://github.com/rails/rails/pull/58267
- https://github.com/rails/rails/pull/58527
- https://github.com/rails/rails/pull/58177

and

- https://github.com/rails/rails/pull/58528

A `SELECT` without `ORDER BY` has no specified row order, but databases return one consistently enough that code and tests come to depend on it.

When enabled, Active Record shuffles the rows of most queries it generates.

## usage

Disabled by default, intended for the test environment:

```ruby
config.active_record.shuffle_unordered_selects = true
```
FYI @byroot 

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
