### PR TITLE
Upgrade to Marcel 2 for Active Storage content type detection

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,7 @@ PATH
       activejob (= 8.2.0.alpha)
       activerecord (= 8.2.0.alpha)
       activesupport (= 8.2.0.alpha)
-      marcel (~> 1.0)
+      marcel (~> 2.0)
     activesupport (8.2.0.alpha)
       base64
       bigdecimal
@@ -331,7 +331,7 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.2.1)
+    marcel (2.1.0)
     matrix (0.4.2)
     mdl (0.12.0)
       kramdown (~> 2.3)
@@ -868,7 +868,7 @@ CHECKSUMS
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   loofah (2.25.0) sha256=df5ed7ac3bac6a4ec802df3877ee5cc86d027299f8952e6243b3dac446b060e6
   mail (2.8.1) sha256=ec3b9fadcf2b3755c78785cb17bc9a0ca9ee9857108a64b6f5cfc9c0b5bfc9ad
-  marcel (1.2.1) sha256=1678e9360e32f9eafa917c80029e2f6d10b2715c66a4b87b6d0da9b9cd1f859f
+  marcel (2.1.0) sha256=f8b0327111dc7e516331eeefe052e981ce50e2bd826c1042a53cdf047fcc3512
   matrix (0.4.2) sha256=71083ccbd67a14a43bfa78d3e4dc0f4b503b9cc18e5b4b1d686dc0f9ef7c4cc0
   mdl (0.12.0) sha256=66718347ba0ad8126173f431bb99028b0300196f9b9ba90802a221ebd51364be
   mini_magick (5.3.1) sha256=29395dfd76badcabb6403ee5aff6f681e867074f8f28ce08d78661e9e4a351c4

--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Marcel 2 for content type detection
+
+    Broader and more precise MIME type detection, security hardening, and uses canonical types
+    instead of aliases (`text/x-yaml` → `application/yaml`).
+
+    *Jeremy Daer*
+
 *   Allow ffmpeg and ffprobe input arguments to be configured.
 
     Two new configuration parameters are introduced.

--- a/activestorage/activestorage.gemspec
+++ b/activestorage/activestorage.gemspec
@@ -37,5 +37,5 @@ Gem::Specification.new do |s|
   s.add_dependency "activejob",     version
   s.add_dependency "activerecord",  version
 
-  s.add_dependency "marcel",    "~> 1.0"
+  s.add_dependency "marcel",    "~> 2.0"
 end


### PR DESCRIPTION
### Summary

Bumps Active Storage's marcel dependency from `~> 1.0` to `~> 2.0` and updates the checked-in lockfile to marcel 2.1.0.

### Reasoning

Marcel 2 brings broader and more precise MIME type detection and security hardening (see below). Requiring it, rather than merely allowing it alongside 1.x, means apps pick up the hardening on upgrade instead of being left on whatever 1.x their lockfile happens to hold.

Marcel 2.x requires Ruby >= 3.3, which is within Rails main's own floor (>= 3.3.1), so bundler resolves 2.1.0 everywhere main runs.

### Behavior impact

Marcel 2.0 returns canonical types where 1.x returned aliases, affecting **newly analyzed or uploaded blobs only** (existing blobs keep their stored content types; lookups by the old aliases still resolve):

- `audio/x-aac` → `audio/aac`
- `audio/x-flac` → `audio/flac`
- `audio/vnd.wave` → `audio/x-wav`
- `text/x-yaml` → `application/yaml`
- `image/bmp;format=compressed` → `image/bmp`
- full list in the [marcel v2.0.0 release notes](https://github.com/rails/marcel/releases/tag/v2.0.0)

Marcel 2.x also adds detection (OOXML via ZIP central directory, XML vocabularies by root element, CR2, RAR, AVIF sequences) and IO-handling/robustness hardening — see the [v2.0.0](https://github.com/rails/marcel/releases/tag/v2.0.0) and [v2.1.0](https://github.com/rails/marcel/releases/tag/v2.1.0) release notes.

### Validation

- Lockfile CHECKSUMS row for marcel 2.1.0 (`sha256=f8b0327111dc7e516331eeefe052e981ce50e2bd826c1042a53cdf047fcc3512`) verified against RubyGems.
- Full Active Storage suite (`cd activestorage && bin/test`) against marcel 2.1.0: 611 runs, 1876 assertions, 0 failures. (One environmental error in `javascript_package_test` — `yarn` absent from the test machine's PATH, exit 127; unrelated to this change.)
- No content-type assertion changes were needed anywhere in the suite.
- Fleet validation on two large production apps (full CI with this branch + marcel 2.1.0 pinned) is in progress; results will be posted here before this is considered mergeable.
