### PR TITLE
Key the habtm join model's `left_side` association to the owner

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Key the `has_and_belongs_to_many` join model's `left_side` association to the owner.
+
+    The join model generated for a `has_and_belongs_to_many` association declares
+    a `belongs_to :left_side` back to the owner without a foreign key, so it
+    derived a `left_side_id` column that does not exist on the join table.
+    Reading `left_side` therefore always returned `nil`. It now uses the same
+    foreign key as the association, including a custom `:foreign_key`.
+
+    *Carlos Daniel Pohlod*
+
 *   Add `config.active_record.shuffle_unordered_selects`.
 
     When enabled, Active Record shuffles the rows of every `SELECT` it generates

--- a/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
@@ -49,7 +49,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
       join_model.table_name_resolver = -> { table_name }
       join_model.left_model          = lhs_model
 
-      join_model.add_left_association :left_side, anonymous_class: lhs_model
+      join_model.add_left_association :left_side, anonymous_class: lhs_model, foreign_key: left_side_foreign_key
       join_model.add_right_association association_name, belongs_to_options(options)
       join_model
     end
@@ -66,6 +66,10 @@ module ActiveRecord::Associations::Builder # :nodoc:
     end
 
     private
+      def left_side_foreign_key
+        options[:foreign_key] || lhs_model.model_name.to_s.foreign_key
+      end
+
       def middle_options(join_model)
         middle_options = {}
         middle_options[:class_name] = "#{lhs_model.name}::#{join_model.name}"

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -1011,6 +1011,28 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     sink = Sink.create! kitchen: Kitchen.new, sources: [Source.new]
     assert_equal 1, sink.sources.count
   end
+
+  def test_join_model_left_side_uses_the_owner_foreign_key
+    join_model = Developer.const_get(:HABTM_Projects)
+
+    assert_equal "developer_id", join_model._reflect_on_association(:left_side).foreign_key
+  end
+
+  def test_join_model_left_side_returns_the_owner
+    developer = Developer.create!(name: "Jane")
+    developer.projects << Project.create!(name: "Bounty")
+
+    join_model = Developer.const_get(:HABTM_Projects)
+    join_record = join_model.find_by(developer_id: developer.id)
+
+    assert_equal developer, join_record.left_side
+  end
+
+  def test_join_model_left_side_honors_a_custom_foreign_key
+    join_model = SubDeveloper.const_get(:HABTM_SpecialProjects)
+
+    assert_equal "project_id", join_model._reflect_on_association(:left_side).foreign_key
+  end
 end
 
 class DeprecatedHasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase


### PR DESCRIPTION
Fixes #57909.

### Summary

The join model that `has_and_belongs_to_many` generates declares a `belongs_to :left_side` back to the owner, but passes no `:foreign_key`. `belongs_to` then derives the foreign key from the association name and looks for a `left_side_id` column, which the join table never has. 

ps> Because the association is built with `required: false`, nothing raises, reading `left_side` silently returns `nil`. 

```ruby
class Developer < ActiveRecord::Base
  has_and_belongs_to_many :projects
end

join_model = Developer.const_get(:HABTM_Projects)
join_model._reflect_on_association(:left_side).foreign_key
# => "left_side_id"   # no such column

developer.projects << Project.create!
join_model.first.left_side
# => nil               # expected the Developer
```

### Fix

Derive the foreign key the same way the middle `has_many` does: `options[:foreign_key]` when given, otherwise `lhs_model.model_name.to_s.foreign_key`, so a custom `:foreign_key` on the association is honored as well.

### Testing

Three cases added to `has_and_belongs_to_many_associations_test.rb`: the derived foreign key, a custom `:foreign_key`, and that `left_side` actually returns the owner record. All three fail on `main` and pass with the change.

