### PR TITLE
Document Solid Queue batch jobs in the Active Job guide [ci-skip]

### DIFF
--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -1257,6 +1257,67 @@ You can learn more about [Recurring
 Tasks](https://github.com/rails/solid_queue?tab=readme-ov-file#recurring-tasks)
 in the Solid Queue documentation.
 
+### Batch Jobs
+
+Solid Queue supports grouping jobs into batches, so you can track the progress
+of a set of jobs as a whole and run a callback when all of them are done. For
+example, you might import a large file with one job per row, then send a
+notification once every row has been processed.
+
+A batch can fire three callbacks, depending on how it ends:
+
+- `on_finish`: runs when all the jobs have finished, including retries, even if
+  some of them failed.
+- `on_success`: runs when all the jobs have succeeded, including retries. It
+  won't run if any job failed, but it will run if jobs were discarded using
+  `discard_on`.
+- `on_failure`: runs when all the jobs have finished, including retries, and one
+  or more of them failed.
+
+Callbacks are regular jobs. They can access the batch they belong to through
+the `batch` accessor:
+
+```ruby
+class ImportRowJob < ApplicationJob
+  def perform(row)
+    # ... import the row
+  end
+end
+
+class ImportCompletedJob < ApplicationJob
+  def perform
+    Rails.logger.info "All #{batch.completed_jobs} rows imported!"
+  end
+end
+
+SolidQueue::Batch.enqueue(
+  description: "Nightly imports",
+  on_success: ImportCompletedJob,
+  user_id: 123
+) do
+  5.times { |i| ImportRowJob.perform_later(i) }
+end
+```
+
+In the above example:
+
+- The five `ImportRowJob`s are enqueued inside the block, so they belong to the
+  batch.
+- `ImportCompletedJob` runs once, after all five of them have succeeded.
+- The `:description` option gives the batch a human-readable label.
+- Any other keyword arguments, like `user_id: 123`, are stored as the batch's
+  `metadata`. You can also pass a `metadata:` hash explicitly.
+
+NOTE: If you installed Solid Queue before version 1.7, batches need database
+tables that your app doesn't have yet. Add them by running
+`bin/rails solid_queue:update` followed by `bin/rails db:migrate`. Until then,
+jobs work as usual, and starting a batch raises
+`SolidQueue::Batch::PendingMigrations`.
+
+You can learn more about [Batch
+Jobs](https://github.com/rails/solid_queue?tab=readme-ov-file#batch-jobs) in the
+Solid Queue documentation.
+
 Alternate Queuing Backends
 --------------------------
 


### PR DESCRIPTION
### Motivation / Background

Solid Queue 1.7 added support for grouping jobs into batches (rails/solid_queue#142) - this updates the Active Job guide to mention them. The guide has a substantial "Default Backend: Solid Queue" section covering the backend's other features (concurrency controls, recurring tasks, transactional integrity), so batches are a natural fit.

### Detail

Adds a `### Batch Jobs` subsection after Recurring Tasks, following the structure of the neighboring sections, followed by a closing link to the Solid Queue documentation for deeper details.

Every claim was verified against the released solid_queue 1.7.0 gem. Documentation only, no behavior change. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message.
* [x] Tests are added or updated if you fix a bug or add a feature. (n/a — documentation only)
* [x] CHANGELOG files are updated for the changed libraries. (n/a — guides changes don't update CHANGELOGs)
