### PR TITLE
Add Herb as an HTML-aware ERB implementation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,7 @@ PATH
       activesupport (= 8.2.0.alpha)
       builder (~> 3.1)
       erubi (~> 1.11)
+      herb (>= 0.10)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.7)
     activejob (8.2.0.alpha)
@@ -275,6 +276,11 @@ GEM
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
     hashdiff (1.1.2)
+    herb (0.10.3)
+    herb (0.10.3-aarch64-linux-gnu)
+    herb (0.10.3-arm64-darwin)
+    herb (0.10.3-x86_64-darwin)
+    herb (0.10.3-x86_64-linux-gnu)
     httpclient (2.9.0)
       mutex_m
     i18n (1.14.8)
@@ -846,6 +852,11 @@ CHECKSUMS
   google-protobuf (4.29.3-x86_64-linux) sha256=4ac194b06c59559457ce1d1d57d03760b50e009dbcfe5ef065a1af48ce4a2d0e
   googleauth (1.12.2) sha256=3d3177b1b253a9a3ce92222a91fcabcfad206cec2a5c823a6a251a6db4d8d67f
   hashdiff (1.1.2) sha256=2c30eeded6ed3dce8401d2b5b99e6963fe5f14ed85e60dd9e33c545a44b71a77
+  herb (0.10.3) sha256=da76e8bfbb302586ee51a4fb608624f48218fbfea198a9493540b42f7654024b
+  herb (0.10.3-aarch64-linux-gnu) sha256=1eaea87e6577557492a1b0ddaae989fba8a8ddd382e888ee5f939ce6ded06eb8
+  herb (0.10.3-arm64-darwin) sha256=1a5bef57d925d775496328e7a01a9c1260e1d83bed8038b60a4f8c81b12c15a3
+  herb (0.10.3-x86_64-darwin) sha256=e02e43b3bb1977f4fd08f3330b5f2aa3292ca2d572a8bd59688eca8b79725f46
+  herb (0.10.3-x86_64-linux-gnu) sha256=cbb49b66f2bdc92d17109d1ea9452e88ba6a8ae52e9ddd5279deff83dcc4c66d
   httpclient (2.9.0) sha256=4b645958e494b2f86c2f8a2f304c959baa273a310e77a2931ddb986d83e498c8
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   image_processing (2.0.1) sha256=69c93216dafe1179343a6c3ae8bfa554e3c1f5eece4043f255595e76df2cbf3f

--- a/actionview/actionview.gemspec
+++ b/actionview/actionview.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "builder",       "~> 3.1"
   s.add_dependency "erubi",         "~> 1.11"
+  s.add_dependency "herb",          ">= 0.10"
   s.add_dependency "rails-html-sanitizer", "~> 1.7"
   s.add_dependency "rails-dom-testing", "~> 2.2"
 

--- a/actionview/lib/action_view/template/handlers/erb.rb
+++ b/actionview/lib/action_view/template/handlers/erb.rb
@@ -8,6 +8,7 @@ module ActionView
     module Handlers
       class ERB # :nodoc:
         autoload :Erubi, "action_view/template/handlers/erb/erubi"
+        autoload :Herb, "action_view/template/handlers/erb/herb"
 
         # Specify trim mode for the ERB compiler. Defaults to '-'.
         # See ERB documentation for suitable values.

--- a/actionview/lib/action_view/template/handlers/erb/herb.rb
+++ b/actionview/lib/action_view/template/handlers/erb/herb.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+# :markup: markdown
+
+require "herb"
+require "herb/engine"
+
+module ActionView
+  class Template
+    module Handlers
+      class ERB
+        class Herb < ::Herb::Engine
+          # :nodoc: all
+          def initialize(input, properties = {})
+            @newline_pending = 0
+
+            # Dup properties so that we don't modify argument
+            properties = Hash[properties]
+
+            properties[:bufvar]     ||= "@output_buffer"
+            properties[:preamble]   ||= ""
+            properties[:postamble]  ||= "#{properties[:bufvar]}"
+
+            # Tell Herb whether the template will be compiled with `frozen_string_literal: true`
+            properties[:freeze_template_literals] = !Template.frozen_string_literal
+
+            # Leave all escaping to ActionView::OutputBuffer.
+            properties[:escapefunc] = ""
+            properties[:attrfunc]   = nil
+            properties[:jsfunc]     = nil
+            properties[:cssfunc]    = nil
+
+            super
+          end
+
+        private
+          def add_text(text)
+            return if text.empty?
+
+            if text == "\n"
+              @newline_pending += 1
+            else
+              with_buffer do
+                src << ".safe_append='"
+                src << "\n" * @newline_pending if @newline_pending > 0
+                src << text.gsub(/['\\]/, '\\\\\&') << @text_end
+              end
+              @newline_pending = 0
+            end
+          end
+
+          def add_expression_block(indicator, code)
+            add_expression(indicator, code, block: true)
+          end
+
+          def add_expression(indicator, code, block: false)
+            flush_newline_if_pending(src)
+
+            with_buffer do
+              if (indicator == "==") || @escape
+                src << ".safe_expr_append="
+              else
+                src << ".append="
+              end
+
+              if block
+                src << " " << code
+              else
+                src << "(" << code << trailing_newline(code) << ")"
+              end
+            end
+          end
+
+          def add_code(code)
+            flush_newline_if_pending(src)
+            super
+          end
+
+          def add_postamble(_)
+            flush_newline_if_pending(src)
+            super
+          end
+
+          def flush_newline_if_pending(src)
+            if @newline_pending > 0
+              with_buffer { src << ".safe_append='#{"\n" * @newline_pending}" << @text_end }
+              @newline_pending = 0
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/actionview/test/template/erb/herb_test.rb
+++ b/actionview/test/template/erb/herb_test.rb
@@ -1,0 +1,185 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "action_view/template/handlers/erb/herb"
+
+class HerbTest < ActiveSupport::TestCase
+  test "can configure bufvar" do
+    template = <<~ERB
+      foo
+
+      <%= "foo".upcase %>
+
+      <%== "foo".length %>
+    ERB
+
+    baseline = ActionView::Template::Handlers::ERB::Herb.new(template)
+    herb = ActionView::Template::Handlers::ERB::Herb.new(template, bufvar: "boofer")
+
+    assert_equal baseline.src.gsub(baseline.bufvar, "boofer"), herb.src
+  end
+
+  test "renders the same output as Erubi" do
+    templates = [
+      "<p>plain</p>\n",
+      "<p><%= name %></p>\n",
+      "<p><%== name %></p>\n",
+      "<p><%= safe_name %></p>\n",
+      "foo\n\n<%= name %>\n\nbar\n",
+      "<%# a comment %>\n<div>content</div>\n",
+      "<% if name %>\n  <span><%= name %></span>\n<% else %>\n  <span>anonymous</span>\n<% end %>\n",
+      "<ul>\n<% 3.times do |i| %>\n  <li><%= i %></li>\n<% end %>\n</ul>\n",
+      "<input type=\"text\" name=\"<%= name %>\">\n",
+      "<script>\n  var name = \"<%= name %>\";\n</script>\n",
+      "<a href=\"#anchor\"><%= \"#anchor\" %></a>\n",
+      "<p><%= <<~TXT\n  hello\nTXT\n%></p>\n"
+    ]
+
+    templates.each do |template|
+      assert_equal render_with(erubi, template), render_with(herb, template), "expected Herb and Erubi to render the same output for #{template.inspect}"
+    end
+  end
+
+  test "renders whitespace trimming tags the same as Erubi" do
+    templates = [
+      "<% value = 1 -%>\n<p><%= value %></p>\n",
+      "text\n  <%- value = 1 %>\n<p><%= value %></p>\n",
+      "<div>\n  <% if name -%>\n    <span>x</span>\n  <% end -%>\n</div>\n"
+    ]
+
+    templates.each do |template|
+      assert_equal render_with(erubi, template), render_with(herb, template), "expected Herb and Erubi to trim the same way for #{template.inspect}"
+    end
+  end
+
+  test "renders multi-line code tags the same as Erubi" do
+    template = <<~ERB
+      <table>
+       <tbody>
+        <% i = 0
+           list.each_with_index do |item, i| %>
+        <tr>
+         <td><%= i + 1 %></td>
+         <td><%== item %></td>
+        </tr>
+       <% end %>
+       </tbody>
+      </table>
+      <%== i + 1 %>
+    ERB
+
+    assert_equal render_with(erubi, template), render_with(herb, template)
+  end
+
+  test "renders case expressions the same as Erubi" do
+    template = <<~ERB
+      <% case name %>
+      <% when "AT&T" %>
+        <p>att</p>
+      <% else %>
+        <p>other</p>
+      <% end %>
+    ERB
+
+    assert_equal render_with(erubi, template), render_with(herb, template)
+  end
+
+  test "renders block expressions the same as Erubi" do
+    template = "<%= wrapper do %>\n  <p>hi</p>\n<% end %>\n"
+
+    assert_equal render_with(erubi, template), render_with(herb, template)
+  end
+
+  test "renders escaped block expressions the same as Erubi" do
+    template = "<%== wrapper do %>\n  <p>hi</p>\n<% end %>\n"
+
+    assert_equal render_with(erubi, template), render_with(herb, template)
+  end
+
+  test "compiles expressions containing Ruby comments" do
+    template = "<p><%= name # visible name %></p>\n"
+
+    assert_equal "<p>AT&amp;T</p>\n", render_with(herb, template)
+  end
+
+  test "renders the same output as Erubi with the escape option" do
+    template = "Hello <%= name %> <%== name %>\n"
+
+    assert_equal render_with(erubi, template, escape: true), render_with(herb, template, escape: true)
+    assert_equal "Hello AT&T AT&T\n", render_with(herb, template, escape: true)
+  end
+
+  test "renders the render annotation preamble and postamble the same as Erubi" do
+    template = "<p><%= name %></p>\n"
+    options = {
+      preamble: "@output_buffer.safe_append='<!-- BEGIN app/views/users/show.html.erb\n-->';",
+      postamble: "@output_buffer.safe_append='<!-- END app/views/users/show.html.erb -->';@output_buffer"
+    }
+
+    herb_output = render_with(herb, template, options)
+
+    assert_equal render_with(erubi, template, options), herb_output
+    assert_includes herb_output, "<!-- BEGIN app/views/users/show.html.erb"
+    assert_includes herb_output, "<!-- END app/views/users/show.html.erb -->"
+  end
+
+  test "ties template literal freezing to frozen_string_literal like Erubi" do
+    template = "<p><%= name %></p>\n"
+
+    assert_includes herb.new(template).src, ".freeze"
+
+    original = ActionView::Template.frozen_string_literal
+    ActionView::Template.frozen_string_literal = true
+
+    assert_no_match(/\.freeze/, herb.new(template).src)
+  ensure
+    ActionView::Template.frozen_string_literal = original
+  end
+
+  test "reports runtime errors at the same template line as Erubi" do
+    template = "<div>\n  <p>ok</p>\n  <% raise \"boom\" %>\n</div>\n"
+
+    herb_line = error_line(herb, template)
+
+    assert_equal error_line(erubi, template), herb_line
+    assert_equal 3, herb_line
+  end
+
+  test "escapes attribute values through the output buffer only" do
+    template = "<input type=\"text\" name=\"<%= name %>\">\n"
+    source = herb.new(template).src
+
+    assert_no_match(/Herb::Engine/, source)
+    assert_equal "<input type=\"text\" name=\"AT&amp;T\">\n", render_with(herb, template)
+  end
+
+  private
+    def erubi
+      ActionView::Template::Handlers::ERB::Erubi
+    end
+
+    def herb
+      ActionView::Template::Handlers::ERB::Herb
+    end
+
+    def build_context
+      context = Object.new
+      context.instance_variable_set(:@output_buffer, ActionView::OutputBuffer.new)
+      context.define_singleton_method(:name) { "AT&T" }
+      context.define_singleton_method(:safe_name) { "<b>safe</b>".html_safe }
+      context.define_singleton_method(:list) { ["a&b", "c"] }
+      context.define_singleton_method(:wrapper) { |&block| @output_buffer.capture(&block).upcase }
+      context
+    end
+
+    def render_with(implementation, template, options = {})
+      build_context.instance_eval(implementation.new(template, options).src).to_s
+    end
+
+    def error_line(implementation, template)
+      build_context.instance_eval(implementation.new(template).src, "inline template")
+      flunk "expected template to raise"
+    rescue RuntimeError => error
+      error.backtrace_locations.find { |location| location.path == "inline template" }.lineno
+    end
+end


### PR DESCRIPTION
### Motivation / Background

ERB templates in Rails apps are overwhelmingly HTML, but today Action View compiles them with an engine that never looks at the Ruby and HTML markup inside the templates.

[Herb](https://herb-tools.dev) parses HTML and ERB into a single syntax tree and uses [Prism](https://github.com/ruby/prism) to parse the Ruby inside the ERB tags. Based on this parser, `Herb::Engine` is an HTML-aware ERB rendering engine that also understands the HTML semantics during template compilation, guaranteeing that templates cannot produce invalid Ruby and markup.

That structual understanding is what makes precise template errors and compile-time validation possible while also enabling future developer experience improvements and performance optimizations. It is also the same foundation the Herb developer tools build on, including the linter, formatter, and language server for HTML+ERB, which means the compiler and the editor tooling share one understanding of a template. 

[better-html](https://github.com/Shopify/better-html) has enforced HTML-aware constraints on ERB from the outside for years, and now, Herb builds that understanding directly into the template compiler itself.

This work has been discussed with several members of the Rails core team and has their general support. This pull request deliberately is the minimal first step. 

### Detail

This pull request adds `ActionView::Template::Handlers::ERB::Herb`, a `::Herb::Engine` subclass that closly mirrors `ActionView::Template::Handlers::ERB::Erubi`. `Herb::Engine` is specifically built for HTML+ERB templates and is designed to be API-comaptible with `Erubi::Engine`.

It keeps the same `@output_buffer` conventions and append protocol, the same newline batching, and the same `frozen_string_literal` wiring. Escaping is left entirely to `ActionView::OutputBuffer` at render time. One difference is that block expressions are detected from the Herb syntax tree via Prism instead of the `BLOCK_EXPR` regexp that Erubi uses. Finally, the `herb` gem becomes a dependency of `actionview` which is declared in the same way as `erubi` is today.

While this ERB implementation is technically accessible by calling `ActionView::Template::Handlers::ERB.erb_implementation=`, I propose a follow-up pull request that will include an optional user-facing config to route HTML templates through Herb (while kepping all other formats on Erubi), as well as a changelog entry to document the change.


### Additional information

Herb's Erubi compatibility is a tested contract in the Herb repo. A [compat suite](https://github.com/marcoroth/herb/blob/main/test/engine/engine_erubi_compat_test.rb) pins where compiled output matches Erubi byte for byte, and a [divergence suite](https://github.com/marcoroth/herb/blob/main/test/engine/engine_erubi_divergence_test.rb) pins every intentional deviation.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.