### PR TITLE
Escape attachment captions in `Attachment#to_markdown`

### DIFF
--- a/actiontext/lib/action_text/attachment.rb
+++ b/actiontext/lib/action_text/attachment.rb
@@ -155,18 +155,34 @@ module ActionText
     #       include ActionText::Attachable
     #
     #       def attachable_markdown_representation(caption, attachment_links: false)
-    #         MarkdownConversion.markdown_link("@#{name}", Rails.application.routes.url_helpers.person_url(self))
+    #         ActionText::MarkdownConversion.markdown_link("@#{name}", Rails.application.routes.url_helpers.person_url(self))
     #       end
     #     end
     #
     #     attachable = Person.create! name: "Javan"
     #     attachment = ActionText::Attachment.from_attachable(attachable)
     #     attachment.to_markdown # => "[@Javan](http://example.com/people/1)"
+    #
+    # NOTE: When overriding `attachable_markdown_representation`, the `caption` parameter is derived
+    # from the document and should be considered untrusted, so an implementation must escape any
+    # caption-derived text with `ActionText::MarkdownConversion.escape_markdown_text`, or pass it
+    # through `ActionText::MarkdownConversion.markdown_link`, which escapes the link title and
+    # rejects disallowed URI schemes. Returning the caption unchanged lets a stored rich text body
+    # inject arbitrary Markdown.
+    #
+    #     class Person < ApplicationRecord
+    #       include ActionText::Attachable
+    #
+    #       def attachable_markdown_representation(caption, attachment_links: false)
+    #         ActionText::MarkdownConversion.escape_markdown_text(caption.to_s) # take care to escape the caption
+    #       end
+    #     end
+    #
     def to_markdown(attachment_links: false)
       if respond_to?(:attachable_markdown_representation)
         attachable_markdown_representation(caption, attachment_links: attachment_links)
       else
-        caption.to_s
+        MarkdownConversion.escape_markdown_text(caption.to_s)
       end
     end
 

--- a/actiontext/test/unit/markdown_conversion_test.rb
+++ b/actiontext/test/unit/markdown_conversion_test.rb
@@ -1140,6 +1140,28 @@ class ActionText::MarkdownConversionTest < ActiveSupport::TestCase
     assert_equal content.to_markdown, content.to_markdown
   end
 
+  test "attachable without a Markdown representation escapes its caption" do
+    page = Page.create!
+    html = %Q(<action-text-attachment sgid="#{page.attachable_sgid}" caption="[click](javascript:alert(1))"></action-text-attachment>)
+
+    assert_converted_to "\\[click\\](javascript:alert(1))", html
+  end
+
+  test "attachable without a Markdown representation escapes metacharacters in its caption" do
+    page = Page.create!
+    html = %Q(<action-text-attachment sgid="#{page.attachable_sgid}" caption="**bold**"></action-text-attachment>)
+
+    assert_converted_to "\\*\\*bold\\*\\*", html
+  end
+
+  test "Attachment#to_markdown escapes the caption of an attachable without a Markdown representation" do
+    page = Page.create!
+    html = %Q(<action-text-attachment sgid="#{page.attachable_sgid}" caption="[click](javascript:alert(1))"></action-text-attachment>)
+    attachment = ActionText::Content.new(html).attachments.first
+
+    assert_equal "\\[click\\](javascript:alert(1))", attachment.to_markdown
+  end
+
   # --- Fragment and Rich Text tests ---
 
   test "Fragment#to_markdown memoizes the result" do


### PR DESCRIPTION
### Motivation / Background

`ActionText::Attachment#to_markdown` returns the attachment's `caption` unescaped when the attachable does not implement `attachable_markdown_representation`:

    def to_markdown(attachment_links: false)
      if respond_to?(:attachable_markdown_representation)
        attachable_markdown_representation(caption, attachment_links: attachment_links)
      else
        caption.to_s
      end
    end

The caption reaches the Markdown output verbatim, skipping both `MarkdownConversion.escape_markdown_text` and the URI scheme check in `MarkdownConversion.markdown_link`.

An unescaped caption is emitted when all of these hold:

* the attachable is application-defined — it includes `ActionText::Attachable` and does not implement `attachable_markdown_representation`. Rails' own attachables (`ActiveStorage::Blob`, `RemoteImage`, `ContentAttachment`, `MissingAttachable`) all implement it and are unaffected;
* the attachment carries a `caption`, which is document-derived and so influenced by whoever authored the rich text;
* something converts that content to Markdown — `Content#to_markdown`, `render markdown:`, or `Attachment#to_markdown` directly.

A caption of `[click](javascript:alert(1))` then emerges as a working Markdown link.

`to_markdown` is unreleased, so no released version of Action Text is affected.

### Detail

Escape the caption with `MarkdownConversion.escape_markdown_text`. A caption of `[click](javascript:alert(1))` previously produced `[click](javascript:alert(1))` and now produces `\[click\](javascript:alert(1))`.

The escaping is in `Attachment#to_markdown` rather than in `MarkdownConversion.render_attachment`, because `render markdown: attachment` and direct `Attachment#to_markdown` callers reach the caption without passing through `render_attachment`. Tests cover all three routes.

This also documents the contract on `attachable_markdown_representation`, since escaping the fallback does not cover an application's own implementation: it receives the same untrusted caption, and its return value is emitted as already-rendered Markdown. That RDoc example referenced `MarkdownConversion` unqualified, which raises `NameError` in a top-level model; it is now qualified.

### Additional information

Pre-existing on `main`, and the same class of issue as 2191ca0d — content-derived text reaching the Markdown output without passing through an escaping sink.

No CHANGELOG entry: `to_markdown` is unreleased and its existing entry already describes the feature.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
