### PR TITLE
Fix PostgreSQL primary key introspection for covering indexes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Fix PostgreSQL primary key introspection for covering indexes.
+
+    `pg_index.indkey` includes non-key columns added with `INCLUDE`. Primary
+    keys are now read from `pg_constraint.conkey`, so those columns remain
+    writable during bulk upserts.
+
+    *Aleksandar Maksimovic*
+
 *   Re-enable PostgreSQL triggers when the block given to `disable_referential_integrity` raises.
 
     On PostgreSQL versions without `NOT ENFORCED` constraints (before 18.4), the

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -1020,7 +1020,7 @@ module ActiveRecord
               # that has it, the way ::regclass would for a single table.
               by_name = query_all(<<~SQL).group_by { |row| row["table_name"] }
                 SELECT t.relname AS table_name, a.attname AS column_name
-                FROM pg_index i
+                FROM pg_constraint cons
                 JOIN (
                   SELECT DISTINCT ON (c.relname) c.oid, c.relname
                   FROM pg_class c
@@ -1028,12 +1028,12 @@ module ActiveRecord
                   WHERE n.nspname = #{schema}
                     AND c.relname IN (#{quoted_table_names(group)})
                   ORDER BY c.relname, array_position(current_schemas(false), n.nspname)
-                ) t ON t.oid = i.indrelid
+                ) t ON t.oid = cons.conrelid
                 JOIN pg_attribute a
-                  ON a.attrelid = i.indrelid
-                  AND a.attnum = ANY(i.indkey)
-                WHERE i.indisprimary
-                ORDER BY t.relname, array_position(i.indkey, a.attnum)
+                  ON a.attrelid = cons.conrelid
+                  AND a.attnum = ANY(cons.conkey)
+                WHERE cons.contype = 'p'
+                ORDER BY t.relname, array_position(cons.conkey, a.attnum)
               SQL
 
               group.index_with { |table| rows_for(by_name, table).map { |row| row["column_name"] } }

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -482,6 +482,21 @@ class SchemaTest < ActiveRecord::PostgreSQLTestCase
     end
   end
 
+  def test_primary_keys_exclude_included_columns
+    skip("PostgreSQL does not support included columns") unless @connection.supports_index_include?
+
+    table_name = "#{SCHEMA_NAME}.table_with_covering_primary_key"
+    @connection.create_table table_name, id: false do |t|
+      t.integer :tenant_id, null: false
+      t.integer :id, null: false
+      t.text :name
+      t.index [:tenant_id, :id], unique: true, include: :name, name: "covering_primary_key"
+    end
+    @connection.execute "ALTER TABLE #{table_name} ADD PRIMARY KEY USING INDEX covering_primary_key"
+
+    assert_equal ["tenant_id", "id"], @connection.primary_keys(table_name)
+  end
+
   def test_table_options_for_a_name_in_two_schemas_reads_the_first_on_the_search_path
     @connection.execute "COMMENT ON TABLE #{SCHEMA_NAME}.#{TABLE_NAME} IS 'in schema one'"
     @connection.execute "COMMENT ON TABLE #{SCHEMA2_NAME}.#{TABLE_NAME} IS 'in schema two'"


### PR DESCRIPTION
### Motivation / Background

PostgreSQL primary key indexes can include non-key columns with `INCLUDE`. Active Record reads `pg_index.indkey`, which contains both key and included columns, so included columns are reported as part of the primary key. Bulk upserts can then treat writable columns as read-only and omit their updates.

Aurora DSQL creates covering primary-key indexes by default, making the issue easy to reproduce there.

Fixes #58556

### Detail

This Pull Request reads primary-key columns from `pg_constraint.conkey`, the authoritative ordered column list for the primary-key constraint. It preserves the existing batched lookup and schema-search-path behavior and adds regression coverage for a composite covering primary key.

### Additional information

Before the query change, the regression test returns `["tenant_id", "id", "name"]`; afterward it returns `["tenant_id", "id"]`. The PostgreSQL schema test suite passes with 85 runs and 318 assertions.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.