### PR TITLE
Fix `permit` to honor `explicit_arrays` with a double array filter

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Fix `ActionController::Parameters#permit` to honor `explicit_arrays` when
+    the filter is shaped like a double array (e.g. `[[:flavor]]`).
+
+    `permit` passes `explicit_arrays: false` to stay permissive about unexpected
+    types, but `array_filter?` was evaluated before that flag was consulted, so
+    a double array filter was still interpreted strictly. A plain hash value was
+    then silently dropped via `params[key] = result unless result.nil?`,
+    producing `{}` instead of the permitted hash. This restores the permissive
+    behavior from Rails 7.2, where the double array fell through to the
+    hash/array matching path.
+
+    *Javier Omar Pacheco Moreno*
+
 *   Allow `translate`'s (and `t`'s) `scope:` option to be resolved relative to
     the current controller and action when it starts with a period,
     mirroring the existing behavior for the key argument.

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -1340,7 +1340,7 @@ module ActionController
       #
       # When using `permit`, arrays are specified the same way as hashes:
       #
-      #     params.expect(pies: [:flavor])
+      #     params.permit(pies: [:flavor])
       #
       # In this case, `permit` would also allow matching with a hash (or vice versa):
       #
@@ -1456,7 +1456,7 @@ module ActionController
           permit_array_of_scalars(value)
         elsif filter == EMPTY_HASH # Declaration { preferences: {} }.
           permit_hash(value, filter, on_unpermitted:, explicit_arrays:)
-        elsif array_filter?(filter) # Declaration { comments: [[:text]] }
+        elsif explicit_arrays && array_filter?(filter) # Declaration { comments: [[:text]] }
           permit_array_of_hashes(value, filter.first, on_unpermitted:, explicit_arrays:)
         elsif explicit_arrays # Declaration { user: { address: ... } } or { user: [:name, ...] } (only allows hash value)
           permit_hash(value, filter, on_unpermitted:, explicit_arrays:)

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -612,4 +612,21 @@ class ParametersPermitTest < ActiveSupport::TestCase
       ActionController::Parameters.new({ foo: 1 } => :bar)
     end
   end
+
+  test "permit ignores the double array syntax and permits a hash value" do
+    params = ActionController::Parameters.new(comments: { flavor: "cherry" })
+
+    permitted = params.permit(comments: [[:flavor]])
+
+    assert_equal({ "flavor" => "cherry" }, permitted[:comments].to_h)
+  end
+
+  test "permit ignores the double array syntax and permits an array of hashes" do
+    params = ActionController::Parameters.new(comments: [{ flavor: "cherry" }, { flavor: "apple" }])
+
+    permitted = params.permit(comments: [[:flavor]])
+
+    assert_equal({ "flavor" => "cherry" }, permitted[:comments][0].to_h)
+    assert_equal({ "flavor" => "apple" }, permitted[:comments][1].to_h)
+  end
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `ActionController::Parameters#permit` does not honor the compatibility promise made when `Parameters#expect` was introduced in #51674.

The changelog of that PR states:

> In order to preserve compatibility, `permit` does not adopt the new double array syntax and is therefore more permissive about unexpected types. Using `expect` everywhere is recommended.

However, `permit` passes `explicit_arrays: false` while `array_filter?` is evaluated **before** that flag is consulted in `permit_value`. A filter shaped like a double array is therefore still interpreted strictly, contrary to the promise.

A double array filter is easy to produce by accident, e.g. wrapping a `map` in `[...]`:

```ruby
custom_attrs: [@attributes&.map(&:name)]   # map already returns an array -> [["name"]]
```

With such a filter, `permit_array_of_hashes` requires the value to be an array of hashes. When the actual value is a plain hash, it returns `nil`, and `hash_filter` silently drops the key:

```ruby
result = permit_value(value, filter[key], ...)
params[key] = result unless result.nil?
```

No exception, no warning. Params that worked in 7.2 (where `each_element` flattened the nesting by tolerance) silently produced `{}` in 8.0:

| Rails | `permit(custom_attrs: [["Atributo1"]])` (value is a hash) |
|-------|----------------------------------------------------------|
| 7.2   | `{"Atributo1" => "Valor attr"}` (worked by tolerance)    |
| 8.0   | `{}` (silently dropped)                                  |

### Detail

This Pull Request gates `array_filter?` behind `explicit_arrays` in `permit_value`:

```ruby
elsif explicit_arrays && array_filter?(filter) # Declaration { comments: [[:text]] }
  permit_array_of_hashes(value, filter.first, on_unpermitted:, explicit_arrays:)
```

This way:

- `expect` (`explicit_arrays: true`): the double array is still strict, still raises `ParameterMissing` on a hash value. No change.
- `permit` (`explicit_arrays: false`): the double array is ignored and falls through to `permit_hash_or_array`, the permissive path that matches a hash **or** an array of hashes, restoring the 7.2 behavior.

Just reordering the branches (moving `array_filter?` under `explicit_arrays`) would break `expect`, since the `elsif explicit_arrays` branch would catch the double array first and treat it as hash-only. Guarding with `&&` preserves the strict semantics of `expect`.

### Additional information

This is the upstream continuation of an internal investigation and fix where the discrepancy was surfaced by 24 failing controller tests after the Rails 7.2 -> 8.0 upgrade. The internal analysis is summarized [here](https://github.com/bukhr/buk-webapp/pull/142263).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
