### PR TITLE
Document that rate_limit needs a counting store [ci skip]

### DIFF
--- a/actionpack/lib/action_controller/metal/rate_limiting.rb
+++ b/actionpack/lib/action_controller/metal/rate_limiting.rb
@@ -40,6 +40,12 @@ module ActionController # :nodoc:
       # datastore as your general caches, you can pass a custom store in the `store`
       # parameter.
       #
+      # The limit is only enforced when the store's `increment` returns the updated
+      # count. Stores that don't count return `nil` instead, which silently turns
+      # `rate_limit` into a no-op. That includes `ActiveSupport::Cache::NullStore`,
+      # the default in the generated test environment, and any store that fails open
+      # while its backend is unavailable.
+      #
       # If you want to use multiple rate limits per controller, you need to give each of
       # them an explicit name via the `name:` option.
       #


### PR DESCRIPTION
### Summary

`rate_limit` only enforces the limit when the backing store's `increment` returns the
updated count:

```ruby
count = store.increment(cache_key, 1, expires_in: within)
if count && count > to
```

The `count &&` guard means a store that returns `nil` disables rate limiting entirely --
no exception, no warning, no log line. `ActiveSupport::Cache::NullStore#increment` is an
empty method, and `:null_store` is what `rails new` generates for the test environment
([test.rb.tt#L27](https://github.com/rails/rails/blob/main/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt#L27)),
so `rate_limit` is a no-op there by default.

The docs already tell you to switch to `MemoryStore` when testing `rate_limit`
(60d92e4). What's missing is why that advice exists: the default store doesn't count, so
the limiter is off rather than merely untested.

This is easy to hit and hard to notice. The natural test -- "the 11th request is blocked"
-- does fail when the limiter is off, but only if you write it. A suite that exercises the
happy path stays green while the protection is silently gone. The same is true in
production for any store that fails open while its backend is unavailable.

I ran into this on an app with `rate_limit` on the login action: the specs passed against
`:null_store` while the 11th attempt sailed through.

### Why documentation rather than a behavior change

This was already discussed in #50781, the PR that introduced the current
`ActiveSupport::Cache`-backed implementation. The `count &&` guard arrived with that
refactor in d839ddb, and a week later @dhh raised the consequence in the same thread:

> Problem with this in testing is that we default to `null_store`. So the value doesn't
> persist. So you can't test it.

@byroot considered detecting the store and concluded:

> we could detect when it's `NullStore` and fallback to a `MemoryStore`, but that sounds
> a bit too brittle.

and the thread settled on changing the default instead:

> I think we should default to MemoryStore, but make it a dedicated test instance, and
> then also ensure #clear is called by default.

That change hasn't landed -- the generated `test.rb` still sets `:null_store`, and the
guard itself is unchanged since d839ddb. So this PR documents the current behavior rather
than re-proposing something the thread already weighed. The fail-open itself looks
deliberate (a cache outage locking every user out is worse than letting requests
through), so I'm not touching it.

**If you'd rather have the default changed as described above, I'm happy to attempt that
instead and close this.**

### What this changes

Documentation only -- one paragraph in the `rate_limit` rdoc. No behavior change, no
CHANGELOG entry.
