### PR TITLE
Allow redis gem 6 in the Action Cable adapter on Rails 8.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -108,7 +108,7 @@ end
 group :cable do
   gem "puma", ">= 5.0.3", require: false
 
-  gem "redis", ">= 4.0.1", "< 6", require: false
+  gem "redis", ">= 4.0.1", "< 7", require: false
 
   gem "redis-namespace"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -448,9 +448,9 @@ GEM
       psych (>= 4.0.0)
       tsort
     redcarpet (3.6.1)
-    redis (5.4.1)
-      redis-client (>= 0.22.0)
-    redis-client (0.29.0)
+    redis (6.0.0)
+      redis-client (= 0.30.1)
+    redis-client (0.30.1)
       connection_pool
     redis-namespace (1.11.0)
       redis (>= 4)
@@ -723,7 +723,7 @@ DEPENDENCIES
   rails!
   rake (>= 13)
   redcarpet (~> 3.6.1)
-  redis (>= 4.0.1, < 6)
+  redis (>= 4.0.1, < 7)
   redis-namespace
   releaser!
   resque

--- a/actioncable/lib/action_cable/subscription_adapter/redis.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/redis.rb
@@ -2,7 +2,7 @@
 
 # :markup: markdown
 
-gem "redis", ">= 4", "< 6"
+gem "redis", ">= 4", "< 7"
 require "redis"
 
 require "active_support/core_ext/hash/except"


### PR DESCRIPTION
### Motivation / Background

redis-rb 6.0.0 was released on July 31, 2026. The Action Cable redis subscription adapter still declares its supported versions at require time:

```
gem "redis", ">= 4", "< 6"
```

Apps that depend on redis 6 therefore fail to load the adapter:

```
Gem::LoadError: Error loading the 'redis' Action Cable pubsub adapter.
Missing a gem it depends on? can't activate redis (>= 4, < 6), already
activated redis-6.0.0.
```

#58344 pinned the repository Gemfile to < 6 so CI on 8-1-stable stayed green, but left the adapter constraint unchanged for applications.

(main no longer needs this change: the adapter was reimplemented on redis-client in ef812c2652)

### Detail

Raise the Action Cable adapter upper bound from < 6 to < 7, matching how previous redis major bumps were handled (#30748 for 4.x, #45856 / #45873 for 5.x). Also raise the Gemfile pin from #58344 from < 6 to < 7 so the suite resolves redis 6.

### Additional information

(No adapter code changes were required. redis-rb 6 is largely a drop-in for the APIs Action Cable uses (subscribe, _client, without_reconnect, etc.). The main change in redis-rb 6 is that RESP3 is now the default protocol. Older Redis servers remain supported through automatic fallback to RESP2.)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
