### PR TITLE
fix: Serve disk blobs with no content type as `application/octet-stream`

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,9 +1,17 @@
+*   Serve disk blobs with no content type as `application/octet-stream`
+
+    Serve a disk blob whose signed URL carries no content type as
+    `application/octet-stream`, instead of raising `NameError`.
+
+    *Seb Jacobs*
+
 *   Marcel 2 for content type detection
 
     Broader and more precise MIME type detection, security hardening, and uses canonical types
     instead of aliases (`text/x-yaml` → `application/yaml`).
 
     *Jeremy Daer*
+
 
 *   Allow ffmpeg and ffprobe input arguments to be configured.
 

--- a/activestorage/app/controllers/concerns/active_storage/file_server.rb
+++ b/activestorage/app/controllers/concerns/active_storage/file_server.rb
@@ -3,6 +3,9 @@
 require "active_support/core_ext/hash/except"
 
 module ActiveStorage::FileServer # :nodoc:
+  DEFAULT_SEND_FILE_TYPE        = ActionController::DataStreaming::DEFAULT_SEND_FILE_TYPE
+  DEFAULT_SEND_FILE_DISPOSITION = ActionController::DataStreaming::DEFAULT_SEND_FILE_DISPOSITION
+
   private
     def serve_file(path, content_type:, disposition:)
       ::Rack::Files.new(nil).serving(request, path).tap do |(status, headers, body)|

--- a/activestorage/test/controllers/disk_controller_test.rb
+++ b/activestorage/test/controllers/disk_controller_test.rb
@@ -23,6 +23,28 @@ class ActiveStorage::DiskControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Hello world!", response.body
   end
 
+  test "showing signed blob with no content type falls back to application/octet-stream" do
+    blob = create_blob
+
+    get blob.service.url(blob.key, expires_in: 1.minute, filename: blob.filename, content_type: nil, disposition: :inline)
+
+    assert_response :ok
+    assert_equal "application/octet-stream", response.headers["Content-Type"]
+    assert_equal "Hello world!", response.body
+  end
+
+  test "showing public blob with no content type falls back to application/octet-stream" do
+    with_service("local_public") do
+      blob = create_blob
+
+      get blob.service.url(blob.key, filename: blob.filename)
+
+      assert_response :ok
+      assert_equal "application/octet-stream", response.headers["Content-Type"]
+      assert_equal "Hello world!", response.body
+    end
+  end
+
   test "showing blob range" do
     blob = create_blob
     get blob.url, headers: { "Range" => "bytes=5-9" }


### PR DESCRIPTION
### Motivation / Background
=======================

When you call `image_tag user.avatar` with a blob you are handed back a URL which points to `ActiveStorage::Blobs::RedirectController`.

When `ActiveStorage::Blobs::RedirectController` handles the request it asks the blob's service for a URL. For a Cloud service this returns a URL but for a Disk service it returns a Rails route path signed with a token(composed from the file key, content type and disposition).

The Rails route path is handled by `DiskController#show` and serves the asset using `ActiveStorage::FileServer#serve_file`.

From looking at the `ActiveStorage::FileServer` code I can see it is supposed to handle the absense of a `content_type` or `content_disposition` falling back `DEFAULT_SEND_FILE_TYPE` and `DEFAULT_SEND_FILE_DISPOSITION` however in practice this does **not** seem to be the case for example:

When a URL is generated without a `content_type` I would expect it to resolve to `application/octet-stream` but from what I can see this scenario results in an exception: `NameError: uninitialized constant ActiveStorage::FileServer::DEFAULT_SEND_FILE_TYPE`.

Both the `content_type` and `disposition` fall backs are read from unqualified constants which do not appear to be available in the lexical scope.

### Detail
=========

I have addressed the constant lookup issue by aliasing the constants defined in `ActionController::DataStreaming`.

I have also provided a couple of unit tests which should document the issue and prevent future regressions.

### Things to note
================

I have aliased `DEFAULT_SEND_FILE_DISPOSITION` in the same way as `DEFAULT_SEND_FILE_TYPE` however setting up the unit test for that scenario was pretty hacky and so I have left it untested.


### Checklist
============

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.