### PR TITLE
Add low-quality image placeholders to Active Storage

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add opt-in low-quality image placeholders.
+
+    Enable `config.active_storage.generate_image_placeholders` to store a small
+    ThumbHash-rendered PNG data URL in image blob metadata during analysis. Access
+    the result through `ActiveStorage::Blob#placeholder`.
+
+    *Sebastian Arrieta*
+
 *   Allow ffmpeg and ffprobe input arguments to be configured.
 
     Two new configuration parameters are introduced.

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -26,7 +26,7 @@ class ActiveStorage::Blob < ActiveStorage::Record
 
   # FIXME: these property should never have been stored in the metadata.
   # The blob table should be migrated to have dedicated columns for these.
-  PROTECTED_METADATA = %w(analyzed identified composed).freeze
+  PROTECTED_METADATA = %w(analyzed identified composed placeholder).freeze
   private_constant :PROTECTED_METADATA
   store :metadata, accessors: [ :analyzed, :identified, :composed ], coder: ActiveRecord::Coders::JSON
 
@@ -201,6 +201,12 @@ class ActiveStorage::Blob < ActiveStorage::Record
   #
   #   ActiveStorage::Blob.first.metadata
   #   => {"identified" => true, "width" => 763, "height" => 588, "analyzed" => true}
+
+  # Returns an inline low-quality placeholder for an analyzed image blob when
+  # +config.active_storage.generate_image_placeholders+ is enabled.
+  def placeholder
+    metadata[:placeholder]
+  end
 
   # Returns a signed ID for this blob that's suitable for reference on the client-side without fear of tampering.
   def signed_id(purpose: :blob_id, expires_in: nil, expires_at: nil)

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -43,6 +43,7 @@ module ActiveStorage
 
   autoload :Attached
   autoload :FixtureSet
+  autoload :ImagePlaceholder
   autoload :Service
   autoload :Previewer
   autoload :Analyzer
@@ -58,6 +59,7 @@ module ActiveStorage
   mattr_accessor :previewers, default: []
   mattr_accessor :analyzers,  default: []
   mattr_accessor :analyze,    default: :later
+  mattr_accessor :generate_image_placeholders, default: false
 
   mattr_accessor :paths, default: {}
 

--- a/activestorage/lib/active_storage/analyzer/image_analyzer.rb
+++ b/activestorage/lib/active_storage/analyzer/image_analyzer.rb
@@ -3,7 +3,8 @@
 module ActiveStorage
   # = Active Storage Image \Analyzer
   #
-  # This is an abstract base class for image analyzers, which extract width and height from an image blob.
+  # This is an abstract base class for image analyzers, which extract width and height from an image blob. When
+  # +ActiveStorage.generate_image_placeholders+ is enabled, they also extract an inline placeholder.
   #
   # If the image contains EXIF data indicating its angle is 90 or 270 degrees, its width and height are swapped for convenience.
   #
@@ -23,12 +24,26 @@ module ActiveStorage
 
     def metadata
       read_image do |image|
-        if rotated_image?(image)
+        dimensions = if rotated_image?(image)
           { width: image.height, height: image.width }
         else
           { width: image.width, height: image.height }
         end
+
+        dimensions.merge(placeholder_metadata(image))
       end
     end
+
+    private
+      def placeholder_metadata(image)
+        if ActiveStorage.generate_image_placeholders && (placeholder = image_placeholder(image))
+          { placeholder: placeholder }
+        else
+          {}
+        end
+      end
+
+      def image_placeholder(_image)
+      end
   end
 end

--- a/activestorage/lib/active_storage/analyzer/image_analyzer/image_magick.rb
+++ b/activestorage/lib/active_storage/analyzer/image_analyzer/image_magick.rb
@@ -44,5 +44,16 @@ module ActiveStorage
       def rotated_image?(image)
         %w[ LeftTop RightTop RightBottom LeftBottom ].include?(image["%[orientation]"])
       end
+
+      def image_placeholder(image)
+        placeholder = MiniMagick::Image.open(image.path)
+        placeholder.auto_orient
+        placeholder.resize("100x100>")
+        placeholder.colorspace("sRGB")
+
+        ImagePlaceholder.data_url(placeholder.width, placeholder.height, placeholder.get_pixels("RGBA").flatten)
+      ensure
+        placeholder&.destroy!
+      end
   end
 end

--- a/activestorage/lib/active_storage/analyzer/image_analyzer/vips.rb
+++ b/activestorage/lib/active_storage/analyzer/image_analyzer/vips.rb
@@ -46,5 +46,13 @@ module ActiveStorage
       rescue ::Vips::Error
         false
       end
+
+      def image_placeholder(image)
+        image = image.thumbnail_image(100, height: 100, size: :down)
+        image = image.colourspace(:srgb)
+        image = image.addalpha unless image.has_alpha?
+
+        ImagePlaceholder.data_url(image.width, image.height, image.cast(:uchar).write_to_memory.unpack("C*"))
+      end
   end
 end

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -179,6 +179,7 @@ module ActiveStorage
         ActiveStorage.ffprobe_arguments = app.config.active_storage.ffprobe_arguments || ""
         ActiveStorage.track_variants = app.config.active_storage.track_variants || false
         ActiveStorage.analyze = app.config.active_storage.analyze || :later
+        ActiveStorage.generate_image_placeholders = app.config.active_storage.generate_image_placeholders || false
         ActiveStorage.streaming_chunk_max_size = app.config.active_storage.streaming_chunk_max_size || 100.megabytes
       end
     end

--- a/activestorage/lib/active_storage/image_placeholder.rb
+++ b/activestorage/lib/active_storage/image_placeholder.rb
@@ -1,0 +1,289 @@
+# frozen_string_literal: true
+
+# The ThumbHash codec in this file is adapted from https://github.com/evanw/thumbhash.
+# Copyright (c) 2023 Evan Wallace
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+require "base64"
+require "zlib"
+
+module ActiveStorage
+  module ImagePlaceholder # :nodoc:
+    MAX_SIZE = 16
+
+    class << self
+      def data_url(width, height, rgba)
+        hash = rgba_to_thumb_hash(width, height, rgba)
+        width, height, rgba = thumb_hash_to_rgba(hash)
+        rgba_to_data_url(width, height, rgba)
+      end
+
+      private
+        def rgba_to_thumb_hash(width, height, rgba)
+          average_red = average_green = average_blue = average_alpha = 0.0
+
+          (width * height).times do |index|
+            offset = index * 4
+            alpha = rgba[offset + 3] / 255.0
+            average_red += alpha * rgba[offset] / 255.0
+            average_green += alpha * rgba[offset + 1] / 255.0
+            average_blue += alpha * rgba[offset + 2] / 255.0
+            average_alpha += alpha
+          end
+
+          if average_alpha > 0
+            average_red /= average_alpha
+            average_green /= average_alpha
+            average_blue /= average_alpha
+          end
+
+          has_alpha = average_alpha < width * height
+          luminance_limit = has_alpha ? 5 : 7
+          luminance_x = [ 1, (luminance_limit * width.to_f / [ width, height ].max).round ].max
+          luminance_y = [ 1, (luminance_limit * height.to_f / [ width, height ].max).round ].max
+          luminance = Array.new(width * height)
+          yellow_blue = Array.new(width * height)
+          red_green = Array.new(width * height)
+          alpha = Array.new(width * height)
+
+          (width * height).times do |index|
+            offset = index * 4
+            pixel_alpha = rgba[offset + 3] / 255.0
+            red = average_red * (1 - pixel_alpha) + pixel_alpha * rgba[offset] / 255.0
+            green = average_green * (1 - pixel_alpha) + pixel_alpha * rgba[offset + 1] / 255.0
+            blue = average_blue * (1 - pixel_alpha) + pixel_alpha * rgba[offset + 2] / 255.0
+            luminance[index] = (red + green + blue) / 3
+            yellow_blue[index] = (red + green) / 2 - blue
+            red_green[index] = red - green
+            alpha[index] = pixel_alpha
+          end
+
+          luminance_dc, luminance_ac, luminance_scale = encode_channel(luminance, [ 3, luminance_x ].max, [ 3, luminance_y ].max, width, height)
+          yellow_blue_dc, yellow_blue_ac, yellow_blue_scale = encode_channel(yellow_blue, 3, 3, width, height)
+          red_green_dc, red_green_ac, red_green_scale = encode_channel(red_green, 3, 3, width, height)
+          alpha_dc, alpha_ac, alpha_scale = has_alpha ? encode_channel(alpha, 5, 5, width, height) : []
+
+          landscape = width > height
+          header24 = (63 * luminance_dc).round |
+            ((31.5 + 31.5 * yellow_blue_dc).round << 6) |
+            ((31.5 + 31.5 * red_green_dc).round << 12) |
+            ((31 * luminance_scale).round << 18) |
+            (has_alpha ? (1 << 23) : 0)
+          header16 = (landscape ? luminance_y : luminance_x) |
+            ((63 * yellow_blue_scale).round << 3) |
+            ((63 * red_green_scale).round << 9) |
+            (landscape ? (1 << 15) : 0)
+          hash = [ header24 & 255, (header24 >> 8) & 255, header24 >> 16, header16 & 255, header16 >> 8 ]
+          hash << ((15 * alpha_dc).round | ((15 * alpha_scale).round << 4)) if has_alpha
+
+          channels = has_alpha ? [ luminance_ac, yellow_blue_ac, red_green_ac, alpha_ac ] : [ luminance_ac, yellow_blue_ac, red_green_ac ]
+          channels.flatten.each_with_index do |factor, index|
+            hash_index = (has_alpha ? 6 : 5) + (index >> 1)
+            hash[hash_index] ||= 0
+            hash[hash_index] |= (15 * factor).round << ((index & 1) << 2)
+          end
+
+          hash
+        end
+
+        def encode_channel(channel, channel_width, channel_height, width, height)
+          dc = scale = 0.0
+          ac = []
+          factors_x = Array.new(width)
+
+          channel_height.times do |channel_y|
+            channel_x = 0
+            while channel_x * channel_height < channel_width * (channel_height - channel_y)
+              factor = 0.0
+              width.times do |x|
+                factors_x[x] = Math.cos(Math::PI / width * channel_x * (x + 0.5))
+              end
+              height.times do |y|
+                factor_y = Math.cos(Math::PI / height * channel_y * (y + 0.5))
+                width.times { |x| factor += channel[x + y * width] * factors_x[x] * factor_y }
+              end
+              factor /= width * height
+
+              if channel_x.zero? && channel_y.zero?
+                dc = factor
+              else
+                ac << factor
+                scale = [ scale, factor.abs ].max
+              end
+              channel_x += 1
+            end
+          end
+
+          ac.map! { |factor| 0.5 + 0.5 / scale * factor } if scale > 0
+          [ dc, ac, scale ]
+        end
+
+        def thumb_hash_to_rgba(hash)
+          header24 = hash[0] | (hash[1] << 8) | (hash[2] << 16)
+          header16 = hash[3] | (hash[4] << 8)
+          luminance_dc = (header24 & 63) / 63.0
+          yellow_blue_dc = ((header24 >> 6) & 63) / 31.5 - 1
+          red_green_dc = ((header24 >> 12) & 63) / 31.5 - 1
+          luminance_scale = ((header24 >> 18) & 31) / 31.0
+          has_alpha = (header24 >> 23) != 0
+          yellow_blue_scale = ((header16 >> 3) & 63) / 63.0
+          red_green_scale = ((header16 >> 9) & 63) / 63.0
+          landscape = (header16 >> 15) != 0
+          luminance_x = [ 3, landscape ? (has_alpha ? 5 : 7) : header16 & 7 ].max
+          luminance_y = [ 3, landscape ? header16 & 7 : (has_alpha ? 5 : 7) ].max
+          alpha_dc = has_alpha ? (hash[5] & 15) / 15.0 : 1.0
+          alpha_scale = has_alpha ? (hash[5] >> 4) / 15.0 : 0.0
+          ac_start = has_alpha ? 6 : 5
+          ac_index = 0
+
+          decode_channel = ->(channel_width, channel_height, scale) do
+            factors = []
+            channel_height.times do |channel_y|
+              channel_x = channel_y.zero? ? 1 : 0
+              while channel_x * channel_height < channel_width * (channel_height - channel_y)
+                value = hash[ac_start + (ac_index >> 1)]
+                factors << (((value >> ((ac_index & 1) << 2)) & 15) / 7.5 - 1) * scale
+                ac_index += 1
+                channel_x += 1
+              end
+            end
+            factors
+          end
+
+          luminance_ac = decode_channel.call(luminance_x, luminance_y, luminance_scale)
+          yellow_blue_ac = decode_channel.call(3, 3, yellow_blue_scale * 1.25)
+          red_green_ac = decode_channel.call(3, 3, red_green_scale * 1.25)
+          alpha_ac = decode_channel.call(5, 5, alpha_scale) if has_alpha
+          ratio = luminance_x.to_f / luminance_y
+          width = (ratio > 1 ? MAX_SIZE : MAX_SIZE * ratio).round
+          height = (ratio > 1 ? MAX_SIZE / ratio : MAX_SIZE).round
+          rgba = Array.new(width * height * 4, 0)
+          factors_x = []
+          factors_y = []
+
+          height.times do |y|
+            width.times do |x|
+              luminance = luminance_dc
+              yellow_blue = yellow_blue_dc
+              red_green = red_green_dc
+              alpha = alpha_dc
+
+              [ luminance_x, has_alpha ? 5 : 3 ].max.times do |channel_x|
+                factors_x[channel_x] = Math.cos(Math::PI / width * (x + 0.5) * channel_x)
+              end
+              [ luminance_y, has_alpha ? 5 : 3 ].max.times do |channel_y|
+                factors_y[channel_y] = Math.cos(Math::PI / height * (y + 0.5) * channel_y)
+              end
+
+              index = 0
+              luminance_y.times do |channel_y|
+                channel_x = channel_y.zero? ? 1 : 0
+                while channel_x * luminance_y < luminance_x * (luminance_y - channel_y)
+                  luminance += luminance_ac[index] * factors_x[channel_x] * factors_y[channel_y] * 2
+                  index += 1
+                  channel_x += 1
+                end
+              end
+
+              index = 0
+              3.times do |channel_y|
+                channel_x = channel_y.zero? ? 1 : 0
+                while channel_x < 3 - channel_y
+                  factor = factors_x[channel_x] * factors_y[channel_y] * 2
+                  yellow_blue += yellow_blue_ac[index] * factor
+                  red_green += red_green_ac[index] * factor
+                  index += 1
+                  channel_x += 1
+                end
+              end
+
+              if has_alpha
+                index = 0
+                5.times do |channel_y|
+                  channel_x = channel_y.zero? ? 1 : 0
+                  while channel_x < 5 - channel_y
+                    alpha += alpha_ac[index] * factors_x[channel_x] * factors_y[channel_y] * 2
+                    index += 1
+                    channel_x += 1
+                  end
+                end
+              end
+
+              blue = luminance - 2.0 / 3 * yellow_blue
+              red = (3 * luminance - blue + red_green) / 2
+              green = red - red_green
+              offset = (x + y * width) * 4
+              rgba[offset] = (255 * red.clamp(0, 1)).to_i
+              rgba[offset + 1] = (255 * green.clamp(0, 1)).to_i
+              rgba[offset + 2] = (255 * blue.clamp(0, 1)).to_i
+              rgba[offset + 3] = (255 * alpha.clamp(0, 1)).to_i
+            end
+          end
+
+          [ width, height, rgba ]
+        end
+
+        def rgba_to_data_url(width, height, rgba)
+          pixels = String.new(capacity: height * (width * 4 + 1), encoding: Encoding::BINARY)
+          previous_row = Array.new(width * 4, 0)
+          height.times do |y|
+            row = rgba.slice(y * width * 4, width * 4)
+            filter, filtered = png_filter(row, previous_row)
+            pixels << filter.chr << filtered.pack("C*")
+            previous_row = row
+          end
+
+          header = [ width, height, 8, 6, 0, 0, 0 ].pack("NNC5")
+          png = "\x89PNG\r\n\x1a\n".b + png_chunk("IHDR", header) + png_chunk("IDAT", Zlib::Deflate.deflate(pixels, Zlib::BEST_COMPRESSION)) + png_chunk("IEND", "")
+          "data:image/png;base64,#{Base64.strict_encode64(png)}"
+        end
+
+        def png_filter(row, previous_row)
+          filters = 5.times.map do |type|
+            row.each_index.map do |index|
+              left = index >= 4 ? row[index - 4] : 0
+              above = previous_row[index]
+              upper_left = index >= 4 ? previous_row[index - 4] : 0
+              predictor = case type
+              when 0 then 0
+              when 1 then left
+              when 2 then above
+              when 3 then (left + above) / 2
+              when 4 then paeth_predictor(left, above, upper_left)
+              end
+              (row[index] - predictor) & 255
+            end
+          end
+          type = filters.each_index.min_by { |index| filters[index].sum { |byte| [ byte, 256 - byte ].min } }
+          [ type, filters[type] ]
+        end
+
+        def paeth_predictor(left, above, upper_left)
+          prediction = left + above - upper_left
+          distances = [ (prediction - left).abs, (prediction - above).abs, (prediction - upper_left).abs ]
+          [ left, above, upper_left ][distances.each_index.min_by { |index| distances[index] }]
+        end
+
+        def png_chunk(type, data)
+          [ data.bytesize ].pack("N") + type + data + [ Zlib.crc32(type + data) ].pack("N")
+        end
+    end
+  end
+end

--- a/activestorage/lib/active_storage/image_placeholder.rb
+++ b/activestorage/lib/active_storage/image_placeholder.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# :markup: markdown
+
 # The ThumbHash codec in this file is adapted from https://github.com/evanw/thumbhash.
 # Copyright (c) 2023 Evan Wallace
 #

--- a/activestorage/test/analyzer/image_analyzer/image_magick_test.rb
+++ b/activestorage/test/analyzer/image_analyzer/image_magick_test.rb
@@ -16,6 +16,34 @@ class ActiveStorage::Analyzer::ImageAnalyzer::ImageMagickTest < ActiveSupport::T
     end
   end
 
+  test "generating an image placeholder" do
+    ActiveStorage.with(generate_image_placeholders: true) do
+      analyze_with_image_magick do
+        blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+
+        assert_image_placeholder extract_metadata_from(blob)
+      end
+    end
+  end
+
+  test "image placeholders are disabled by default" do
+    analyze_with_image_magick do
+      blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+
+      assert_nil extract_metadata_from(blob)[:placeholder]
+    end
+  end
+
+  test "generating a transparent image placeholder" do
+    ActiveStorage.with(generate_image_placeholders: true) do
+      analyze_with_image_magick do
+        blob = create_file_blob(filename: "image.gif", content_type: "image/gif")
+
+        assert_image_placeholder extract_metadata_from(blob), landscape: nil, transparent: true
+      end
+    end
+  end
+
   test "analyzing a rotated JPEG image" do
     analyze_with_image_magick do
       blob = create_file_blob(filename: "racecar_rotated.jpg", content_type: "image/jpeg")
@@ -23,6 +51,16 @@ class ActiveStorage::Analyzer::ImageAnalyzer::ImageMagickTest < ActiveSupport::T
 
       assert_equal 2736, metadata[:width]
       assert_equal 4104, metadata[:height]
+    end
+  end
+
+  test "generating an autorotated image placeholder" do
+    ActiveStorage.with(generate_image_placeholders: true) do
+      analyze_with_image_magick do
+        blob = create_file_blob(filename: "racecar_rotated.jpg", content_type: "image/jpeg")
+
+        assert_image_placeholder extract_metadata_from(blob), landscape: false
+      end
     end
   end
 

--- a/activestorage/test/analyzer/image_analyzer/vips_test.rb
+++ b/activestorage/test/analyzer/image_analyzer/vips_test.rb
@@ -16,6 +16,34 @@ class ActiveStorage::Analyzer::ImageAnalyzer::VipsTest < ActiveSupport::TestCase
     end
   end
 
+  test "generating an image placeholder" do
+    ActiveStorage.with(generate_image_placeholders: true) do
+      analyze_with_vips do
+        blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+
+        assert_image_placeholder extract_metadata_from(blob)
+      end
+    end
+  end
+
+  test "image placeholders are disabled by default" do
+    analyze_with_vips do
+      blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+
+      assert_nil extract_metadata_from(blob)[:placeholder]
+    end
+  end
+
+  test "generating a transparent image placeholder" do
+    ActiveStorage.with(generate_image_placeholders: true) do
+      analyze_with_vips do
+        blob = create_file_blob(filename: "image.gif", content_type: "image/gif")
+
+        assert_image_placeholder extract_metadata_from(blob), landscape: nil, transparent: true
+      end
+    end
+  end
+
   test "analyzing a rotated JPEG image" do
     analyze_with_vips do
       blob = create_file_blob(filename: "racecar_rotated.jpg", content_type: "image/jpeg")
@@ -23,6 +51,16 @@ class ActiveStorage::Analyzer::ImageAnalyzer::VipsTest < ActiveSupport::TestCase
 
       assert_equal 2736, metadata[:width]
       assert_equal 4104, metadata[:height]
+    end
+  end
+
+  test "generating an autorotated image placeholder" do
+    ActiveStorage.with(generate_image_placeholders: true) do
+      analyze_with_vips do
+        blob = create_file_blob(filename: "racecar_rotated.jpg", content_type: "image/jpeg")
+
+        assert_image_placeholder extract_metadata_from(blob), landscape: false
+      end
     end
   end
 

--- a/activestorage/test/analyzer/image_analyzer_test.rb
+++ b/activestorage/test/analyzer/image_analyzer_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "active_storage/analyzer/image_analyzer"
+
+class ActiveStorage::Analyzer::ImageAnalyzerTest < ActiveSupport::TestCase
+  class CustomAnalyzer < ActiveStorage::Analyzer::ImageAnalyzer
+    private
+      def read_image
+        yield Struct.new(:width, :height).new(640, 480)
+      end
+
+      def rotated_image?(image)
+        false
+      end
+  end
+
+  test "custom analyzers do not need to implement image placeholders" do
+    ActiveStorage.with(generate_image_placeholders: true) do
+      assert_equal({ width: 640, height: 480 }, CustomAnalyzer.new(nil).metadata)
+    end
+  end
+end

--- a/activestorage/test/controllers/direct_uploads_controller_test.rb
+++ b/activestorage/test/controllers/direct_uploads_controller_test.rb
@@ -137,6 +137,7 @@ class ActiveStorage::DiskDirectUploadsControllerTest < ActionDispatch::Integrati
       "analyzed" => "yolo",
       "identified" => 42,
       "composed" => "maybe",
+      "placeholder" => "data:image/png;base64,untrusted",
     }
 
     all_metadata = metadata.merge(protected_metadata)

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -46,6 +46,17 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
     assert_equal "image/jpeg", blob.content_type
   end
 
+  test "placeholder returns analyzed image placeholder metadata" do
+    placeholder = "data:image/png;base64,image-data"
+    blob = ActiveStorage::Blob.new(metadata: { placeholder: placeholder })
+
+    assert_equal placeholder, blob.placeholder
+  end
+
+  test "placeholder is nil without analyzed image placeholder metadata" do
+    assert_nil ActiveStorage::Blob.new.placeholder
+  end
+
   test "create_and_upload prefers given content type over filename" do
     blob = create_blob content_type: "specific/type", filename: "file.txt"
     assert_equal "specific/type", blob.content_type

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -75,6 +75,23 @@ class ActiveSupport::TestCase
       blob.tap(&:analyze).metadata
     end
 
+    def assert_image_placeholder(metadata, landscape: true, transparent: false)
+      assert_match(/\Adata:image\/png;base64,/, metadata[:placeholder])
+      assert_operator metadata[:placeholder].bytesize, :<, 1024
+      image = MiniMagick::Image.read(Base64.strict_decode64(metadata[:placeholder].delete_prefix("data:image/png;base64,")))
+
+      assert_operator image.width, :<=, 16
+      assert_operator image.height, :<=, 16
+      if landscape == true
+        assert_operator image.width, :>, image.height
+      elsif landscape == false
+        assert_operator image.height, :>, image.width
+      end
+      assert image.get_pixels("RGBA").flatten.each_slice(4).any? { |pixel| pixel.last < 255 } if transparent
+    ensure
+      image&.destroy!
+    end
+
     def fixture_file_upload(filename)
       Rack::Test::UploadedFile.new file_fixture(filename).to_s
     end

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -838,6 +838,19 @@ these, as well as `duration`, `angle`, `display_aspect_ratio`, and `video` and
 `audio` booleans to indicate the presence of those channels. Audio analysis
 provides `duration` and `bit_rate` attributes.
 
+Active Storage can also generate an inline low-quality placeholder while analyzing
+an image. Enable this behavior with
+[`config.active_storage.generate_image_placeholders`][]. The placeholder is stored
+in the blob's metadata and exposed by the [`placeholder`][] method:
+
+```erb
+<%= image_tag user.profile_photo,
+      style: "background-image: url('#{user.profile_photo.placeholder}')" %>
+```
+
+Enabling placeholders applies to newly analyzed images. Call `analyze_later` on
+existing image blobs to generate placeholders for them.
+
 ### Controlling When Analysis is Performed
 
 You can control *when* metadata analysis is performed by using the `analyze`
@@ -900,6 +913,10 @@ using JavaScript instead.
 https://api.rubyonrails.org/classes/ActiveStorage/Blob.html#method-i-metadata
 [`analyzed?`]:
 https://api.rubyonrails.org/classes/ActiveStorage/Blob/Analyzable.html#method-i-analyzed-3F
+[`placeholder`]:
+https://api.rubyonrails.org/classes/ActiveStorage/Blob.html#method-i-placeholder
+[`config.active_storage.generate_image_placeholders`]:
+configuring.html#config-active-storage-generate-image-placeholders
 
 Displaying Images, Videos, and PDFs
 -----------------------------------

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -3559,6 +3559,18 @@ If you want to disable analyzers, you can set this to an empty array:
 config.active_storage.analyzers = []
 ```
 
+#### `config.active_storage.generate_image_placeholders`
+
+Controls whether image analyzers generate low-quality placeholders that can be
+inlined while the original image loads. Placeholders are stored in blob metadata
+and returned by `ActiveStorage::Blob#placeholder`. The default value is `false`.
+
+```ruby
+config.active_storage.generate_image_placeholders = true
+```
+
+Existing analyzed image blobs must be analyzed again to generate a placeholder.
+
 #### `config.active_storage.analyze`
 
 Controls when attachment analysis (image/video/audio metadata extraction) is performed:

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -4398,6 +4398,20 @@ module ApplicationTests
       assert_equal [ ActiveStorage::Analyzer::ImageAnalyzer::Vips ], ActiveStorage.analyzers
     end
 
+    test "ActiveStorage.generate_image_placeholders is disabled by default" do
+      app "development"
+
+      assert_not ActiveStorage.generate_image_placeholders
+    end
+
+    test "ActiveStorage.generate_image_placeholders can be configured" do
+      add_to_config "config.active_storage.generate_image_placeholders = true"
+
+      app "development"
+
+      assert ActiveStorage.generate_image_placeholders
+    end
+
     test "ActiveStorage.draw_routes can be configured via config.active_storage.draw_routes" do
       app_file "config/environments/development.rb", <<-RUBY
         Rails.application.configure do


### PR DESCRIPTION
### Motivation / Background

Images can display an inline low-quality placeholder while their full contents load, avoiding an empty area or abrupt transition without requiring a client-side decoder. Active Storage already downloads and decodes images during metadata analysis, so it can generate this placeholder in the same pass.

Placeholder generation is opt-in because resizing pixels and encoding the result adds work to every analyzed image.

### Detail

This Pull Request adds `config.active_storage.generate_image_placeholders`, disabled by default. When enabled, the existing Vips and ImageMagick analyzers:

1. Resize and autorotate a copy of the analyzed image to at most 100 pixels.
2. Encode the pixels as a ThumbHash.
3. Render the ThumbHash to a compressed PNG data URL smaller than 1 KB.
4. Store the final data URL in `blob.metadata["placeholder"]`.

Applications can access the result through `blob.placeholder` or an attachment that delegates to its blob:

```ruby
post.cover.placeholder
# => "data:image/png;base64,..."
```

This keeps the implementation within the existing image-analysis pipeline. It does not add a parallel analyzer, database column, persisted variant, public ThumbHash API, request-time image processing, or Action View helper. Placeholder metadata is protected from direct-upload clients. Existing analyzed images can be explicitly analyzed again to backfill placeholders.

### Additional information

The ThumbHash codec is adapted from Evan Wallace's MIT-licensed reference implementation. Both image-processing backends preserve alpha and autorotate placeholder pixels according to EXIF orientation. Custom image analyzer subclasses remain compatible when placeholder generation is enabled.

Verification:

* Active Storage focused tests: 77 runs, 236 assertions, 0 failures
* Railties configuration tests: 2 runs, 2 assertions, 0 failures
* RuboCop: 14 files, no offenses
* Markdown lint: no offenses
* Full Active Storage suite: 618 tests completed without assertion failures; the unrelated JavaScript package test could not run because `yarn` is unavailable locally

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated because this adds a feature.
* [x] The Active Storage CHANGELOG is updated for the additional feature.