### PR TITLE
Make en.rb translation load path contents ractor safe

### DIFF
--- a/activesupport/lib/active_support/locale/en.rb
+++ b/activesupport/lib/active_support/locale/en.rb
@@ -5,7 +5,7 @@
   en: {
     number: {
       nth: {
-        ordinals: lambda do |_key, options|
+        ordinals: ActiveSupport::Ractors.shareable_lambda do |_key, options|
           number = options[:number]
           case number
           when 1; "st"
@@ -24,7 +24,7 @@
           end
         end,
 
-        ordinalized: lambda do |_key, options|
+        ordinalized: ActiveSupport::Ractors.shareable_lambda do |_key, options|
           number = options[:number]
           "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
         end

--- a/activesupport/test/i18n_test.rb
+++ b/activesupport/test/i18n_test.rb
@@ -3,6 +3,7 @@
 require_relative "abstract_unit"
 require "active_support/time"
 require "active_support/core_ext/array/conversions"
+require "active_support/testing/ractors_assertions"
 
 class I18nTest < ActiveSupport::TestCase
   def setup
@@ -102,5 +103,16 @@ class I18nTest < ActiveSupport::TestCase
 
   def test_to_sentence_with_empty_i18n_store
     assert_equal "a, b, and c", %w[a b c].to_sentence(locale: "empty")
+  end
+
+  class RactorTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::RactorsAssertions
+    include ActiveSupport::Testing::Isolation
+
+    test "en.rb contents are Ractor shareable" do
+      contents = I18n.translate(:"number.nth", raise: true)
+
+      assert_ractor_make_shareable contents
+    end
   end
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I18n load path procs set by Rails are not Ractor shareable.

### Detail

This Pull Request changes en.rb procs to use the ractor helpers we have to safely cast them to Ractor-safe procs.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
