### PR TITLE
Fix PostgreSQL exclusion constraints with multiline expressions

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -1201,7 +1201,7 @@ module ActiveRecord
           def build_exclusion_constraints(table_name, exclusion_info)
             exclusion_info.map do |row|
               method_and_elements, predicate = row["constraintdef"].split(" WHERE ")
-              method_and_elements_parts = method_and_elements.match(/EXCLUDE(?: USING (?<using>\S+))? \((?<expression>.+)\)/)
+              method_and_elements_parts = method_and_elements.match(/EXCLUDE(?: USING (?<using>\S+))? \((?<expression>.+)\)/m)
               predicate.remove!(/ DEFERRABLE(?: INITIALLY (?:IMMEDIATE|DEFERRED))?/) if predicate
               predicate = predicate.from(2).to(-3) if predicate # strip 2 opening and closing parentheses
 

--- a/activerecord/test/cases/migration/exclusion_constraint_test.rb
+++ b/activerecord/test/cases/migration/exclusion_constraint_test.rb
@@ -92,6 +92,17 @@ if ActiveRecord::Base.lease_connection.supports_exclusion_constraints?
           assert_equal "daterange(start_date, end_date) WITH &&", constraint.expression
         end
 
+        def test_add_exclusion_constraint_with_multiline_expression
+          @connection.add_exclusion_constraint :invoices,
+            "daterange(start_date, CASE WHEN end_date IS NULL THEN 'infinity'::date ELSE end_date END, '[]') WITH &&",
+            using: :gist
+
+          constraint = @connection.exclusion_constraints("invoices").first
+
+          assert_includes constraint.expression, "CASE"
+          assert_includes constraint.expression, "WITH &&"
+        end
+
         def test_add_exclusion_constraint_deferrable_false
           @connection.add_exclusion_constraint :invoices, "daterange(start_date, end_date) WITH &&", using: :gist, deferrable: false
 


### PR DESCRIPTION
### Motivation / Background

PostgreSQL may return exclusion constraint definitions containing newlines from `pg_get_constraintdef`, such as constraints whose expressions contain a `CASE`.

Active Record parsed these definitions with a regular expression whose dot did not match newlines. The match returned `nil`, causing `exclusion_constraints` to raise and schema dumps to omit the affected table.

### Detail

This Pull Request enables multiline matching when parsing PostgreSQL exclusion constraint definitions.

It also adds a PostgreSQL regression test that creates a `CASE`-based exclusion constraint and verifies Active Record reads the expression back.

### Additional information

Formatting the original migration as one line does not avoid the issue because PostgreSQL deparses the stored expression with newlines.

This is separate from #58107, which concerns `WHERE` predicate parsing in the same method.

Verification:

* Targeted regression test: 1 run, 4 assertions, 0 failures, 0 errors
* Full PostgreSQL suite: 10,690 runs, 38,546 assertions, 0 failures, 0 errors, 28 skips
* RuboCop on the changed Ruby source and test: no offenses
* `git diff --check`: clean

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.