### PR TITLE
Fix RouteSetTest::SimpleApp#call referencing an undefined local variable

### DIFF
--- a/actionpack/test/dispatch/routing/route_set_test.rb
+++ b/actionpack/test/dispatch/routing/route_set_test.rb
@@ -15,7 +15,7 @@ module ActionDispatch
         end
 
         def call(env)
-          [ 200, { "Content-Type" => "text/plain" }, [response] ]
+          [ 200, { "Content-Type" => "text/plain" }, [@response] ]
         end
       end
 
@@ -31,6 +31,18 @@ module ActionDispatch
         end
 
         assert_not_empty @set
+      end
+
+      test "dispatching a request to a route added with a rack app" do
+        draw do
+          get "foo", to: SimpleApp.new("foo#index")
+        end
+
+        env = Rack::MockRequest.env_for("/foo", "REQUEST_METHOD" => "GET")
+        status, _headers, body = @set.call(env)
+
+        assert_equal 200, status
+        assert_equal ["foo#index"], body.each.to_a
       end
 
       class FooController < ActionController::Base


### PR DESCRIPTION
### Motivation / Background

`RouteSetTest::SimpleApp#initialize` stores its argument in `@response`, but `#call` returns the bare word `response`, which resolves to neither a local variable nor a method in that scope. Dispatching a request to a route mounted on a `SimpleApp` therefore raises `NameError` instead of returning the stored Rack body:

```
NameError: undefined local variable or method 'response' for an instance of SimpleApp
```

This went unnoticed because every existing test in `route_set_test.rb` uses `SimpleApp.new(...)` only as a routing target, to inspect route and URL helper generation. None of them dispatch a request through the route set, so the broken line is never exercised.

### Detail

- `actionpack/test/dispatch/routing/route_set_test.rb`: `[response]` becomes `[@response]` in `SimpleApp#call`.
- Add a regression test that draws the route and dispatches a real request through `@set.call`, asserting on the returned status and body, so the app object is actually invoked.

### Additional information

`bin/test` does not run on this machine: the workspace bundle does not resolve here (151 gems missing) and I did not want to touch the `Gemfile` or install anything. CI is the real check.

I did run the new test itself, under minitest and `ActiveSupport::TestCase`, loading `SimpleApp` and the test body straight out of `route_set_test.rb` and skipping only `abstract_unit`:

```
# with [@response]
1 runs, 2 assertions, 0 failures, 0 errors, 0 skips

# with [response], the ivar removed again
RouteSetNewTest#test_dispatching_a_request_to_a_route_added_with_a_rack_app:
NameError: undefined local variable or method 'response' for an instance of SimpleApp
    actionpack/lib/action_dispatch/routing/mapper.rb:62:in 'Constraints#serve'
    actionpack/lib/action_dispatch/journey/router.rb:31:in 'Router#serve'
    actionpack/lib/action_dispatch/routing/route_set.rb:913:in 'RouteSet#call'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
```

The failure goes through the real `RouteSet#call`, so the new test does exercise dispatch rather than the app object in isolation.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.


> Spotted by itaruby(to be released), a Ruby type checker I'm working on.
