### PR TITLE
Fix QueryCacheRegistry#clear calling an undefined method

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -123,7 +123,7 @@ module ActiveRecord
         end
 
         def clear
-          @map.synchronize do
+          @mutex.synchronize do
             @map.clear
           end
         end

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -1189,3 +1189,15 @@ class TransactionInCachedSqlActiveRecordPayloadTest < ActiveRecord::TestCase
     assert_same expected_transaction, notification.payload[:transaction]
   end
 end
+
+class QueryCacheRegistryTest < ActiveRecord::TestCase
+  def test_clear_drops_the_cached_stores
+    registry = ActiveRecord::ConnectionAdapters::QueryCache::QueryCacheRegistry.new
+    store = registry.compute_if_absent(Thread.current) { Object.new }
+    assert_same store, registry.compute_if_absent(Thread.current) { Object.new }
+
+    registry.clear
+
+    assert_not_same store, registry.compute_if_absent(Thread.current) { Object.new }
+  end
+end


### PR DESCRIPTION
### Motivation / Background

`QueryCacheRegistry#clear` wraps its work in `@map.synchronize`, but `@map` is a `ConnectionPool::WeakThreadKeyMap`, which does not respond to `synchronize` on either branch of its definition. On Ruby >= 3.3.5 it is an alias for `ObjectSpace::WeakKeyMap`; below that, the fallback class defines only `initialize`, `clear`, `[]` and `[]=`. Calling `#clear` raises:

```
NoMethodError: undefined method 'synchronize' for an instance of ObjectSpace::WeakKeyMap
    activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:126:in 'QueryCacheRegistry#clear'
```

Nothing in the framework calls `#clear` today: `@thread_query_caches` is only ever reached through `#compute_if_absent`. The bug is therefore dormant rather than user visible, but the method is broken for anyone who calls it, including future callers inside Active Record.

### Detail

- `activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb`: `@map.synchronize` becomes `@mutex.synchronize`. `@mutex` is assigned in `#initialize` and `#compute_if_absent` already guards `@map` with it exactly this way, so this is the mutex the method was reaching for.
- Add a regression test asserting the actual contract of `#clear`, that a context which had a cached store gets a fresh one afterwards, which exercises the method rather than only asserting it does not raise.

### Additional information

`bin/test` does not run on this machine: the workspace bundle does not resolve here and I did not want to touch the `Gemfile` or install anything. CI is the real check.

I did run the new test, under minitest, using the real `QueryCacheRegistry` from this branch and the test body read out of `query_cache_test.rb`, skipping only the Active Record test helper, which the new test does not need since it touches no database:

```
# with @mutex.synchronize
1 runs, 2 assertions, 0 failures, 0 errors, 0 skips

# with @map.synchronize, the fix reverted in the file
QueryCacheRegistryTest#test_clear_drops_the_cached_stores:
NoMethodError: undefined method 'synchronize' for an instance of ObjectSpace::WeakKeyMap
    activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:126:in 'QueryCacheRegistry#clear'

1 runs, 1 assertions, 0 failures, 1 errors, 0 skips
```

Both branches of `WeakThreadKeyMap` were checked on Ruby 3.4.2, the second one by evaluating the fallback class as it is written in `connection_pool.rb`:

```
ObjectSpace::WeakKeyMap#synchronize -> NoMethodError
fallback WeakThreadKeyMap instance methods -> [:[], :[]=, :clear]
```

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

> Spotted by itaruby(to be released), a Ruby type checker I'm working on.
