### PR TITLE
Remove unused `request` helper from RouteSetTest

### DIFF
--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -1014,10 +1014,6 @@ class RouteSetTest < ActiveSupport::TestCase
     @set = make_set
   end
 
-  def request
-    @request ||= ActionController::TestRequest.new
-  end
-
   def default_route_set
     @default_route_set ||= begin
       set = ActionDispatch::Routing::RouteSet.new


### PR DESCRIPTION
### Motivation / Background

Follow-up to the recent unused-code cleanups (#58217, #58219, #58223), in the same spirit: one piece of dead code, verified with repo-wide greps including dynamic dispatch.

`RouteSetTest#request` memoized `ActionController::TestRequest.new`, but that constructor takes three required arguments (`actionpack/lib/action_controller/test_case.rb:69`):

```ruby
def initialize(env, session, controller_class)
```

So the helper raised `ArgumentError` on any call. It was never called, which is why the suite is green.

### Detail

`ActionDispatch::RoutingVerbs`, included in the class, was the plausible caller. It is not one: it dispatches through `routes.call(params)` and reads `controller.request`, the controller's own request, never the helper. `RoutingTestHelpers`, also included, neither defines nor uses `request`.

Verification, matching the standard the cleanup PRs above used:

* the only `request` occurrences in the class body are `request_path_params` calls and a `lambda { |request| ... }` constraint parameter, which is that block's own local
* no `send(:request)`, `public_send(:request)` or `respond_to?(:request)` anywhere under `actionpack/test`
* no `method_missing` and no `delegate` in the file

### Additional information

`bin/test` does not run on this machine: the workspace bundle does not resolve here and I did not want to touch the `Gemfile` or install anything. CI is the real check. The file parses (`ruby -c` clean), and since the removed method has no callers there is no behavior to exercise.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

### Why the helper cannot be in use

The stronger argument than grepping for callers: `ActionController::TestRequest#initialize` takes three required positionals (`env`, `session`, `controller_class`), and the helper called `ActionController::TestRequest.new` with none. Any invocation raises `ArgumentError`, so nothing on a passing path can be calling it, whatever the greps say. The factory the rest of the suite uses is `TestRequest.create(controller_class)`.

For completeness on the lookup side: `RouteSetTest` includes `RoutingTestHelpers` and `ActionDispatch::RoutingVerbs`, and neither calls a bare `request`. `RoutingVerbs#request_path_params` calls `controller.request`, a different receiver. The only bare `request` tokens inside the class body are block parameters of a routing constraint lambda, which are locals.

> Spotted by itaruby(to be released), a Ruby type checker I'm working on.

