### PR TITLE
Remove unused Active Record internals

### DIFF
--- a/activerecord/lib/arel/nodes/homogeneous_in.rb
+++ b/activerecord/lib/arel/nodes/homogeneous_in.rb
@@ -52,11 +52,7 @@ module Arel # :nodoc: all
       end
 
       def fetch_attribute(&block)
-        if attribute
-          attribute.fetch_attribute(&block)
-        else
-          expr.fetch_attribute(&block)
-        end
+        attribute.fetch_attribute(&block)
       end
 
       protected

--- a/activerecord/test/cases/arel/nodes/homogeneous_in_test.rb
+++ b/activerecord/test/cases/arel/nodes/homogeneous_in_test.rb
@@ -29,6 +29,32 @@ class Arel::Nodes::HomogeneousInTest < Arel::Test
     }, expr.to_sql
   end
 
+  test "fetch_attribute yields the attribute" do
+    table = Arel::Table.new name: :users, type_caster: fake_pg_caster
+
+    expr = Arel::Nodes::HomogeneousIn.new(["Bobby", "Robert"], table[:name], :in)
+
+    fetched = []
+    expr.fetch_attribute { |attribute| fetched << attribute }
+
+    assert_equal [table[:name]], fetched
+  end
+
+  test "fetch_attribute yields nothing for an attribute node that is a function" do
+    table = Arel::Table.new name: :users, type_caster: fake_pg_caster
+
+    node = TypedNode.new("COALESCE",
+                         [table[:nickname], table[:name]],
+                         STRING_TYPE
+                        )
+    expr = Arel::Nodes::HomogeneousIn.new(["Bobby", "Robert"], node, :in)
+
+    fetched = []
+
+    assert_nil expr.fetch_attribute { |attribute| fetched << attribute }
+    assert_empty fetched
+  end
+
   private
     STRING_TYPE = ActiveModel::Type::String.new.freeze
 

--- a/activerecord/test/cases/arel/support/fake_record.rb
+++ b/activerecord/test/cases/arel/support/fake_record.rb
@@ -109,10 +109,6 @@ module FakeRecord
       @connection.tables.include? name.to_s
     end
 
-    def columns_hash
-      @connection.columns_hash
-    end
-
     def schema_cache
       @connection
     end


### PR DESCRIPTION
### Motivation / Background

Follow-up to the recent unused-code cleanups (#58217, #58219, #58223), same shape: one commit per piece of dead code, each verified with repo-wide greps including dynamic dispatch.

Two pieces, both of which would raise if they were ever reached.

**`HomogeneousIn#fetch_attribute`** guarded on `attribute` and fell back to `expr`, which is not defined anywhere in Arel, so the else branch would raise `NameError`. It cannot be taken: every construction site passes a real attribute (`PredicateBuilder::ArrayHandler`, `#invert`, and the node's own tests), and `#right`, `#casted_values` and `#proc_for_binds` all call `attribute.` with no guard at all, so a falsy attribute would break the node in three other places before reaching this one.

**The Arel fake record's `columns_hash`** called `@connection.columns_hash` with no argument, while `FakeConnection#columns_hash(table_name)` requires one, so it raised `ArgumentError` on any call.

### Detail

Verification for each:

* `grep -c 'def expr'` across Arel: 0
* every `.columns_hash` in the repository is `SomeModel.columns_hash`, the unrelated Active Record method; nothing calls the fake record's
* no `send(:columns_hash)`, `public_send`, or `respond_to?` reaching either symbol
* no `method_missing` and no `delegate` in `homogeneous_in.rb` or `fake_record.rb`
* `fetch_attribute` itself stays: it is called through `Arel.fetch_attribute` and `Node#fetch_attribute`. Only the dead branch goes.

### Additional information

`bin/test` does not run on this machine: the workspace bundle does not resolve here and I did not want to touch the `Gemfile` or install anything. CI is the real check.

For the branch removal I exercised `fetch_attribute` through the real Arel path on both revisions, building a `HomogeneousIn` over `Arel::Table.new(name: :users)[:name]`, and the behavior is identical:

```
# before
fetch_attribute yielded: #<struct Arel::Attributes::Attribute relation=#<Arel::Table @name="users">, name="name">
Arel.fetch_attribute: "users"
equality?: true  invert: :notin

# after
fetch_attribute yielded: #<struct Arel::Attributes::Attribute relation=#<Arel::Table @name="users">, name="name">
Arel.fetch_attribute: "users"
equality?: true  invert: :notin
```

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

### On the missing test

The reasonable objection to a removal like this is that nothing in the suite would catch it if the branch were reachable. `HomogeneousIn#fetch_attribute` had no test at all: `homogeneous_in_test.rb` only covered `#to_sql`. The third commit adds that coverage, so the surviving path is now pinned.

To be precise about what the tests do and do not prove: they pass identically before and after the removal, because `attribute` is always present. They are coverage for a method that had none, not a regression test for the branch.

The branch itself is unreachable because `expr` is not defined on the class. `HomogeneousIn < Node`, and `expr` exists only as `attr_accessor :expr` on `Arel::Nodes::Unary`, which `Grouping` inherits and uses legitimately in the same shape. `HomogeneousIn` does not inherit from `Unary`, so the fallback would raise. Every construction site passes a real attribute, and `#right`, `#casted_values` and `#proc_for_binds` all dereference `attribute.` with no guard, so a nil attribute could never have worked anyway.

> Spotted by itaruby(to be released), a Ruby type checker I'm working on.

