### PR TITLE
Remove unreachable default for DerivedSecretKeyProvider#derive_key_from

### DIFF
--- a/activerecord/lib/active_record/encryption/derived_secret_key_provider.rb
+++ b/activerecord/lib/active_record/encryption/derived_secret_key_provider.rb
@@ -9,7 +9,7 @@ module ActiveRecord
       end
 
       private
-        def derive_key_from(password, using: key_generator)
+        def derive_key_from(password, using:)
           secret = using.derive_key_from(password)
           ActiveRecord::Encryption::Key.new(secret)
         end


### PR DESCRIPTION
### Motivation / Background

Follow-up to the recent unused-code cleanups (#58217, #58219, #58223), same shape: one piece of dead code, verified with repo-wide greps including dynamic dispatch.

`DerivedSecretKeyProvider#derive_key_from` declares `using: key_generator` as its default, but `key_generator` is not a method on the instance. The `key_generator` visible in `#initialize` is that method's own keyword argument, so the default cannot resolve:

```
NameError: undefined local variable or method 'key_generator' for an instance of
ActiveRecord::Encryption::DerivedSecretKeyProvider
```

### Detail

The default is unreachable, so this is a cleanup rather than a bug fix:

* `derive_key_from` is `private`
* its only caller, `#initialize`, always passes `using: key_generator` explicitly
* neither subclass calls it: `DeterministicKeyProvider` (library) and `EncryptedPost::MutableDerivedSecretKeyProvider` (test model) both only override `#initialize` or add an accessor
* no `send(:derive_key_from)` or `public_send` anywhere in the repository

Making the keyword required states the actual contract: the caller supplies the generator. No working call changes behavior. A call that omits `using:` raised before and still raises, `ArgumentError` instead of `NameError`.

### Additional information

`bin/test` does not run on this machine: the workspace bundle does not resolve here and I did not want to touch the `Gemfile` or install anything. CI is the real check.

I exercised the reachable paths on both revisions, with encryption configured, and they are identical:

```
# before                                        # after
caminho normal: Encryption::Key                 caminho normal: Encryption::Key
DeterministicKeyProvider: Encryption::Key       DeterministicKeyProvider: Encryption::Key
default via send: NameError                     default via send: ArgumentError (missing keyword: :using)
```

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

> Spotted by itaruby(to be released), a Ruby type checker I'm working on.
