### PR TITLE
Fix RedisCacheStore clear and stats with redis-client

### DIFF
--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -306,14 +306,14 @@ module ActiveSupport
           if namespace = merged_options(options)[:namespace]
             delete_matched "*", namespace: namespace
           else
-            redis.then { |c| c.flushdb }
+            redis.then { |c| c.call("flushdb") }
           end
         end
       end
 
       # Get info from redis servers.
       def stats
-        redis.then { |c| c.info }
+        redis.then { |c| c.call("info") }
       end
 
       private

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -139,6 +139,30 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       end
   end
 
+  class CommandsTest < ActiveSupport::TestCase
+    setup do
+      skip "Redis server is not up" unless REDIS_UP
+      @cache = ActiveSupport::Cache::RedisCacheStore.new(client: RedisClient.config(url: REDIS_URL), pool: false)
+    end
+
+    teardown do
+      @cache&.redis&.close
+    end
+
+    test "clear without a namespace flushes the database" do
+      @cache.write("foo", "bar")
+      assert_equal "bar", @cache.read("foo")
+
+      @cache.clear
+
+      assert_nil @cache.read("foo")
+    end
+
+    test "stats returns server info" do
+      assert_match(/redis_version/, @cache.stats)
+    end
+  end
+
   class StoreTest < ActiveSupport::TestCase
     module NotificationMiddleware
       def call(command, _redis_config)


### PR DESCRIPTION
### Motivation / Background

`RedisCacheStore#clear` and `#stats` call command methods that `redis-client` does not provide. This raises `NoMethodError` when clearing an unnamespaced cache or reading stats (see https://github.com/redis-rb/redis-client/issues/311)

### Detail

Use `RedisClient#call` for the `FLUSHDB` and `INFO` commands. Add regression tests with a client that only provides `call`.

### Additional information

Tested with `cd activesupport && bin/test test/cache/stores/redis_cache_store_test.rb`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
