### PR TITLE
Run `test:prepare` in a subprocess for `bin/rails test`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Run the `test:prepare` task in a subprocess when `bin/rails test` runs it.
+
+    Prepare tasks that depend on `:environment`, such as the asset builds that
+    gems like `tailwindcss-rails` enhance the task with, booted the application
+    inside the test process before any test file was loaded. Coverage tools
+    started from `test_helper.rb` cannot see code loaded before they start, so
+    `bin/rails test` and `bin/rails test test/` reported different coverage for
+    the same suite. The application now boots in the subprocess, and the test
+    process still boots it from `test_helper.rb`, after coverage has started.
+
+    Fixes #58477.
+
+    *Adrián Mugnolo*
+
 *   Make mounted route helpers (e.g. `main_app`, engine mount proxies) trigger
     the lazy route load instead of raising `NoMethodError` when called before
     routes are drawn.

--- a/railties/lib/rails/commands/rake/rake_command.rb
+++ b/railties/lib/rails/commands/rake/rake_command.rb
@@ -16,6 +16,10 @@ module Rails
           end
         end
 
+        def task_defined?(task)
+          with_rake { |rake| !!rake.lookup(task) }
+        end
+
         def perform(task, args, config)
           with_rake(task, *args) do |rake|
             if unrecognized_task = (rake.top_level_tasks - ["default"]).find { |task| !rake.lookup(task[/[^\[]+/]) }

--- a/railties/lib/rails/commands/test/test_command.rb
+++ b/railties/lib/rails/commands/test/test_command.rb
@@ -77,9 +77,12 @@ module Rails
         end
 
         def run_prepare_task
-          Rails::Command::RakeCommand.perform("test:prepare", [], {})
-        rescue UnrecognizedCommandError => error
-          raise unless error.name == "test:prepare"
+          return unless Rails::Command::RakeCommand.task_defined?("test:prepare")
+
+          # A subprocess keeps prepare tasks that depend on :environment from booting
+          # the app ahead of test_helper.rb and the coverage tools it starts.
+          # Kernel.system: a bare system is the Thor command behind `bin/rails test:system`.
+          Kernel.system("rake", "test:prepare") || exit(false)
         end
     end
   end

--- a/railties/test/commands/test_test.rb
+++ b/railties/test/commands/test_test.rb
@@ -13,6 +13,44 @@ class Rails::Command::TestTest < ActiveSupport::TestCase
     end
   end
 
+  test "test command runs test:prepare task outside the test process" do
+    app_file "Rakefile", <<~RUBY, "a"
+      task booting: :environment do
+        puts "test:prepare booted the app: \#{Rails.application.initialized?}"
+      end
+      Rake::Task["test:prepare"].enhance(["booting"])
+    RUBY
+
+    app_file "test/boot_state_test.rb", <<~RUBY
+      puts "app booted before tests loaded: \#{!!Rails.application&.initialized?}"
+      require "test_helper"
+
+      class BootStateTest < ActiveSupport::TestCase
+        test "truth" do
+          assert true
+        end
+      end
+    RUBY
+
+    output = run_test_command("test")
+    assert_successful_run output
+    assert_match "test:prepare booted the app: true", output
+    assert_match "app booted before tests loaded: false", output
+  end
+
+  test "test command does not run tests when test:prepare fails" do
+    app_file "Rakefile", <<~RUBY, "a"
+      task :failing do
+        abort "test:prepare failed"
+      end
+      Rake::Task["test:prepare"].enhance(["failing"])
+    RUBY
+
+    error = assert_raises(RuntimeError) { run_test_command("test") }
+    assert_match "test:prepare failed", error.message
+    assert_no_match "0 failures", error.message
+  end
+
   test "test command with path arg skips test:prepare task" do
     app_file "test/some_test.rb", ""
 


### PR DESCRIPTION
### Motivation / Background

Fixes #58477.

Without a path argument, `bin/rails test` invokes `test:prepare` in process, before minitest loads any test file. Gems enhance that task with asset builds that depend on `:environment` — `tailwindcss-rails`, `jsbundling-rails`, `cssbundling-rails` — so the application boots inside the test process, ahead of everything `test_helper.rb` does.

Coverage tools cannot see code loaded before they start. SimpleCov starts at the top of `test_helper.rb`, where its README says to, and everything the boot already touched reports 0% with no warning. An initializer using `to_prepare` to reference an application constant — the pattern the autoloading guide prescribes — is enough to load `ApplicationController` and every file in `app/helpers`. A path argument matches `EXACT_TEST_ARGUMENT_PATTERN` and skips prepare, so `bin/rails test` and `bin/rails test test/` disagree about the same suite.

The early boot also front-runs `test_helper.rb` itself: anything the helper sets up before `require_relative "../config/environment"` — coverage, environment variables, framework configuration — is skipped or ignored, because the requires inside are already satisfied.

### Detail

`run_prepare_task` now runs the task in a subprocess, the way this same flow already shells out elsewhere: `maintain_test_schema!` runs `bin/rails db:test:prepare`, and `test:db` runs `rake db:test:prepare test`. The application still boots for the prepare task — in the subprocess — and the test process still boots it from `test_helper.rb`, after coverage has started. The extra boot lands only on invocations that run prepare at all.

Whether the task exists is still decided in process, through the Rakefile that `RakeCommand` already loads, so an application or plugin with no `test:prepare` task keeps running its tests as before instead of failing on rake's unknown-task error. Loading the Rakefile does not initialize the application; only running `:environment` does.

Two details of the invocation. `Kernel.system`, because inside `TestCommand` a bare `system` is the Thor command behind `bin/rails test:system`. And a bare `rake` rather than `bin/rake`, matching `test:db` and `Runner.run_from_rake`: it works in plugins, which generate no `bin/rake`, and inherits the Bundler environment either way. A failing prepare task still stops the run with a nonzero exit, as the in-process rake session did, and now it is covered by a test.

### Additional information

simplecov-ruby/simplecov#1082 reports the same problem from the other side. It closed with a workaround — starting coverage inside `bin/rails` — which conflicts with Bootsnap's compile cache. Only Rails can fix this ordering.

The alternative in #58477, deferring the invoke until after test files load, avoids the extra boot but reorders prepare relative to test file loading, which would break prepare tasks that generate code the tests require. The subprocess keeps the documented ordering: prepare first, then tests.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
