### PR TITLE
Fix RedisCacheStore#clear and #stats with multiple Redis URLs

### DIFF
--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -306,14 +306,15 @@ module ActiveSupport
           if namespace = merged_options(options)[:namespace]
             delete_matched "*", namespace: namespace
           else
-            redis.then { |c| c.call("flushdb") }
+            redis.nodes.each { |node| node.call("flushdb") }
           end
         end
       end
 
       # Get info from redis servers.
       def stats
-        redis.then { |c| c.call("info") }
+        infos = redis.nodes.map { |node| node.call("info") }
+        infos.size == 1 ? infos.first : infos
       end
 
       private

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -75,6 +75,34 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       assert_equal REDIS_URLS.map { |u| u.delete_suffix("/0") }, @cache.redis.nodes.map { |n| n.config.server_url }
     end
 
+    test "clear without a namespace issues FLUSHDB on each HashRing node" do
+      @cache = build url: REDIS_URLS
+      flushed = []
+
+      @cache.redis.nodes.each do |node|
+        node.define_singleton_method(:call) do |command, *|
+          flushed << command
+          "OK"
+        end
+      end
+
+      @cache.clear
+
+      assert_equal ["flushdb"] * REDIS_URLS.size, flushed
+    end
+
+    test "stats collects INFO from each HashRing node" do
+      @cache = build url: REDIS_URLS
+
+      @cache.redis.nodes.each_with_index do |node, index|
+        node.define_singleton_method(:call) do |command, *|
+          "info-#{index}" if command == "info"
+        end
+      end
+
+      assert_equal ["info-0", "info-1"], @cache.stats
+    end
+
     test "one :client Config" do
       @cache = ActiveSupport::Cache::RedisCacheStore.new(client: RedisClient.config(url: REDIS_URL))
       assert_equal 1, @cache.redis.connect_timeout


### PR DESCRIPTION
### Motivation / Background

Fixes #58573

`clear` and `stats` raise `NoMethodError` when the store is configured with more than one Redis URL.

### Detail

Those methods now talk to each Redis server instead of treating the ring as a single client. One URL still works as before.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.