### PR TITLE
Actionpack ractorize

### DIFF
--- a/actionpack/lib/action_dispatch/http/param_builder.rb
+++ b/actionpack/lib/action_dispatch/http/param_builder.rb
@@ -16,7 +16,7 @@ module ActionDispatch
       @param_depth_limit = param_depth_limit
     end
 
-    cattr_accessor :default
+    singleton_class.attr_accessor :default
     self.default = make_default(100).freeze
 
     class << self

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -28,7 +28,7 @@ module ActionDispatch
     include ActionDispatch::ContentSecurityPolicy::Request
     include Rack::Request::Env
 
-    LOCALHOST   = Regexp.union [/^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/, /^::1$/, /^0:0:0:0:0:0:0:1(%.*)?$/]
+    LOCALHOST = Regexp.union([/^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/, /^::1$/, /^0:0:0:0:0:0:0:1(%.*)?$/]).freeze
 
     ENV_METHODS = %w[ AUTH_TYPE GATEWAY_INTERFACE
         PATH_TRANSLATED REMOTE_HOST

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -2,7 +2,7 @@
 
 # :markup: markdown
 
-require "active_support/core_ext/module/attribute_accessors"
+require "active_support/core_ext/class/attribute"
 require "action_dispatch/http/filter_redirect"
 require "action_dispatch/http/cache"
 require "monitor"
@@ -99,8 +99,8 @@ module ActionDispatch # :nodoc:
     SET_COOKIE   = "Set-Cookie"
     NO_CONTENT_CODES = [100, 101, 102, 103, 204, 205, 304].freeze
 
-    cattr_accessor :default_charset, default: "utf-8"
-    cattr_accessor :default_headers
+    class_attribute :default_charset, default: "utf-8", instance_accessor: false
+    class_attribute :default_headers, instance_accessor: false
 
     include Rack::Response::Helpers
     # Aliasing these off because AD::Http::Cache::Response defines them.

--- a/actionpack/test/dispatch/param_builder_test.rb
+++ b/actionpack/test/dispatch/param_builder_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "abstract_unit"
+require "active_support/testing/ractors_assertions"
 
 class ParamBuilderTest < ActiveSupport::TestCase
   # Much of the behavioral details are covered by long-standing
@@ -27,5 +28,19 @@ class ParamBuilderTest < ActiveSupport::TestCase
 
     result = ActionDispatch::ParamBuilder.from_query_string("[foo][bar]=baz")
     assert_equal({ "[foo]" => { "bar" => "baz" } }, result)
+  end
+
+  class RactorTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::RactorsAssertions
+
+    test "default builder is Ractor shareable" do
+      assert_ractor_shareable ActionDispatch::ParamBuilder.default
+    end
+
+    test "parses a query string through the default builder on a non-main Ractor" do
+      params = on_ractor { ActionDispatch::ParamBuilder.from_query_string("a=1&b[c]=2") }
+
+      assert_equal({ "a" => "1", "b" => { "c" => "2" } }, params)
+    end
   end
 end

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "abstract_unit"
+require "active_support/testing/ractors_assertions"
 
 class BaseRequestTest < ActiveSupport::TestCase
   def setup
@@ -14,6 +15,23 @@ class BaseRequestTest < ActiveSupport::TestCase
   def url_for(options = {})
     options = { host: "www.example.com" }.merge!(options)
     ActionDispatch::Http::URL.url_for(options)
+  end
+
+  class RactorTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+    include ActiveSupport::Testing::RactorsAssertions
+
+    test "LOCALHOST is Ractor shareable" do
+      assert_ractor_shareable ActionDispatch::Request::LOCALHOST
+    end
+
+    test "local? matches loopback addresses on a non-main Ractor" do
+      local = on_ractor do
+        ActionDispatch::Request.new("REMOTE_ADDR" => "127.0.0.1", "action_dispatch.remote_ip" => "::1").local?
+      end
+
+      assert local
+    end
   end
 
   private

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "abstract_unit"
+require "active_support/core_ext/object/with"
+require "active_support/testing/ractors_assertions"
 require "timeout"
 require "rack/content_length"
 
@@ -431,6 +433,22 @@ class ResponseTest < ActiveSupport::TestCase
 
     _status, headers, _body = Rack::ContentLength.new(app).call(env)
     assert_header "content-length", "5", headers
+  end
+
+  class RactorTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::RactorsAssertions
+
+    test "default_charset is readable from a non-main Ractor" do
+      assert_equal "utf-8", on_ractor { ActionDispatch::Response.default_charset }
+    end
+
+    test "default_headers assigned on the main Ractor are readable from a non-main Ractor" do
+      headers = { "x-frame-options" => "SAMEORIGIN" }.freeze
+
+      ActionDispatch::Response.with(default_headers: headers) do
+        assert_equal headers, on_ractor { ActionDispatch::Response.default_headers }
+      end
+    end
   end
 end
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because various components of Action Pack are not ractor safe. This fixes a few of them.

### Detail

This Pull Request changes the following:
- Make `ActionDispatch::ParamBuilder.default` ractor safe by using singleton class attr accessor.
- Make `ActionDispatch::Request::LOCALHOST` ractor safe by freezing the regex.
- Make `ActionDispatch::Response.default_charset` and `ActionDispatch::Response.default_headers` ractor safe by using class attributes.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
