### PR TITLE
Support primary key resetting on Ractors

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -99,10 +99,12 @@ module ActiveRecord
           end
 
           def reset_primary_key # :nodoc:
-            if base_class?
-              self.primary_key = get_primary_key(base_class.name)
-            else
-              self.primary_key = base_class.primary_key
+            ActiveSupport::Ractors.on_main(self) do
+              if base_class?
+                self.primary_key = get_primary_key(base_class.name)
+              else
+                self.primary_key = base_class.primary_key
+              end
             end
           end
 

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -33,6 +33,10 @@ class PrimaryKeysTest < ActiveRecord::TestCase
     assert_nil on_ractor { NonPrimaryKey.primary_key }
   end
 
+  def test_primary_key_can_be_reset_from_a_ractor
+    assert_equal "id", on_ractor { Topic.reset_primary_key }
+  end
+
   def test_query_constraints_list_is_ractor_shareable
     assert_ractor_shareable Topic.query_constraints_list
   end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because primary key assignment doesn't seem to work on non main ractors.

### Detail

This Pull Request changes `reset_primary_key` to happen on the main ractor to make non main ractors proxy to the main ractor for assignment, if it isn't already set.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
