### PR TITLE
Ractorize Active Record schema context

### DIFF
--- a/activemodel/lib/active_model/attribute_registration.rb
+++ b/activemodel/lib/active_model/attribute_registration.rb
@@ -8,10 +8,14 @@ module ActiveModel
   module AttributeRegistration # :nodoc:
     extend ActiveSupport::Concern
 
+    included do
+      @pending_attribute_modifications = []
+    end
+
     module ClassMethods # :nodoc:
       def inherited(base)
         super
-        base.instance_variable_set(:@pending_attribute_modifications, nil)
+        base.instance_variable_set(:@pending_attribute_modifications, [])
       end
 
       def attribute(name, type = nil, default: (no_default = true), **options)
@@ -19,8 +23,8 @@ module ActiveModel
         type = resolve_type_name(type, **options) if type.is_a?(Symbol)
         type = hook_attribute_type(name, type) if type
 
-        pending_attribute_modifications << PendingType.new(name, type) if type || no_default
-        pending_attribute_modifications << PendingDefault.new(name, default) unless no_default
+        add_pending_attribute_modification(PendingType.new(name, type)) if type || no_default
+        add_pending_attribute_modification(PendingDefault.new(name, default)) unless no_default
 
         reset_default_attributes
       end
@@ -28,7 +32,7 @@ module ActiveModel
       def decorate_attributes(names = nil, &decorator) # :nodoc:
         names = names&.map { |name| resolve_attribute_name(name) }
 
-        pending_attribute_modifications << PendingDecorator.new(names, decorator)
+        add_pending_attribute_modification(PendingDecorator.new(names, decorator))
 
         reset_default_attributes
       end
@@ -66,6 +70,14 @@ module ActiveModel
         end
       end
 
+      def make_pending_attribute_modifications_shareable # :nodoc:
+        if superclass.respond_to?(:make_pending_attribute_modifications_shareable, true)
+          superclass.send(:make_pending_attribute_modifications_shareable)
+        end
+
+        @pending_attribute_modifications = ActiveSupport::Ractors.try_make_shareable(@pending_attribute_modifications)
+      end
+
       private
         PendingType = Struct.new(:name, :type) do # :nodoc:
           def apply_to(attribute_set)
@@ -90,8 +102,10 @@ module ActiveModel
           end
         end
 
-        def pending_attribute_modifications
-          @pending_attribute_modifications ||= []
+        attr_reader :pending_attribute_modifications
+
+        def add_pending_attribute_modification(modification)
+          @pending_attribute_modifications = [*@pending_attribute_modifications, modification]
         end
 
         def reset_default_attributes

--- a/activemodel/lib/active_model/type.rb
+++ b/activemodel/lib/active_model/type.rb
@@ -36,9 +36,11 @@ module ActiveModel
       end
 
       def default_value # :nodoc:
-        @default_value ||= Value.new
+        DEFAULT_TYPE
       end
     end
+
+    DEFAULT_TYPE = Value.new.freeze # :nodoc:
 
     register(:big_integer, Type::BigInteger)
     register(:binary, Type::Binary)

--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -255,11 +255,11 @@ module ActiveRecord
       end
 
       def _default_attributes # :nodoc:
-        schema_context._default_attributes
+        schema_context.attributes.defaults
       end
 
       def attribute_types # :nodoc:
-        schema_context.attribute_types
+        schema_context.attributes.types
       end
 
       def type_for_column(column) # :nodoc:

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -462,7 +462,7 @@ module ActiveRecord
       end
 
       def attributes_builder # :nodoc:
-        schema_context.attributes_builder
+        schema_context.attributes.builder
       end
 
       def columns_hash # :nodoc:
@@ -474,11 +474,15 @@ module ActiveRecord
       end
 
       def _returning_columns_for_insert(connection) # :nodoc:
-        schema_context._returning_columns_for_insert(connection)
+        @_returning_columns_for_insert || ActiveSupport::Ractors.on_main(self) do
+          @_returning_columns_for_insert ||= schema_context._returning_columns_for_insert(connection)
+        end
       end
 
       def _returning_columns_for_update(connection) # :nodoc:
-        schema_context._returning_columns_for_update(connection)
+        @_returning_columns_for_update || ActiveSupport::Ractors.on_main(self) do
+          @_returning_columns_for_update ||= schema_context._returning_columns_for_update(connection)
+        end
       end
 
       # Returns the column object for the named attribute.
@@ -504,7 +508,7 @@ module ActiveRecord
       # Returns a hash where the keys are column names and the values are
       # default values when instantiating the Active Record object for this table.
       def column_defaults
-        schema_context.column_defaults
+        schema_context.attributes.column_defaults
       end
 
       # Returns an array of column names as strings.
@@ -557,12 +561,12 @@ module ActiveRecord
       # or directly from the database.
       def load_schema
         return if schema_loaded?
+
         @load_schema_monitor.synchronize do
           unless schema_loaded? || @schema_context
-            context = build_schema_context
-            @schema_context = context
-            context.load_schema!
-
+            @schema_context = build_schema_context
+            @schema_context.load_schema!
+            ActiveSupport::Ractors.make_shareable(@schema_context)
             unless @schema_hooks_loaded
               load_schema!
               @schema_hooks_loaded = true
@@ -596,6 +600,8 @@ module ActiveRecord
 
         def reload_schema_contexts_from_cache
           @schema_context = nil
+          @_returning_columns_for_insert = nil
+          @_returning_columns_for_update = nil
         end
 
       private

--- a/activerecord/lib/active_record/model_schema/schema_context.rb
+++ b/activerecord/lib/active_record/model_schema/schema_context.rb
@@ -7,12 +7,48 @@ module ActiveRecord
     # SchemaContext owns all schema-derived state for a model: columns,
     # attribute types, and column defaults.
     class SchemaContext # :nodoc:
+      # Attributes owns a model's attribute-derived state: attribute
+      # defaults, attribute types, and column defaults.
+      class Attributes # :nodoc:
+        attr_reader :context, :defaults
+
+        def initialize(context)
+          attribute_set = context.attribute_set
+          context.model_class.apply_pending_attribute_modifications(attribute_set)
+
+          @defaults = attribute_set
+          @context = context
+        end
+
+        def types
+          @types ||= defaults.cast_types.tap do |hash|
+            hash.default = ActiveModel::Type.default_value
+          end
+        end
+
+        def builder
+          primary_key_defaults = defaults.except(*(context.model_class.column_names - Array(context.model_class.primary_key)))
+          ActiveModel::AttributeSet::Builder.new(types, primary_key_defaults)
+        end
+
+        def column_defaults
+          @column_defaults ||= defaults.deep_dup.to_hash.freeze
+        end
+      end
+
       attr_reader :model_class, :columns_hash, :columns, :column_names,
-                  :attribute_types, :content_columns
+                  :content_columns
 
       def initialize(model_class)
         @model_class = model_class
         @schema_loaded = false
+        @attributes_key = :"active_record_schema_attributes_#{object_id}"
+      end
+
+      def attributes
+        ActiveSupport::Ractors.store_if_absent(@attributes_key) do
+          Attributes.new(self)
+        end
       end
 
       def table_name
@@ -23,35 +59,18 @@ module ActiveRecord
         model_class.primary_key
       end
 
-      def _default_attributes
-        @default_attributes
-      end
-
-      def attributes_builder
-        defaults = _default_attributes.except(*(column_names - Array(primary_key)))
-        ActiveModel::AttributeSet::Builder.new(attribute_types, defaults)
-      end
-
-      def column_defaults
-        @column_defaults ||= _default_attributes.deep_dup.to_hash.freeze
-      end
-
       def _returning_columns_for_insert(connection)
-        @_returning_columns_for_insert || ActiveSupport::Ractors.on_main(self) do
-          @_returning_columns_for_insert ||= begin
-            auto_populated_columns = columns.filter_map do |c|
-              -c.name if connection.return_value_after_insert?(c)
-            end
-
-            (auto_populated_columns.empty? ? Array(primary_key) : auto_populated_columns).freeze
-          end
+        auto_populated_columns = columns.filter_map do |c|
+          -c.name if connection.return_value_after_insert?(c)
         end
+
+        (auto_populated_columns.empty? ? Array(primary_key) : auto_populated_columns).freeze
       end
 
       def _returning_columns_for_update(connection)
-        @_returning_columns_for_update ||= columns.filter_map do |c|
+        columns.filter_map do |c|
           c.name if connection.return_value_after_update?(c)
-        end
+        end.freeze
       end
 
       def cached_find_by_statement(connection, key, &block) # :nodoc:
@@ -69,6 +88,18 @@ module ActiveRecord
 
       def schema_loaded?
         @schema_loaded
+      end
+
+      def attribute_set
+        attributes_hash = model_class.columns_hash.transform_values do |column|
+          ActiveModel::Attribute.from_database(column.name, column.default, model_class.type_for_column(column))
+        end
+        ActiveModel::AttributeSet.new(attributes_hash)
+      end
+
+      def freeze
+        load_schema!
+        super
       end
 
       def load_schema!
@@ -89,25 +120,14 @@ module ActiveRecord
         @columns = @columns_hash.values.freeze
         @column_names = @columns.map(&:name).freeze
 
-        @default_attributes = begin
-          attributes_hash = @columns_hash.transform_values do |column|
-            ActiveModel::Attribute.from_database(column.name, column.default, model_class.type_for_column(column))
-          end
-
-          attribute_set = ActiveModel::AttributeSet.new(attributes_hash)
-          model_class.apply_pending_attribute_modifications(attribute_set)
-          attribute_set
-        end
-
-        @attribute_types = @default_attributes.cast_types.tap do |hash|
-          hash.default = ActiveModel::Type.default_value
-        end
-
         @content_columns = @columns.reject do |c|
           Array(primary_key).include?(c.name) ||
           c.name == model_class.inheritance_column ||
           c.name.end_with?("_id", "_count")
         end.freeze
+
+        model_class.make_pending_attribute_modifications_shareable
+        attributes
 
         @schema_loaded = true
       end

--- a/activerecord/test/cases/attributes_test.rb
+++ b/activerecord/test/cases/attributes_test.rb
@@ -2,6 +2,7 @@
 
 require "cases/helper"
 require "active_support/testing/ractors_assertions"
+require "active_support/core_ext/object/with"
 
 class OverloadedType < ActiveRecord::Base
   attribute :overloaded_float, :integer
@@ -24,22 +25,6 @@ end
 
 module ActiveRecord
   class CustomPropertiesTest < ActiveRecord::TestCase
-    include ActiveSupport::Testing::RactorsAssertions
-
-    if RUBY_VERSION >= "4.0"
-      test "attribute type is available in a Ractor" do
-        skip "SchemaContext is not yet Ractor-shareable; attribute types are unreachable from a Ractor"
-
-        OverloadedType.reset_column_information
-
-        type = on_ractor do
-          OverloadedType.type_for_attribute("overloaded_float")
-        end
-
-        assert_equal :integer, type.type
-      end
-    end
-
     test "overloading types" do
       data = OverloadedType.new
 
@@ -464,23 +449,24 @@ module ActiveRecord
       assert_equal default_string_type.serialize(false), immutable_string_type.serialize(false)
     end
 
-    class RactorTest < ActiveRecord::TestCase
-      include ActiveSupport::Testing::RactorsAssertions
-      include ActiveSupport::Testing::Isolation unless in_memory_db?
+    if RUBY_VERSION >= "4.0" && !in_memory_db?
 
-      test "default_attributes are Ractor-shareable" do
-        skip "SchemaContext is not yet Ractor-shareable; _default_attributes is unreachable from a Ractor"
-        model = Class.new(ActiveRecord::Base) do
-          def self.name = "ractor_safe_default_attributes"
-          self.table_name = "topics"
-        end
+      class RactorTest < ActiveRecord::TestCase
+        include ActiveSupport::Testing::RactorsAssertions
+        include ActiveSupport::Testing::Isolation
 
-        previous = ActiveSupport::Ractors.unshareable_proc_action
-        ActiveSupport::Ractors.unshareable_proc_action = :raise
-        begin
-          assert_ractor_shareable model._default_attributes
-        ensure
-          ActiveSupport::Ractors.unshareable_proc_action = previous
+
+        test "attribute type is available in a Ractor" do
+          OverloadedType.reset_column_information
+          ActiveSupport::Ractors.with(unshareable_proc_action: :raise) do
+            OverloadedType.load_schema
+          end
+
+          type = on_ractor do
+            OverloadedType.type_for_attribute("overloaded_float")
+          end
+
+          assert_equal :integer, type.type
         end
       end
     end

--- a/activerecord/test/cases/core_test.rb
+++ b/activerecord/test/cases/core_test.rb
@@ -2,6 +2,7 @@
 
 require "cases/helper"
 require "active_support/testing/ractors_assertions"
+require "active_support/core_ext/object/with"
 require "models/person"
 require "models/topic"
 require "pp"
@@ -290,17 +291,28 @@ class CoreTest < ActiveRecord::TestCase
     assert_not_equal Cpk::Book.new(author_id: 1, title: "Same title").hash, Cpk::Book.new(author_id: 1, title: "Same title").hash
   end
 
-  if RUBY_VERSION >= "4.0"
+  if RUBY_VERSION >= "4.0" && !in_memory_db?
     class RactorTest < ActiveRecord::TestCase
       include ActiveSupport::Testing::Isolation
       include ActiveSupport::Testing::RactorsAssertions
 
+      def test_schema_context_is_ractor_shareable_and_accessible_on_a_non_main_ractor
+        model = Class.new(ActiveRecord::Base) do
+          def self.name = "ractor_safe_schema_context"
+          self.table_name = "topics"
+        end
+        context = model.schema_context
+
+        assert_ractor_shareable context
+        assert_same context, on_ractor { model.schema_context }
+      end
+
       def test_find_by_statement_cache_is_ractor_local
-        skip "SchemaContext is not yet Ractor-shareable; will be enabled when SC is made shareable"
         model = Class.new(ActiveRecord::Base) do
           def self.name = "ractor_safe_find_by_cache"
           self.table_name = "topics"
         end
+        model.load_schema
 
         worker_marker, worker_stable = on_ractor do
           cache = model.schema_context.find_by_statement_cache
@@ -311,6 +323,46 @@ class CoreTest < ActiveRecord::TestCase
         assert_equal :from_worker, worker_marker
         assert worker_stable
         assert_nil model.schema_context.find_by_statement_cache[true][:ractor_marker]
+      end
+
+      def test_pending_attribute_modifications_are_shareable_and_applied_on_a_non_main_ractor
+        model = Class.new(ActiveRecord::Base) do
+          def self.name = "ractor_safe_pending_modifications"
+          self.table_name = "topics"
+          attribute :approved, default: true
+          attribute :title, :string, default: -> { "title-#{rand}" }
+        end
+        ActiveSupport::Ractors.with(unshareable_proc_action: :raise) do
+          model.load_schema
+        end
+
+        assert_ractor_shareable model.send(:pending_attribute_modifications)
+
+        approved_default, title_a, title_b = on_ractor do
+          defaults = model.schema_context.attributes.defaults
+          [
+            defaults["approved"].value,
+            defaults.deep_dup.fetch_value("title"),
+            defaults.deep_dup.fetch_value("title"),
+          ]
+        end
+
+        assert_equal true, approved_default
+        assert_match(/\Atitle-/, title_a)
+        assert_not_equal title_a, title_b
+      end
+
+      def test_unshareable_pending_attribute_modifications_do_not_break_schema_load
+        unshareable = +"local default"
+        model = Class.new(ActiveRecord::Base) do
+          def self.name = "ractor_unsafe_pending_modifications"
+          self.table_name = "topics"
+          attribute :title, :string, default: -> { unshareable }
+        end
+
+        assert_nothing_raised { model.load_schema }
+        assert_not_ractor_shareable model.send(:pending_attribute_modifications)
+        assert_equal "local default", model.new.title
       end
     end
   end

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -18,25 +18,6 @@ class PrimaryKeysTest < ActiveRecord::TestCase
 
   fixtures :topics, :subscribers, :movies, :mixed_case_monkeys
 
-  def test_primary_key_can_be_read_from_a_ractor_when_single
-    Topic.primary_key
-    assert_equal "id", on_ractor { Topic.primary_key }
-  end
-
-  def test_primary_key_can_be_read_from_a_ractor_when_composite
-    Cpk::Order.primary_key
-    assert_equal ["shop_id", "id"], on_ractor { Cpk::Order.primary_key }
-  end
-
-  def test_primary_key_can_be_read_from_a_ractor_when_absent
-    NonPrimaryKey.primary_key
-    assert_nil on_ractor { NonPrimaryKey.primary_key }
-  end
-
-  def test_primary_key_can_be_reset_from_a_ractor
-    assert_equal "id", on_ractor { Topic.reset_primary_key }
-  end
-
   def test_query_constraints_list_is_ractor_shareable
     assert_ractor_shareable Topic.query_constraints_list
   end
@@ -361,6 +342,32 @@ class PrimaryKeysTest < ActiveRecord::TestCase
       column = Topic.columns_hash[Topic.primary_key]
       assert_equal "nextval('topics_id_seq'::regclass)", column.default_function
       assert_predicate column, :serial?
+    end
+  end
+
+  if RUBY_VERSION >= "4.0" && !in_memory_db?
+    class PrimaryKeysRactorTest < ActiveRecord::TestCase
+      include ActiveSupport::Testing::Isolation
+      include ActiveSupport::Testing::RactorsAssertions
+
+      def test_primary_key_can_be_read_from_a_ractor_when_single
+        Topic.primary_key
+        assert_equal "id", on_ractor { Topic.primary_key }
+      end
+
+      def test_primary_key_can_be_read_from_a_ractor_when_composite
+        Cpk::Order.primary_key
+        assert_equal ["shop_id", "id"], on_ractor { Cpk::Order.primary_key }
+      end
+
+      def test_primary_key_can_be_read_from_a_ractor_when_absent
+        NonPrimaryKey.primary_key
+        assert_nil on_ractor { NonPrimaryKey.primary_key }
+      end
+
+      def test_primary_key_can_be_reset_from_a_ractor
+        assert_equal "id", on_ractor { Topic.reset_primary_key }
+      end
     end
   end
 end

--- a/activerecord/test/cases/relation/predicate_builder_test.rb
+++ b/activerecord/test/cases/relation/predicate_builder_test.rb
@@ -109,15 +109,18 @@ module ActiveRecord
     class TrackingString < ActiveRecord::Type::String
       include ActiveRecord::Type::QueryPredicates
 
-      attr_reader :expressions
+      class << self
+        def expressions
+          @expressions ||= []
+        end
+      end
 
-      def initialize
-        @expressions = []
-        super
+      def expressions
+        self.class.expressions
       end
 
       def comparison_expression(expression)
-        expressions << expression
+        self.class.expressions << expression
         expression
       end
     end
@@ -125,15 +128,18 @@ module ActiveRecord
     class MutableSerializedType < ActiveRecord::Type::Value
       include ActiveRecord::Type::QueryPredicates
 
-      attr_reader :serializations
+      class << self
+        attr_accessor :serializations
+      end
 
-      def initialize
-        @serializations = 0
-        super
+      @serializations = 0
+
+      def serializations
+        self.class.serializations
       end
 
       def serialize(value)
-        @serializations += 1
+        self.class.serializations += 1
         value[:value]
       end
 
@@ -278,6 +284,7 @@ module ActiveRecord
     end
 
     def test_scalar_query_predicate_expressions_are_built_eagerly
+      TrackingString.expressions.clear
       type = TrackingString.new
       topic = topic_model_with_title_type(type)
       relation = topic.where(title: "CAFE")
@@ -439,6 +446,7 @@ module ActiveRecord
     end
 
     def test_comparison_expression_preserves_serialized_values
+      MutableSerializedType.serializations = 0
       type = MutableSerializedType.new
       topic = topic_model_with_title_type(type)
       value = { value: "original" }

--- a/activerecord/test/cases/relation/predicate_builder_test.rb
+++ b/activerecord/test/cases/relation/predicate_builder_test.rb
@@ -237,18 +237,25 @@ module ActiveRecord
       assert_ractor_shareable Topic.predicate_builder
     end
 
-    def test_is_eagerly_built_and_reachable_from_a_ractor
-      model = Class.new(ActiveRecord::Base) do
-        def self.name
-          "PredicateBuilderEagerModel"
+    if RUBY_VERSION >= "4.0" && !in_memory_db?
+      class PredicateBuilderRactorTest < ActiveRecord::TestCase
+        include ActiveSupport::Testing::Isolation
+        include ActiveSupport::Testing::RactorsAssertions
+
+        def test_is_eagerly_built_and_reachable_from_a_ractor
+          model = Class.new(ActiveRecord::Base) do
+            def self.name
+              "PredicateBuilderEagerModel"
+            end
+
+            self.table_name = "topics"
+          end
+
+          builder = on_ractor(model) { |m| m.instance_variable_get(:@predicate_builder) }
+
+          assert_same model.predicate_builder, builder
         end
-
-        self.table_name = "topics"
       end
-
-      builder = on_ractor(model) { |m| m.instance_variable_get(:@predicate_builder) }
-
-      assert_same model.predicate_builder, builder
     end
 
     def test_attribute_type_can_define_a_comparison_expression

--- a/activesupport/lib/active_support/testing/ractors_assertions.rb
+++ b/activesupport/lib/active_support/testing/ractors_assertions.rb
@@ -24,6 +24,10 @@ module ActiveSupport
           def assert_ractor_shareable(obj)
             assert Ractor.shareable?(obj), "Expected #{obj.inspect} to be shareable, but it is not."
           end
+
+          def assert_not_ractor_shareable(obj)
+            assert_not Ractor.shareable?(obj), "Expected #{obj.inspect} to not be shareable, but it is."
+          end
         else
           def on_ractor(*args)
             yield(*args)
@@ -34,6 +38,10 @@ module ActiveSupport
           end
 
           def assert_ractor_shareable(obj)
+            assert true
+          end
+
+          def assert_not_ractor_shareable(obj)
             assert true
           end
         end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `SchemaContext` attributes code needs to be split into a separate class that's embedded in Ractor storage (so it can change per-reactor).

### Detail

This Pull Request changes `SchemaContext` to have an embedded `Attributes` object. It also moves schema context specific ivars down model class so they may be evaluated lazily on the main ractor.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
