### PR TITLE
Get rid of `QueryCacheRegistry#clear`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -121,12 +121,6 @@ module ActiveRecord
             @map[context] ||= yield
           end
         end
-
-        def clear
-          @map.synchronize do
-            @map.clear
-          end
-        end
       end
 
       module ConnectionPoolConfiguration # :nodoc:


### PR DESCRIPTION
Close: https://github.com/rails/rails/pull/58566

The method is dead code.
