### PR TITLE
[8-1-stable] Silence `Time.rfc3339` redefinition warning

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -6,6 +6,7 @@ require "active_support/time_with_zone"
 require "active_support/core_ext/time/zones"
 require "active_support/core_ext/date_and_time/calculations"
 require "active_support/core_ext/date/calculations"
+require "active_support/core_ext/module/redefine_method"
 require "active_support/core_ext/module/remove_method"
 
 class Time
@@ -58,6 +59,8 @@ class Time
     ruby2_keywords :at_with_coercion
     alias_method :at_without_coercion, :at
     alias_method :at, :at_with_coercion
+
+    silence_redefinition_of_method :rfc3339
 
     # Creates a +Time+ instance from an RFC 3339 string.
     #


### PR DESCRIPTION
### Motivation / Background

Ruby 4.1 is expected to include `Time.rfc3339` via time as a default gem (added to Ruby master in https://github.com/ruby/ruby/commit/6c9f9f5c6118ae024b9ffad8e0cb7eda625e8b2d). Active Support has defined `Time.rfc3339` since Rails 5.1 (08e05d4a49), so on Ruby 4.1 loading `active_support/core_ext/time/calculations.rb` emits a "method redefined" warning, which `tools/strict_warnings.rb` turns into `RailsStrictWarnings::WarningError` on CI. Every job that loads `active_support/test_case` aborts before running any test. This is what rails-nightly reported on main before #58402 (https://buildkite.com/rails/rails-nightly/builds/4564#019f8154-590a-4568-b7c6-7b31021f4286/L1318):

```
/rails/activesupport/lib/active_support/core_ext/time/calculations.rb:69: warning: method redefined; discarding old rfc3339
/usr/local/lib/ruby/4.1.0+4/time.rb:657: warning: previous definition of rfc3339 was here
/rails/tools/strict_warnings.rb:42:in 'RailsStrictWarnings#warn': /rails/activesupport/lib/active_support/core_ext/time/calculations.rb:69: warning: method redefined; discarding old rfc3339 (RailsStrictWarnings::WarningError)
```

8-1-stable has the same definition. When Ruby 4.1 is released (expected December 2026), 8.1.x is the only series still under the maintenance policy (8.0.x security support ends on 2026-11-07, 7.2.x ended on 2026-08-09), so this pull request targets 8-1-stable only.

### Detail

On main this is resolved by 3e46bf2f10 (#58402), which defines `Time.rfc3339` only when Ruby does not provide it and adopts Ruby's representation for the "Z" designator (a UTC time instead of a +00:00 fixed offset) as a documented behavior change, with a CHANGELOG entry. That behavior change is not suitable for a patch release of 8.1.x.

This pull request instead keeps Active Support's `Time.rfc3339` active on every Ruby version, including 4.1, and only suppresses the redefinition warning with `silence_redefinition_of_method`, the helper Active Support already uses for `Date#to_time`, `Date#xmlschema`, and `Time#to_time`, which Ruby also defines.

Behavior on 8-1-stable, before and after this pull request:

```ruby
Time.rfc3339("2026-08-26T10:00:00Z")
# => 2026-08-26 10:00:00 +0000 (utc? => false), on every Ruby version
```

| Ruby | `Time.rfc3339` definition | Result for "Z" | Warning when loading Active Support (before → after) |
|---|---|---|---|
| time gem without `Time.rfc3339` (all released Rubies) | Active Support | +00:00 fixed offset (`utc?` is false) | none → none |
| time gem with `Time.rfc3339` (expected from Ruby 4.1) | Active Support, redefining Ruby's | +00:00 fixed offset (`utc?` is false) | "method redefined", an error under strict warnings → none |

The only cell this pull request changes is the warning on Ruby 4.1. This is not a backport of #58402: on main, Ruby's definition is used when present and `Time.rfc3339("...Z")` returns a UTC time.

### Additional information

Verified with Ruby master in docker (`ruby 4.1.0dev (2026-08-17T13:42:42Z master b52af71445) +PRISM [x86_64-linux]`, which already provides `Time.rfc3339`), running `RAILS_STRICT_WARNINGS=1 bundle exec rake test` in `activesupport`:

* 8-1-stable at 878fa64cd0: aborts while loading the tests with the same `RailsStrictWarnings::WarningError`.
* With this change: 5812 runs, 19307 assertions, 0 failures, 0 errors, 1065 skips (memcached and redis are not running in that container, so the memcached and redis store tests are skipped). The `Time.rfc3339` tests in `time_ext_test.rb`, `time_with_zone_test.rb`, and `time_zone_test.rb` pass with Active Support's definition.

The warning can also be reproduced on a released Ruby by defining a singleton `Time.rfc3339` before loading Active Support:

```
$ RAILS_STRICT_WARNINGS=1 ruby -w -I activesupport/lib -r ./tools/strict_warnings -e '
  require "time"
  class << Time; def rfc3339(s); end; end
  require "active_support"
  require "active_support/core_ext/time/calculations"
  puts Time.rfc3339("2026-08-26T10:00:00Z").inspect'
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
