### PR TITLE
Optimize CallbackChain#remove_duplicates with an index

### DIFF
--- a/activemodel/test/cases/validations/with_validation_test.rb
+++ b/activemodel/test/cases/validations/with_validation_test.rb
@@ -82,8 +82,7 @@ class ValidatesWithTest < ActiveModel::TestCase
     validator = Minitest::Mock.new
     validator.expect(:new, validator, [{ foo: :bar, if: :condition_is_true, class: Topic }])
     validator.expect(:validate, nil, [topic])
-    validator.expect(:is_a?, false, [String]) # Call run by ActiveSupport::Callbacks::Callback.build
-    validator.expect(:is_a?, false, [Proc])   # Call run by ActiveSupport::Callbacks::Callback#try_shareable_proc
+    def validator.is_a?(klass) = false
 
     Topic.validates_with(validator, if: :condition_is_true, foo: :bar)
     assert_predicate topic, :valid?

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -272,15 +272,6 @@ module ActiveSupport
           @kind == _kind && (filter == _filter || (@original_filter == _filter.object_id))
         end
 
-        def duplicates?(other)
-          case @filter
-          when Symbol
-            matches?(other.kind, other.filter)
-          else
-            false
-          end
-        end
-
         def compiled
           @compiled ||=
             begin
@@ -630,13 +621,18 @@ module ActiveSupport
         def delete(o)
           @all_callbacks = nil
           @single_callbacks.clear
-          @chain.delete(o)
+          result = @chain.delete(o)
+          if o.is_a?(Callback) && o.filter.is_a?(Symbol)
+            chain_index.delete([o.kind, o.filter])
+          end
+          result
         end
 
         def clear
           @all_callbacks = nil
           @single_callbacks.clear
           @chain.clear
+          @chain_index = {}
           self
         end
 
@@ -645,6 +641,7 @@ module ActiveSupport
           @single_callbacks = {}
           @chain     = other.chain.dup
           @mutex     = Mutex.new
+          @chain_index = other.chain_index.dup
         end
 
         def compile(type)
@@ -685,6 +682,10 @@ module ActiveSupport
         protected
           attr_reader :chain
 
+          def chain_index
+            @chain_index ||= {}
+          end
+
         private
           def compile_sequence(type)
             final_sequence = CallbackSequence.new
@@ -698,6 +699,7 @@ module ActiveSupport
             @single_callbacks.clear
             remove_duplicates(callback)
             @chain.push(callback)
+            chain_index[[callback.kind, callback.filter]] = callback if callback.filter.is_a?(Symbol)
           end
 
           def prepend_one(callback)
@@ -705,12 +707,19 @@ module ActiveSupport
             @single_callbacks.clear
             remove_duplicates(callback)
             @chain.unshift(callback)
+            chain_index[[callback.kind, callback.filter]] = callback if callback.filter.is_a?(Symbol)
           end
 
           def remove_duplicates(callback)
             @all_callbacks = nil
             @single_callbacks.clear
-            @chain.delete_if { |c| callback.duplicates?(c) }
+
+            return unless callback.filter.is_a?(Symbol)
+
+            key = [callback.kind, callback.filter]
+            if (existing = chain_index.delete(key))
+              @chain.delete(existing)
+            end
           end
 
           class DefaultTerminator # :nodoc:


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

In our codebase, we have a model with 800+ has_many relations. The loading of this model is slow. I found out that we spend ~60ms in `ActiveSupport::Callbacks::CallbackChain#remove_duplicates`. This PR completely removes it.

### Detail

Replace the O(n) linear scan in `remove_duplicates` with an O(1) hash index keyed on `[kind, filter]`. The index is maintained by `append_one`, `prepend_one`, `delete`, `clear`, and `initialize_copy`, covering all mutation paths. Non-Symbol filters fall back to the previous behaviour since they cannot be keyed cheaply.
