### PR TITLE
[actionview]: Add count option to Action View pluralize helper

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `count: false` to `pluralize` to return only the singular or plural word.
+
+    *Victor Cobos*
+
 *   Allow `translate`'s (and `t`'s) `scope:` option to be resolved relative to
     the current template when it starts with a period, mirroring the existing
     behavior for the key argument.

--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -289,19 +289,22 @@ module ActionView
       #   pluralize(3, 'person', plural: 'users')
       #   # => "3 users"
       #
+      #   pluralize(3, 'person', count: false)
+      #   # => "people"
+      #
       #   pluralize(0, 'person')
       #   # => "0 people"
       #
       #   pluralize(2, 'Person', locale: :de)
       #   # => "2 Personen"
-      def pluralize(count, singular, plural_arg = nil, plural: plural_arg, locale: I18n.locale)
-        word = if count == 1 || count.to_s.match?(/^1(\.0+)?$/)
+      def pluralize(number, singular, plural_arg = nil, plural: plural_arg, locale: I18n.locale, count: true)
+        word = if number == 1 || number.to_s.match?(/^1(\.0+)?$/)
           singular
         else
           plural || singular.pluralize(locale)
         end
 
-        "#{count || 0} #{word}"
+        count ? "#{number || 0} #{word}" : word
       end
 
       # Wraps the +text+ into lines no longer than +line_width+ width. This method

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -425,6 +425,16 @@ class TextHelperTest < ActionView::TestCase
     assert_equal("12 berries", pluralize(12, "berry"))
   end
 
+  def test_pluralization_without_count
+    assert_equal("count", pluralize(1, "count", count: false))
+    assert_equal("counts", pluralize(2, "count", count: false))
+    assert_equal("count", pluralize("1", "count", count: false))
+    assert_equal("counts", pluralize("2", "count", count: false))
+    assert_equal("counters", pluralize(2, "count", "counters", count: false))
+    assert_equal("counters", pluralize(2, "count", plural: "counters", count: false))
+    assert_equal("people", pluralize(nil, "person", count: false))
+  end
+
   def test_localized_pluralization
     old_locale = I18n.locale
 
@@ -438,6 +448,7 @@ class TextHelperTest < ActionView::TestCase
       assert_equal("1 region",   pluralize(1, "region"))
       assert_equal("2 regionen", pluralize(2, "region"))
       assert_equal("2 regions",  pluralize(2, "region", locale: :en))
+      assert_equal("regionen",   pluralize(2, "region", count: false))
     ensure
       I18n.locale = old_locale
     end

--- a/guides/source/action_view_helpers.md
+++ b/guides/source/action_view_helpers.md
@@ -186,6 +186,7 @@ Returns the singular or plural form of a word based on the value of a number.
 pluralize(1, "person") # => 1 person
 pluralize(2, "person") # => 2 people
 pluralize(3, "person", plural: "users") # => 3 users
+pluralize(2, "person", count: false) # => people
 ```
 
 See the [`pluralize` API


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `pluralize` is sometimes useful in views only for selecting the singular or plural word, without rendering the numeric count.

For example, an application may already display the count separately but still want to use Action View's existing pluralization behavior:

```ruby
pluralize(2, "person", count: false)
# => "people"
```

The existing behavior remains unchanged by default:
```ruby
pluralize(2, "person")
# => "2 people"
```
### Detail
This Pull Request changes `ActionView::Helpers::TextHelper#pluralize` to accept a new `count: false` option.
When `count: false` is passed, `pluralize` returns only the selected singular or plural word:

```ruby
pluralize(1, "person", count: false)
# => "person"

pluralize(2, "person", count: false)
# => "people"
```

The change preserves the existing default behavior and keeps support for:
- positional custom plural forms
- the plural: keyword
- the locale: keyword
- existing `nil` count behavior