### PR TITLE
Optimize schema cache dump load

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -230,7 +230,7 @@ module ActiveRecord
 
         read(filename) do |file|
           if filename.include?(".dump")
-            Marshal.load(file)
+            Marshal.load(file, freeze: true)
           else
             YAML.unsafe_load(file)
           end
@@ -433,8 +433,7 @@ module ActiveRecord
       def marshal_load(array) # :nodoc:
         @version, @columns, _columns_hash, @primary_keys, @data_sources, @indexes, _database_version = array
         @indexes ||= {}
-
-        derive_columns_hash_and_deduplicate_values
+        @columns_hash = @columns.transform_values { |columns| columns.index_by(&:name) }
       end
 
       private


### PR DESCRIPTION
 ### Motivation / Background

  Loading .dump schema cache files calls derive_columns_hash_and_deduplicate_values, which walks the entire deserialized object graph to intern strings. This is redundant when Marshal.load is given freeze: true, which interns all strings in C during deserialization itself.
  
In our codebase with 1000+ tables, this removes 40ms when loading the schema

### Detail

  This Pull Request changes SchemaCache._load_from and marshal_load to take advantage of Marshal.load's freeze: true keyword (available since Ruby 2.7):

  - _load_from: passes freeze: true to Marshal.load for .dump and .dump.gz files, so all strings are frozen/interned at deserialization time. Also switches File.read to File.binread to avoid unnecessary encoding conversion.
  - marshal_load: skips derive_columns_hash_and_deduplicate_values entirely and only rebuilds @columns_hash, the one field not persisted in the dump.