### PR TITLE
Honor `pool: false` in RedisCacheStore

### DIFF
--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -150,8 +150,10 @@ module ActiveSupport
         end
 
         clients = clients.map do |c|
-          if c.respond_to?(:new_pool)
-            c.new_pool(**(pool_options || {}))
+          if pool_options
+            c.respond_to?(:new_pool) ? c.new_pool(**pool_options) : c
+          elsif c.respond_to?(:new_client)
+            c.new_client
           else
             c
           end

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -135,6 +135,16 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       assert_kind_of ActiveSupport::Cache::DeprecatedRedisCacheStore, @cache
     end
 
+    test "pool: false uses an unpooled RedisClient" do
+      @cache = ActiveSupport::Cache::RedisCacheStore.new(url: REDIS_URL, pool: false)
+      assert_instance_of ::RedisClient, @cache.redis
+    end
+
+    test "pool: false with :client uses an unpooled RedisClient" do
+      @cache = ActiveSupport::Cache::RedisCacheStore.new(client: RedisClient.config(url: REDIS_URL), pool: false)
+      assert_instance_of ::RedisClient, @cache.redis
+    end
+
     test "validate pool arguments" do
       assert_raises TypeError do
         build(url: REDIS_URL, pool: { size: [] })


### PR DESCRIPTION
### Motivation / Background

`pool: false` still wrapped the Redis client in a connection pool. Regression from #57004.

### Detail

When pooling is disabled, build a single `RedisClient` instead of calling `new_pool`.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
