### PR TITLE
Accept a RedisClient instance via RedisCacheStore :client

### DIFF
--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -108,6 +108,7 @@ module ActiveSupport
       # like `redis-cluster-client`, you can pass an already configured client via the +:client+ option:
       #
       #   config.cache_store = :redis_cache_store, client: RedisClient.config(...)
+      #   config.cache_store = :redis_cache_store, client: RedisClient.config(...).new_client
       #   config.cache_store = :redis_cache_store, client: [RedisClient.config(...), RedisClient.config(...)]
       #   config.cache_store = :redis_cache_store, client: -> { RedisClient.config(...) }
       #
@@ -140,7 +141,8 @@ module ActiveSupport
 
         if redis_options.key?(:client)
           client = redis_options.delete(:client)
-          clients = Array.wrap(client.respond_to?(:call) ? client.call : client)
+          client = client.call if client.is_a?(Proc)
+          clients = Array.wrap(client)
         else
           urls = Array.wrap(redis_options.delete(:url))
           urls << nil if urls.empty?

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -121,6 +121,18 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       assert_kind_of ::RedisClient::Pooled, @cache.redis
     end
 
+    test "accepts a RedisClient instance via :client" do
+      client = RedisClient.config(url: REDIS_URL, protocol: 2).new_client
+      @cache = ActiveSupport::Cache::RedisCacheStore.new(client: client)
+      assert_same client, @cache.redis
+    end
+
+    test "accepts a RedisClient::Pooled instance via :client" do
+      client = RedisClient.config(url: REDIS_URL, protocol: 2).new_pool
+      @cache = ActiveSupport::Cache::RedisCacheStore.new(client: client)
+      assert_same client, @cache.redis
+    end
+
     test "array of :client Configs is not mutated" do
       clients = REDIS_URLS.map { |url| RedisClient.config(url: url) }.freeze
       @cache = ActiveSupport::Cache::RedisCacheStore.new(client: clients)


### PR DESCRIPTION
### Motivation / Background

Passing a `RedisClient` instance via `:client` raises `ArgumentError: can't issue an empty redis command`. Regression from #57004.

### Detail

`respond_to?(:call)` treated the client as a factory because `RedisClient#call` is a Redis command. Only invoke `#call` when `:client` is a Proc.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
