### PR TITLE
Include database configuration name in connection error messages

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Include the database configuration name from `config/database.yml` in
+    `ActiveRecord::DatabaseConnectionError` messages raised by the PostgreSQL,
+    MySQL, and Trilogy adapters, so multi-database apps can tell which database
+    failed to connect. A non-default role or shard is appended to the end of
+    the message.
+
+    ```
+    There is an issue connecting to your 'primary' database with your username/password, username: example_user.
+
+    Please check your database configuration to ensure the username/password are valid. (role: reading, shard: shard_one)
+    ```
+
+    *Chris Oliver*
+
 *   Add `config.active_record.shuffle_unordered_selects`.
 
     When enabled, Active Record shuffles the rows of every `SELECT` it generates

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -36,6 +36,8 @@ module ActiveRecord
       def checkin(_); end
       def remove(_); end
       def async_executor; end
+      def role; end
+      def shard; end
 
       def db_config
         NULL_CONFIG

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -22,16 +22,16 @@ module ActiveRecord
       include Mysql2::DatabaseStatements
 
       class << self
-        def new_client(config)
+        def new_client(config, connection_name: nil, role: nil, shard: nil)
           ::Mysql2::Client.new(config)
         rescue ::Mysql2::Error => error
           case error.error_number
           when ER_BAD_DB_ERROR
             raise ActiveRecord::NoDatabaseError.db_error(config[:database])
           when ER_DBACCESS_DENIED_ERROR, ER_ACCESS_DENIED_ERROR
-            raise ActiveRecord::DatabaseConnectionError.username_error(config[:username])
+            raise ActiveRecord::DatabaseConnectionError.username_error(config[:username], connection_name: connection_name, role: role, shard: shard)
           when ER_CONN_HOST_ERROR, ER_UNKNOWN_HOST_ERROR
-            raise ActiveRecord::DatabaseConnectionError.hostname_error(config[:host])
+            raise ActiveRecord::DatabaseConnectionError.hostname_error(config[:host], connection_name: connection_name, role: role, shard: shard)
           else
             raise ActiveRecord::ConnectionNotEstablished, error.message
           end
@@ -141,7 +141,7 @@ module ActiveRecord
         end
 
         def connect
-          @raw_connection = self.class.new_client(@connection_parameters)
+          @raw_connection = self.class.new_client(@connection_parameters, connection_name: @pool.db_config.name, role: @pool.role, shard: @pool.shard)
         rescue ConnectionNotEstablished => ex
           raise ex.set_pool(@pool)
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -52,7 +52,7 @@ module ActiveRecord
       ADAPTER_NAME = "PostgreSQL"
 
       class << self
-        def new_client(conn_params)
+        def new_client(conn_params, connection_name: nil, role: nil, shard: nil)
           PG.connect(**conn_params)
         rescue ::PG::Error => error
           if conn_params && conn_params[:dbname] == "postgres"
@@ -60,9 +60,9 @@ module ActiveRecord
           elsif conn_params && conn_params[:dbname] && error.message.include?(conn_params[:dbname])
             raise ActiveRecord::NoDatabaseError.db_error(conn_params[:dbname])
           elsif conn_params && conn_params[:user] && error.message.include?(conn_params[:user])
-            raise ActiveRecord::DatabaseConnectionError.username_error(conn_params[:user])
+            raise ActiveRecord::DatabaseConnectionError.username_error(conn_params[:user], connection_name: connection_name, role: role, shard: shard)
           elsif conn_params && conn_params[:host] && error.message.include?(conn_params[:host])
-            raise ActiveRecord::DatabaseConnectionError.hostname_error(conn_params[:host])
+            raise ActiveRecord::DatabaseConnectionError.hostname_error(conn_params[:host], connection_name: connection_name, role: role, shard: shard)
           else
             raise ActiveRecord::ConnectionNotEstablished, error.message
           end
@@ -1115,7 +1115,7 @@ module ActiveRecord
         # Connects to a PostgreSQL server and sets up the adapter depending on the
         # connected server's characteristics.
         def connect
-          @raw_connection = self.class.new_client(@connection_parameters)
+          @raw_connection = self.class.new_client(@connection_parameters, connection_name: @pool.db_config.name, role: @pool.role, shard: @pool.shard)
         rescue ConnectionNotEstablished => ex
           raise ex.set_pool(@pool)
         end

--- a/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -27,11 +27,11 @@ module ActiveRecord
       }.freeze
 
       class << self
-        def new_client(config)
+        def new_client(config, connection_name: nil, role: nil, shard: nil)
           config[:ssl_mode] = parse_ssl_mode(config[:ssl_mode]) if config[:ssl_mode]
           ::Trilogy.new(config)
         rescue ::Trilogy::Error => error
-          raise translate_connect_error(config, error)
+          raise translate_connect_error(config, error, connection_name: connection_name, role: role, shard: shard)
         end
 
         def parse_ssl_mode(mode)
@@ -43,15 +43,15 @@ module ActiveRecord
           SSL_MODES.fetch(m.to_sym, mode)
         end
 
-        def translate_connect_error(config, error)
+        def translate_connect_error(config, error, connection_name: nil, role: nil, shard: nil)
           case error.error_code
           when ER_DBACCESS_DENIED_ERROR, ER_BAD_DB_ERROR
             ActiveRecord::NoDatabaseError.db_error(config[:database])
           when ER_ACCESS_DENIED_ERROR
-            ActiveRecord::DatabaseConnectionError.username_error(config[:username])
+            ActiveRecord::DatabaseConnectionError.username_error(config[:username], connection_name: connection_name, role: role, shard: shard)
           else
             if error.message.include?("TRILOGY_DNS_ERROR")
-              ActiveRecord::DatabaseConnectionError.hostname_error(config[:host])
+              ActiveRecord::DatabaseConnectionError.hostname_error(config[:host], connection_name: connection_name, role: role, shard: shard)
             else
               ActiveRecord::ConnectionNotEstablished.new(error.message)
             end
@@ -154,7 +154,7 @@ module ActiveRecord
         end
 
         def connect
-          @raw_connection = self.class.new_client(@config)
+          @raw_connection = self.class.new_client(@config, connection_name: @pool.db_config.name, role: @pool.role, shard: @pool.shard)
         rescue ConnectionNotEstablished => ex
           raise ex.set_pool(@pool)
         end

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -104,19 +104,28 @@ module ActiveRecord
     end
 
     class << self
-      def hostname_error(hostname)
+      def hostname_error(hostname, connection_name: nil, role: nil, shard: nil)
         DatabaseConnectionError.new(<<~MSG)
-          There is an issue connecting with your hostname: #{hostname}.\n
-          Please check your database configuration and ensure there is a valid connection to your database.
+          There is an issue connecting to your #{connection_name ? "'#{connection_name}' database" : "database"} with your hostname: #{hostname}.\n
+          Please check your database configuration and ensure there is a valid connection to your database.#{connection_context(role, shard)}
         MSG
       end
 
-      def username_error(username)
+      def username_error(username, connection_name: nil, role: nil, shard: nil)
         DatabaseConnectionError.new(<<~MSG)
-          There is an issue connecting to your database with your username/password, username: #{username}.\n
-          Please check your database configuration to ensure the username/password are valid.
+          There is an issue connecting to your #{connection_name ? "'#{connection_name}' database" : "database"} with your username/password, username: #{username}.\n
+          Please check your database configuration to ensure the username/password are valid.#{connection_context(role, shard)}
         MSG
       end
+
+      private
+        def connection_context(role, shard)
+          context = [
+            ("role: #{role}" if role && role != ActiveRecord::Base.default_role),
+            ("shard: #{shard}" if shard && shard != ActiveRecord::Base.default_shard),
+          ].compact
+          " (#{context.join(", ")})" if context.any?
+        end
     end
   end
 

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -44,6 +44,32 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
     assert_kind_of ActiveRecord::ConnectionAdapters::NullPool, error.connection_pool
   end
 
+  def test_database_connection_error_includes_connection_name_from_pool
+    access_denied = Mysql2::Error.new("Access denied for user 'db_user'@'localhost'", nil, ActiveRecord::ConnectionAdapters::Mysql2Adapter::ER_ACCESS_DENIED_ERROR)
+    Mysql2::Client.stub(:new, ->(*) { raise access_denied }) do
+      db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+      connection = ActiveRecord::ConnectionAdapters::Mysql2Adapter.new(db_config.configuration_hash.merge(username: "db_user"))
+      connection.pool = ActiveRecord::Base.connection_pool
+
+      error = assert_raises ActiveRecord::DatabaseConnectionError do
+        connection.connect!
+      end
+      assert_includes error.message, "your 'primary' database"
+      assert_not_includes error.message, "(role:"
+    end
+  end
+
+  def test_database_connection_error_includes_non_default_role_and_shard
+    access_denied = Mysql2::Error.new("Access denied for user 'db_user'@'localhost'", nil, ActiveRecord::ConnectionAdapters::Mysql2Adapter::ER_ACCESS_DENIED_ERROR)
+    Mysql2::Client.stub(:new, ->(*) { raise access_denied }) do
+      error = assert_raises ActiveRecord::DatabaseConnectionError do
+        ActiveRecord::ConnectionAdapters::Mysql2Adapter.new_client({ username: "db_user" }, connection_name: "animals", role: :reading, shard: :shard_one)
+      end
+      assert_includes error.message, "your 'animals' database"
+      assert_includes error.message, "(role: reading, shard: shard_one)"
+    end
+  end
+
   def test_reconnection_error
     fake_connection = Class.new do
       def query_options

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -102,6 +102,34 @@ module ActiveRecord
         end
       end
 
+      def test_database_connection_error_includes_connection_name_from_pool
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+        configuration = db_config.configuration_hash.merge(username: "db_user")
+
+        connect_raises_error = proc { |**_conn_params| raise(PG::ConnectionBad, 'FATAL:  password authentication failed for user "db_user"') }
+        PG.stub(:connect, connect_raises_error) do
+          connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(configuration)
+          connection.pool = ActiveRecord::Base.connection_pool
+
+          error = assert_raises ActiveRecord::DatabaseConnectionError do
+            connection.connect!
+          end
+          assert_includes error.message, "your 'primary' database"
+          assert_not_includes error.message, "(role:"
+        end
+      end
+
+      def test_database_connection_error_includes_non_default_role_and_shard
+        connect_raises_error = proc { |**_conn_params| raise(PG::ConnectionBad, 'FATAL:  password authentication failed for user "db_user"') }
+        PG.stub(:connect, connect_raises_error) do
+          error = assert_raises ActiveRecord::DatabaseConnectionError do
+            ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new_client({ user: "db_user" }, connection_name: "animals", role: :reading, shard: :shard_one)
+          end
+          assert_includes error.message, "your 'animals' database"
+          assert_includes error.message, "(role: reading, shard: shard_one)"
+        end
+      end
+
       def test_reconnect_after_bad_connection_on_check_version_with_0_return
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
         with_postgresql_adapter(db_config.configuration_hash.merge(connection_retries: 0)) do |connection|

--- a/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
+++ b/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
@@ -22,6 +22,42 @@ class TrilogyAdapterTest < ActiveRecord::TrilogyTestCase
     assert_kind_of ActiveRecord::ConnectionAdapters::NullPool, error.connection_pool
   end
 
+  test "database connection error includes connection name from pool" do
+    access_denied = Class.new(Trilogy::BaseError) do
+      def error_code
+        ActiveRecord::ConnectionAdapters::TrilogyAdapter::ER_ACCESS_DENIED_ERROR
+      end
+    end
+
+    Trilogy.stub(:new, ->(*) { raise access_denied, "Access denied for user 'db_user'@'localhost'" }) do
+      db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+      connection = ActiveRecord::ConnectionAdapters::TrilogyAdapter.new(db_config.configuration_hash.merge(username: "db_user"))
+      connection.pool = ActiveRecord::Base.connection_pool
+
+      error = assert_raises ActiveRecord::DatabaseConnectionError do
+        connection.connect!
+      end
+      assert_includes error.message, "your 'primary' database"
+      assert_not_includes error.message, "(role:"
+    end
+  end
+
+  test "database connection error includes non-default role and shard" do
+    access_denied = Class.new(Trilogy::BaseError) do
+      def error_code
+        ActiveRecord::ConnectionAdapters::TrilogyAdapter::ER_ACCESS_DENIED_ERROR
+      end
+    end
+
+    Trilogy.stub(:new, ->(*) { raise access_denied, "Access denied for user 'db_user'@'localhost'" }) do
+      error = assert_raises ActiveRecord::DatabaseConnectionError do
+        ActiveRecord::ConnectionAdapters::TrilogyAdapter.new_client({ username: "db_user" }, connection_name: "animals", role: :reading, shard: :shard_one)
+      end
+      assert_includes error.message, "your 'animals' database"
+      assert_includes error.message, "(role: reading, shard: shard_one)"
+    end
+  end
+
   test "timeout in transaction doesnt query closed connection" do
     assert_timeout_and_remove_connection do
       @conn.transaction do


### PR DESCRIPTION
### Motivation / Background

Now that Rails uses 4 databases by default, it can be very confusing when deploying an app for the first time.

```
ActiveRecord::DatabaseConnectionError: There is an issue connecting to your database with your username/password, username: example. (ActiveRecord::DatabaseConnectionError)
```

It's impossible to know if this was raised from connecting to the `primary`, `cache`, `queue`, or `cable` databases.

### Detail

When a connection fails in a multi-database app, `DatabaseConnectionError` messages now include the database name from `config/database.yml`:

```
There is an issue connecting to your 'queue' database with your username/password, username: example_user.

Please check your database configuration to ensure the username/password are valid. (role: reading, shard: shard_one)
```

This should be enough context to realize you forgot to set `QUEUE_DATABASE_URL` in your env and it's not actually a problem with the primary `DATABASE_URL` or another database.

### Additional information

This should be backwards compatible so any third-party ActiveRecord adapters are unaffected.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

Fixes #49331.
Fixes #50935.
Closes #49337.