### PR TITLE
Fix allow_browser blocking current Opera for Android

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Fix `allow_browser` blocking every current version of Opera for Android.
+
+    Opera for Android is versioned independently of desktop Opera (e.g. Opera
+    for Android 100 ships the same Chromium as desktop Opera 134), but both
+    are reported as "Opera" and were compared against the desktop threshold
+    (106 in the `:modern` set), so mobile Opera users were served a 406.
+
+    Opera for Android is now matched under its own `opera_mobile` name, with a
+    minimum of 80 in the `:modern` set, and can be gated explicitly:
+
+    ```ruby
+    allow_browser versions: { opera: 106, opera_mobile: 80 }
+    ```
+
+    *Carlos Daniel Pohlod*
+
 *   Allow `translate`'s (and `t`'s) `scope:` option to be resolved relative to
     the current controller and action when it starts with a period,
     mirroring the existing behavior for the key argument.

--- a/actionpack/lib/action_controller/metal/allow_browser.rb
+++ b/actionpack/lib/action_controller/metal/allow_browser.rb
@@ -20,7 +20,11 @@ module ActionController # :nodoc:
       # In addition to specifically named browser versions, you can also pass
       # `:modern` as the set to restrict support to browsers natively supporting webp
       # images, web push, badges, import maps, CSS nesting, and CSS :has. This
-      # includes Safari 17.2+, Chrome 120+, Firefox 121+, Opera 106+.
+      # includes Safari 17.2+, Chrome 120+, Firefox 121+, Opera 106+, Opera for
+      # Android 80+.
+      #
+      # Opera for Android is versioned independently of desktop Opera, so it's
+      # matched under its own `opera_mobile` name rather than `opera`.
       #
       # You can use https://caniuse.com to check for browser versions supporting the
       # features you use.
@@ -72,7 +76,7 @@ module ActionController # :nodoc:
 
       class BrowserBlocker # :nodoc:
         SETS = {
-          modern: { safari: 17.2, chrome: 120, firefox: 121, opera: 106, ie: false }.freeze
+          modern: { safari: 17.2, chrome: 120, firefox: 121, opera: 106, opera_mobile: 80, ie: false }.freeze
         }.freeze
 
         attr_reader :request, :versions
@@ -125,8 +129,13 @@ module ActionController # :nodoc:
           def normalized_browser_name
             case name = parsed_user_agent.browser.downcase
             when "internet explorer" then "ie"
+            when "opera" then opera_mobile? ? "opera_mobile" : "opera"
             else name
             end
+          end
+
+          def opera_mobile?
+            request.user_agent.match?(/\bMobile\b/)
           end
       end
   end

--- a/actionpack/test/controller/allow_browser_test.rb
+++ b/actionpack/test/controller/allow_browser_test.rb
@@ -18,6 +18,11 @@ class AllowBrowserController < ActionController::Base
     head :ok
   end
 
+  allow_browser versions: { opera_mobile: "80" }, block: -> { head :upgrade_required }, only: :opera_mobile
+  def opera_mobile
+    head :ok
+  end
+
   private
     def head_upgrade_required
       head :upgrade_required
@@ -32,7 +37,10 @@ class AllowBrowserTest < ActionController::TestCase
   SAFARI_17_2_0 = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2.0 Safari/605.1.15"
   FIREFOX_114   = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/114.0"
   IE_11         = "Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko"
+  OPERA_105     = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36 OPR/105.0.0.0"
   OPERA_106     = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 OPR/106.0.0.0"
+  OPERA_MOBILE_79  = "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Mobile Safari/537.36 OPR/79.0.0.0"
+  OPERA_MOBILE_100 = "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Mobile Safari/537.36 OPR/100.0.0.0"
   GOOGLE_BOT    = "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/W.X.Y.Z Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
 
   test "blocked browser below version limit with callable" do
@@ -71,7 +79,32 @@ class AllowBrowserTest < ActionController::TestCase
     get_with_agent :modern, CHROME_120
     assert_response :ok
 
+    get_with_agent :modern, OPERA_105
+    assert_response :upgrade_required
+
     get_with_agent :modern, OPERA_106
+    assert_response :ok
+
+    get_with_agent :modern, OPERA_MOBILE_79
+    assert_response :upgrade_required
+
+    get_with_agent :modern, OPERA_MOBILE_100
+    assert_response :ok
+  end
+
+  test "opera mobile is not gated by the desktop opera version" do
+    get_with_agent :hello, OPERA_MOBILE_100
+    assert_response :ok
+  end
+
+  test "opera mobile can be gated by its own version" do
+    get_with_agent :opera_mobile, OPERA_MOBILE_79
+    assert_response :upgrade_required
+
+    get_with_agent :opera_mobile, OPERA_MOBILE_100
+    assert_response :ok
+
+    get_with_agent :opera_mobile, OPERA_105
     assert_response :ok
   end
 

--- a/guides/source/action_controller_advanced_topics.md
+++ b/guides/source/action_controller_advanced_topics.md
@@ -113,7 +113,7 @@ class ApplicationController < ActionController::Base
 end
 ```
 
-TIP: Modern browsers includes Safari 17.2+, Chrome 120+, Firefox 121+, Opera 106+. You can use [caniuse.com](https://caniuse.com/) to check for browser versions supporting the features you'd like to use.
+TIP: Modern browsers includes Safari 17.2+, Chrome 120+, Firefox 121+, Opera 106+, Opera for Android 80+. You can use [caniuse.com](https://caniuse.com/) to check for browser versions supporting the features you'd like to use.
 
 In addition to the default of `:modern`, you can also specify the browser versions manually:
 


### PR DESCRIPTION
### Motivation / Background

Fixes #58499.

`allow_browser versions: :modern` serves a 406 to every current version of Opera for Android.

Opera for Android is versioned independently of desktop Opera. Today desktop Opera sends `OPR/134` (Chromium 150) while Opera for Android sends `OPR/100` (Chromium 149). The `useragent` gem reports both as `"Opera"` (and its `mobile?` only recognizes Opera Mini), so `BrowserBlocker` compared the mobile version against the desktop threshold of 106 and blocked it.

### Detail

- `BrowserBlocker#normalized_browser_name` now maps Opera to `opera_mobile` when the user agent carries the `Mobile` token (the same convention Chrome and Safari use), and to `opera` otherwise.
- The `:modern` set gains `opera_mobile: 80`. Opera for Android 80 is the release that ships Chromium 120, the same engine the existing `chrome: 120` threshold is based on, and caniuse lists it as supporting webp, web push, badges, import maps, CSS nesting and CSS `:has`.
- Apps that gate `opera:` explicitly no longer block Opera for Android by accident (it becomes an unlisted browser, which `allow_browser` allows by default), and can gate it on purpose with `opera_mobile:`.
- Documentation, guide and CHANGELOG updated.

### Additional information

Verified with the user agents from the issue:

```
desktop: Chrome/150.0.0.0 Safari/537.36 OPR/134.0.0.0        -> Opera 134
mobile:  Chrome/149.0.0.0 Mobile Safari/537.36 OPR/100.0.0.0 -> Opera 100, mobile? => false
```

Opera Mini is unaffected: its user agent has no `Mobile` token, so it keeps matching `opera` and remains blocked by `:modern`, as before.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
