### PR TITLE
Fix orphaned prepared statements docs in the configuring guide [ci skip]

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -4111,6 +4111,14 @@ production:
   advisory_locks: false
 ```
 
+Active Record also uses prepared statements by default. To disable prepared statements, set `prepared_statements` to `false`:
+
+```yaml
+production:
+  adapter: postgresql
+  prepared_statements: false
+```
+
 If enabled, Active Record will create up to `1000` prepared statements per database connection by default. To modify this behavior you can set `statement_limit` to a different value:
 
 ```yaml


### PR DESCRIPTION
### Motivation / Background

Fixes #58500.

The PostgreSQL section of the configuring guide lost its introduction to prepared statements. Commit 7c1c86bffc removed `prepared_statements: false` from the PgBouncer example, because current PgBouncer versions support prepared statements (#55468). But the next two paragraphs still describe prepared statements, so the section now reads wrong in two ways:

- "If enabled, Active Record will create up to `1000` prepared statements per database connection" appears to refer to advisory locks, the topic of the previous paragraph.
- The section tells readers to try "disabling prepared statements" without showing how.

### Detail

This Pull Request restores a short introduction to prepared statements, with an example that sets `prepared_statements` to `false`. It sits between the advisory locks example and the `statement_limit` paragraph, so "If enabled" has a clear referent again.

The PgBouncer guidance from #55468 stays unchanged.

### Additional information

The removed introduction dates back to c5e083af3d (2014). This is a documentation-only change: the commit is tagged `[ci skip]` and there is no CHANGELOG entry, per the contribution guidelines.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature. (n/a: documentation-only change)
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included. (n/a: documentation-only change)
