### PR TITLE
Allow model schema contexts to use an explicit connection pool

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Keep schema-derived model state separate for each connection pool.
+
+    Models connected to shards with different schemas now use the columns,
+    attribute types, defaults, and cached finder statements for the current
+    shard.
+
+    *Joshua Young*
+
 *   Re-enable PostgreSQL triggers when the block given to `disable_referential_integrity` raises.
 
     On PostgreSQL versions without `NOT ENFORCED` constraints (before 18.4), the
@@ -35,7 +43,6 @@
     join would change the number of rows the query returns.
 
     *David Paluy*
-
 *   Add `config.active_record.shuffle_unordered_selects`.
 
     When enabled, Active Record shuffles the rows of every `SELECT` it generates

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,8 +1,8 @@
-*   Keep schema-derived model state separate for each connection pool.
+*   Allow model schema contexts to use an explicit connection pool.
 
-    Models connected to shards with different schemas now use the columns,
-    attribute types, defaults, and cached finder statements for the current
-    shard.
+    Applications can use this with `build_schema_context` to control where a
+    model loads its schema. `attribute_names` now lives in the schema context
+    with the rest of the schema-derived model state.
 
     *Joshua Young*
 
@@ -43,6 +43,7 @@
     join would change the number of rows the query returns.
 
     *David Paluy*
+
 *   Add `config.active_record.shuffle_unordered_selects`.
 
     When enabled, Active Record shuffles the rows of every `SELECT` it generates

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -233,11 +233,12 @@ module ActiveRecord
       #   Person.attribute_names
       #   # => ["id", "created_at", "updated_at", "name", "age"]
       def attribute_names
-        if !abstract_class? && table_exists?
-          schema_context.attribute_names
-        else
-          [].freeze
-        end
+        return [].freeze if abstract_class?
+
+        context = @schema_context&.current_context
+        return context.attribute_names if context&.schema_loaded?
+
+        table_exists? ? schema_context.attribute_names : [].freeze
       end
 
       # Returns true if the given attribute exists, otherwise false.

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -233,11 +233,11 @@ module ActiveRecord
       #   Person.attribute_names
       #   # => ["id", "created_at", "updated_at", "name", "age"]
       def attribute_names
-        @attribute_names ||= if !abstract_class? && table_exists?
-          attribute_types.keys
+        if !abstract_class? && table_exists?
+          schema_context.attribute_names
         else
-          []
-        end.freeze
+          [].freeze
+        end
       end
 
       # Returns true if the given attribute exists, otherwise false.
@@ -266,7 +266,6 @@ module ActiveRecord
           child_class.initialize_generated_modules
           child_class.class_eval do
             @alias_attributes_mass_generated = false
-            @attribute_names = nil
           end
         end
     end

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -234,9 +234,7 @@ module ActiveRecord
       #   # => ["id", "created_at", "updated_at", "name", "age"]
       def attribute_names
         return [].freeze if abstract_class?
-
-        context = @schema_context&.current_context
-        return context.attribute_names if context&.schema_loaded?
+        return @schema_context.attribute_names if @schema_context&.schema_loaded?
 
         table_exists? ? schema_context.attribute_names : [].freeze
       end

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -420,7 +420,7 @@ module ActiveRecord
       end
 
       def cached_find_by_statement(connection, key, &block) # :nodoc:
-        schema_context(connection.pool).cached_find_by_statement(connection, key, &block)
+        schema_context.cached_find_by_statement(connection, key, &block)
       end
 
       private

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -420,7 +420,7 @@ module ActiveRecord
       end
 
       def cached_find_by_statement(connection, key, &block) # :nodoc:
-        schema_context.cached_find_by_statement(connection, key, &block)
+        schema_context(connection.pool).cached_find_by_statement(connection, key, &block)
       end
 
       private

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -200,14 +200,22 @@ module ActiveRecord
     end
 
     module ClassMethods
-      def schema_context # :nodoc:
-        return @schema_context if schema_loaded?
-        load_schema
-        @schema_context
+      def schema_context(connection_pool = nil) # :nodoc:
+        if @schema_context
+          context = connection_pool ? @schema_context.context_for(connection_pool) : @schema_context.current_context
+          return context if context&.schema_loaded?
+        end
+
+        load_schema(connection_pool)
+        connection_pool ? @schema_context.context_for(connection_pool) : @schema_context.current_context
       end
 
       def build_schema_context # :nodoc:
-        ActiveRecord::ModelSchema::SchemaContext::ConnectionPoolProxy.new(self)
+        if sharded?
+          ActiveRecord::ModelSchema::SchemaContext::ConnectionPoolProxy.new(self)
+        else
+          ActiveRecord::ModelSchema::SchemaContext.new(self)
+        end
       end
 
       # Guesses the table name (in forced lower-case) based on the name of the class in the
@@ -474,15 +482,11 @@ module ActiveRecord
       end
 
       def _returning_columns_for_insert(connection) # :nodoc:
-        @_returning_columns_for_insert || ActiveSupport::Ractors.on_main(self) do
-          @_returning_columns_for_insert ||= schema_context._returning_columns_for_insert(connection)
-        end
+        schema_context(connection.pool)._returning_columns_for_insert(connection)
       end
 
       def _returning_columns_for_update(connection) # :nodoc:
-        @_returning_columns_for_update || ActiveSupport::Ractors.on_main(self) do
-          @_returning_columns_for_update ||= schema_context._returning_columns_for_update(connection)
-        end
+        schema_context(connection.pool)._returning_columns_for_update(connection)
       end
 
       # Returns the column object for the named attribute.
@@ -559,13 +563,12 @@ module ActiveRecord
 
       # Load the model's schema information either from the schema cache
       # or directly from the database.
-      def load_schema
-        return if schema_loaded?
-
+      def load_schema(connection_pool = nil)
+        return if schema_loaded?(connection_pool)
         @load_schema_monitor.synchronize do
-          unless schema_loaded? || @schema_context&.schema_loading?
+          unless schema_loaded?(connection_pool) || @schema_context&.schema_loading?(connection_pool)
             @schema_context ||= build_schema_context
-            @schema_context.load_schema!
+            @schema_context.load_schema!(connection_pool)
 
             unless @schema_hooks_loaded
               load_schema!
@@ -614,8 +617,8 @@ module ActiveRecord
           end
         end
 
-        def schema_loaded?
-          @schema_context&.schema_loaded? || false
+        def schema_loaded?(connection_pool = nil)
+          @schema_context&.schema_loaded?(connection_pool) || false
         end
 
         def load_schema!

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -200,22 +200,14 @@ module ActiveRecord
     end
 
     module ClassMethods
-      def schema_context(connection_pool = nil) # :nodoc:
-        if @schema_context
-          context = connection_pool ? @schema_context.context_for(connection_pool) : @schema_context.current_context
-          return context if context&.schema_loaded?
-        end
-
-        load_schema(connection_pool)
-        connection_pool ? @schema_context.context_for(connection_pool) : @schema_context.current_context
+      def schema_context # :nodoc:
+        return @schema_context if schema_loaded?
+        load_schema
+        @schema_context
       end
 
       def build_schema_context # :nodoc:
-        if sharded?
-          ActiveRecord::ModelSchema::SchemaContext::ConnectionPoolProxy.new(self)
-        else
-          ActiveRecord::ModelSchema::SchemaContext.new(self)
-        end
+        ActiveRecord::ModelSchema::SchemaContext.new(self)
       end
 
       # Guesses the table name (in forced lower-case) based on the name of the class in the
@@ -482,11 +474,15 @@ module ActiveRecord
       end
 
       def _returning_columns_for_insert(connection) # :nodoc:
-        schema_context(connection.pool)._returning_columns_for_insert(connection)
+        @_returning_columns_for_insert || ActiveSupport::Ractors.on_main(self) do
+          @_returning_columns_for_insert ||= schema_context._returning_columns_for_insert(connection)
+        end
       end
 
       def _returning_columns_for_update(connection) # :nodoc:
-        schema_context(connection.pool)._returning_columns_for_update(connection)
+        @_returning_columns_for_update || ActiveSupport::Ractors.on_main(self) do
+          @_returning_columns_for_update ||= schema_context._returning_columns_for_update(connection)
+        end
       end
 
       # Returns the column object for the named attribute.
@@ -563,13 +559,14 @@ module ActiveRecord
 
       # Load the model's schema information either from the schema cache
       # or directly from the database.
-      def load_schema(connection_pool = nil)
-        return if schema_loaded?(connection_pool)
-        @load_schema_monitor.synchronize do
-          unless schema_loaded?(connection_pool) || @schema_context&.schema_loading?(connection_pool)
-            @schema_context ||= build_schema_context
-            @schema_context.load_schema!(connection_pool)
+      def load_schema
+        return if schema_loaded?
 
+        @load_schema_monitor.synchronize do
+          unless schema_loaded? || @schema_context
+            @schema_context = build_schema_context
+            @schema_context.load_schema!
+            ActiveSupport::Ractors.make_shareable(@schema_context)
             unless @schema_hooks_loaded
               load_schema!
               @schema_hooks_loaded = true
@@ -617,8 +614,8 @@ module ActiveRecord
           end
         end
 
-        def schema_loaded?(connection_pool = nil)
-          @schema_context&.schema_loaded?(connection_pool) || false
+        def schema_loaded?
+          @schema_context&.schema_loaded? || false
         end
 
         def load_schema!

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -207,7 +207,7 @@ module ActiveRecord
       end
 
       def build_schema_context # :nodoc:
-        ActiveRecord::ModelSchema::SchemaContext.new(self)
+        ActiveRecord::ModelSchema::SchemaContext::ConnectionPoolProxy.new(self)
       end
 
       # Guesses the table name (in forced lower-case) based on the name of the class in the
@@ -563,10 +563,10 @@ module ActiveRecord
         return if schema_loaded?
 
         @load_schema_monitor.synchronize do
-          unless schema_loaded? || @schema_context
-            @schema_context = build_schema_context
+          unless schema_loaded? || @schema_context&.schema_loading?
+            @schema_context ||= build_schema_context
             @schema_context.load_schema!
-            ActiveSupport::Ractors.make_shareable(@schema_context)
+
             unless @schema_hooks_loaded
               load_schema!
               @schema_hooks_loaded = true
@@ -587,7 +587,6 @@ module ActiveRecord
           @schema_hooks_loaded = false
           @arel_table = Arel::Table.new(klass: self)
           @predicate_builder = PredicateBuilder.new(TableMetadata.new(self, @arel_table)) unless self == Base
-          @attribute_names = nil
 
           reload_schema_contexts_from_cache
 

--- a/activerecord/lib/active_record/model_schema/schema_context.rb
+++ b/activerecord/lib/active_record/model_schema/schema_context.rb
@@ -26,6 +26,10 @@ module ActiveRecord
           end
         end
 
+        def names
+          types.keys.freeze
+        end
+
         def builder
           primary_key_defaults = defaults.except(*(context.model_class.column_names - Array(context.model_class.primary_key)))
           ActiveModel::AttributeSet::Builder.new(types, primary_key_defaults)
@@ -39,8 +43,9 @@ module ActiveRecord
       attr_reader :model_class, :columns_hash, :columns, :column_names,
                   :content_columns
 
-      def initialize(model_class)
+      def initialize(model_class, connection_pool = model_class.connection_pool)
         @model_class = model_class
+        @connection_pool = connection_pool
         @schema_loaded = false
         @attributes_key = :"active_record_schema_attributes_#{object_id}"
       end
@@ -72,7 +77,9 @@ module ActiveRecord
       end
 
       def cached_find_by_statement(connection, key, &block) # :nodoc:
-        cache = find_by_statement_cache[connection.prepared_statements]
+        cache = find_by_statement_cache[connection.prepared_statements].compute_if_absent(@connection_pool) do
+          Concurrent::Map.new
+        end
         cache.compute_if_absent(key) { StatementCache.create(connection, &block) }
       end
 
@@ -86,6 +93,14 @@ module ActiveRecord
 
       def schema_loaded?
         @schema_loaded
+      end
+
+      def schema_loading?
+        @schema_loading
+      end
+
+      def attribute_names
+        attributes.names
       end
 
       def attribute_set
@@ -103,11 +118,13 @@ module ActiveRecord
       def load_schema!
         return if @schema_loaded
 
+        @schema_loading = true
+
         unless table_name
           raise ActiveRecord::TableNotSpecified, "#{model_class} has no table configured. Set one with #{model_class}.table_name="
         end
 
-        columns_hash = model_class.connection_pool.schema_cache.columns_hash(table_name)
+        columns_hash = @connection_pool.schema_cache.columns_hash(table_name)
         if model_class.only_columns.present?
           columns_hash = columns_hash.slice(*model_class.only_columns)
         elsif model_class.ignored_columns.present?
@@ -128,6 +145,50 @@ module ActiveRecord
         attributes
 
         @schema_loaded = true
+      ensure
+        @schema_loading = false
+      end
+
+      class ConnectionPoolProxy # :nodoc:
+        delegate :_returning_columns_for_insert, :_returning_columns_for_update,
+          :attribute_names, :attributes, :cached_find_by_statement,
+          :column_names, :columns, :columns_hash, :content_columns,
+          :find_by_statement_cache, to: :current_context
+
+        def initialize(model_class)
+          @model_class = model_class
+          @schema_contexts = Concurrent::Map.new
+        end
+
+        def schema_loaded?
+          context = current_context
+          context ? context.schema_loaded? : false
+        end
+
+        def schema_loading?
+          context = current_context
+          context ? context.schema_loading? : false
+        end
+
+        def load_schema!
+          unless @model_class.table_name
+            raise ActiveRecord::TableNotSpecified, "#{@model_class} has no table configured. Set one with #{@model_class}.table_name="
+          end
+
+          connection_pool = @model_class.connection_pool
+          context = @schema_contexts.compute_if_absent(connection_pool) do
+            SchemaContext.new(@model_class, connection_pool)
+          end
+          @fallback_context ||= context
+          context.load_schema!
+        end
+
+        private
+          def current_context
+            @schema_contexts[@model_class.connection_pool]
+          rescue ActiveRecord::ConnectionNotDefined
+            @fallback_context
+          end
       end
     end
   end

--- a/activerecord/lib/active_record/model_schema/schema_context.rb
+++ b/activerecord/lib/active_record/model_schema/schema_context.rb
@@ -27,7 +27,7 @@ module ActiveRecord
         end
 
         def names
-          types.keys.freeze
+          @names ||= types.keys.freeze
         end
 
         def builder
@@ -46,7 +46,6 @@ module ActiveRecord
       def initialize(model_class, connection_pool = nil)
         @model_class = model_class
         @connection_pool = connection_pool
-        @pool_aware = !connection_pool.nil?
         @schema_loaded = false
         @attributes_key = :"active_record_schema_attributes_#{object_id}"
       end
@@ -79,11 +78,6 @@ module ActiveRecord
 
       def cached_find_by_statement(connection, key, &block) # :nodoc:
         cache = find_by_statement_cache[connection.prepared_statements]
-        if @pool_aware
-          cache = cache.compute_if_absent(@connection_pool) do
-            Concurrent::Map.new
-          end
-        end
         cache.compute_if_absent(key) { StatementCache.create(connection, &block) }
       end
 
@@ -95,12 +89,8 @@ module ActiveRecord
         ActiveSupport::Ractors[model_class.find_by_statement_cache_key] || initialize_find_by_cache
       end
 
-      def schema_loaded?(_connection_pool = nil)
+      def schema_loaded?
         @schema_loaded
-      end
-
-      def schema_loading?(_connection_pool = nil)
-        @schema_loading
       end
 
       def attribute_names
@@ -119,25 +109,17 @@ module ActiveRecord
         super
       end
 
-      def current_context
-        self
-      end
-
-      def context_for(_connection_pool)
-        self
-      end
-
-      def load_schema!(_connection_pool = nil)
+      def load_schema!
         return if @schema_loaded
-
-        @schema_loading = true
 
         unless table_name
           raise ActiveRecord::TableNotSpecified, "#{model_class} has no table configured. Set one with #{model_class}.table_name="
         end
 
-        @connection_pool ||= model_class.connection_pool
-        columns_hash = @connection_pool.schema_cache.columns_hash(table_name)
+        pool = @connection_pool || model_class.connection_pool
+        columns_hash = pool.schema_cache.columns_hash(table_name)
+        # Connection pools are not shareable, and are no longer needed once the schema is loaded.
+        @connection_pool = nil
         if model_class.only_columns.present?
           columns_hash = columns_hash.slice(*model_class.only_columns)
         elsif model_class.ignored_columns.present?
@@ -158,64 +140,6 @@ module ActiveRecord
         attributes
 
         @schema_loaded = true
-      ensure
-        @schema_loading = false
-      end
-
-      class ConnectionPoolProxy # :nodoc:
-        def initialize(model_class)
-          @model_class = model_class
-          @schema_contexts = Concurrent::Map.new
-        end
-
-        def current_context
-          connection_stack_entry = @model_class.connected_to_stack.last
-          # A stack entry is replaced whenever the role or shard changes, so its identity
-          # can cache the current context without resolving the connection pool each time.
-          if (last_context = @last_context) && last_context.first.equal?(connection_stack_entry)
-            last_context.last
-          elsif context = context_for(@model_class.connection_pool)
-            @last_context = [connection_stack_entry, context]
-            context
-          end
-        rescue ActiveRecord::ConnectionNotDefined
-          @fallback_context
-        end
-
-        def context_for(connection_pool)
-          if (last_context = @last_connection_pool_context) && last_context.first.equal?(connection_pool)
-            last_context.last
-          elsif context = @schema_contexts[connection_pool]
-            @last_connection_pool_context = [connection_pool, context]
-            context
-          end
-        end
-
-        def schema_loaded?(connection_pool = nil)
-          context = connection_pool ? context_for(connection_pool) : current_context
-          context ? context.schema_loaded? : false
-        end
-
-        def schema_loading?(connection_pool = nil)
-          context = connection_pool ? context_for(connection_pool) : current_context
-          context ? context.schema_loading? : false
-        end
-
-        def load_schema!(connection_pool = nil)
-          unless @model_class.table_name
-            raise ActiveRecord::TableNotSpecified, "#{@model_class} has no table configured. Set one with #{@model_class}.table_name="
-          end
-
-          current_connection_pool = connection_pool.nil?
-          connection_pool ||= @model_class.connection_pool
-          context = @schema_contexts.compute_if_absent(connection_pool) do
-            SchemaContext.new(@model_class, connection_pool)
-          end
-          @last_context = [@model_class.connected_to_stack.last, context] if current_connection_pool
-          @last_connection_pool_context = [connection_pool, context]
-          @fallback_context ||= context
-          context.load_schema!
-        end
       end
     end
   end

--- a/activerecord/lib/active_record/model_schema/schema_context.rb
+++ b/activerecord/lib/active_record/model_schema/schema_context.rb
@@ -43,9 +43,10 @@ module ActiveRecord
       attr_reader :model_class, :columns_hash, :columns, :column_names,
                   :content_columns
 
-      def initialize(model_class, connection_pool = model_class.connection_pool)
+      def initialize(model_class, connection_pool = nil)
         @model_class = model_class
         @connection_pool = connection_pool
+        @pool_aware = !connection_pool.nil?
         @schema_loaded = false
         @attributes_key = :"active_record_schema_attributes_#{object_id}"
       end
@@ -77,8 +78,11 @@ module ActiveRecord
       end
 
       def cached_find_by_statement(connection, key, &block) # :nodoc:
-        cache = find_by_statement_cache[connection.prepared_statements].compute_if_absent(@connection_pool) do
-          Concurrent::Map.new
+        cache = find_by_statement_cache[connection.prepared_statements]
+        if @pool_aware
+          cache = cache.compute_if_absent(@connection_pool) do
+            Concurrent::Map.new
+          end
         end
         cache.compute_if_absent(key) { StatementCache.create(connection, &block) }
       end
@@ -91,11 +95,11 @@ module ActiveRecord
         ActiveSupport::Ractors[model_class.find_by_statement_cache_key] || initialize_find_by_cache
       end
 
-      def schema_loaded?
+      def schema_loaded?(_connection_pool = nil)
         @schema_loaded
       end
 
-      def schema_loading?
+      def schema_loading?(_connection_pool = nil)
         @schema_loading
       end
 
@@ -115,7 +119,15 @@ module ActiveRecord
         super
       end
 
-      def load_schema!
+      def current_context
+        self
+      end
+
+      def context_for(_connection_pool)
+        self
+      end
+
+      def load_schema!(_connection_pool = nil)
         return if @schema_loaded
 
         @schema_loading = true
@@ -124,6 +136,7 @@ module ActiveRecord
           raise ActiveRecord::TableNotSpecified, "#{model_class} has no table configured. Set one with #{model_class}.table_name="
         end
 
+        @connection_pool ||= model_class.connection_pool
         columns_hash = @connection_pool.schema_cache.columns_hash(table_name)
         if model_class.only_columns.present?
           columns_hash = columns_hash.slice(*model_class.only_columns)
@@ -150,45 +163,59 @@ module ActiveRecord
       end
 
       class ConnectionPoolProxy # :nodoc:
-        delegate :_returning_columns_for_insert, :_returning_columns_for_update,
-          :attribute_names, :attributes, :cached_find_by_statement,
-          :column_names, :columns, :columns_hash, :content_columns,
-          :find_by_statement_cache, to: :current_context
-
         def initialize(model_class)
           @model_class = model_class
           @schema_contexts = Concurrent::Map.new
         end
 
-        def schema_loaded?
-          context = current_context
+        def current_context
+          connection_stack_entry = @model_class.connected_to_stack.last
+          # A stack entry is replaced whenever the role or shard changes, so its identity
+          # can cache the current context without resolving the connection pool each time.
+          if (last_context = @last_context) && last_context.first.equal?(connection_stack_entry)
+            last_context.last
+          elsif context = context_for(@model_class.connection_pool)
+            @last_context = [connection_stack_entry, context]
+            context
+          end
+        rescue ActiveRecord::ConnectionNotDefined
+          @fallback_context
+        end
+
+        def context_for(connection_pool)
+          if (last_context = @last_connection_pool_context) && last_context.first.equal?(connection_pool)
+            last_context.last
+          elsif context = @schema_contexts[connection_pool]
+            @last_connection_pool_context = [connection_pool, context]
+            context
+          end
+        end
+
+        def schema_loaded?(connection_pool = nil)
+          context = connection_pool ? context_for(connection_pool) : current_context
           context ? context.schema_loaded? : false
         end
 
-        def schema_loading?
-          context = current_context
+        def schema_loading?(connection_pool = nil)
+          context = connection_pool ? context_for(connection_pool) : current_context
           context ? context.schema_loading? : false
         end
 
-        def load_schema!
+        def load_schema!(connection_pool = nil)
           unless @model_class.table_name
             raise ActiveRecord::TableNotSpecified, "#{@model_class} has no table configured. Set one with #{@model_class}.table_name="
           end
 
-          connection_pool = @model_class.connection_pool
+          current_connection_pool = connection_pool.nil?
+          connection_pool ||= @model_class.connection_pool
           context = @schema_contexts.compute_if_absent(connection_pool) do
             SchemaContext.new(@model_class, connection_pool)
           end
+          @last_context = [@model_class.connected_to_stack.last, context] if current_connection_pool
+          @last_connection_pool_context = [connection_pool, context]
           @fallback_context ||= context
           context.load_schema!
         end
-
-        private
-          def current_context
-            @schema_contexts[@model_class.connection_pool]
-          rescue ActiveRecord::ConnectionNotDefined
-            @fallback_context
-          end
       end
     end
   end

--- a/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
@@ -479,10 +479,12 @@ module ActiveRecord
           self.partial_inserts = false
         end
 
-        ActiveRecord::Base.connected_to(role: :writing, shard: :default) do
+        default_connection = ActiveRecord::Base.connected_to(role: :writing, shard: :default) do
           model.lease_connection.create_table(:shard_connection_test_models) do |t|
             t.string :shard_key
           end
+          assert_not model.new.has_attribute?(:new_column)
+          model.lease_connection
         end
 
         ActiveRecord::Base.connected_to(role: :writing, shard: :migrated) do
@@ -496,6 +498,7 @@ module ActiveRecord
           assert_equal :string, model.type_for_attribute("new_column").type
           assert_equal "default value", model.column_defaults["new_column"]
           assert_equal "default value", model.new.new_column
+          assert_equal ["id"], model._returning_columns_for_insert(default_connection)
         end
 
         ActiveRecord::Base.connected_to(role: :writing, shard: :default) do
@@ -511,7 +514,7 @@ module ActiveRecord
           assert_equal "default value", record.new_column
         end
 
-        assert_includes model.column_names, "new_column"
+        assert_not_includes model.column_names, "new_column"
       ensure
         SecondaryBase.default_shard = :default
       end

--- a/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
@@ -468,6 +468,54 @@ module ActiveRecord
         assert ShardConnectionTestModel.find_by_shard_key("foo")
       end
 
+      def test_model_schema_is_separate_for_each_shard
+        SecondaryBase.connects_to shards: {
+          default: { writing: { database: ":memory:", adapter: "sqlite3" } },
+          migrated: { writing: { database: ":memory:", adapter: "sqlite3" } }
+        }
+        SecondaryBase.default_shard = :none
+        model = Class.new(SecondaryBase) do
+          self.table_name = "shard_connection_test_models"
+          self.partial_inserts = false
+        end
+
+        ActiveRecord::Base.connected_to(role: :writing, shard: :default) do
+          model.lease_connection.create_table(:shard_connection_test_models) do |t|
+            t.string :shard_key
+          end
+        end
+
+        ActiveRecord::Base.connected_to(role: :writing, shard: :migrated) do
+          model.lease_connection.create_table(:shard_connection_test_models) do |t|
+            t.string :shard_key
+            t.string :new_column, default: "default value"
+          end
+
+          assert_includes model.column_names, "new_column"
+          assert_includes model.attribute_names, "new_column"
+          assert_equal :string, model.type_for_attribute("new_column").type
+          assert_equal "default value", model.column_defaults["new_column"]
+          assert_equal "default value", model.new.new_column
+        end
+
+        ActiveRecord::Base.connected_to(role: :writing, shard: :default) do
+          assert_not_includes model.column_names, "new_column"
+          assert_not_includes model.attribute_names, "new_column"
+          assert_not model.has_attribute?("new_column")
+          assert_not model.column_defaults.key?("new_column")
+          model.create!(shard_key: "default")
+        end
+
+        ActiveRecord::Base.connected_to(role: :writing, shard: :migrated) do
+          record = model.create!(shard_key: "migrated")
+          assert_equal "default value", record.new_column
+        end
+
+        assert_includes model.column_names, "new_column"
+      ensure
+        SecondaryBase.default_shard = :default
+      end
+
       def test_swapping_shards_globally_in_a_multi_threaded_environment
         tf_default = Tempfile.open "shard_key_default"
         tf_shard_one = Tempfile.open "shard_key_one"

--- a/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
@@ -468,55 +468,39 @@ module ActiveRecord
         assert ShardConnectionTestModel.find_by_shard_key("foo")
       end
 
-      def test_model_schema_is_separate_for_each_shard
+      def test_model_schema_can_use_a_connection_pool_different_from_current
         SecondaryBase.connects_to shards: {
-          default: { writing: { database: ":memory:", adapter: "sqlite3" } },
+          authority: { writing: { database: ":memory:", adapter: "sqlite3" } },
           migrated: { writing: { database: ":memory:", adapter: "sqlite3" } }
         }
-        SecondaryBase.default_shard = :none
-        model = Class.new(SecondaryBase) do
-          self.table_name = "shard_connection_test_models"
-          self.partial_inserts = false
-        end
 
-        default_connection = ActiveRecord::Base.connected_to(role: :writing, shard: :default) do
-          model.lease_connection.create_table(:shard_connection_test_models) do |t|
+        authority_pool = ActiveRecord::Base.connected_to(role: :writing, shard: :authority) do
+          SecondaryBase.lease_connection.create_table(:shard_connection_test_models) do |t|
             t.string :shard_key
           end
-          assert_not model.new.has_attribute?(:new_column)
-          model.lease_connection
+          SecondaryBase.connection_pool
         end
 
         ActiveRecord::Base.connected_to(role: :writing, shard: :migrated) do
-          model.lease_connection.create_table(:shard_connection_test_models) do |t|
+          SecondaryBase.lease_connection.create_table(:shard_connection_test_models) do |t|
             t.string :shard_key
             t.string :new_column, default: "default value"
           end
-
-          assert_includes model.column_names, "new_column"
-          assert_includes model.attribute_names, "new_column"
-          assert_equal :string, model.type_for_attribute("new_column").type
-          assert_equal "default value", model.column_defaults["new_column"]
-          assert_equal "default value", model.new.new_column
-          assert_equal ["id"], model._returning_columns_for_insert(default_connection)
         end
 
-        ActiveRecord::Base.connected_to(role: :writing, shard: :default) do
-          assert_not_includes model.column_names, "new_column"
-          assert_not_includes model.attribute_names, "new_column"
-          assert_not model.has_attribute?("new_column")
-          assert_not model.column_defaults.key?("new_column")
-          model.create!(shard_key: "default")
+        model = Class.new(SecondaryBase) do
+          self.table_name = "shard_connection_test_models"
+        end
+        model.define_singleton_method(:build_schema_context) do
+          ActiveRecord::ModelSchema::SchemaContext.new(self, authority_pool)
         end
 
         ActiveRecord::Base.connected_to(role: :writing, shard: :migrated) do
-          record = model.create!(shard_key: "migrated")
-          assert_equal "default value", record.new_column
+          assert_equal %w[id shard_key], model.column_names
+          assert_equal %w[id shard_key], model.attribute_names
+          assert_not model.has_attribute?("new_column")
+          assert_not model.column_defaults.key?("new_column")
         end
-
-        assert_not_includes model.column_names, "new_column"
-      ensure
-        SecondaryBase.default_shard = :default
       end
 
       def test_swapping_shards_globally_in_a_multi_threaded_environment


### PR DESCRIPTION
Model schema state is shared across every connection pool. If shards temporarily have different schemas during a rolling migration, whichever shard loads a model first determines its columns and related caches for every shard in that process. APIs such as `insert_all` can then generate SQL using columns that do not exist on the shard receiving the query.

~~This PR keeps a separate `SchemaContext` for each connection pool, so sharded models use the columns and related caches for the currently selected shard.~~

This approach added a measurable cost to warmed schema calls. After profiling with Vernier, the second commit added fast paths that removed more than 85% of the schema access overhead and cut the extra model construction cost by around a third. It was still slower than the existing single context in Rails, and generated attribute methods remained shared by the model.

Following the review, this now only lets a `SchemaContext` use an explicit connection pool and moves `attribute_names` alongside the rest of the schema-derived state. Rails keeps one context per model by default. Applications can use `build_schema_context` to choose where model metadata comes from.

At [Buildkite](https://github.com/buildkite), we plan to use one shard as the schema authority and migrate it last. This keeps the application on the old schema until every other shard has migrated, without making Rails choose a context on every schema call.
