### PR TITLE
Remove no-op `Marshalling.format_version` handling from tests

### DIFF
--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1570,7 +1570,7 @@ class BasicsTest < ActiveRecord::TestCase
     assert_predicate post, :new_record?, "should be a new record"
   end
 
-  def test_marshalling_with_associations_6_1
+  def test_marshalling_with_associations
     post = Post.new
     post.comments.build
 
@@ -1578,21 +1578,6 @@ class BasicsTest < ActiveRecord::TestCase
     post       = Marshal.load(marshalled)
 
     assert_equal 1, post.comments.length
-  end
-
-  def test_marshalling_with_associations_7_1
-    previous_format_version = ActiveRecord::Marshalling.format_version
-    ActiveRecord::Marshalling.format_version = 7.1
-
-    post = Post.new
-    post.comments.build
-
-    marshalled = Marshal.dump(post)
-    post       = Marshal.load(marshalled)
-
-    assert_equal 1, post.comments.length
-  ensure
-    ActiveRecord::Marshalling.format_version = previous_format_version
   end
 
   if Process.respond_to?(:fork) && !in_memory_db?

--- a/activerecord/test/cases/marshal_serialization_test.rb
+++ b/activerecord/test/cases/marshal_serialization_test.rb
@@ -7,14 +7,6 @@ require "models/reply"
 class MarshalSerializationTest < ActiveRecord::TestCase
   fixtures :topics
 
-  setup do
-    @previous_format_version = ActiveRecord::Marshalling.format_version
-  end
-
-  teardown do
-    ActiveRecord::Marshalling.format_version = @previous_format_version
-  end
-
   def test_deserializing_rails_6_1_marshal_basic
     Topic.undefine_attribute_methods
     topic = Marshal.load(marshal_fixture("rails_6_1_topic"))
@@ -58,21 +50,7 @@ class MarshalSerializationTest < ActiveRecord::TestCase
     assert_same topic, topic.replies.first.topic
   end
 
-  def test_rails_6_1_rountrip
-    topic = Topic.find(1)
-    topic.replies.to_a
-    topic = Marshal.load(Marshal.dump(topic))
-
-    assert_not_predicate topic, :new_record?
-    assert_equal 1, topic.id
-    assert_equal "The First Topic", topic.title
-    assert_equal "Have a nice day", topic.content
-    assert_predicate topic.association(:replies), :loaded?
-  end
-
   def test_rails_7_1_rountrip
-    ActiveRecord::Marshalling.format_version = 7.1
-
     topic = Topic.find(1)
     topic.replies.each(&:topic)
     assert_not_equal 0, topic.replies.size


### PR DESCRIPTION
Since #57382, `format_version` is always `7.1` and `format_version=` raises for anything else, so saving and restoring it is a no-op.

Without it, `test_rails_6_1_rountrip` is a strict subset of `test_rails_7_1_rountrip`, and `test_marshalling_with_associations_6_1` and `_7_1` are identical, so the redundant ones are removed.
