### PR TITLE
dependent: :destroy_async on has_many :through destroys target record…

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix `dependent: :destroy_async` on `has_many :through` associations to
+    destroy join records instead of associated records.
+
+    *Nicolas Vandenbogaerde*
+
 *   Support dumping `schema_migrations` in `db/schema.rb`.
 
     When the new `ActiveRecord.dump_schema_migrations` flag is true, `:ruby`

--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -28,25 +28,26 @@ module ActiveRecord
           load_target.each { |t| t.destroyed_by_association = reflection }
           destroy_all
         when :destroy_async
-          load_target.each do |t|
-            t.destroyed_by_association = reflection
+          records = destroy_async_records
+          records.each do |t|
+            t.destroyed_by_association = destroy_async_reflection
           end
 
-          unless target.empty?
-            association_class = target.first.class
-            if association_class.query_constraints_list
-              primary_key_column = association_class.query_constraints_list
-              ids = target.collect { |assoc| primary_key_column.map { |col| assoc.public_send(col) } }
+          unless records.empty?
+            record_class = records.first.class
+            if record_class.query_constraints_list
+              primary_key_column = record_class.query_constraints_list
+              ids = records.collect { |assoc| primary_key_column.map { |col| assoc.public_send(col) } }
             else
-              primary_key_column = association_class.primary_key
-              ids = target.collect { |assoc| assoc.public_send(primary_key_column) }
+              primary_key_column = record_class.primary_key
+              ids = records.collect { |assoc| assoc.public_send(primary_key_column) }
             end
 
             ids.each_slice(owner.class.destroy_association_async_batch_size || ids.size) do |ids_batch|
               enqueue_destroy_association(
                 owner_model_name: owner.class.to_s,
                 owner_id: owner.id,
-                association_class: reflection.klass.to_s,
+                association_class: destroy_async_reflection.klass.to_s,
                 association_ids: ids_batch,
                 association_primary_key_column: primary_key_column,
                 ensuring_owner_was_method: options.fetch(:ensuring_owner_was, nil)
@@ -64,6 +65,14 @@ module ActiveRecord
       end
 
       private
+        def destroy_async_records
+          load_target
+        end
+
+        def destroy_async_reflection
+          reflection
+        end
+
         # Returns the number of records in this collection.
         #
         # If the association has a counter cache it gets that value. Otherwise

--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -34,6 +34,22 @@ module ActiveRecord
       end
 
       private
+        def destroy_async_records
+          records = load_target
+
+          if records.empty?
+            records
+          else
+            scope = through_association.scope
+            scope.where! construct_join_attributes(*records)
+            scope.where(through_scope_attributes).to_a
+          end
+        end
+
+        def destroy_async_reflection
+          through_reflection
+        end
+
         def concat_records(records)
           ensure_not_nested
 

--- a/activerecord/test/activejob/destroy_association_async_test.rb
+++ b/activerecord/test/activejob/destroy_association_async_test.rb
@@ -32,20 +32,27 @@ class DestroyAssociationAsyncTest < ActiveRecord::TestCase
   include ActiveJob::TestHelper
 
   test "destroying a record destroys the has_many :through records using a job" do
-    tag = Tag.create!(name: "Der be treasure")
-    tag2 = Tag.create!(name: "Der be rum")
+    tag = Tag.create!(name: "Shared treasure")
     book = BookDestroyAsync.create!
-    book.tags << [tag, tag2]
-    book.save!
+    other_book = BookDestroyAsync.create!
+    book.tags << tag
+    other_book.tags << tag
+    tagging = book.taggings.first
+    other_tagging = other_book.taggings.first
 
     assert_enqueued_jobs 1, only: ActiveRecord::DestroyAssociationAsyncJob do
       book.destroy
     end
 
-    assert_difference -> { Tag.count }, -2 do
-      perform_enqueued_jobs only: ActiveRecord::DestroyAssociationAsyncJob
+    assert_no_difference -> { Tag.count } do
+      assert_difference -> { Tagging.count }, -1 do
+        perform_enqueued_jobs only: ActiveRecord::DestroyAssociationAsyncJob
+      end
     end
+    assert_not Tagging.exists?(tagging.id)
+    assert Tagging.exists?(other_tagging.id)
   ensure
+    Tagging.delete_all
     Tag.delete_all
     BookDestroyAsync.delete_all
   end
@@ -65,19 +72,22 @@ class DestroyAssociationAsyncTest < ActiveRecord::TestCase
       blog_post.destroy
     end
 
-    sql = capture_sql do
-      assert_difference -> { Sharded::Tag.count }, -2 do
-        perform_enqueued_jobs only: ActiveRecord::DestroyAssociationAsyncJob
+    assert_no_difference -> { Sharded::Tag.count } do
+      sql = capture_sql do
+        assert_difference -> { Sharded::BlogPostTag.count }, -2 do
+          perform_enqueued_jobs only: ActiveRecord::DestroyAssociationAsyncJob
+        end
+      end
+
+      delete_sqls = sql.select { |sql| sql.start_with?("DELETE") }
+      assert_equal 2, delete_sqls.count
+
+      delete_sqls.each do |sql|
+        assert_match(/#{Regexp.escape(quote_table_name("sharded_blog_posts_tags.blog_id"))} =/, sql)
       end
     end
-
-    delete_sqls = sql.select { |sql| sql.start_with?("DELETE") }
-    assert_equal 2, delete_sqls.count
-
-    delete_sqls.each do |sql|
-      assert_match(/#{Regexp.escape(quote_table_name("sharded_tags.blog_id"))} =/, sql)
-    end
   ensure
+    Sharded::BlogPostTag.delete_all
     Sharded::Tag.delete_all
     Sharded::BlogPostDestroyAsync.delete_all
     Sharded::Blog.delete_all
@@ -94,13 +104,13 @@ class DestroyAssociationAsyncTest < ActiveRecord::TestCase
 
     parent.destroy
 
-    assert_difference -> { Tag.count }, -1 do
-      perform_enqueued_jobs only: ActiveRecord::DestroyAssociationAsyncJob
-    end
-    assert_raises ActiveRecord::RecordNotFound do
-      tag2.reload
+    assert_no_difference -> { Tag.count } do
+      assert_difference -> { Tagging.count }, -1 do
+        perform_enqueued_jobs only: ActiveRecord::DestroyAssociationAsyncJob
+      end
     end
     assert tag.reload
+    assert tag2.reload
   ensure
     Tag.delete_all
     Tagging.delete_all
@@ -116,7 +126,7 @@ class DestroyAssociationAsyncTest < ActiveRecord::TestCase
     parent.destroy
 
     assert_difference -> { DlKeyedJoin.count }, -2 do
-      assert_difference -> { DlKeyedHasManyThrough.count }, -2 do
+      assert_no_difference -> { DlKeyedHasManyThrough.count } do
         perform_enqueued_jobs only: ActiveRecord::DestroyAssociationAsyncJob
       end
     end
@@ -135,8 +145,9 @@ class DestroyAssociationAsyncTest < ActiveRecord::TestCase
     book.tags << [tag, tag2]
     book.save!
 
-    job_1_args = ->(job_args) { job_args.first[:association_ids] == [tag.id] }
-    job_2_args = ->(job_args) { job_args.first[:association_ids] == [tag2.id] }
+    tagging_ids = book.taggings.ids
+    job_1_args = ->(job_args) { job_args.first[:association_ids] == [tagging_ids.first] }
+    job_2_args = ->(job_args) { job_args.first[:association_ids] == [tagging_ids.second] }
 
     assert_enqueued_with(job: ActiveRecord::DestroyAssociationAsyncJob, args: job_1_args) do
       assert_enqueued_with(job: ActiveRecord::DestroyAssociationAsyncJob, args: job_2_args) do
@@ -144,10 +155,13 @@ class DestroyAssociationAsyncTest < ActiveRecord::TestCase
       end
     end
 
-    assert_difference -> { Tag.count }, -2 do
-      perform_enqueued_jobs only: ActiveRecord::DestroyAssociationAsyncJob
+    assert_no_difference -> { Tag.count } do
+      assert_difference -> { Tagging.count }, -2 do
+        perform_enqueued_jobs only: ActiveRecord::DestroyAssociationAsyncJob
+      end
     end
   ensure
+    Tagging.delete_all
     Tag.delete_all
     BookDestroyAsync.delete_all
     ActiveRecord::Base.destroy_association_async_batch_size = nil
@@ -359,10 +373,13 @@ class DestroyAssociationAsyncTest < ActiveRecord::TestCase
     end
 
     parent.destroy
-    assert_difference -> { Tag.count }, -2 do
-      perform_enqueued_jobs only: ActiveRecord::DestroyAssociationAsyncJob
+    assert_no_difference -> { Tag.count } do
+      assert_difference -> { Tagging.count }, -2 do
+        perform_enqueued_jobs only: ActiveRecord::DestroyAssociationAsyncJob
+      end
     end
   ensure
+    Tagging.delete_all
     Tag.delete_all
     DestroyAsyncParentSoftDelete.delete_all
   end


### PR DESCRIPTION
Fixes #58564

### Motivation / Background

`dependent: :destroy_async` behaved differently from the synchronous deletion path on a `has_many :through` association.

The documented behavior for `:through` associations is that the **join records** are the ones removed, not the target records:

> If using with the `:through` option, the association on the join model must be a `belongs_to`, and the records which get deleted are the join records, rather than the associated records.
> — `ActiveRecord::Associations::ClassMethods#has_many`

> NOTE: The `:dependent` option is ignored with the `:through` option. When using `:through`, the join model must have a `belongs_to` association, and the deletion affects only the join records, not the associated records.
> — Active Record Associations guide

However, the asynchronous path collected the ids of the **target** records and enqueued them, so `ActiveRecord::DestroyAssociationAsyncJob` destroyed the targets themselves. With a shared target this silently deleted records still referenced by other owners, and ran their destroy callbacks.

```ruby
class Team < ApplicationRecord
  has_many :memberships
  has_many :users, through: :memberships, dependent: :destroy_async
end

user = User.create!
team_one = Team.create!
team_two = Team.create!
team_one.users << user
team_two.users << user

team_one.destroy!
# after the job runs

User.exists?(user.id)                              # => false  (before this PR)
Membership.exists?(team: team_two, user: user)     # => false  (before this PR)
```

The same scenario with `dependent: :destroy` only removes `team_one`'s membership, which is the behavior `:destroy_async` should match.

### Detail

`HasManyAssociation#handle_dependency` now resolves the records to enqueue and the reflection to enqueue them for through two overridable hooks instead of always using `load_target` and `reflection`:

* `destroy_async_records` — records whose ids get enqueued
* `destroy_async_reflection` — reflection providing the class the job instantiates

For a plain `has_many` these return `load_target` and `reflection`, so its behavior is unchanged.

`HasManyThroughAssociation` overrides both to target the join model. `destroy_async_records` builds the join-record scope with the exact same three lines already used by the synchronous `delete_records`:

```ruby
scope = through_association.scope
scope.where! construct_join_attributes(*records)
scope.where(through_scope_attributes)
```

Reusing `construct_join_attributes` and `through_scope_attributes` means association scopes, `:source_type` polymorphic joins, STI conditions and composite/custom primary keys are handled identically to the synchronous path. `destroy_async_reflection` returns `through_reflection`, so the job receives the join class and destroys join records — running their destroy callbacks, as `:destroy` does.

Batching via `destroy_association_async_batch_size` and the `:ensuring_owner_was` option keep working, now slicing join-record ids.

Existing tests in `destroy_association_async_test.rb` asserted the previous, undocumented behavior and were updated to assert the documented one: join records are destroyed and targets are left alone. The first test now uses a target shared by two owners so the regression from #58564 is covered directly.

### Additional information

This is a behavior change for applications relying on `dependent: :destroy_async` destroying target records on a `has_many :through`. That behavior contradicted both the documentation and the synchronous path, and could delete records shared with other owners. Applications that do want the targets destroyed can declare `dependent: :destroy_async` on the underlying `has_many` instead.

The issue was first reported to the Rails security team, which classified it as a non-security issue and directed it to the public tracker.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
