### PR TITLE
Set timeout-minutes for ci.yml jobs

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   A generated application's ci.yml file now sets `timeout-minutes: 15` for
+    each job to prevent transisent network errors, etc. from hanging the
+    action until the default 360 minutes kicks in and potentially eat up an
+    org's allotted runner minutes.
+
+    *Tony Drake*
+
 *   Make mounted route helpers (e.g. `main_app`, engine mount proxies) trigger
     the lazy route load instead of raising `NoMethodError` when called before
     routes are drawn.

--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -12,6 +12,7 @@ jobs:
 <%- unless skip_brakeman? && skip_bundler_audit? -%>
   scan_ruby:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code
@@ -36,6 +37,7 @@ jobs:
 <%- if using_importmap? -%>
   scan_js:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code
@@ -53,6 +55,7 @@ jobs:
 <%- unless skip_rubocop? -%>
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       RUBOCOP_CACHE_ROOT: tmp/rubocop
     steps:
@@ -81,6 +84,7 @@ jobs:
 <% unless options[:skip_test] -%>
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     <%- if options[:database] == "sqlite3" -%>
     # services:
@@ -154,6 +158,7 @@ jobs:
 
   system-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     <%- if options[:database] == "sqlite3" -%>
     # services:


### PR DESCRIPTION
### Motivation / Background

Github actions may have transient network errors during both downtime and normal operations. In those cases, steps that involve installing operating system packages may just hang and stall the entire job. It will sit there until the default 360 minute timeout kicks in and cancels the job. This can eat up organization runner minutes.

### Detail

To work around this, each job has a `timeout-minutes` option set to 15 for new applications. This should give enough ceiling for most jobs for apps with large test suites to run without issue while capping the amount of wasted minutes if it were to hang. Users can raise or remove the timeout if they want themselves. I choose to set it on all jobs just for sake of completeness and in case some other transient hanging issue creeps up in a different job.

### Additional information

Ref:
https://x.com/excid3/status/2089708290963886540
https://x.com/excid3/status/2089835568188264471

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
