### PR TITLE
Prefixed partial names ractor safe

### DIFF
--- a/actionview/lib/action_view/renderer/abstract_renderer.rb
+++ b/actionview/lib/action_view/renderer/abstract_renderer.rb
@@ -30,10 +30,6 @@ module ActionView
     end
 
     module ObjectRendering # :nodoc:
-      PREFIXED_PARTIAL_NAMES = Concurrent::Map.new do |h, k|
-        h.compute_if_absent(k) { Concurrent::Map.new }
-      end
-
       def initialize(lookup_context, options)
         super
         @context_prefix = lookup_context.prefixes.first
@@ -83,9 +79,15 @@ module ActionView
           end
 
           if view.prefix_partial_path_with_controller_namespace
-            PREFIXED_PARTIAL_NAMES[@context_prefix][path] ||= merge_prefix_into_object_path(@context_prefix, path.dup)
+            prefixed_partial_names[@context_prefix][path] ||= merge_prefix_into_object_path(@context_prefix, path.dup)
           else
             path
+          end
+        end
+
+        def prefixed_partial_names
+          ActiveSupport::Ractors.store_if_absent(:action_view_prefixed_partial_names) do
+            Concurrent::Map.new { |h, k| h.compute_if_absent(k) { Concurrent::Map.new } }
           end
         end
 

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -3,6 +3,7 @@
 require "abstract_unit"
 require "controller/fake_models"
 require "test_renderable"
+require "active_support/testing/ractors_assertions"
 require "active_model/validations"
 
 class TestController < ActionController::Base
@@ -1107,6 +1108,45 @@ class CachedCollectionViewRenderTest < ActiveSupport::TestCase
       "1 | 2 | 3 | 4 | 4",
       "1 | 2 | 3 | 4 | 6"
     ], splited_result
+  end
+
+  class ObjectRenderingRactorTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+    include ActiveSupport::Testing::RactorsAssertions
+
+    class ModelType
+      def to_partial_path
+        "model_types/model_type"
+      end
+    end
+
+    def self.render_object_partial
+      resolver = ActionView::FixtureResolver.new(
+        "admin/model_types/_model_type.html.erb" => "Hello from <%= model_type.to_partial_path %>"
+      )
+      details = { locale: [:en], formats: [:html], variants: [], handlers: [:erb] }
+      lookup_context = ActionView::LookupContext.new([resolver], details, ["admin/posts"])
+      view = ActionView::Base.with_empty_template_cache.with_context(lookup_context)
+      view.render(partial: ModelType.new)
+    end
+
+    test "renders an object partial with a namespaced partial name inside a non-main Ractor" do
+      Mime.eager_load!
+      rendered_on_main = self.class.render_object_partial
+      assert_equal "Hello from model_types/model_type", rendered_on_main
+
+      ActionView::Template::Handlers::ERB.escape_ignore_list.freeze
+      ActiveSupport::Ractors.unshareable_proc_action = :raise
+      ActiveSupport::Notifications.send(:record_subscriptions)
+
+      I18n::Config.prepend(Module.new do
+        def available_locales = [:en].freeze
+      end)
+
+      rendered_in_ractor = on_ractor { ObjectRenderingRactorTest.render_object_partial }
+
+      assert_equal rendered_on_main, rendered_in_ractor
+    end
   end
 
   private

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -289,7 +289,6 @@ module ActiveRecord
         end
 
         @table_name        = value
-        @arel_table        = Arel::Table.new(klass: self)
         @sequence_name     = nil unless @explicit_sequence_name
       end
 

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -289,6 +289,7 @@ module ActiveRecord
         end
 
         @table_name        = value
+        @arel_table        = Arel::Table.new(klass: self)
         @sequence_name     = nil unless @explicit_sequence_name
       end
 

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -117,7 +117,13 @@ module ActiveSupport
   singleton_class.attr_accessor :error_reporter # :nodoc:
 
   @event_reporter = ActiveSupport::EventReporter.new
-  singleton_class.attr_accessor :event_reporter # :nodoc:
+  singleton_class.attr_writer :event_reporter # :nodoc:
+
+  def self.event_reporter # :nodoc:
+    return @event_reporter if ActiveSupport::Ractors.main?
+
+    Ractor[:__event_reporter] ||= ActiveSupport::EventReporter.new
+  end
 
   cattr_accessor :filter_parameters, default: [] # :nodoc:
 

--- a/activesupport/test/event_reporter_test.rb
+++ b/activesupport/test/event_reporter_test.rb
@@ -2,6 +2,7 @@
 
 require_relative "abstract_unit"
 require "active_support/event_reporter/test_helper"
+require "active_support/testing/ractors_assertions"
 require "json"
 
 module ActiveSupport
@@ -693,6 +694,26 @@ module ActiveSupport
         timestamp: 1738964843208679035,
         source_location: { filepath: "/path/to/file.rb", lineno: 42, label: "test_method" }
       }
+    end
+  end
+
+  class EventReporterRactorTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::RactorsAssertions
+
+    if RUBY_VERSION >= "4.0"
+      test "each Ractor gets its own event reporter" do
+        main_subscriber_count = ActiveSupport.event_reporter.subscribers.size
+
+        event_names = on_ractor do
+          subscriber = EventReporter::TestHelper::EventSubscriber.new
+          ActiveSupport.event_reporter.subscribe(subscriber)
+          ActiveSupport.event_reporter.notify("ractor_event")
+          subscriber.events.map { |event| event[:name] }
+        end
+
+        assert_equal ["ractor_event"], event_names
+        assert_equal main_subscriber_count, ActiveSupport.event_reporter.subscribers.size
+      end
     end
   end
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because object rendering features in action view aren't ractor safe. This makes the prefix cache and the event notifier (found via testing) ractor safe by storing them per-ractor.

### Detail

This Pull Request changes the following:
- Replaces `ActionView::AbstractRenderer::ObjectRendering::PREFIXED_PARTIAL_NAMES` with a `prefixed_partial_names` ,method that caches the prefixed partial names in a per ractor cache.
- Changes `ActiveSupport.event_reporter` to use ractor local event reporters on non-main ractors, and the normal ivar otherwise.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
