### PR TITLE
Fix reloader interlock completion across fibers

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -183,6 +183,11 @@
 
     *Andrew Novoselac*
 
+*   Fix the reloader interlock leaking a shared lock when a Rack server invokes
+    `rack.response_finished` from a different fiber than the request.
+
+    *Samuel Williams*
+
 *   Fix `ActiveSupport::Concurrency::ShareLock` to honor `isolation_level`.
 
     Lock ownership was keyed on `Thread.current`. Under

--- a/activesupport/lib/active_support/concurrency/share_lock.rb
+++ b/activesupport/lib/active_support/concurrency/share_lock.rb
@@ -113,9 +113,8 @@ module ActiveSupport
         end
       end
 
-      def start_sharing
+      def start_sharing(owner: current_owner)
         synchronize do
-          owner = current_owner
           if @sharing[owner] > 0 || @exclusive_owner == owner
             # We already hold a lock; nothing to wait for
           elsif @waiting[owner]
@@ -131,9 +130,8 @@ module ActiveSupport
         end
       end
 
-      def stop_sharing
+      def stop_sharing(owner: current_owner)
         synchronize do
-          owner = current_owner
           if @sharing[owner] > 1
             @sharing[owner] -= 1
           else
@@ -161,11 +159,12 @@ module ActiveSupport
 
       # Execute the supplied block while holding the Share lock.
       def sharing
-        start_sharing
+        owner = current_owner
+        start_sharing(owner: owner)
         begin
           yield
         ensure
-          stop_sharing
+          stop_sharing(owner: owner)
         end
       end
 

--- a/activesupport/lib/active_support/dependencies/interlock.rb
+++ b/activesupport/lib/active_support/dependencies/interlock.rb
@@ -32,11 +32,13 @@ module ActiveSupport # :nodoc:
       end
 
       def start_running
-        @lock.start_sharing
+        owner = ActiveSupport::IsolatedExecutionState.context
+        @lock.start_sharing(owner: owner)
+        owner
       end
 
-      def done_running
-        @lock.stop_sharing
+      def done_running(owner = ActiveSupport::IsolatedExecutionState.context)
+        @lock.stop_sharing(owner: owner)
       end
 
       def running(&block)

--- a/activesupport/test/executor_test.rb
+++ b/activesupport/test/executor_test.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require_relative "abstract_unit"
+require "active_support/core_ext/object/with"
+require "active_support/dependencies"
 
 class ExecutorTest < ActiveSupport::TestCase
   class DummyError < Exception
@@ -132,6 +134,34 @@ class ExecutorTest < ActiveSupport::TestCase
     executor.wrap { }
 
     assert_equal :some_state, supplied_state
+  end
+
+  def test_hook_can_release_interlock_from_another_fiber
+    ActiveSupport::IsolatedExecutionState.with(isolation_level: :fiber) do
+      interlock = ActiveSupport::Dependencies::Interlock.new
+
+      hook = Class.new do
+        define_method(:run) do
+          interlock.start_running
+        end
+
+        define_method(:complete) do |owner|
+          interlock.done_running(owner)
+        end
+      end.new
+
+      executor.register_hook(hook)
+
+      request_fiber = Fiber.new { executor.run! }
+      state = request_fiber.resume
+      assert_not request_fiber.alive?
+
+      Fiber.new { state.complete! }.resume
+
+      interlock.raw_state do |owners|
+        assert_empty owners
+      end
+    end
   end
 
   def test_nil_state_is_sufficient

--- a/activesupport/test/share_lock_test.rb
+++ b/activesupport/test/share_lock_test.rb
@@ -714,6 +714,23 @@ class ShareLockFiberTest < ActiveSupport::TestCase
     fiber_b.resume
   end
 
+  def test_share_can_be_released_by_explicit_owner_from_another_fiber
+    owner = Fiber.new do
+      @lock.start_sharing
+      Fiber.current
+    end.resume
+
+    assert_not owner.alive?
+
+    Fiber.new do
+      @lock.stop_sharing(owner: owner)
+    end.resume
+
+    @lock.raw_state do |state|
+      assert_empty state
+    end
+  end
+
   def test_thread_isolation_level_still_collapses_fibers_to_one_owner
     ActiveSupport::IsolatedExecutionState.isolation_level = :thread
     lock = ActiveSupport::Concurrency::ShareLock.new

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -112,8 +112,8 @@ module Rails
           ActiveSupport::Dependencies.interlock.start_running
         end
 
-        def self.complete(_state)
-          ActiveSupport::Dependencies.interlock.done_running
+        def self.complete(owner)
+          ActiveSupport::Dependencies.interlock.done_running(owner)
         end
       end
 


### PR DESCRIPTION
### Motivation / Background

When `ActiveSupport::IsolatedExecutionState` uses fiber isolation, the reloader interlock's shared lock is owned by the fiber that begins request execution.

Rack permits `rack.response_finished` callbacks to be invoked as part of response completion. A server may perform that completion from a different fiber than the one that called the application. In that case, Rails currently attempts to release the shared lock using the callback fiber as its owner, leaving the request fiber's lock held. A subsequent development reload then waits indefinitely for that leaked share.

This was reproduced with Falcon over HTTP/2 and is tracked in https://github.com/socketry/falcon/issues/359.

### Detail

This Pull Request:

* Allows `ShareLock#start_sharing` and `#stop_sharing` to receive an explicit owner while retaining the current execution context as their default.
* Captures the owner in `Interlock#start_running` and returns it as executor hook state.
* Passes that state to `Interlock#done_running`, allowing completion to release the same owner even when it runs in another fiber.
* Ensures `ShareLock#sharing` likewise releases the owner it originally acquired.
* Adds regression coverage for explicit cross-fiber release and executor hook completion from another fiber.

### Additional information

The Falcon reproduction confirms that the request and `rack.response_finished` callback execute in different fibers, the original owner's shared lock is released, and a request after a source-file change reloads successfully.

Targeted test results:

* `activesupport/bin/test test/share_lock_test.rb` — 33 runs, 183 assertions
* `activesupport/bin/test test/executor_test.rb` — 14 runs, 23 assertions
* `actionpack/bin/test test/dispatch/executor_test.rb` — 16 runs, 35 assertions

Focused RuboCop checks pass for all changed Ruby files.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated for the bug fix.
* [x] The Active Support CHANGELOG is updated.
