### PR TITLE
Fix compatibility with json 3.0

### DIFF
--- a/activerecord/lib/active_record/coders/json.rb
+++ b/activerecord/lib/active_record/coders/json.rb
@@ -5,11 +5,12 @@ require "active_support/json"
 module ActiveRecord
   module Coders
     class JSON # :nodoc:
-      DEFAULT_OPTIONS = { escape: false }.freeze
+      DEFAULT_ENCODE_OPTIONS = { escape: false }.freeze
 
-      def initialize(options = nil)
-        @options = options ? DEFAULT_OPTIONS.merge(options) : DEFAULT_OPTIONS
-        @encoder = ActiveSupport::JSON::Encoding.json_encoder.new(@options)
+      def initialize(encode_options: nil, decode_options: nil)
+        encode_options = encode_options ? DEFAULT_ENCODE_OPTIONS.merge(options) : DEFAULT_ENCODE_OPTIONS
+        @decode_options = decode_options
+        @encoder = ActiveSupport::JSON::Encoding.json_encoder.new(encode_options)
       end
 
       def dump(obj)
@@ -17,7 +18,7 @@ module ActiveRecord
       end
 
       def load(json)
-        ActiveSupport::JSON.decode(json, @options) unless json.blank?
+        ActiveSupport::JSON.decode(json, @decode_options) unless json.blank?
       end
     end
   end

--- a/activerecord/test/cases/coders/json_test.rb
+++ b/activerecord/test/cases/coders/json_test.rb
@@ -16,7 +16,7 @@ module ActiveRecord
       end
 
       def test_coder_with_symbolize_names
-        coder = JSON.new(symbolize_names: true)
+        coder = JSON.new(decode_options: { symbolize_names: true })
         assert_equal({ foo: "bar" }, coder.load('{"foo":"bar"}'))
       end
 

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -156,7 +156,7 @@ class SerializedAttributeTest < ActiveRecord::TestCase
   end
 
   def test_json_symbolize_names_returns_symbolized_names
-    Topic.serialize :content, coder: ActiveRecord::Coders::JSON.new(symbolize_names: true)
+    Topic.serialize :content, coder: ActiveRecord::Coders::JSON.new(decode_options: { symbolize_names: true })
     my_post = posts(:welcome)
 
     t = Topic.new(content: my_post)

--- a/activesupport/lib/active_support/json/decoding.rb
+++ b/activesupport/lib/active_support/json/decoding.rb
@@ -23,7 +23,7 @@ module ActiveSupport
       # # => 2.39
       # ```
       def decode(json, options = {})
-        data = ::JSON.parse(json, options)
+        data = ::JSON.parse(json, **options)
 
         if ActiveSupport.parse_json_times
           convert_dates_from(data)


### PR DESCRIPTION
### Motivation / Background

It needs keywords arguments now.

I guess the method signature should really be `def decode(...)` and just pass stuff along but theres a test that a hash works and there's also the `encode` equivalent.

Either way, this works with both versions.

cc @byroot. Maybe you want to do a different fix

### Detail

https://github.com/ruby/json/blob/master/CHANGES.md#2026-08-11-300rc1

> All methods options are now either keyword arguments or checked like keyword arguments, meaning unknown options such as typos raise ArgumentError.

As well as a positional hash. Sample backtrace
```
ArgumentError: wrong number of arguments (given 2, expected 1)
    vendor/ruby/4.1.0+4/bundler/gems/json-d3c71136ca56/lib/json/common.rb:296:in 'JSON.parse'
    vendor/ruby/4.1.0+4/bundler/gems/rails-0f6800185229/activesupport/lib/active_support/json/decoding.rb:26:in 'ActiveSupport::JSON.decode'
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
