### PR TITLE
[8-0-stable] Fix compatibility with json 3.0

### DIFF
--- a/activesupport/lib/active_support/json/decoding.rb
+++ b/activesupport/lib/active_support/json/decoding.rb
@@ -22,7 +22,7 @@ module ActiveSupport
       #   ActiveSupport::JSON.decode("2.39")
       #   # => 2.39
       def decode(json)
-        data = ::JSON.parse(json, quirks_mode: true)
+        data = ::JSON.parse(json)
 
         if ActiveSupport.parse_json_times
           convert_dates_from(data)

--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -107,7 +107,7 @@ module ActiveSupport
 
           # Encode a "jsonified" Ruby data structure using the JSON gem
           def stringify(jsonified)
-            ::JSON.generate(jsonified, quirks_mode: true, max_nesting: false)
+            ::JSON.generate(jsonified, max_nesting: false)
           end
       end
 

--- a/activesupport/test/core_ext/object/json_gem_encoding_test.rb
+++ b/activesupport/test/core_ext/object/json_gem_encoding_test.rb
@@ -45,7 +45,7 @@ class JsonGemEncodingTest < ActiveSupport::TestCase
 
     def assert_same_with_or_without_active_support(subject)
       begin
-        expected = JSON.generate(subject, quirks_mode: true)
+        expected = JSON.generate(subject)
       rescue JSON::GeneratorError => e
         exception = e
       end
@@ -54,10 +54,10 @@ class JsonGemEncodingTest < ActiveSupport::TestCase
 
       if exception
         assert_raises JSON::GeneratorError, match: e.message do
-          JSON.generate(subject, quirks_mode: true)
+          JSON.generate(subject)
         end
       else
-        assert_equal expected, JSON.generate(subject, quirks_mode: true)
+        assert_equal expected, JSON.generate(subject)
       end
     end
 end


### PR DESCRIPTION
Same as https://github.com/rails/rails/pull/58601 except much easier since both the changes that made the PR necessary haven't been made yet.
Doesn't appear to be anything else that needs chaning except removing some legacy options
