### PR TITLE
Improve performance of Active Record model class predicate builders

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -439,7 +439,7 @@ module ActiveRecord
 
           subclass.class_eval do
             @arel_table = Arel::Table.new(klass: self)
-            @predicate_builder = nil
+            @predicate_builder = PredicateBuilder.new(TableMetadata.new(self, @arel_table))
             @inspection_filter = nil
             @filter_attributes ||= nil
             @generated_association_methods ||= nil

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -282,14 +282,15 @@ module ActiveRecord
       def table_name=(value)
         value = (value && value.to_s).freeze
 
-        if defined?(@table_name)
+        renaming = defined?(@table_name)
+        if renaming
           return if value == @table_name
           reset_column_information if connected?
-          @predicate_builder = nil
         end
 
         @table_name        = value
         @arel_table        = Arel::Table.new(klass: self)
+        @predicate_builder = PredicateBuilder.new(TableMetadata.new(self, @arel_table)) if renaming
         @sequence_name     = nil unless @explicit_sequence_name
       end
 
@@ -581,6 +582,7 @@ module ActiveRecord
         def reload_schema_from_cache(recursive = true)
           @schema_hooks_loaded = false
           @arel_table = Arel::Table.new(klass: self)
+          @predicate_builder = PredicateBuilder.new(TableMetadata.new(self, @arel_table)) unless self == Base
           @attribute_names = nil
 
           reload_schema_contexts_from_cache

--- a/activerecord/test/cases/relation/predicate_builder_test.rb
+++ b/activerecord/test/cases/relation/predicate_builder_test.rb
@@ -231,6 +231,20 @@ module ActiveRecord
       assert_ractor_shareable Topic.predicate_builder
     end
 
+    def test_is_eagerly_built_and_reachable_from_a_ractor
+      model = Class.new(ActiveRecord::Base) do
+        def self.name
+          "PredicateBuilderEagerModel"
+        end
+
+        self.table_name = "topics"
+      end
+
+      builder = on_ractor(model) { |m| m.instance_variable_get(:@predicate_builder) }
+
+      assert_same model.predicate_builder, builder
+    end
+
     def test_attribute_type_can_define_a_comparison_expression
       topic = topic_model_with_title_type(UnaccentedString.new)
       sql = topic.where(title: "CAFE").to_sql


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because predicate builder ivars can be eagerly assigned in Active Record models. The main proxying on assignment isn't needed, and would slow down initial requests / queries.

### Detail

This Pull Request changes Active Record to eagerly assign the predicate builder to avoid lazy main proxying.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
