### PR TITLE
Allow records as values in tuple-syntax where clauses

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Allow records as values in tuple-syntax `where` clauses. Records that respond to
+    `#id` are now resolved to their primary key values automatically.
+
+    ```ruby
+    Cpk::Book.where([:author_id, :id] => book)
+    Cpk::Book.where([:author_id, :id] => [book])
+    ```
+
+    *Htet Wun San*
+
 *   Avoid unnecessary association preloader queries for nil foreign keys when
     the foreign key and association primary key have different types.
 

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -122,8 +122,10 @@ module ActiveRecord
           end
 
           if key.is_a?(Array)
-            queries = Array(value).map do |ids_set|
+            queries = Array(value).map do |value|
+              ids_set = value.respond_to?(:id) ? value.id : value
               raise ArgumentError, "Expected corresponding value for #{key} to be an Array" unless ids_set.is_a?(Array)
+
               attributes = convert_dot_notation_to_hash(key.zip(ids_set).to_h)
               expand_from_hash(attributes)
             end

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -116,6 +116,16 @@ module ActiveRecord
       assert_empty Cpk::Book.where([:author_id, :id] => [[1, 4], [3, 2]])
     end
 
+    def test_where_with_tuple_syntax_on_composite_models_accepts_records
+      book_one = Cpk::Book.create!(id: [1, 2])
+      book_two = Cpk::Book.create!(id: [3, 4])
+
+      assert_equal [book_one], Cpk::Book.where([:author_id, :id] => book_one)
+      assert_equal [book_one], Cpk::Book.where([:author_id, :id] => [book_one])
+      assert_equal [book_one, book_two].sort, Cpk::Book.where(Cpk::Book.primary_key => [book_one, book_two]).sort
+      assert_empty Cpk::Book.where([:author_id, :id] => [[1, 4], [3, 2]])
+    end
+
     def test_where_with_tuple_syntax_with_incorrect_arity
       error = assert_raise ArgumentError do
         Cpk::Book.where([:one, :two, :three] => [1, 2, 3])


### PR DESCRIPTION
`where` with an array key now resolves values that respond to `#id` to their
primary key values, so records (e.g. composite primary key models) can be
passed directly as tuple values.

```ruby
Cpk::Book.where([:author_id, :id] => book)
Cpk::Book.where([:author_id, :id] => [book])
```

Previously this raised ArgumentError because records are not arrays.

### Motivation / Background

"where" with tuple-syntax previously only accepted raw arrays of primary key
values, raising `ArgumentError: Expected corresponding value for [:author_id, :id]
to be an Array` when a record (e.g. a composite primary key model) was passed,
even though its `#id` provides exactly the needed values. This aligns with how
records are accepted elsewhere in the predicate builder.

### Detail

This Pull Request changes `PredicateBuilder#expand_from_hash` to resolve a value
that responds to `:id` to its primary key values before validating it is an Array
and zipping it against the key columns, so `Cpk::Book.where([:author_id, :id] => [book])`
builds the same query as `Cpk::Book.where([:author_id, :id] => [book.id])`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.