### PR TITLE
Fix encrypted fixtures for JSON columns

### DIFF
--- a/activerecord/lib/active_record/encryption/encrypted_fixtures.rb
+++ b/activerecord/lib/active_record/encryption/encrypted_fixtures.rb
@@ -15,10 +15,7 @@ module ActiveRecord
           model_class&.encrypted_attributes&.each do |attribute_name|
             if clean_value = fixture[attribute_name.to_s]
               @clean_values[attribute_name.to_s] = clean_value
-
-              type = model_class.type_for_attribute(attribute_name)
-              encrypted_value = type.serialize(clean_value)
-              fixture[attribute_name.to_s] = encrypted_value
+              fixture[attribute_name.to_s] = encrypt(model_class, attribute_name, clean_value)
             end
           end
         end
@@ -27,10 +24,18 @@ module ActiveRecord
           model_class&.encrypted_attributes&.each do |attribute_name|
             if source_attribute_name = model_class.source_attribute_from_preserved_attribute(attribute_name)
               clean_value = @clean_values[source_attribute_name.to_s]
-              type = model_class.type_for_attribute(attribute_name)
-              encrypted_value = type.serialize(clean_value)
-              fixture[attribute_name.to_s] = encrypted_value
+              fixture[attribute_name.to_s] = encrypt(model_class, attribute_name, clean_value)
             end
+          end
+        end
+
+        def encrypt(model_class, attribute_name, clean_value)
+          encrypted_value = model_class.type_for_attribute(attribute_name).serialize(clean_value)
+
+          if column = model_class.columns_hash[attribute_name.to_s]
+            column.cast_type.deserialize(encrypted_value)
+          else
+            encrypted_value
           end
         end
     end

--- a/activerecord/test/cases/encryption/encrypted_fixtures_test.rb
+++ b/activerecord/test/cases/encryption/encrypted_fixtures_test.rb
@@ -6,7 +6,7 @@ require "models/book_encrypted"
 class ActiveRecord::Encryption::EncryptableFixtureTest < ActiveRecord::EncryptionTestCase
   self.use_transactional_tests = false
 
-  fixtures :encrypted_books, :encrypted_book_that_ignores_cases
+  fixtures :encrypted_books, :encrypted_book_that_ignores_cases, :encrypted_book_with_json
 
   test "fixtures get encrypted automatically" do
     assert encrypted_books(:awdr).encrypted_attribute?(:name)
@@ -18,5 +18,13 @@ class ActiveRecord::Encryption::EncryptableFixtureTest < ActiveRecord::Encryptio
     assert_encrypted_attribute book, :name, "Ruby for Rails"
 
     assert EncryptedBookThatIgnoresCase.find_by_name("Ruby for Rails")
+  end
+
+  test "fixtures for json columns get encrypted automatically" do
+    skip "JSON columns are not supported" unless ActiveRecord::Base.lease_connection.supports_json?
+
+    book = encrypted_book_with_json(:pickaxe)
+    assert book.encrypted_attribute?(:metadata)
+    assert_encrypted_attribute book, :metadata, { "pages" => 448, "edition" => 4 }
   end
 end

--- a/activerecord/test/fixtures/encrypted_book_with_json.yml
+++ b/activerecord/test/fixtures/encrypted_book_with_json.yml
@@ -1,0 +1,6 @@
+pickaxe:
+  author_id: 1
+  name: "Programming Ruby"
+  metadata:
+    pages: 448
+    edition: 4

--- a/activerecord/test/models/book_encrypted.rb
+++ b/activerecord/test/models/book_encrypted.rb
@@ -75,6 +75,12 @@ class EncryptedBookWithBinary < ActiveRecord::Base
   encrypts :logo
 end
 
+class EncryptedBookWithJson < ActiveRecord::Base
+  self.table_name = "encrypted_books"
+
+  encrypts :metadata
+end
+
 class EncryptedBookWithSerializedFirstBinary < ActiveRecord::Base
   self.table_name = "encrypted_books"
 

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -170,6 +170,7 @@ ActiveRecord::Schema.define do
     t.column :name, :string, default: "<untitled>", limit: 1024
     t.column :original_name, :string
     t.column :logo, :binary
+    t.json :metadata
 
     t.datetime :created_at
     t.datetime :updated_at


### PR DESCRIPTION
### Motivation / Background

Fixes #48601.

With `config.active_record.encryption.encrypt_fixtures = true`, a fixture for an `encrypts` attribute on a `json` or `jsonb` column raises `ActiveRecord::Encryption::Errors::Decryption` when read.

The encrypted value was serialized twice. `EncryptedFixtures` stores the encrypted payload (a String) in the fixture, and `build_fixture_sql` then serializes every fixture value again with the column type. For `Type::Json` that encodes the payload as a JSON string, so the database ends up with `"{\"p\":...}"` instead of `{"p":...}`. String columns never showed the problem because serializing a String with `Type::String` is the identity.

### Detail

`EncryptedFixtures` now hands the payload back in the column's cast form (`column.cast_type.deserialize`), so `build_fixture_sql` serializes it once and stores the same JSON object a regular save would. String and binary columns are unaffected since their round-trip is the identity.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
