### PR TITLE
Don't mutate the options passed to SourceAnnotationExtractor

### DIFF
--- a/railties/lib/rails/source_annotation_extractor.rb
+++ b/railties/lib/rails/source_annotation_extractor.rb
@@ -121,8 +121,8 @@ module Rails
     def self.enumerate(tag = nil, options = {})
       tag ||= Annotation.tags.join("|")
       extractor = new(tag)
-      dirs = options.delete(:dirs) || Annotation.directories
-      extractor.display(extractor.find(dirs), options)
+      dirs = options[:dirs] || Annotation.directories
+      extractor.display(extractor.find(dirs), options.except(:dirs))
     end
 
     attr_reader :tag
@@ -177,7 +177,7 @@ module Rails
     # Prints the mapping from filenames to annotations in +results+ ordered by filename.
     # The +options+ hash is passed to each annotation's +to_s+.
     def display(results, options = {})
-      options[:indent] = results.flat_map { |f, a| a.map(&:line) }.max.to_s.size
+      options = options.merge(indent: results.flat_map { |f, a| a.map(&:line) }.max.to_s.size)
       results.keys.sort.each do |file|
         puts "#{file}:"
         results[file].each do |note|

--- a/railties/test/source_annotation_extractor_test.rb
+++ b/railties/test/source_annotation_extractor_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "rails/source_annotation_extractor"
+
+class SourceAnnotationExtractorTest < ActiveSupport::TestCase
+  def setup
+    @dir = File.expand_path("fixtures/tmp", __dir__)
+    FileUtils.mkdir_p(@dir)
+    File.write(File.join(@dir, "some_file.rb"), "# TODO: note in some file")
+  end
+
+  def teardown
+    FileUtils.rm_rf(@dir)
+  end
+
+  test "enumerate does not modify the given options" do
+    options = { dirs: [@dir], tag: true }
+
+    capture(:stdout) { Rails::SourceAnnotationExtractor.enumerate("TODO", options) }
+
+    assert_equal({ dirs: [@dir], tag: true }, options)
+  end
+
+  test "display does not modify the given options" do
+    extractor = Rails::SourceAnnotationExtractor.new("TODO")
+    results = extractor.find([@dir])
+    options = { tag: true }
+
+    capture(:stdout) { extractor.display(results, options) }
+
+    assert_equal({ tag: true }, options)
+  end
+end


### PR DESCRIPTION
### Motivation / Background

Fixes #58607.

`Rails::SourceAnnotationExtractor.enumerate` deleted `:dirs` from the options Hash it was handed, and `#display` then wrote `:indent` into that same Hash. Both are public methods, so a caller that reused or inspected its own options after running the extractor got them back rewritten with the extractor's internal bookkeeping:

```ruby
options = { dirs: ["lib"], tag: true }
Rails::SourceAnnotationExtractor.enumerate("TODO", options)
options # => { tag: true, indent: 1 }
```

### Detail

`enumerate` now reads `:dirs` instead of deleting it and passes `#display` a copy without that key, and `#display` builds its `:indent` entry with `merge` rather than assigning into the Hash it was given. The `rails notes` output is unchanged.

### Additional information

No CHANGELOG entry, since this is a minor bug fix with no change to `rails notes` output. Happy to add one if you'd prefer it documented.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
