### PR TITLE
Fix `NameError` when `ActiveRecord::Coders::JSON` is given encode options

### DIFF
--- a/activerecord/lib/active_record/coders/json.rb
+++ b/activerecord/lib/active_record/coders/json.rb
@@ -8,7 +8,7 @@ module ActiveRecord
       DEFAULT_ENCODE_OPTIONS = { escape: false }.freeze
 
       def initialize(encode_options: nil, decode_options: nil)
-        encode_options = encode_options ? DEFAULT_ENCODE_OPTIONS.merge(options) : DEFAULT_ENCODE_OPTIONS
+        encode_options = encode_options ? DEFAULT_ENCODE_OPTIONS.merge(encode_options) : DEFAULT_ENCODE_OPTIONS
         @decode_options = decode_options
         @encoder = ActiveSupport::JSON::Encoding.json_encoder.new(encode_options)
       end

--- a/activerecord/test/cases/coders/json_test.rb
+++ b/activerecord/test/cases/coders/json_test.rb
@@ -24,6 +24,11 @@ module ActiveRecord
         coder = JSON.new
         assert_equal '{"k":"<>&"}', coder.dump({ "k" => "<>&" })
       end
+
+      def test_dump_with_encode_options
+        coder = JSON.new(encode_options: { escape: true })
+        assert_equal '{"k":"\\u003c\\u003e\\u0026"}', coder.dump({ "k" => "<>&" })
+      end
     end
   end
 end


### PR DESCRIPTION
### Motivation / Background

Fixes #58609.

`ActiveRecord::Coders::JSON.new(encode_options: { escape: true })` raises `NameError: undefined local variable or method 'options'`. #58601 renamed the initializer argument from `options` to the `encode_options` keyword, but the line merging it into `DEFAULT_ENCODE_OPTIONS` kept referring to the old name, so the coder blows up as soon as encode options are actually passed.

### Detail

This Pull Request changes that merge to use the `encode_options` keyword, which restores the previous behaviour of layering the caller's options over the defaults. A test covering a coder built with encode options is added, since the existing ones only exercise the default and the decode side.

### Additional information

The regression is on `main` and `8-1-stable` but has not shipped in a release yet, so there is no CHANGELOG entry.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
