### PR TITLE
Don't count insignificant leading characters against the integer byte cap

### DIFF
--- a/activemodel/lib/active_model/type/integer.rb
+++ b/activemodel/lib/active_model/type/integer.rb
@@ -114,11 +114,20 @@ module ActiveModel
           when ::Integer
             value
           when ::String
-            str = value.bytesize > _limit * 4 ? value.byteslice(0, _limit * 4) : value
+            str = value.bytesize > _limit * 4 ? truncate_to_limit(value) : value
             str.to_i rescue nil
           else
             value.to_i rescue nil
           end
+        end
+
+        def truncate_to_limit(value)
+          # to_i skips leading whitespace, a sign and zeroes, so they must not
+          # use up the byte budget. The lookahead keeps the match from eating a
+          # digit that to_i would read, or a sign that it would stop at.
+          match = INSIGNIFICANT_PREFIX.match(value) if value.encoding.ascii_compatible?
+          return value.byteslice(0, _limit * 4) unless match
+          match[1] + value.byteslice(match.byteoffset(0).last, _limit * 4)
         end
 
         def max_value
@@ -132,6 +141,9 @@ module ActiveModel
         def _limit
           limit || DEFAULT_LIMIT
         end
+
+        INSIGNIFICANT_PREFIX = /\A\s*([+-]?)0*(?=\d)/
+        private_constant :INSIGNIFICANT_PREFIX
     end
   end
 end

--- a/activemodel/test/cases/type/integer_test.rb
+++ b/activemodel/test/cases/type/integer_test.rb
@@ -179,6 +179,32 @@ module ActiveModel
         assert_equal 42, type.cast("42-some-slug")
       end
 
+      test "leading whitespace, sign and zeros don't count towards the byte cap" do
+        type = Type::Integer.new # default limit: 4, byte cap: 16
+        # The cap applies to the significant digits, not to the padding in front of them
+        assert_equal 1, type.cast("0" * 100 + "1")
+        assert_equal 1, type.cast("+" + "0" * 100 + "1")
+        assert_equal(-12, type.cast(" \t-" + "0" * 100 + "12tail"))
+        assert_equal 42, type.cast(" " * 100 + "42")
+        assert_equal 0, type.cast("0" * 100)
+        assert_equal 0, type.cast("-" + "0" * 100)
+        # The cap is still enforced once the padding is skipped
+        assert_equal ("9" * 16).to_i, type.cast("0" * 100 + "9" * 30)
+      end
+
+      test "skipping the padding doesn't let to_i read a sign it would have stopped at" do
+        type = Type::Integer.new # default limit: 4, byte cap: 16
+        # to_i only honours a sign that leads the string, so padding must not change the value
+        assert_equal type.cast("0-1"), type.cast("0" * 100 + "-1")
+        assert_equal type.cast("0 5"), type.cast("  " + "0" * 100 + " 5")
+        assert_equal 0, type.cast("-" + "a" * 100)
+      end
+
+      test "long strings in a non ASCII compatible encoding are cast to nil" do
+        type = Type::Integer.new # default limit: 4, byte cap: 16
+        assert_nil type.cast(("0" * 100 + "1").encode("UTF-16LE"))
+      end
+
       test "Marshal round-trip preserves behaviour" do
         type = Integer.new
         restored = Marshal.load(Marshal.dump(type))


### PR DESCRIPTION
### Motivation / Background

Since #57368, `ActiveModel::Type::Integer#cast` only looks at the first `_limit * 4` bytes of a string before calling `to_i`. Leading whitespace, a sign and leading zeros fill up those bytes without contributing anything to the resulting integer, so a padded value loses its digits:

```ruby
type = ActiveModel::Type::Integer.new

type.cast("0" * 100 + "1")   # => 0, expected 1
type.cast(" " * 100 + "42")  # => 0, expected 42
```

Zero padded ids coming from external systems and fixed width files hit this. The cap itself is still worth having, it just shouldn't be spent on characters `to_i` skips anyway.

### Detail

The prefix `to_i` ignores is matched first, then the byte cap is applied to what follows, with the sign carried over. So the cap now bounds the significant digits, and anything longer than that is out of range for the column regardless.

The prefix has to end on a digit. Without that, skipping it would hand `to_i` a sign or a space that never led the string, and `cast` would answer with a value `to_i` itself never returns:

```ruby
type.cast("0-1")               # => 0
type.cast("0" * 100 + "-1")    # => 0, not -1
```

A few notes on the edges:

* Matching the prefix is a linear scan where the old code did a constant time `byteslice`, but `cast` already scans the whole string in `blank?`, and the pattern has no alternation or nested quantifier, so this is a constant factor rather than a change in complexity. The superlinear `to_i` that #57368 set out to bound is still bounded.
* Strings in an encoding the pattern can't be matched against (`UTF-16LE` and friends) fall back to the plain byte cap, so they keep casting the way they do today instead of raising `Encoding::CompatibilityError`.
* `#serialize` calls `to_i` on the whole string and is unaffected by the cap, so it doesn't have this bug. It does mean the DoS hardening in #57368 doesn't cover that path, but that seemed like a separate concern from this data loss fix, happy to follow up.
* No CHANGELOG entry: #57368 is unreleased, so its existing entry still describes the intended behaviour and this only restores it.

Fixes #58608

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
