### PR TITLE
Fix PostgreSQL bytea deserialization of already decoded binary strings

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Fix PostgreSQL `bytea` deserialization of already decoded binary strings.
+
+    When a record is rebuilt from raw decoded `bytea` values (for example after a
+    cache serialization round-trip that loses the decoded marker), `Bytea#deserialize`
+    passed the raw bytes to `PG::Connection.unescape_bytea`, which raised
+    `ArgumentError: string contains null byte` or silently corrupted values
+    containing backslashes. Binary strings that cannot be PostgreSQL escaped
+    output are now returned as-is.
+
+    Fixes #56952.
+
+    *Dmytro Rymar*
+
 *   Add `config.active_record.shuffle_unordered_selects`.
 
     When enabled, Active Record shuffles the rows of every `SELECT` it generates

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/bytea.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/bytea.rb
@@ -5,6 +5,9 @@ module ActiveRecord
     module PostgreSQL
       module OID # :nodoc:
         class Bytea < Type::Binary # :nodoc:
+          ESCAPED_BYTEA_CHARACTERS = /\A[\x20-\x7e]*\z/n
+          private_constant :ESCAPED_BYTEA_CHARACTERS
+
           def deserialize(value)
             case value
             when nil
@@ -26,6 +29,10 @@ module ActiveRecord
 
               elsif value.encoding == Encoding::BINARY &&
                   !value.instance_variable_defined?(:@ar_pg_bytea_decoded)
+
+                # Escaped bytea output is always printable ASCII, so anything
+                # else is already decoded data that lost its marker.
+                return value unless value.match?(ESCAPED_BYTEA_CHARACTERS)
 
                 ActiveRecord.deprecator.warn(<<~MSG.squish)
                   bytea column received a binary string for unescaping. In Rails 9.0, binary strings

--- a/activerecord/test/cases/adapters/postgresql/bytea_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bytea_test.rb
@@ -55,6 +55,40 @@ class PostgresqlByteaTest < ActiveRecord::PostgreSQLTestCase
     end
   end
 
+  def test_type_cast_unmarked_binary_value_with_null_bytes
+    decoded = "\x01\x00\x02\x00\x03".b
+
+    assert_not_deprecated(ActiveRecord.deprecator) do
+      result = @type.deserialize(decoded)
+      assert_equal decoded, result
+      assert_equal Encoding::BINARY, result.encoding
+    end
+  end
+
+  def test_type_cast_unmarked_binary_value_with_non_ascii_bytes_and_backslashes
+    decoded = "\xC3\\xFF\\\\".b
+
+    assert_not_deprecated(ActiveRecord.deprecator) do
+      result = @type.deserialize(decoded)
+      assert_equal decoded, result
+      assert_equal Encoding::BINARY, result.encoding
+    end
+  end
+
+  def test_attributes_for_database_round_trip_of_decoded_value
+    data = Digest::MD5.digest("test19") # contains \x00 and non-ASCII bytes
+    record = ByteaDataType.create!(payload: data)
+    record.reload
+
+    # Simulates a cache round-trip (e.g. Paquito::ActiveRecordCoder) which
+    # stores raw decoded bytes and rebuilds the record from them.
+    attributes = record.attributes_for_database.transform_values { |v| v.is_a?(ActiveModel::Type::Binary::Data) ? v.to_s : v }
+    restored = ByteaDataType.instantiate(attributes)
+
+    assert_equal data.bytes, restored.attributes_for_database["payload"].to_s.bytes
+    assert_equal data.bytes, restored.payload.bytes
+  end
+
   def test_type_cast_marked_true_value
     decoded = "\\x414243".b
     decoded.instance_variable_set(:@ar_pg_bytea_decoded, true)


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `Bytea#deserialize` crashes or silently corrupts data when it receives an already decoded binary string.

`Bytea#deserialize` relies on the `@ar_pg_bytea_decoded` instance variable to know whether a binary string still needs unescaping. That marker is lost whenever a record is rebuilt from raw attribute values, e.g. after a cache serialization round-trip through Paquito or YAML, so the unmarked binary string fell through to `PG::Connection.unescape_bytea`. For data containing null bytes that raised `ArgumentError: string contains null byte`; for data containing backslashes it silently corrupted the value.

Fixes #56952

### Detail

This Pull Request changes `Bytea#deserialize` to return unmarked binary strings as-is when they cannot possibly be escaped bytea output.

PostgreSQL's text representation of bytea (both "hex" and "escape" output formats) only ever contains printable ASCII, so a binary string holding any byte outside `0x20–0x7e` cannot be escaped output and must already be decoded. Such values are now returned as-is, which is also the behavior announced for Rails 9.0. Printable-ASCII binary strings keep the current deprecated unescaping path, so genuinely escaped values are unaffected.

### Additional information

#56935 attempted to fix the same issue by rescuing the `ArgumentError` from `unescape_bytea`. That only covers values containing null bytes, already decoded values containing backslashes don't raise and were still silently corrupted (e.g. `"\xC3\\xFF\\\\"` became `"\xC3xFF\\"`). Detecting non-printable bytes up front handles both failure modes, and is exact rather than heuristic: it can never misclassify a genuinely escaped value.

The added test simulates the cache round-trip in-tree(dump via `attributes_for_database`, rebuild via `instantiate`), mirroring what `Paquito::ActiveRecordCoder` does, so no external gem is needed.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be
included.