### PR TITLE
Add config.active_storage.default_variant_format

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Add `config.active_storage.default_variant_format` to configure the format
+    of variants generated from images that are not web images, such as TIFF,
+    BMP, or HEIC files. Variants of web images keep the format of the original.
+
+    The default is `:png`. Applications loading the 8.2 framework defaults use
+    `:webp`, which produces smaller variants that all major browsers support.
+
+    ```ruby
+    config.active_storage.default_variant_format = :webp
+    ```
+
+    *Carlos Daniel Pohlod* and *Daniel Lopez*
+
 *   Marcel 2 for content type detection
 
     Broader and more precise MIME type detection, security hardening, and uses canonical types

--- a/activestorage/app/models/active_storage/blob/representable.rb
+++ b/activestorage/app/models/active_storage/blob/representable.rb
@@ -171,9 +171,9 @@ module ActiveStorage::Blob::Representable
 
     def default_variant_format
       if web_image?
-        format || :png
+        format || ActiveStorage.default_variant_format
       else
-        :png
+        ActiveStorage.default_variant_format
       end
     end
 

--- a/activestorage/app/models/active_storage/variation.rb
+++ b/activestorage/app/models/active_storage/variation.rb
@@ -60,7 +60,7 @@ class ActiveStorage::Variation
   end
 
   def format
-    transformations.fetch(:format, :png).tap do |format|
+    transformations.fetch(:format) { ActiveStorage.default_variant_format }.tap do |format|
       if Marcel::Magic.by_extension(format.to_s).nil?
         raise ArgumentError, "Invalid variant format (#{format.inspect})"
       end

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -52,6 +52,7 @@ module ActiveStorage
   mattr_accessor :variant_processor, default: :mini_magick
 
   mattr_accessor :variant_transformer
+  mattr_accessor :default_variant_format, default: :png
 
   mattr_accessor :queues, default: {}
 

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -178,6 +178,7 @@ module ActiveStorage
         ActiveStorage.video_preview_input_arguments = app.config.active_storage.video_preview_input_arguments || ""
         ActiveStorage.ffprobe_arguments = app.config.active_storage.ffprobe_arguments || ""
         ActiveStorage.track_variants = app.config.active_storage.track_variants || false
+        ActiveStorage.default_variant_format = app.config.active_storage.default_variant_format || :png
         ActiveStorage.analyze = app.config.active_storage.analyze || :later
         ActiveStorage.streaming_chunk_max_size = app.config.active_storage.streaming_chunk_max_size || 100.megabytes
       end

--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -83,10 +83,10 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
 
     with_vips_loaders_enabled(*VIPS_MAGICK_LOADERS) do
       variant = blob.variant(resize_to_limit: [20, 20]).processed
-      assert_match(/icon\.png/, variant.url)
+      assert_match(/icon\.webp/, variant.url)
 
       image = read_image(variant)
-      assert_equal "PNG", image.type
+      assert_equal "WEBP", image.type
       assert_equal 20, image.width
       assert_equal 20, image.height
     end
@@ -105,10 +105,10 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
 
     with_vips_loaders_enabled(*VIPS_MAGICK_LOADERS) do
       variant = blob.variant(resize_to_limit: [20, 20]).processed
-      assert_match(/icon\.png/, variant.url)
+      assert_match(/icon\.webp/, variant.url)
 
       image = read_image(variant)
-      assert_equal "PNG", image.type
+      assert_equal "WEBP", image.type
       assert_equal 20, image.width
       assert_equal 20, image.height
     end
@@ -117,10 +117,10 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
   test "resized variation of TIFF blob" do
     blob = create_file_blob(filename: "racecar.tif")
     variant = blob.variant(resize_to_limit: [50, 50]).processed
-    assert_match(/racecar\.png/, variant.url)
+    assert_match(/racecar\.webp/, variant.url)
 
     image = read_image(variant)
-    assert_equal "PNG", image.type
+    assert_equal "WEBP", image.type
     assert_equal 50, image.width
     assert_equal 33, image.height
   end
@@ -138,12 +138,34 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
 
     with_vips_loaders_enabled(*VIPS_MAGICK_LOADERS) do
       variant = blob.variant(resize_to_limit: [15, 15]).processed
-      assert_match(/colors\.png/, variant.url)
+      assert_match(/colors\.webp/, variant.url)
+
+      image = read_image(variant)
+      assert_equal "WEBP", image.type
+      assert_equal 15, image.width
+      assert_equal 8, image.height
+    end
+  end
+
+  test "resized variation of TIFF blob with a configured default variant format" do
+    with_default_variant_format(:png) do
+      blob = create_file_blob(filename: "racecar.tif")
+      variant = blob.variant(resize_to_limit: [50, 50]).processed
+      assert_match(/racecar\.png/, variant.url)
 
       image = read_image(variant)
       assert_equal "PNG", image.type
-      assert_equal 15, image.width
-      assert_equal 8, image.height
+      assert_equal 50, image.width
+      assert_equal 33, image.height
+    end
+  end
+
+  test "web image blobs keep their format regardless of the default variant format" do
+    with_default_variant_format(:webp) do
+      blob = create_file_blob(filename: "racecar.jpg")
+      variant = blob.variant(resize_to_limit: [50, 50]).processed
+      assert_match(/racecar\.jpg/, variant.url)
+      assert_equal "JPEG", read_image(variant).type
     end
   end
 
@@ -252,7 +274,7 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
     end
 
     assert_nil blob.send(:format)
-    assert_equal :png, blob.send(:default_variant_format)
+    assert_equal :webp, blob.send(:default_variant_format)
   end
 
   test "variations with dangerous argument string raise UnsupportedImageProcessingArgument" do

--- a/activestorage/test/models/variation_test.rb
+++ b/activestorage/test/models/variation_test.rb
@@ -57,6 +57,12 @@ class ActiveStorage::VariationTest < ActiveSupport::TestCase
     assert_equal ActiveStorage::Variation.encode(transformations), variation.key
   end
 
+  test "format defaults to the configured default variant format" do
+    with_default_variant_format(:jpeg) do
+      assert_equal :jpeg, ActiveStorage::Variation.new(resize_to_limit: [100, 100]).format
+    end
+  end
+
   test "default_to fills in missing transformations" do
     variation = ActiveStorage::Variation.new(resize_to_limit: [100, 100])
       .default_to(format: :png)
@@ -71,10 +77,10 @@ class ActiveStorage::VariationTest < ActiveSupport::TestCase
     assert_equal({ format: :jpg, resize_to_limit: [100, 100] }, variation.transformations)
   end
 
-  test "format defaults to png" do
+  test "format defaults to webp" do
     variation = ActiveStorage::Variation.new(resize_to_limit: [100, 100])
 
-    assert_equal :png, variation.format
+    assert_equal :webp, variation.format
   end
 
   test "format accepts valid extensions" do
@@ -103,9 +109,9 @@ class ActiveStorage::VariationTest < ActiveSupport::TestCase
     assert_equal "image/jpeg", variation.content_type
   end
 
-  test "content_type defaults to png" do
+  test "content_type defaults to webp" do
     variation = ActiveStorage::Variation.new(resize_to_limit: [100, 100])
 
-    assert_equal "image/png", variation.content_type
+    assert_equal "image/webp", variation.content_type
   end
 end

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -115,6 +115,13 @@ class ActiveSupport::TestCase
       class_names.each { |class_name| Vips.block(class_name, VIPS_LOADERS_DISABLED_AT_BOOT) }
     end
 
+    def with_default_variant_format(format)
+      previous, ActiveStorage.default_variant_format = ActiveStorage.default_variant_format, format
+      yield
+    ensure
+      ActiveStorage.default_variant_format = previous
+    end
+
     def with_strict_loading_by_default(&block)
       strict_loading_was = ActiveRecord::Base.strict_loading_by_default
       ActiveRecord::Base.strict_loading_by_default = true

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -70,6 +70,7 @@ Below are the default values associated with each target version. In cases of co
 - [`config.active_record.postgresql_adapter_decode_bytea`](#config-active-record-postgresql-adapter-decode-bytea): `true`
 - [`config.active_record.postgresql_adapter_decode_money`](#config-active-record-postgresql-adapter-decode-money): `true`
 - [`config.active_storage.analyze`](#config-active-storage-analyze): `:immediately`
+- [`config.active_storage.default_variant_format`](#config-active-storage-default-variant-format): `:webp`
 
 #### Default Values for Target Version 8.1
 
@@ -3683,7 +3684,8 @@ config.active_storage.variable_content_types = %w(image/png image/gif image/jpeg
 #### `config.active_storage.web_image_content_types`
 
 Accepts an array of strings regarded as web image content types in which
-variants can be processed without being converted to the fallback PNG format.
+variants can be processed without being converted to the format set by
+[`config.active_storage.default_variant_format`](#config-active-storage-default-variant-format).
 For example, if you want to use `AVIF` variants in your application you can add
 `image/avif` to this array.
 
@@ -3693,6 +3695,23 @@ The default value depends on the `config.load_defaults` target version:
 | --------------------- | ----------------------------------------------- |
 | (original)            | `%w(image/png image/jpeg image/gif)`            |
 | 7.2                   | `%w(image/png image/jpeg image/gif image/webp)` |
+
+#### `config.active_storage.default_variant_format`
+
+Sets the format of variants generated from images that are not web images (see [`config.active_storage.web_image_content_types`](#config-active-storage-web-image-content-types)), such as TIFF, BMP, or HEIC files. Variants of web images keep the format of the original image.
+
+```ruby
+config.active_storage.default_variant_format = :webp
+```
+
+Passing `format:` to `variant` still takes precedence for a specific variant.
+
+The default value depends on the `config.load_defaults` target version:
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `:png`               |
+| 8.2                   | `:webp`              |
 
 #### `config.active_storage.content_types_to_serve_as_binary`
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -392,6 +392,7 @@ module Rails
 
           if respond_to?(:active_storage)
             active_storage.analyze = :immediately
+            active_storage.default_variant_format = :webp
           end
 
           if respond_to?(:active_job)

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
@@ -94,6 +94,16 @@
 #++
 # Rails.application.config.active_storage.analyze = :immediately
 
+###
+# Generate WEBP variants from images that are not web images, such as TIFF,
+# BMP, or HEIC files. Variants of web images keep the format of the original.
+#
+# WEBP variants are smaller than the PNG variants generated before, and all
+# major browsers support them. Existing variants of affected images will be
+# regenerated the next time they are requested.
+#++
+# Rails.application.config.active_storage.default_variant_format = :webp
+
 # Controls whether the `rescue_from_handled.action_controller` notification payload includes the full backtrace.
 #
 # When set to `:array`, the full backtrace is included as an array of strings.

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3499,6 +3499,30 @@ module ApplicationTests
       assert_equal false, ActiveJob::Base.enqueue_after_transaction_commit
     end
 
+    test "config.active_storage.default_variant_format defaults to :webp for new apps" do
+      app "development"
+
+      assert_equal :webp, ActiveStorage.default_variant_format
+    end
+
+    test "config.active_storage.default_variant_format can be set for new apps" do
+      app_file "config/initializers/default_variant_format.rb", <<-RUBY
+        Rails.application.config.active_storage.default_variant_format = :jpeg
+      RUBY
+
+      app "development"
+
+      assert_equal :jpeg, ActiveStorage.default_variant_format
+    end
+
+    test "config.active_storage.default_variant_format defaults to :png for upgraded apps" do
+      remove_from_config '.*config\.load_defaults.*\n'
+
+      app "development"
+
+      assert_equal :png, ActiveStorage.default_variant_format
+    end
+
     test "config.active_job.enqueue_after_transaction_commit can be set to true for upgraded apps" do
       remove_from_config '.*config\.load_defaults.*\n'
 


### PR DESCRIPTION
### Motivation / Background

This picks up #51115, which has been inactive since 2024. That PR switched the fallback variant format from PNG to WEBP unconditionally, and the review asked for the change to be opt-in through a configuration option so existing applications don't regenerate their variants unexpectedly.

Variants of images that are not web images (TIFF, BMP, HEIC and so on) are always generated as PNG today. WEBP variants are smaller and all major browsers support them; `image/webp` has been part of `web_image_content_types` since Rails 7.2.

### Detail

Adds `config.active_storage.default_variant_format`, used by `Blob#variant` and `Variation#format` when no `format:` is given for a non web image. The default stays `:png`. `config.load_defaults 8.2` sets it to `:webp`, and the option is documented in the configuring guide and in the 8.2 new framework defaults initializer.

Variants of web images keep the format of the original, as before. Passing `format:` to `variant` still takes precedence.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
