### PR TITLE
Wrap GCS IAM signer authorization failures in ActiveStorage::AuthorizationError

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Wrap GCS IAM signer authorization failures in `ActiveStorage::AuthorizationError`
+
+    When the GCS service is configured with `iam: true`, generating a signed URL calls out to the
+    IAM credentials API to sign the request. If the underlying credentials (e.g. expired
+    `gcloud auth application-default login` reauth tokens in development) fail to authorize, this
+    previously raised `Signet::AuthorizationError` straight from the `google-cloud-storage` gem.
+    It's now wrapped in a new, generic `ActiveStorage::AuthorizationError`, so applications can
+    `rescue_from` it without depending on a Google-specific exception class -- and so other
+    services can raise the same error for their own authorization failures in the future.
+
+    *Bogdan Gusiev*
+
 *   Marcel 2 for content type detection
 
     Broader and more precise MIME type detection, security hardening, and uses canonical types

--- a/activestorage/lib/active_storage/errors.rb
+++ b/activestorage/lib/active_storage/errors.rb
@@ -30,4 +30,8 @@ module ActiveStorage
   # Raised when a storage key resolves to a path outside the service's root
   # directory, indicating a potential path traversal attack.
   class InvalidKeyError < Error; end
+
+  # Raised when a service fails to authorize with its backing cloud provider,
+  # e.g. expired or invalid credentials.
+  class AuthorizationError < Error; end
 end

--- a/activestorage/lib/active_storage/service/gcs_service.rb
+++ b/activestorage/lib/active_storage/service/gcs_service.rb
@@ -227,6 +227,8 @@ module ActiveStorage
           resource = "projects/-/serviceAccounts/#{issuer}"
           response = iam_client.sign_service_account_blob(resource, request)
           response.signed_blob
+        rescue Signet::AuthorizationError => e
+          raise ActiveStorage::AuthorizationError, e.message
         end
       end
 

--- a/activestorage/test/service/gcs_service_test.rb
+++ b/activestorage/test/service/gcs_service_test.rb
@@ -214,6 +214,21 @@ if SERVICE_CONFIGURATIONS[:gcs]
         WebMock.disable!
       end
 
+      test "signer wraps authorization errors from the IAM client" do
+        WebMock.enable!
+        config_with_adc = { gcs: SERVICE_CONFIGURATIONS[:gcs].merge({ iam: true }) }
+        service = ActiveStorage::Service.configure(:gcs, config_with_adc)
+
+        stub_request(:post, "https://www.googleapis.com/oauth2/v4/token")
+          .to_return(status: 400, body: { error: "invalid_grant", error_subtype: "invalid_rapt" }.to_json)
+        key = SecureRandom.base58(24)
+        assert_raises(ActiveStorage::AuthorizationError) do
+          service.url(key, expires_in: 2.minutes, disposition: :inline, filename: ActiveStorage::Filename.new("test.txt"), content_type: "text/plain")
+        end
+      ensure
+        WebMock.disable!
+      end
+
       test "overridden IAM client credentials" do
         WebMock.enable!
         config_with_adc = { gcs: SERVICE_CONFIGURATIONS[:gcs].merge({ iam: true }) }


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `ActiveStorage::Service::GCSService` doesn't rescue authorization failures when signing a GCS URL through the IAM credentials API (`iam: true` config).

When the configured credentials fail to authorize -- for example, expired `gcloud auth application-default login` reauth tokens locally, or a misconfigured/revoked service account in any environment -- `google-cloud-storage` raises `Signet::AuthorizationError` straight from the underlying gem. Every caller of `ActiveStorage::Blob#url` (redirect controllers, direct uploads, view helpers) has to know to rescue a Google-specific, non-`ActiveStorage` exception class to handle this gracefully, or it bubbles up as an unhandled 500.

### Detail

This Pull Request changes `ActiveStorage::Service::GCSService#signer` to rescue `Signet::AuthorizationError` and re-raise it as a new `ActiveStorage::AuthorizationError`, added to `activestorage/lib/active_storage/errors.rb` alongside the other generic, service-agnostic errors (`IntegrityError`, `FileNotFoundError`, etc.) rather than nested inside `GCSService`, since authorization failure isn't a GCS-specific concept -- other services could raise the same error for their own auth failures in the future.

`Signet::AuthorizationError` is rescued rather than `Google::Auth::AuthorizationError` because the latter doesn't exist in older `googleauth` versions (it was only added as a subclass of `Signet::AuthorizationError` in a later release); rescuing the stable base class covers both.

### Additional information

Deliberately scoped to just the new exception class and the rescue site -- no default `config.action_dispatch.rescue_responses` mapping is added. None of ActiveStorage's other error classes (`FileNotFoundError`, `IntegrityError`, etc.) get a default HTTP status either; adding one only for this new class would be inconsistent, and picking a "correct" default status (503? 502?) for an error that can be either transient (expired token) or permanent (revoked service account) isn't something the library can decide on the app's behalf. Applications that want a specific response can `rescue_from ActiveStorage::AuthorizationError` themselves.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
