### PR TITLE
Add ActiveRecord::Base.skip_callback_monitor

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -21,6 +21,25 @@
 
     *viralpraxis*
 
+*   Add `ActiveRecord::Base.skip_callback_monitor` to allow applications to record or
+    react whenever persistence methods bypass Active Record callbacks.
+
+    The hook receives the current caller object as its argument:
+    the record instance for `update_columns`/`delete`, the relation for
+    `update_all`/`delete_all`, and the `InsertAll` instance for
+    `insert_all`/`insert_all!`/`upsert_all`.
+
+    ```ruby
+    class ApplicationRecord < ActiveRecord::Base
+      self.abstract_class = true
+      self.skip_callback_monitor = ->(caller) {
+        Rails.logger.warn "#{caller.class} bypassed Active Record callbacks"
+      }
+    end
+    ```
+
+    *OuYangJinTing*
+
 *   Add `config.active_record.schema_ignored_tables` to exclude tables from both the
     schema cache and the schema file.
 

--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -287,6 +287,10 @@ module ActiveRecord
     module ClassMethods
       include ActiveModel::Callbacks
 
+      def invoke_skip_callback_monitor(caller) # :nodoc:
+        skip_callback_monitor&.call(caller)
+      end
+
       ##
       # :method: after_initialize
       #
@@ -410,6 +414,8 @@ module ActiveRecord
 
     included do
       include ActiveModel::Validations::Callbacks
+
+      class_attribute :skip_callback_monitor, default: nil, instance_reader: false, instance_writer: false, instance_predicate: false
 
       define_model_callbacks :initialize, :find, :touch, only: :after
       define_model_callbacks :save, :create, :update, :destroy

--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -47,6 +47,8 @@ module ActiveRecord
     def execute
       return ActiveRecord::Result.empty if inserts.empty?
 
+      model.invoke_skip_callback_monitor(self)
+
       message = +"#{model.name} "
       message << "Bulk " if inserts.many?
       message << (on_duplicate == :update ? "Upsert" : "Insert")

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -405,7 +405,11 @@ module ActiveRecord
     # callbacks or any <tt>:dependent</tt> association
     # options, use #destroy.
     def delete
-      _delete_row if persisted?
+      if persisted?
+        self.class.invoke_skip_callback_monitor(self)
+        _delete_row
+      end
+
       @destroyed = true
       @previously_new_record = false
       freeze
@@ -593,6 +597,8 @@ module ActiveRecord
       raise ActiveRecordError, "cannot update a new record" if new_record?
       raise ActiveRecordError, "cannot update a destroyed record" if destroyed?
       _raise_readonly_record_error if readonly?
+
+      self.class.invoke_skip_callback_monitor(self)
 
       attributes = attributes.transform_keys do |key|
         name = key.to_s

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -604,6 +604,8 @@ module ActiveRecord
 
       return 0 if @none
 
+      model.invoke_skip_callback_monitor(self)
+
       invalid_methods = INVALID_METHODS_FOR_UPDATE_AND_DELETE_ALL.select do |method|
         value = @values[method]
         method == :distinct ? value : value&.any?
@@ -1076,6 +1078,8 @@ module ActiveRecord
     #   # => ActiveRecord::ActiveRecordError: delete_all doesn't support distinct
     def delete_all
       return 0 if @none
+
+      model.invoke_skip_callback_monitor(self)
 
       invalid_methods = INVALID_METHODS_FOR_UPDATE_AND_DELETE_ALL.select do |method|
         value = @values[method]

--- a/activerecord/test/cases/callbacks_test.rb
+++ b/activerecord/test/cases/callbacks_test.rb
@@ -129,6 +129,13 @@ class ContextualCallbacksDeveloper < ActiveRecord::Base
   end
 end
 
+class ParentSkipCallbackMonitorDeveloper < ActiveRecord::Base
+  self.table_name = "developers"
+end
+
+class ChildSkipCallbackMonitorDeveloper < ParentSkipCallbackMonitorDeveloper
+end
+
 class CallbackHaltedDeveloper < ActiveRecord::Base
   self.table_name = "developers"
 
@@ -498,5 +505,56 @@ class CallbacksTest < ActiveRecord::TestCase
       end
     end
     assert_equal "Unknown key: :on. Valid keys are: :if, :unless, :prepend", exception.message
+  end
+
+  def test_skip_callback_monitor_is_not_called_when_not_set
+    dev = ParentSkipCallbackMonitorDeveloper.create!(name: "NoHook")
+    assert dev.update_columns(name: "Still NoHook")
+  ensure
+    ParentSkipCallbackMonitorDeveloper.skip_callback_monitor = nil
+  end
+
+  def test_update_columns_invokes_skip_callback_monitor_with_record
+    calls = []
+    ParentSkipCallbackMonitorDeveloper.skip_callback_monitor = ->(record) { calls << record }
+    dev = ParentSkipCallbackMonitorDeveloper.create!(name: "Hooked")
+    dev.update_columns(name: "Updated")
+    assert_equal [dev], calls
+  ensure
+    ParentSkipCallbackMonitorDeveloper.skip_callback_monitor = nil
+  end
+
+  def test_update_column_invokes_skip_callback_monitor_once
+    calls = []
+    ParentSkipCallbackMonitorDeveloper.skip_callback_monitor = ->(record) { calls << record }
+    dev = ParentSkipCallbackMonitorDeveloper.create!(name: "Hooked")
+    dev.update_column(:name, "Updated")
+    assert_equal [dev], calls
+  ensure
+    ParentSkipCallbackMonitorDeveloper.skip_callback_monitor = nil
+  end
+
+  def test_delete_invokes_skip_callback_monitor_with_record
+    calls = []
+    ParentSkipCallbackMonitorDeveloper.skip_callback_monitor = ->(record) { calls << record }
+    dev = ParentSkipCallbackMonitorDeveloper.create!(name: "Hooked")
+    dev.delete
+    assert_equal [dev], calls
+  ensure
+    ParentSkipCallbackMonitorDeveloper.skip_callback_monitor = nil
+  end
+
+  def test_subclass_skip_callback_monitor_overrides_parent
+    parent_calls = []
+    child_calls = []
+    ParentSkipCallbackMonitorDeveloper.skip_callback_monitor = ->(record) { parent_calls << record }
+    ChildSkipCallbackMonitorDeveloper.skip_callback_monitor = ->(record) { child_calls << record }
+    dev = ChildSkipCallbackMonitorDeveloper.create!(name: "Child")
+    dev.update_columns(name: "Updated")
+    assert_equal [], parent_calls
+    assert_equal [dev], child_calls
+  ensure
+    ParentSkipCallbackMonitorDeveloper.skip_callback_monitor = nil
+    ChildSkipCallbackMonitorDeveloper.skip_callback_monitor = nil
   end
 end

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -1206,6 +1206,60 @@ class InsertAllTest < ActiveRecord::TestCase
                  klass.find_by(title: "json_str_insert").content
   end
 
+  def test_insert_all_invokes_skip_callback_monitor_with_insert_all
+    calls = []
+    Book.skip_callback_monitor = ->(insert_all) { calls << insert_all }
+    Book.insert_all([{ id: 1_000_000, name: "Hook", author_id: 1 }])
+    assert_kind_of ActiveRecord::InsertAll, calls.first
+    assert_equal Book, calls.first.model
+  ensure
+    Book.skip_callback_monitor = nil
+  end
+
+  def test_insert_all_bang_invokes_skip_callback_monitor_with_insert_all
+    calls = []
+    Book.skip_callback_monitor = ->(insert_all) { calls << insert_all }
+    Book.insert_all!([{ id: 1_000_001, name: "Hook2", author_id: 1 }])
+    assert_kind_of ActiveRecord::InsertAll, calls.first
+    assert_equal Book, calls.first.model
+  ensure
+    Book.skip_callback_monitor = nil
+  end
+
+  def test_upsert_all_invokes_skip_callback_monitor_with_insert_all
+    skip unless supports_insert_on_duplicate_update?
+    calls = []
+    Book.skip_callback_monitor = ->(insert_all) { calls << insert_all }
+    begin
+      Book.upsert_all([{ id: 1, name: "Upsert Hook", author_id: 1 }])
+    ensure
+      Book.skip_callback_monitor = nil
+    end
+    assert_kind_of ActiveRecord::InsertAll, calls.first
+    assert_equal Book, calls.first.model
+  end
+
+  def test_insert_invokes_skip_callback_monitor_once
+    calls = []
+    Book.skip_callback_monitor = ->(insert_all) { calls << insert_all }
+    Book.insert({ id: 2_000_000, name: "Hook", author_id: 1 })
+    assert_equal 1, calls.size
+  ensure
+    Book.skip_callback_monitor = nil
+  end
+
+  def test_upsert_invokes_skip_callback_monitor_once
+    skip unless supports_insert_on_duplicate_update?
+    calls = []
+    Book.skip_callback_monitor = ->(insert_all) { calls << insert_all }
+    begin
+      Book.upsert({ id: 2, name: "Upsert Once", author_id: 1 })
+    ensure
+      Book.skip_callback_monitor = nil
+    end
+    assert_equal 1, calls.size
+  end
+
   private
     def capture_log_output
       output = StringIO.new

--- a/activerecord/test/cases/relation/delete_all_test.rb
+++ b/activerecord/test/cases/relation/delete_all_test.rb
@@ -162,4 +162,15 @@ class DeleteAllTest < ActiveRecord::TestCase
     join_scope = Cpk::Order.joins(:order_agreements).where(order_agreements: { signature: agreement.signature })
     assert_equal 1, join_scope.delete_all
   end
+
+  def test_delete_all_invokes_skip_callback_monitor_with_relation
+    calls = []
+    Author.skip_callback_monitor = ->(relation) { calls << relation }
+    relation = Author.where(id: -1)
+    relation.delete_all
+    assert_same relation, calls.first
+    assert_equal Author, calls.first.model
+  ensure
+    Author.skip_callback_monitor = nil
+  end
 end

--- a/activerecord/test/cases/relation/update_all_test.rb
+++ b/activerecord/test/cases/relation/update_all_test.rb
@@ -596,4 +596,15 @@ class UpdateAllTest < ActiveRecord::TestCase
     assert_equal "bulk update!", posts(:thinking).body
     assert_not_equal "bulk update!", posts(:welcome).body
   end
+
+  def test_update_all_invokes_skip_callback_monitor_with_relation
+    calls = []
+    Author.skip_callback_monitor = ->(relation) { calls << relation }
+    relation = Author.where(id: -1)
+    relation.update_all(name: "Nobody")
+    assert_same relation, calls.first
+    assert_equal Author, calls.first.model
+  ensure
+    Author.skip_callback_monitor = nil
+  end
 end

--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -800,6 +800,30 @@ important business rules and application logic in callbacks that you do not want
 to bypass. Bypassing them without understanding the potential implications may
 lead to invalid data.
 
+### Monitoring Bypassed Callbacks
+
+If you want to record or react whenever callbacks are bypassed, you can set
+`skip_callback_monitor` on your model:
+
+```ruby
+class ApplicationRecord < ActiveRecord::Base
+  self.skip_callback_monitor = ->(caller) {
+    Rails.logger.warn "#{caller.class} bypassed Active Record callbacks"
+  }
+end
+```
+
+The hook receives the current caller object as its argument:
+
+* the record instance for `update_columns` and `delete`
+* the relation instance for `update_all` and `delete_all`
+* the `InsertAll` instance for `insert_all`, `insert_all!`, and `upsert_all`
+
+Higher-level methods such as `update_column`, `increment!`, `decrement!`,
+`touch_all`, `update_counters`, `delete_by`, `insert`, and `upsert` delegate to
+these lower-level methods, so the hook is still called exactly once per
+operation.
+
 [`decrement!`]:
     https://api.rubyonrails.org/classes/ActiveRecord/Persistence.html#method-i-decrement-21
 [`decrement_counter`]:


### PR DESCRIPTION
### Motivation / Background

ActiveRecord allows several persistence methods (`update_columns`, `update_all`, `delete_all`, `insert_all`, etc.) to bypass callbacks entirely. Currently there is no built-in way for an application to record or react to these skips, which can make it easy to silently bypass important business logic and introduce subtle bugs.

This Pull Request adds `ActiveRecord::Base.skip_callback_monitor`, a class-level monitor that is invoked whenever a persistence method bypasses Active Record callbacks. Applications can use it to log, audit, or even raise errors when callbacks are skipped, helping to prevent misuse.

### Detail

- Introduces `class_attribute :skip_callback_monitor` on `ActiveRecord::Callbacks`.
- Adds `ClassMethods#invoke_skip_callback_monitor(caller)` to centralize the check and call.
- The monitor receives the current caller object as its argument:
  - `ActiveRecord::Persistence#update_columns` and `#delete` pass the record instance.
  - `ActiveRecord::Relation#update_all` and `#delete_all` pass the relation instance.
  - `ActiveRecord::InsertAll#execute` passes the `InsertAll` instance, so direct use of `InsertAll` is also covered.
- Triggers the monitor from the lowest-level bypass methods:
  - `ActiveRecord::Persistence#update_columns`
  - `ActiveRecord::Persistence#delete`
  - `ActiveRecord::Relation#update_all`
  - `ActiveRecord::Relation#delete_all`
  - `ActiveRecord::InsertAll#execute` (used by `insert_all`, `insert_all!`, and `upsert_all`)
- Higher-level methods (`update_column`, `increment!`, `decrement!`, `touch_all`, `update_counters`, `delete`, `delete_by`, `insert`, `insert!`, `upsert`) delegate to these, so the monitor is called exactly once per operation.
- If no monitor is declared (`nil`), there is no overhead.
- Adds tests in `callbacks_test.rb`, `update_all_test.rb`, `delete_all_test.rb`, and `insert_all_test.rb`.
- Updates `activerecord/CHANGELOG.md`.

Example usage:

```ruby
class ApplicationRecord < ActiveRecord::Base
  self.skip_callback_monitor = ->(caller) {
    Rails.logger.warn "#{caller.class} bypassed Active Record callbacks"
  }
end
```

### Additional information

All relevant tests and RuboCop checks pass.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.