### PR TITLE
Reduce allocation overhead of #50623

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Only attach `ActionView::StructuredEventSubscriber` to `action_view` notifications when `Rails.event.debug_mode?` is true, avoiding unnecessary instrumentation overhead in non-debug apps.
+
+    *Joel Hawksley*
+
 *   Reduce allocation overhead of #50623.
 
     #50623 closed a long-present gap between the render pipeline for

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -6,9 +6,8 @@
     keeps the unified pipeline but recovers most of the lost allocations
     by memoizing per-class `render_in` arity and `format` lookups,
     skipping redundant `prepend_formats` writes, reusing the
-    `TemplateRenderer` within a `Renderer`, gating the
-    `render_template.action_view` notification on active subscribers,
-    and pooling `Template::Renderable` when no block is given.
+    `TemplateRenderer` within a `Renderer`, and pooling
+    `Template::Renderable` when no block is given.
 
     *Joel Hawksley*
 

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Reduce allocation overhead of rendering `render_in`-compatible objects.
+
+    PR #50623 introduced a ~5x allocation regression for objects rendered via
+    `render(renderable)` (including ViewComponent) because every such call
+    began flowing through the standard template rendering pipeline. This
+    change memoizes per-class metadata used by `Template::Renderable`,
+    avoids redundant `prepend_formats` writes, reuses the `TemplateRenderer`
+    within a `Renderer`, gates the `render_template.action_view`
+    notification payload construction on active subscribers, and reuses
+    a pooled `Template::Renderable` when no block is supplied.
+
+    *Joel Hawksley*
+
 *   Allow `translate`'s (and `t`'s) `scope:` option to be resolved relative to
     the current template when it starts with a period, mirroring the existing
     behavior for the key argument.

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,13 +1,14 @@
-*   Reduce allocation overhead of rendering `render_in`-compatible objects.
+*   Reduce allocation overhead of #50623.
 
-    PR #50623 introduced a ~5x allocation regression for objects rendered via
-    `render(renderable)` (including ViewComponent) because every such call
-    began flowing through the standard template rendering pipeline. This
-    change memoizes per-class metadata used by `Template::Renderable`,
-    avoids redundant `prepend_formats` writes, reuses the `TemplateRenderer`
-    within a `Renderer`, gates the `render_template.action_view`
-    notification payload construction on active subscribers, and reuses
-    a pooled `Template::Renderable` when no block is supplied.
+    #50623 closed a long-present gap between the render pipeline for
+    renderables and non-renderables, which introduced a significant
+    increase in allocations on ViewComponent-heavy routes. This change
+    keeps the unified pipeline but recovers most of the lost allocations
+    by memoizing per-class `render_in` arity and `format` lookups,
+    skipping redundant `prepend_formats` writes, reusing the
+    `TemplateRenderer` within a `Renderer`, gating the
+    `render_template.action_view` notification on active subscribers,
+    and pooling `Template::Renderable` when no block is given.
 
     *Joel Hawksley*
 

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -2,6 +2,7 @@
 
 require "rails"
 require "action_view"
+require "action_view/structured_event_subscriber"
 
 module ActionView
   # = Action View Railtie
@@ -89,6 +90,12 @@ module ActionView
           next if k == :render_tracker
           send "#{k}=", v
         end
+      end
+    end
+
+    config.after_initialize do
+      if Rails.event.debug_mode?
+        ActionView::StructuredEventSubscriber.attach_to :action_view
       end
     end
 

--- a/actionview/lib/action_view/renderer/abstract_renderer.rb
+++ b/actionview/lib/action_view/renderer/abstract_renderer.rb
@@ -173,7 +173,7 @@ module ActionView
         return if formats.empty? || @lookup_context.html_fallback_for_js
 
         current = @lookup_context.formats
-        return if (formats - current).empty?
+        return if current.first(formats.length) == formats
 
         @lookup_context.formats = formats | current
       end

--- a/actionview/lib/action_view/renderer/abstract_renderer.rb
+++ b/actionview/lib/action_view/renderer/abstract_renderer.rb
@@ -172,7 +172,10 @@ module ActionView
         formats = Array(formats)
         return if formats.empty? || @lookup_context.html_fallback_for_js
 
-        @lookup_context.formats = formats | @lookup_context.formats
+        current = @lookup_context.formats
+        return if (formats - current).empty?
+
+        @lookup_context.formats = formats | current
       end
 
       def build_rendered_template(content, template)

--- a/actionview/lib/action_view/renderer/renderer.rb
+++ b/actionview/lib/action_view/renderer/renderer.rb
@@ -55,7 +55,7 @@ module ActionView
 
     private
       def render_template_to_object(context, options, &block)
-        TemplateRenderer.new(@lookup_context).render(context, options, &block)
+        (@_template_renderer ||= TemplateRenderer.new(@lookup_context)).render(context, options, &block)
       end
 
       def render_partial_to_object(context, options, &block)

--- a/actionview/lib/action_view/renderer/template_renderer.rb
+++ b/actionview/lib/action_view/renderer/template_renderer.rb
@@ -2,9 +2,6 @@
 
 module ActionView
   class TemplateRenderer < AbstractRenderer # :nodoc:
-    RENDER_TEMPLATE_NOTIFICATION = "render_template.action_view"
-    private_constant :RENDER_TEMPLATE_NOTIFICATION
-
     def render(context, options, &block)
       @details = extract_details(options)
       template = determine_template(options, &block)
@@ -46,8 +43,8 @@ module ActionView
         elsif options.key?(:renderable)
           if block.nil?
             pooled = (@_pooled_renderable ||= Template::Renderable.allocate)
-            pooled.instance_variable_set(:@renderable, options[:renderable])
-            pooled.instance_variable_set(:@block, nil)
+            pooled.renderable = options[:renderable]
+            pooled.block = nil
             pooled
           else
             Template::Renderable.new(options[:renderable], &block)
@@ -67,16 +64,12 @@ module ActionView
       # supplied as well.
       def render_template(view, template, layout_name, locals)
         render_with_layout(view, template, layout_name, locals) do |layout|
-          if ActiveSupport::Notifications.notifier.listening?(RENDER_TEMPLATE_NOTIFICATION)
-            ActiveSupport::Notifications.instrument(
-              RENDER_TEMPLATE_NOTIFICATION,
-              identifier: template.identifier,
-              layout: layout && layout.virtual_path,
-              locals: locals
-            ) do
-              template.render(view, locals) { |*name| view._layout_for(*name) }
-            end
-          else
+          ActiveSupport::Notifications.instrument(
+            "render_template.action_view",
+            identifier: template.identifier,
+            layout: layout && layout.virtual_path,
+            locals: locals
+          ) do
             template.render(view, locals) { |*name| view._layout_for(*name) }
           end
         end

--- a/actionview/lib/action_view/renderer/template_renderer.rb
+++ b/actionview/lib/action_view/renderer/template_renderer.rb
@@ -2,6 +2,9 @@
 
 module ActionView
   class TemplateRenderer < AbstractRenderer # :nodoc:
+    RENDER_TEMPLATE_NOTIFICATION = "render_template.action_view"
+    private_constant :RENDER_TEMPLATE_NOTIFICATION
+
     def render(context, options, &block)
       @details = extract_details(options)
       template = determine_template(options, &block)
@@ -41,7 +44,14 @@ module ActionView
           end
           Template::Inline.new(options[:inline], "inline template", handler, locals: keys, format: format)
         elsif options.key?(:renderable)
-          Template::Renderable.new(options[:renderable], &block)
+          if block.nil?
+            pooled = (@_pooled_renderable ||= Template::Renderable.allocate)
+            pooled.instance_variable_set(:@renderable, options[:renderable])
+            pooled.instance_variable_set(:@block, nil)
+            pooled
+          else
+            Template::Renderable.new(options[:renderable], &block)
+          end
         elsif options.key?(:template)
           if options[:template].respond_to?(:render)
             options[:template]
@@ -57,12 +67,16 @@ module ActionView
       # supplied as well.
       def render_template(view, template, layout_name, locals)
         render_with_layout(view, template, layout_name, locals) do |layout|
-          ActiveSupport::Notifications.instrument(
-            "render_template.action_view",
-            identifier: template.identifier,
-            layout: layout && layout.virtual_path,
-            locals: locals
-          ) do
+          if ActiveSupport::Notifications.notifier.listening?(RENDER_TEMPLATE_NOTIFICATION)
+            ActiveSupport::Notifications.instrument(
+              RENDER_TEMPLATE_NOTIFICATION,
+              identifier: template.identifier,
+              layout: layout && layout.virtual_path,
+              locals: locals
+            ) do
+              template.render(view, locals) { |*name| view._layout_for(*name) }
+            end
+          else
             template.render(view, locals) { |*name| view._layout_for(*name) }
           end
         end

--- a/actionview/lib/action_view/structured_event_subscriber.rb
+++ b/actionview/lib/action_view/structured_event_subscriber.rb
@@ -105,5 +105,3 @@ module ActionView
     end
   end
 end
-
-ActionView::StructuredEventSubscriber.attach_to :action_view

--- a/actionview/lib/action_view/template/renderable.rb
+++ b/actionview/lib/action_view/template/renderable.rb
@@ -15,6 +15,8 @@ module ActionView
         @block = block
       end
 
+      attr_writer :renderable, :block # :nodoc:
+
       def identifier
         @renderable.class.name
       end

--- a/actionview/lib/action_view/template/renderable.rb
+++ b/actionview/lib/action_view/template/renderable.rb
@@ -1,9 +1,15 @@
 # frozen_string_literal: true
 
+require "concurrent/map"
+
 module ActionView
   class Template
     # = Action View Renderable Template for objects that respond to #render_in
     class Renderable # :nodoc:
+      RENDER_IN_ARITY = Concurrent::Map.new
+      FORMAT_RESPONDER = Concurrent::Map.new
+      private_constant :RENDER_IN_ARITY, :FORMAT_RESPONDER
+
       def initialize(renderable, &block)
         @renderable = renderable
         @block = block
@@ -14,9 +20,16 @@ module ActionView
       end
 
       def render(context, locals)
-        render_in_method = Kernel.instance_method(:method).bind_call(@renderable, :render_in)
+        klass = @renderable.class
+        arity = if klass.method_defined?(:render_in)
+          RENDER_IN_ARITY.fetch_or_store(klass) do
+            klass.instance_method(:render_in).arity
+          end
+        else
+          Kernel.instance_method(:method).bind_call(@renderable, :render_in).arity
+        end
 
-        if render_in_method.arity == 1
+        if arity == 1
           ActionView.deprecator.warn <<~WARN
             Action View support for #render_in without options is deprecated.
 
@@ -36,7 +49,13 @@ module ActionView
       end
 
       def format
-        @renderable.try(:format)
+        klass = @renderable.class
+        responds = if klass.method_defined?(:format)
+          FORMAT_RESPONDER.fetch_or_store(klass) { true }
+        else
+          @renderable.respond_to?(:format)
+        end
+        responds ? @renderable.format : nil
       end
     end
   end

--- a/actionview/test/abstract_unit.rb
+++ b/actionview/test/abstract_unit.rb
@@ -19,6 +19,8 @@ require "active_support/testing/autorun"
 require "active_support/testing/method_call_assertions"
 require "action_controller"
 require "action_view"
+require "action_view/structured_event_subscriber"
+ActionView::StructuredEventSubscriber.attach_to :action_view
 require "action_view/testing/resolvers"
 require "active_support/dependencies"
 require "active_model"

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -471,10 +471,6 @@ module RenderTestCases
   # ViewComponent) by ~5x. Uses a minimal view / lookup context and swaps
   # in a fresh notifier (no subscribers) so the measurement reflects the
   # production case and targets the renderable dispatch path itself.
-  #
-  # Pre-#50623 was 4 obj/render; post-#50623 was 19; this branch is 9.
-  # Any change to that number should be a deliberate one — bump this
-  # constant and update the PR/CHANGELOG.
   def test_render_renderable_allocation_ceiling
     renderable = Class.new do
       def render_in(_view_context, **) = "hello"

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -471,6 +471,10 @@ module RenderTestCases
   # ViewComponent) by ~5x. Uses a minimal view / lookup context and swaps
   # in a fresh notifier (no subscribers) so the measurement reflects the
   # production case and targets the renderable dispatch path itself.
+  #
+  # Pre-#50623 was 4 obj/render; post-#50623 was 19; this branch is 9.
+  # Any change to that number should be a deliberate one — bump this
+  # constant and update the PR/CHANGELOG.
   def test_render_renderable_allocation_ceiling
     renderable = Class.new do
       def render_in(_view_context, **) = "hello"
@@ -489,12 +493,13 @@ module RenderTestCases
 
     GC.disable
     before = GC.stat(:total_allocated_objects)
-    100.times { view.render(renderable) }
-    per_render = (GC.stat(:total_allocated_objects) - before) / 100.0
+    1000.times { view.render(renderable) }
+    diff = GC.stat(:total_allocated_objects) - before
+    per_render = diff / 1000
 
-    assert_operator per_render, :<=, 16,
-      "Expected `render(renderable)` to allocate <= 16 objects/render, " \
-      "got #{per_render}. See https://github.com/rails/rails/issues/57781."
+    assert_equal 9, per_render,
+      "Expected `render(renderable)` to allocate exactly 9 objects/render, " \
+      "got #{per_render} (diff=#{diff}). See https://github.com/rails/rails/issues/57781."
   ensure
     GC.enable
     ActiveSupport::Notifications.notifier = old_notifier if old_notifier

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -466,6 +466,40 @@ module RenderTestCases
     assert_equal options.to_s, @view.render(renderable: renderable, **options)
   end
 
+  # Guards against regressions like #57781, where #50623 unintentionally
+  # increased per-render allocations for `render_in` objects (including
+  # ViewComponent) by ~5x. Uses a minimal view / lookup context and swaps
+  # in a fresh notifier (no subscribers) so the measurement reflects the
+  # production case and targets the renderable dispatch path itself.
+  def test_render_renderable_allocation_ceiling
+    renderable = Class.new do
+      def render_in(_view_context, **) = "hello"
+      def format; :html; end
+    end.new
+
+    lookup_context = ActionView::LookupContext.new([])
+    view = ActionView::Base.with_empty_template_cache.new(lookup_context, {}, ActionController::Base.new)
+
+    old_notifier = ActiveSupport::Notifications.notifier
+    ActiveSupport::Notifications.notifier = ActiveSupport::Notifications::Fanout.new
+
+    # Warm any per-class caches (arity memoization, format lookup, etc.)
+    # before sampling.
+    view.render(renderable)
+
+    GC.disable
+    before = GC.stat(:total_allocated_objects)
+    100.times { view.render(renderable) }
+    per_render = (GC.stat(:total_allocated_objects) - before) / 100.0
+
+    assert_operator per_render, :<=, 16,
+      "Expected `render(renderable)` to allocate <= 16 objects/render, " \
+      "got #{per_render}. See https://github.com/rails/rails/issues/57781."
+  ensure
+    GC.enable
+    ActiveSupport::Notifications.notifier = old_notifier if old_notifier
+  end
+
   def test_render_object_different_name
     assert_equal "Hello: t.lo", @view.render(partial: "test/template_not_named_customer", object: Customer.new("t.lo"), as: "customer").chomp
   end


### PR DESCRIPTION
## Problem

https://github.com/rails/rails/pull/50623 closed a long-present gap between the render pipeline for renderables and non-renderables. GitHub saw a [significant increase](https://github.com/rails/rails/issues/57781) in allocations on ViewComponent-heavy routes as a result.

## Alternative solution

@seanpdoyle proposed walking back most of the changes in https://github.com/rails/rails/compare/seanpdoyle:issue-57781. While I think that is an acceptable fix (and one we should land if this PR is not accepted), I would rather try to optimize the current implementation so we can keep the rendering of renderables as close to the same as non-renderables.

## Proposed solution

_Benchmarks are for renders in a non-debug production Rails app._

I found a handful of optimizations that get us down to 12 obj/render, when we had 4 obj/render before #50623.

| Scenario | Objects/render |
|---|---|
| Pre-#50623 (main @ 343fe92b) | 4 |
| seanpdoyle bypass fix | 8 |
| Post-#50623 (main today) | 103 |
| + skip `StructuredEventSubscriber` attach when not in debug mode | 19 |
| + memoize `render_in` arity + `respond_to?(:format)` | 15 |
| + skip `prepend_formats` when subset | 14 |
| + reuse `TemplateRenderer` per `Renderer` | 13 |
| + pool `Template::Renderable` when no block | 12 |

## Benchmark code

```ruby
# frozen_string_literal: true
require "benchmark/memory"
require "action_controller/railtie"
require "action_view/railtie"

class BenchApp < Rails::Application
  config.load_defaults Rails::VERSION::STRING.to_f
  config.eager_load = true
  config.logger = Logger.new(IO::NULL)
  config.secret_key_base = "x" * 64
  config.action_view.logger = Logger.new(IO::NULL)
end
Rails.application.initialize!

class MiniComponent
  def initialize(name); @name = name; end
  def render_in(view_context, **) = "<p>Hello, #{@name}!</p>".html_safe
  def format; :html; end
end

lookup_context = ActionView::LookupContext.new([])
view = ActionView::Base.with_empty_template_cache.new(lookup_context, {}, ActionController::Base.new)
components = Array.new(50) { |i| MiniComponent.new("row-#{i}") }
components.each { |c| view.render(c) } # warmup

Benchmark.memory do |x|
  x.report("50 render_in calls") do
    components.each { |c| view.render(c) }
  end
end
```