### PR TITLE
Avoid preloading nil converted association keys

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Avoid unnecessary association preloader queries for nil foreign keys when
+    the foreign key and association primary key have different types.
+
+    *Thrwat Elmoselhi*
+
 *   Add `config.active_record.shuffle_unordered_selects`.
 
     When enabled, Active Record shuffles the rows of every `SELECT` it generates

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -273,7 +273,7 @@ module ActiveRecord
 
           def convert_key(key)
             if key_conversion_required?
-              key.to_s
+              key&.to_s
             else
               key
             end

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -858,6 +858,14 @@ class PreloaderTest < ActiveRecord::TestCase
     end
   end
 
+  def test_preload_skips_query_when_foreign_key_is_nil_and_key_types_differ
+    post = Postesque.new(author_id: nil)
+
+    assert_no_queries do
+      ActiveRecord::Associations::Preloader.new(records: [post], associations: :author_with_address).call
+    end
+  end
+
   def test_preload_does_not_concatenate_duplicate_records
     post = posts(:welcome)
     post.reload
@@ -1216,7 +1224,8 @@ class PreloaderTest < ActiveRecord::TestCase
 
   def test_preload_does_not_group_same_class_different_scope
     post = posts(:welcome)
-    postesque = Postesque.create(author: Author.last)
+    author = Author.last
+    postesque = Postesque.create(author: author, author_id: author.id)
     postesque.reload
 
     # When the scopes differ in the generated SQL:


### PR DESCRIPTION
### Motivation / Background

When an association's foreign key and primary key report different types, the preloader converts both keys to strings so they can be matched. This conversion currently turns a `nil` owner key into an empty string.

Because the empty string is truthy, the owner remains in `owners_by_key` and the preloader sends a query even when there is no association key to load. The query cannot find a record and the association still resolves to `nil`, so this is unnecessary work.

### Detail

Preserve `nil` in `Preloader::Association#convert_key` while continuing to stringify every non-`nil` key when conversion is required. This lets the existing `owners_by_key` guard exclude owners without foreign keys, as it already does when key conversion is not required.

The regression test uses an existing association whose string foreign key points to an integer primary key. An existing query-grouping test now supplies a present foreign key explicitly so it continues to test two differently scoped queries rather than relying on the unnecessary nil-key query.

### Additional information

Verified with:

```bash
cd activerecord
ARCONN=sqlite3 bin/test test/cases/associations_test.rb
```

Result: 137 runs, 525 assertions, 0 failures, 0 errors, 0 skips.

Targeted RuboCop checks also report no offenses.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes are in separate PRs.
* [x] The commit message describes what changed and why.
* [x] Tests are added for the bug fix.
* [x] The Active Record CHANGELOG is updated.

---
_Generated with Pi._
<!-- github-gate:footer -->
<!-- github-gate:idempotency=rails-preloader-nil-key-20260831 -->