### PR TITLE
Check PATCH and QUERY in routing assertions with method: :all

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Check `PATCH` and `QUERY` in `assert_recognizes` and `assert_routing` with `method: :all`.
+
+    Both assertions only recognized the path for `GET`, `POST`, `PUT` and
+    `DELETE`, so a route that did not accept `PATCH` or `QUERY` still passed an
+    assertion meant to cover every verb.
+
+    An assertion that passes today on a route drawn without those verbs now
+    fails, which is what it was meant to do.
+
+    *Carlos Daniel Pohlod*
+
 *   Allow `translate`'s (and `t`'s) `scope:` option to be resolved relative to
     the current controller and action when it starts with a period,
     mirroring the existing behavior for the key argument.

--- a/actionpack/lib/action_dispatch/testing/assertions/routing.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/routing.rb
@@ -150,6 +150,12 @@ module ActionDispatch
       #     # Asserts that POSTing to /items will call the create action on ItemsController
       #     assert_recognizes({controller: 'items', action: 'create'}, {path: 'items', method: :post})
       #
+      # Pass `:all` as the method to assert that the path is recognized for each of
+      # `GET`, `POST`, `PUT`, `PATCH`, `DELETE` and `QUERY`, as a route declared
+      # with `via: :all` is:
+      #
+      #     assert_recognizes({controller: 'items', action: 'show'}, {path: 'items', method: :all})
+      #
       # You can also pass in `extras` with a hash containing URL parameters that would
       # normally be in the query string. This can be used to assert that values in the
       # query string will end up in the params hash correctly. To test query strings
@@ -175,7 +181,7 @@ module ActionDispatch
       #     assert_recognizes({controller: 'items', action: 'show', id: '1'}, 'view/item1')
       def assert_recognizes(expected_options, path, extras = {}, msg = nil)
         if path.is_a?(Hash) && path[:method].to_s == "all"
-          [:get, :post, :put, :delete].each do |method|
+          [:get, :post, :put, :patch, :delete, :query].each do |method|
             assert_recognizes(expected_options, path.merge(method: method), extras, msg)
           end
         else

--- a/actionpack/test/controller/resources_test.rb
+++ b/actionpack/test/controller/resources_test.rb
@@ -1145,6 +1145,30 @@ class ResourcesTest < ActionController::TestCase
     end
   end
 
+  def test_assert_routing_fails_when_patch_is_not_recognized
+    with_routing do |set|
+      set.draw do
+        match "/products", to: "products#show", via: [:get, :post, :put, :delete, :query]
+      end
+
+      assert_raises(Minitest::Assertion) do
+        assert_routing({ method: "all", path: "/products" }, { controller: "products", action: "show" })
+      end
+    end
+  end
+
+  def test_assert_routing_fails_when_query_is_not_recognized
+    with_routing do |set|
+      set.draw do
+        match "/products", to: "products#show", via: [:get, :post, :put, :patch, :delete]
+      end
+
+      assert_raises(Minitest::Assertion) do
+        assert_routing({ method: "all", path: "/products" }, { controller: "products", action: "show" })
+      end
+    end
+  end
+
   def test_singleton_resource_name_is_not_singularized
     with_singleton_resources(:products) do
       assert_singleton_restful_for :products


### PR DESCRIPTION
### Motivation / Background

`assert_recognizes` and `assert_routing` accept `method: :all` to assert that a path is recognized for every HTTP verb, the way a route drawn with `via: :all` is. The existing test for this is named `test_assert_routing_fails_when_not_all_http_methods_are_recognized`.

The implementation only iterates over `GET`, `POST`, `PUT` and `DELETE`. A route drawn as `via: [:get, :post, :put, :delete]` therefore passes an assertion that claims to cover every verb, even though the route rejects `PATCH` and `QUERY`. The list dates back to before PATCH became the default verb for updates in Rails 4, and QUERY was added in this cycle.

### Detail

Adds `:patch` and `:query` to the verbs checked for `method: :all`, and documents the option, which had no RDoc.

`OPTIONS`, `HEAD` and `TRACE` are left out even though a `via: :all` route accepts them too: `HEAD` is served by the `GET` route, `OPTIONS` is commonly answered by middleware rather than a route, and `TRACE` is rarely routed. Happy to include them if you prefer the assertion to cover the full set.

This makes assertions that pass today start failing when the route does not accept those verbs, which is the point of the fix. The CHANGELOG entry calls that out.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
