### PR TITLE
Avoid a redundant join in scoped through associations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Avoid a redundant join when the scope of a `has_many :through` association
+    joins an association that the through chain already joins.
+
+    Given a scope such as `-> { joins(:post) }` on the through association, the
+    same table was joined twice: once by the chain and once by the scope. Only
+    `belongs_to` and `has_one` joins are dropped, since removing a collection
+    join would change the number of rows the query returns.
+
+    *David Paluy*
+
 *   Add `config.active_record.shuffle_unordered_selects`.
 
     When enabled, Active Record shuffles the rows of every `SELECT` it generates

--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -143,6 +143,7 @@ module ActiveRecord
               if scope_chain_item == chain_head.scope
                 scope.merge! item.except(:where, :includes, :unscope, :order)
               elsif !item.references_values.empty?
+                item.joins_values = item.joins_values.reject { |join| redundant_join?(item, chain, join) }
                 scope.merge! item.only(:joins, :left_outer_joins)
 
                 associations = item.eager_load_values | item.includes_values
@@ -174,6 +175,18 @@ module ActiveRecord
             predicate_builder = reflection.klass.predicate_builder.with(TableMetadata.new(reflection.klass, table))
             scope.where!(predicate_builder[key, value])
           end
+        end
+
+        def redundant_join?(item, chain, join)
+          return false unless join.is_a?(Symbol)
+
+          reflection = item.model._reflect_on_association(join)
+
+          # Dropping a collection join would change how many rows the query
+          # returns, so only singular ones are considered redundant here.
+          return false unless reflection && !reflection.collection? && !reflection.through_reflection?
+
+          chain.drop(1).any? { |chain_reflection| chain_reflection == reflection }
         end
 
         def eval_scope(reflection, scope, owner)

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -47,6 +47,20 @@ require "models/interest"
 require "models/human"
 require "models/dats"
 
+class RedundantJoinAuthor < ActiveRecord::Base
+  self.table_name = "authors"
+
+  has_many :scoped_comments, -> { joins(:post).where.not(posts: { id: nil }) }, class_name: "RedundantJoinComment", foreign_key: :author_id
+  has_many :commented_post_authors, through: :scoped_comments, source: :post_author
+end
+
+class RedundantJoinComment < ActiveRecord::Base
+  self.table_name = "comments"
+
+  belongs_to :post
+  has_one :post_author, through: :post, source: :author
+end
+
 class HasManyThroughAssociationsTest < ActiveRecord::TestCase
   fixtures :posts, :readers, :people, :comments, :authors, :categories, :taggings, :tags,
            :owners, :pets, :toys, :jobs, :references, :companies, :members, :author_addresses,
@@ -76,6 +90,18 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_through_association_with_left_joins
     assert_equal [comments(:eager_other_comment1)], authors(:mary).comments.merge(Post.left_joins(:comments))
+  end
+
+  def test_has_many_through_with_scope_joining_source_reflection_does_not_add_a_redundant_join
+    commenter = RedundantJoinAuthor.create!(name: "commenter")
+    post_author = Author.create!(name: "post author")
+    post = Post.create!(author: post_author, title: "title", body: "body")
+    RedundantJoinComment.create!(author_id: commenter.id, post: post, body: "comment")
+
+    sql = commenter.commented_post_authors.to_sql
+
+    assert_equal 1, sql.scan(/JOIN #{Regexp.escape(quote_table_name("posts"))}/).size
+    assert_equal [post_author], commenter.commented_post_authors
   end
 
   def test_through_association_with_through_scope_and_nested_where


### PR DESCRIPTION
When the scope of a `has_many :through` association joins an association that the through chain already joins, the same table was joined twice: once by the chain and once when the scope was merged into it.

Drop such a join from the merged scope when it names a `belongs_to` or `has_one` reflection the chain already covers. Collection joins are left in place, since removing one changes the number of rows the query returns.

This Pull Request has been created because #51259.

### Detail

This Pull Request changes `AssociationScope#add_constraints` to drop those joins before merging the scope. Using the models from #51259:

Before:

```sql
  SELECT "rubygems".* FROM "rubygems"
    INNER JOIN "versions" ON "rubygems"."id" = "versions"."rubygem_id"
    INNER JOIN "dependencies" ON "versions"."id" = "dependencies"."version_id"
    INNER JOIN "versions" "versions_dependencies" ON "versions_dependencies"."id" = "dependencies"."version_id"
    WHERE "dependencies"."rubygem_id" = ? AND "versions"."indexed" = ? AND "versions"."position" = ?
```

  After:

```sql
  SELECT "rubygems".* FROM "rubygems"
    INNER JOIN "versions" ON "rubygems"."id" = "versions"."rubygem_id"
    INNER JOIN "dependencies" ON "versions"."id" = "dependencies"."version_id"
    WHERE "dependencies"."rubygem_id" = ? AND "versions"."indexed" = ? AND "versions"."position" = ?
  ```

The removed join matches on the same key as the one the chain already added, so it filters nothing.

#### Additional information

The reporter's test case now passes, including its assertion that the AST matches the same association written without the joins.

Applications cannot just drop the joins themselves: incoming_dependencies needs it for its own where, and raises without it. It is only redundant once the chain supplies the same table.

### Checklist
  - [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
  - [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: [Fix #issue-number]
  - [x] Tests are added or updated if you fix a bug or add a feature.
  - [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.