### PR TITLE
Optimize EventReporter::LogSubscriber#subscription_filter

### DIFF
--- a/activesupport/lib/active_support/event_reporter/log_subscriber.rb
+++ b/activesupport/lib/active_support/event_reporter/log_subscriber.rb
@@ -27,13 +27,9 @@ module ActiveSupport
         attr_accessor :namespace
 
         def subscription_filter
-          namespace = self.namespace.to_s
+          prefix = "#{namespace}.".freeze
           proc do |event|
-            name = event[:name]
-            if (dot_idx = name.index("."))
-              event_namespace = name[0, dot_idx]
-              namespace == event_namespace
-            end
+            event[:name].start_with?(prefix)
           end
         end
       end


### PR DESCRIPTION
Rather than to extract the namespace from the event name, we can do the opposite and build the prefix from the namespace.
