### PR TITLE
Make ActionPack settings instance variables

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -2,8 +2,6 @@
 
 # :markup: markdown
 
-require "active_support/core_ext/module/attribute_accessors"
-
 module ActionDispatch
   module Http
     module MimeNegotiation
@@ -16,9 +14,12 @@ module ActionDispatch
         ActionDispatch::Http::Parameters::ParseError,
       ].freeze
 
+      @ignore_accept_header = false
+      @strict_accept_header = false
+      accessors = singleton_class.attr_accessor :ignore_accept_header, :strict_accept_header
+
       included do
-        mattr_accessor :ignore_accept_header, default: false
-        mattr_accessor :strict_accept_header, default: false
+        singleton_class.delegate(*accessors, to: MimeNegotiation)
       end
 
       # The MIME type of the HTTP request, such as [Mime](:xml).
@@ -231,12 +232,12 @@ module ActionDispatch
           if xhr?
             accept.present? || content_mime_type
           elsif accept.present?
-            self.class.strict_accept_header || !accept.match?(BROWSER_LIKE_ACCEPTS)
+            MimeNegotiation.strict_accept_header || !accept.match?(BROWSER_LIKE_ACCEPTS)
           end
         end
 
         def use_accept_header
-          !self.class.ignore_accept_header
+          !MimeNegotiation.ignore_accept_header
         end
 
         def format_from_path_extension

--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -9,7 +9,9 @@ require "rack/utils"
 
 module ActionDispatch
   class ExceptionWrapper
-    cattr_accessor :rescue_responses, default: Hash.new(:internal_server_error).merge!(
+    singleton_class.attr_accessor :rescue_responses, :rescue_templates, :wrapper_exceptions, :silent_exceptions
+
+    @rescue_responses = Hash.new(:internal_server_error).merge!(
       "ActionController::RoutingError"                     => :not_found,
       "AbstractController::ActionNotFound"                 => :not_found,
       "ActionController::MethodNotAllowed"                 => :method_not_allowed,
@@ -28,7 +30,7 @@ module ActionDispatch
       "Rack::QueryParser::InvalidParameterError"           => :bad_request
     ).freeze
 
-    cattr_accessor :rescue_templates, default: Hash.new("diagnostics").merge!(
+    @rescue_templates = Hash.new("diagnostics").merge!(
       "ActionView::MissingTemplate"            => "missing_template",
       "ActionController::RoutingError"         => "routing_error",
       "AbstractController::ActionNotFound"     => "unknown_action",
@@ -37,11 +39,11 @@ module ActionDispatch
       "ActionController::MissingExactTemplate" => "missing_exact_template",
     ).freeze
 
-    cattr_accessor :wrapper_exceptions, default: [
+    @wrapper_exceptions = [
       "ActionView::Template::Error"
     ].freeze
 
-    cattr_accessor :silent_exceptions, default: [
+    @silent_exceptions = [
       "ActionController::RoutingError",
       "ActionDispatch::Http::MimeNegotiation::InvalidType"
     ].freeze
@@ -104,7 +106,7 @@ module ActionDispatch
     end
 
     def unwrapped_exception
-      if wrapper_exceptions.include?(@exception_class_name)
+      if self.class.wrapper_exceptions.include?(@exception_class_name)
         @exception.cause
       else
         @exception
@@ -120,7 +122,7 @@ module ActionDispatch
     end
 
     def rescue_template
-      @@rescue_templates[@exception_class_name]
+      self.class.rescue_templates[@exception_class_name]
     end
 
     def status_code
@@ -129,7 +131,7 @@ module ActionDispatch
 
     def exception_trace
       trace = application_trace
-      trace = framework_trace if trace.empty? && !silent_exceptions.include?(@exception_class_name)
+      trace = framework_trace if trace.empty? && !self.class.silent_exceptions.include?(@exception_class_name)
       trace
     end
 
@@ -179,7 +181,7 @@ module ActionDispatch
     end
 
     def self.status_code_for_exception(class_name)
-      ActionDispatch::Response.rack_status_code(@@rescue_responses[class_name])
+      ActionDispatch::Response.rack_status_code(rescue_responses[class_name])
     end
 
     def show?(request)
@@ -198,7 +200,7 @@ module ActionDispatch
     end
 
     def rescue_response?
-      @@rescue_responses.key?(exception.class.name)
+      self.class.rescue_responses.key?(exception.class.name)
     end
 
     def source_extracts

--- a/actionpack/test/dispatch/exception_wrapper_test.rb
+++ b/actionpack/test/dispatch/exception_wrapper_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "abstract_unit"
+require "active_support/testing/ractors_assertions"
 
 module ActionDispatch
   class ExceptionWrapperTest < ActionDispatch::IntegrationTest
@@ -366,6 +367,32 @@ module ActionDispatch
       request = ActionDispatch::Request.new(env)
 
       assert_equal true, wrapper.show?(request)
+    end
+  end
+
+  class ExceptionWrapperRactorTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+    include ActiveSupport::Testing::RactorsAssertions
+
+    test "the rescue tables are readable from a non-main Ractor once shared" do
+      ActiveSupport::Ractors.make_shareable(ExceptionWrapper.rescue_responses)
+      ActiveSupport::Ractors.make_shareable(ExceptionWrapper.rescue_templates)
+      ActiveSupport::Ractors.make_shareable(ExceptionWrapper.wrapper_exceptions)
+      ActiveSupport::Ractors.make_shareable(ExceptionWrapper.silent_exceptions)
+
+      statuses = on_ractor {
+        [
+          ExceptionWrapper.rescue_responses["ActionController::RoutingError"],
+          ExceptionWrapper.rescue_templates["ActionController::RoutingError"],
+          ExceptionWrapper.wrapper_exceptions,
+          ExceptionWrapper.silent_exceptions,
+        ]
+      }
+
+      assert_equal :not_found, statuses[0]
+      assert_equal "routing_error", statuses[1]
+      assert_equal ExceptionWrapper.wrapper_exceptions, statuses[2]
+      assert_equal ExceptionWrapper.silent_exceptions, statuses[3]
     end
   end
 end

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -1748,3 +1748,26 @@ class RequestCacheControlDirectives < BaseRequestTest
     assert_not_predicate request.cache_control_directives, :no_store?
   end
 end
+
+class RequestMimeNegotiationSettingsTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::RactorsAssertions
+
+  test "the negotiation settings are readable from a non-main Ractor" do
+    assert_equal [false, false], on_ractor {
+      [
+        ActionDispatch::Http::MimeNegotiation.ignore_accept_header,
+        ActionDispatch::Request.strict_accept_header,
+      ]
+    }
+  end
+
+  test "request classes delegate the settings to the module" do
+    old = ActionDispatch::Request.ignore_accept_header
+    ActionDispatch::Request.ignore_accept_header = true
+
+    assert_equal true, ActionDispatch::Http::MimeNegotiation.ignore_accept_header
+    assert_equal true, ActionDispatch::TestRequest.ignore_accept_header
+  ensure
+    ActionDispatch::Request.ignore_accept_header = old
+  end
+end


### PR DESCRIPTION
Similar to #58620 

For `MimeNegotiation`, removing `mattr_accessor` also removes instance-level accessors, I think that's OK since they're not documented, and also it's weird when instances indirectly modify their class.

Before this:

```ruby
ActionDispatch::Request.ignore_accept_header
# => false
ActionDispatch::Request.new({}).ignore_accept_header = true
# => true
ActionDispatch::Request.ignore_accept_header
# => true
```