### PR TITLE
Make the allow_browser callback shareable

### DIFF
--- a/actionpack/lib/action_controller/metal/allow_browser.rb
+++ b/actionpack/lib/action_controller/metal/allow_browser.rb
@@ -2,11 +2,18 @@
 
 # :markup: markdown
 
+require "active_support/ractors"
+
 module ActionController # :nodoc:
   module AllowBrowser
     extend ActiveSupport::Concern
 
     module ClassMethods
+      DEFAULT_UNSUPPORTED_BROWSER_RESPONSE = ActiveSupport::Ractors.shareable_lambda do
+        render file: Rails.root.join("public/406-unsupported-browser.html"), layout: false, status: :not_acceptable
+      end
+      private_constant :DEFAULT_UNSUPPORTED_BROWSER_RESPONSE
+
       # Specify the browser versions that will be allowed to access all actions (or
       # some, as limited by `only:` or `except:`). Only browsers matched in the hash
       # or named set passed to `versions:` will be blocked if they're below the
@@ -54,10 +61,10 @@ module ActionController # :nodoc:
       #       # In addition to the browsers blocked by ApplicationController, also block Opera below 104 and Chrome below 119 for the show action.
       #       allow_browser versions: { opera: 104, chrome: 119 }, only: :show
       #     end
-      def allow_browser(versions:, block: -> { render file: Rails.root.join("public/406-unsupported-browser.html"), layout: false, status: :not_acceptable }, **options)
+      def allow_browser(versions:, block: nil, **options)
         require "useragent"
 
-        before_action -> { allow_browser(versions: versions, block: block) }, **options
+        before_action -> { allow_browser(versions: versions, block: block || DEFAULT_UNSUPPORTED_BROWSER_RESPONSE) }, **options
       end
     end
 

--- a/actionpack/test/controller/allow_browser_test.rb
+++ b/actionpack/test/controller/allow_browser_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "abstract_unit"
+require "active_support/testing/ractors_assertions"
 
 class AllowBrowserController < ActionController::Base
   allow_browser versions: { safari: "16.4", chrome: "119", firefox: "123", opera: "106", ie: false }, block: -> { head :upgrade_required }, only: :hello
@@ -97,4 +98,26 @@ class AllowBrowserTest < ActionController::TestCase
       @request.headers["User-Agent"] = agent
       get action
     end
+end
+
+class AllowBrowserRactorTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::RactorsAssertions
+
+  test "the default block is shareable" do
+    assert_ractor_shareable ActionController::AllowBrowser::ClassMethods.const_get(:DEFAULT_UNSUPPORTED_BROWSER_RESPONSE)
+  end
+
+  test "allow_browser registers a shareable callback when the application opts in" do
+    old_action = ActiveSupport::Ractors.unshareable_proc_action
+    ActiveSupport::Ractors.unshareable_proc_action = :raise
+
+    klass = Class.new(ActionController::Base) do
+      allow_browser versions: :modern
+    end
+
+    assert_equal ActionController::Base._process_action_callbacks.count + 1,
+      klass._process_action_callbacks.count
+  ensure
+    ActiveSupport::Ractors.unshareable_proc_action = old_action
+  end
 end


### PR DESCRIPTION
This allows using `allow_browser` with Ractors, by making the default action for unsupported browsers a shareable proc.

I also had to capture the optional keyword `:block` as a separate local variable to allow the lambda to capture it. It's a limitation with Ruby detecting optional keywords with non-literal default values as reassignable.