### PR TITLE
Re-enable PostgreSQL triggers when the block given to `disable_referential_integrity` raises

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Re-enable PostgreSQL triggers when the block given to `disable_referential_integrity` raises.
+
+    The PostgreSQL adapter switches foreign key enforcement off with
+    `ALTER TABLE ... DISABLE TRIGGER ALL`, which is catalog state that outlives the
+    connection. The matching `ENABLE TRIGGER ALL` only ran when the block returned
+    normally, so an exception raised inside it (a truncation blocked by a deadlock, a
+    test process interrupted) left every foreign key in that database disabled for
+    every later connection and every later run. The re-enable now runs in an `ensure`.
+
+    *Lucas Guedes*
+
 *   Avoid unnecessary association preloader queries for nil foreign keys when
     the foreign key and association primary key have different types.
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
@@ -31,13 +31,13 @@ module ActiveRecord
 
               WARNING
               raise e
-            end
-
-            begin
-              transaction(requires_new: true) do
-                execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} ENABLE TRIGGER ALL" }.join(";"))
+            ensure
+              begin
+                transaction(requires_new: true) do
+                  execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} ENABLE TRIGGER ALL" }.join(";"))
+                end
+              rescue ActiveRecord::ActiveRecordError
               end
-            rescue ActiveRecord::ActiveRecordError
             end
           end
         end

--- a/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
@@ -129,6 +129,37 @@ class PostgreSQLReferentialIntegrityTest < ActiveRecord::PostgreSQLTestCase
     end
   end
 
+  def test_re_enables_triggers_when_the_block_raises
+    skip if @connection.supports_enforced_foreign_keys?
+    skip "DISABLE TRIGGER ALL needs a superuser" unless @connection.select_value("SELECT rolsuper FROM pg_roles WHERE rolname = current_user")
+
+    @connection.create_table :ri_test_parents, force: true
+    @connection.create_table :ri_test_children, force: true do |t|
+      t.bigint :parent_id, null: false
+    end
+    @connection.add_foreign_key :ri_test_children, :ri_test_parents, column: :parent_id, name: :ri_test_fk
+
+    begin
+      assert_raises(RuntimeError) do
+        @connection.disable_referential_integrity do
+          assert_operator disabled_trigger_count(:ri_test_children), :>, 0
+          raise "boom"
+        end
+      end
+
+      assert_equal 0, disabled_trigger_count(:ri_test_children)
+    ensure
+      @connection.execute(@connection.tables.map { |name| "ALTER TABLE #{@connection.quote_table_name(name)} ENABLE TRIGGER ALL" }.join(";"))
+    end
+  end
+
+  def disabled_trigger_count(table)
+    @connection.select_value(<<~SQL).to_i
+      SELECT COUNT(*) FROM pg_trigger
+      WHERE tgrelid = #{@connection.quote(table.to_s)}::regclass AND tgisinternal AND tgenabled = 'D'
+    SQL
+  end
+
   def test_disable_referential_integrity_with_partitioned_to_partitioned_fk
     skip unless @connection.supports_enforced_foreign_keys?
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `disable_referential_integrity` on the PostgreSQL adapter can leave every foreign key in a database disabled. It runs `ALTER TABLE ... DISABLE TRIGGER ALL` on every table, yields, and then runs `ENABLE TRIGGER ALL` in a plain `begin` block placed after the `yield` rather than in an `ensure`, so any exception raised inside the block skips the re-enable. `DISABLE TRIGGER ALL` is catalog state (`pg_trigger.tgenabled`), not a session setting: the constraints stay off for every later connection, process and test run until something switches them back on.

We hit it through DatabaseCleaner's truncation strategy under parallel_tests. One truncation that raised (a deadlock against an in-flight request, or an interrupted run) left a worker's database without foreign keys, and unrelated model tests later failed intermittently with the same shape: `ON DELETE RESTRICT` not raising `InvalidForeignKey`, `CASCADE` children surviving, `SET NULL` pointers keeping their value. Every one of them passed in isolation, and the poison only cleared when that worker's next successful truncation happened to switch the triggers back on.

Rails 4.2 re-enabled the triggers in an `ensure`; the rework in 72c1557254 dropped it. The `NOT ENFORCED` path used on PostgreSQL 18.4+ runs inside one transaction and is not affected; the legacy trigger path still is.

### Detail

This Pull Request changes the legacy path of `disable_referential_integrity` to run the `ENABLE TRIGGER ALL` block in an `ensure`, so the triggers come back whatever the block did. The existing `rescue ActiveRecord::ActiveRecordError` around the re-enable is kept: when the block left an outer transaction aborted, the re-enable fails quietly as before and the outer rollback undoes the `DISABLE`.

It adds `test_re_enables_triggers_when_the_block_raises`, which skips where enforced foreign keys are supported (the other path runs there) and when the test role is not a superuser (`DISABLE TRIGGER ALL` needs one). The test re-enables the triggers itself in an `ensure`, so a red run cannot poison the rest of the suite. Without the fix it fails with `Expected: 0` disabled triggers on the child table; with it, it passes.

### Additional information

`8-1-stable` carries the same legacy code, so the change applies there unchanged. Happy to open a backport.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
