### PR TITLE
Keep the connection descriptor on the primary_abstract_class

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Keep the connection descriptor on the `primary_abstract_class` when
+    `ActiveRecord::Base` re-establishes the same pool.
+
+    An application whose `primary_abstract_class` calls `connects_to` names its
+    primary pool after that class. Re-establishing the same pool through
+    `ActiveRecord::Base`, as `ActiveRecord::Migration.maintain_test_schema!`
+    does, renamed the descriptor back to `"ActiveRecord::Base"`. From that point
+    `ApplicationRecord.connected_to(role: :writing)` no longer lifted the
+    readonly guard and the write raised `ActiveRecord::ReadOnlyError`, so the
+    guard behaved one way in a booted application and another under
+    `rails/test_help`.
+
+    The descriptor is now only adopted by the `primary_abstract_class`, which is
+    the direction granular swapping needs. `ActiveRecord::Base.connected_to` is
+    unaffected, since it is matched by class rather than by descriptor name.
+
+    *Ahmed Abd El-Latif*
+
 *   Avoid unnecessary association preloader queries for nil foreign keys when
     the foreign key and association primary key have different types.
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
@@ -130,7 +130,8 @@ module ActiveRecord
           # Update the pool_config's connection class if it differs. This is used
           # for ensuring that ActiveRecord::Base and the primary_abstract_class use
           # the same pool. Without this granular swapping will not work correctly.
-          if owner_name.primary_class? && (existing_pool_config.connection_descriptor != owner_name)
+          if owner_name.primary_class? && (existing_pool_config.connection_descriptor != owner_name) &&
+              (owner_name.application_record_class? || !ActiveRecord.application_record_class)
             existing_pool_config.connection_descriptor = owner_name
           end
 

--- a/activerecord/test/cases/connection_adapters/connection_swapping_nested_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_swapping_nested_test.rb
@@ -622,6 +622,34 @@ module ActiveRecord
           ActiveRecord::Base.establish_connection :arunit
         end
 
+        def test_prevent_writes_can_be_changed_granularly_after_a_primary_class_reestablish
+          # Regression test for https://github.com/rails/rails/issues/58630
+          Object.const_set(:PrimaryRecord, Class.new(ActiveRecord::Base) { primary_abstract_class })
+          PrimaryRecord.connects_to(database: { writing: :arunit, reading: :arunit })
+
+          ActiveRecord::Base.connected_to(role: :writing, prevent_writes: true) do
+            PrimaryRecord.connected_to(role: :writing) do
+              assert_not_predicate PrimaryRecord.lease_connection, :preventing_writes?
+            end
+          end
+
+          # ActiveRecord::Migration.maintain_test_schema! re-establishes the primary
+          # pool through ActiveRecord::Base by way of DatabaseTasks#with_temporary_pool.
+          db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+          ActiveRecord::Base.connection_handler.establish_connection(db_config)
+
+          ActiveRecord::Base.connected_to(role: :writing, prevent_writes: true) do
+            PrimaryRecord.connected_to(role: :writing) do
+              assert_not_predicate PrimaryRecord.lease_connection, :preventing_writes?
+            end
+          end
+        ensure
+          PrimaryRecord.remove_connection
+          ActiveRecord.application_record_class = nil
+          Object.send(:remove_const, :PrimaryRecord)
+          ActiveRecord::Base.establish_connection :arunit
+        end
+
         def test_prevent_writes_handles_class_reloading
           # Regression test for https://github.com/rails/rails/issues/54343
           Object.const_set(:ReloadedRecord, Class.new(ActiveRecord::Base) { self.abstract_class = true })


### PR DESCRIPTION
### Motivation / Background

Fixes #58630.

An application whose `primary_abstract_class` calls `connects_to` names its primary connection pool after that class, and `ApplicationRecord.connected_to(role: :writing)` lifts the readonly guard correctly.

If the same pool is re-established through `ActiveRecord::Base`, the descriptor is renamed to `"ActiveRecord::Base"`. From that point the granular lift stops working and the write raises `ActiveRecord::ReadOnlyError`. Only `ActiveRecord::Base.connected_to(role: :writing)` still works, and that lifts the guard on every database rather than on the one the application named.

`ActiveRecord::Migration.maintain_test_schema!` performs such a re-establish by way of `DatabaseTasks#with_temporary_pool`, whose `ensure` restores the original `db_config` but not the original descriptor. `rails/test_help` calls `maintain_test_schema!` at require time, so every test process starts with the descriptor renamed. The result is that identical application code lifts the guard in development and production and raises `ActiveRecord::ReadOnlyError` under test. An OAuth callback is the common trigger, because the provider redirects back with a GET that must store a token.

### Detail

`preventing_writes?` matches frames on the `connected_to` stack by class name, and the name it is given is the pool descriptor's:

```ruby
def self.preventing_writes?(class_name)
  connected_to_stack.reverse_each do |hash|
    return hash[:prevent_writes] if !hash[:prevent_writes].nil? && hash[:klasses].include?(Base)
    return hash[:prevent_writes] if !hash[:prevent_writes].nil? && hash[:klasses].any? { |klass| klass.name == class_name }
  end

  false
end
```

With the stack `[{ prevent_writes: true, klasses: [ActiveRecord::Base] }, { prevent_writes: false, klasses: [ApplicationRecord] }]` and `class_name == "ActiveRecord::Base"`, the `ApplicationRecord` frame matches neither branch, so the lookup falls through to the outer frame and returns `true`.

`ApplicationRecord.current_preventing_writes` matches by class identity instead, so the two APIs disagree at the same instant, inside the same block:

```
descriptor="ActiveRecord::Base"
ApplicationRecord.current_preventing_writes = false
preventing_writes?(descriptor)              = true
```

`ConnectionDescriptor#name` already reports `"ActiveRecord::Base"` for any primary class, while `current_preventing_writes` deliberately passes the raw `@name` instead. `@name` is therefore meant to hold the specific class that established the pool, and the rename is what breaks that intent.

The clause that renames it was added in #41030 so that `ApplicationRecord` could adopt a pool `ActiveRecord::Base` had created. `ActiveRecord::Base.primary_class?` is also true, so it fires in the other direction as well. This change makes the adoption one-directional.

### Additional information

**Blast radius.** `ConnectionDescriptor#name` returns `"ActiveRecord::Base"` for any primary class, so pool manager keys, `connection_name`, and instrumentation payloads are unchanged. `@name` is read in exactly one place, `current_preventing_writes`, so this cannot affect anything other than the prevent-writes lookup it targets.

`ActiveRecord::Base.connected_to` is unaffected, because those frames are matched by the `klasses.include?(Base)` branch regardless of what the descriptor is called. I confirmed that by pinning the descriptor to `"ApplicationRecord"` after a re-establish and re-running each case:

```
granular lift inside a readonly request:   write ok
no lift, guard must still block:           ReadOnlyError
ActiveRecord::Base lift:                   write ok
```

The reproduction script from the issue now prints `write=ok` both times. Suites run locally against both sqlite3 and postgresql: `connection_swapping_nested`, `connection_handler`, `base_prevent_writes`, `adapter_prevent_writes`, `database_selector`, `multi_db_migrator`, `connection_pool`, `connection_management`, and the rest of `test/cases/connection_adapters/`.

**One note on the line being changed.** `existing_pool_config.connection_descriptor != owner_name` compares a `ConnectionDescriptor` against a `Class`, and `ConnectionDescriptor` defines no `==`, so that sub-condition is always true:

```
live descriptor != ActiveRecord::Base => true
live descriptor class => ActiveRecord::ConnectionAdapters::ConnectionHandler::ConnectionDescriptor
```

It reads as though it were meant to skip the reassignment when the descriptor already matches. I have left it alone to keep this PR to one change, but it means the condition was effectively just `owner_name.primary_class?`, which is why the rename fires in both directions so freely. Happy to open a separate PR for it if that is worth cleaning up.

**Scope.** This stops the rename. It does not close the underlying split between `preventing_writes?` matching by name and `current_preventing_writes` matching by class identity, which is what makes the descriptor name load-bearing in the first place. Happy to follow that up separately if you would prefer the broader change.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.
