### PR TITLE
Re-enable PostgreSQL triggers when `disable_referential_integrity` raises

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Re-enable PostgreSQL triggers when the block given to `disable_referential_integrity` raises.
+
+    On PostgreSQL versions without `NOT ENFORCED` constraints (before 18.4), the
+    adapter ran `ENABLE TRIGGER ALL` only after the block returned. When the block
+    raised outside of a transaction, every foreign key in the database stayed
+    disabled for all later connections.
+
+    *Lucas Guedes*
+
 *   Avoid unnecessary association preloader queries for nil foreign keys when
     the foreign key and association primary key have different types.
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
@@ -31,13 +31,13 @@ module ActiveRecord
 
               WARNING
               raise e
-            end
-
-            begin
-              transaction(requires_new: true) do
-                execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} ENABLE TRIGGER ALL" }.join(";"))
+            ensure
+              begin
+                transaction(requires_new: true) do
+                  execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} ENABLE TRIGGER ALL" }.join(";"))
+                end
+              rescue ActiveRecord::ActiveRecordError
               end
-            rescue ActiveRecord::ActiveRecordError
             end
           end
         end

--- a/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
@@ -129,6 +129,31 @@ class PostgreSQLReferentialIntegrityTest < ActiveRecord::PostgreSQLTestCase
     end
   end
 
+  def test_re_enables_triggers_when_the_block_raises
+    skip if @connection.supports_enforced_foreign_keys?
+    skip "DISABLE TRIGGER ALL requires a superuser" unless @connection.select_value("SHOW is_superuser") == "on"
+
+    @connection.create_table :ri_test_parents, force: true
+    @connection.create_table :ri_test_children, force: true do |t|
+      t.bigint :parent_id, null: false
+    end
+    @connection.add_foreign_key :ri_test_children, :ri_test_parents, column: :parent_id, name: :ri_test_fk
+
+    begin
+      assert_raises(RuntimeError) do
+        @connection.disable_referential_integrity do
+          assert_operator disabled_triggers_count(:ri_test_children), :>, 0
+          raise "boom"
+        end
+      end
+
+      assert_equal 0, disabled_triggers_count(:ri_test_children)
+    ensure
+      # A failure here would leave every table without foreign keys for the rest of the suite.
+      @connection.execute(@connection.tables.map { |name| "ALTER TABLE #{@connection.quote_table_name(name)} ENABLE TRIGGER ALL" }.join(";"))
+    end
+  end
+
   def test_disable_referential_integrity_with_partitioned_to_partitioned_fk
     skip unless @connection.supports_enforced_foreign_keys?
 
@@ -429,5 +454,11 @@ class PostgreSQLReferentialIntegrityTest < ActiveRecord::PostgreSQLTestCase
   private
     def assert_transaction_is_not_broken
       assert_equal 1, @connection.select_value("SELECT 1")
+    end
+
+    def disabled_triggers_count(table)
+      @connection.select_value(<<~SQL)
+        SELECT COUNT(*) FROM pg_trigger WHERE tgrelid = #{@connection.quote(table.to_s)}::regclass AND tgenabled = 'D'
+      SQL
     end
 end


### PR DESCRIPTION
### Motivation / Background

On PostgreSQL versions without `NOT ENFORCED` (before 18.4), `disable_referential_integrity` runs `ALTER TABLE ... DISABLE TRIGGER ALL` on every table, yields, and runs `ENABLE TRIGGER ALL` after the block. There is no `ensure`, so if the block raises the triggers stay disabled.

That is catalog state, not session state. Unless the call was made inside a transaction that gets rolled back, every foreign key in the database stays disabled for every later connection and process until something runs `ENABLE TRIGGER ALL` again.

#50196 covered fixtures by moving the call inside the transaction, so a failed insert rolls the `DISABLE` back. Callers with no transaction open are still exposed: `truncate_tables`, and DatabaseCleaner's truncation strategy, which is where we hit it. One truncation that raised (a deadlock with an in-flight request under `parallel_tests`) left that worker's database with no foreign key enforcement, and unrelated model tests started failing on later runs: `ON DELETE CASCADE` not cascading, `RESTRICT` not raising, `SET NULL` not nulling. All of them passed in isolation, and the failures went away whenever a later truncation happened to succeed, so it looked like flaky tests for a while.

Reproduction on any PostgreSQL before 18.4, connected as a superuser:

```ruby
conn = ActiveRecord::Base.lease_connection
conn.disable_referential_integrity { raise "boom" } rescue nil
conn.select_value("SELECT count(*) FROM pg_trigger WHERE tgenabled = 'D'")
# => every foreign key trigger in the database, and it stays that way across connections and processes
```

### Detail

Moves the `ENABLE TRIGGER ALL` block into an `ensure`. The `rescue ActiveRecord::ActiveRecordError` around it is kept, so when the block aborted an outer transaction the re-enable fails quietly as before and the outer rollback restores the triggers (`test_does_not_break_transactions` covers that).

The `NOT ENFORCED` path on 18.4+ (#57378) toggles and restores inside a single transaction, so it does not have this problem and is untouched.

Adds a test that raises inside the block and checks the child table has no disabled triggers afterwards. It skips on 18.4+ (different path) and when the test role is not a superuser, since `DISABLE TRIGGER ALL` would be a no-op there and the test would pass vacuously.

`8-1-stable` has the same code.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
