### PR TITLE
Remove leftover perform_query stubs in TrilogyAdapterTest

### DIFF
--- a/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
+++ b/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
@@ -306,6 +306,8 @@ class TrilogyAdapterTest < ActiveRecord::TrilogyTestCase
 
     # rollback transaction so it doesn't bleed into other tests
     @conn.rollback_db_transaction
+  ensure
+    @conn.singleton_class.send(:remove_method, :perform_query)
   end
 
   test "#commit_db_transaction raises error" do
@@ -315,6 +317,8 @@ class TrilogyAdapterTest < ActiveRecord::TrilogyTestCase
         @conn.commit_db_transaction
       end
     end
+  ensure
+    @conn.singleton_class.send(:remove_method, :perform_query)
   end
 
   test "#rollback_db_transaction raises error" do
@@ -324,6 +328,8 @@ class TrilogyAdapterTest < ActiveRecord::TrilogyTestCase
         @conn.rollback_db_transaction
       end
     end
+  ensure
+    @conn.singleton_class.send(:remove_method, :perform_query)
   end
 
   test "#select_value returns a single value" do


### PR DESCRIPTION
### Motivation / Background

Build https://buildkite.com/rails/rails/builds/133076#01a05bbe-e3cd-4460-a658-6f7c754f81ea (`main`, activerecord trilogy, Ruby 3.4) failed with four `AsynchronousQueriesTest` retry tests — the failures injected through `with_async_query_failures` never fired:

```
  6) Failure:
AsynchronousQueriesTest#test_load_async_retries_query_failure [test/cases/asynchronous_queries_test.rb:185]:
Expected: 2
  Actual: 0

  7) Failure:
AsynchronousQueriesTest#test_async_query_retries_query_failure [test/cases/asynchronous_queries_test.rb:115]:
Expected: 2
  Actual: 0

  8) Failure:
AsynchronousQueriesTest#test_async_query_retries_connection_failure [test/cases/asynchronous_queries_test.rb:151]:
Expected: 2
  Actual: 0

  9) Failure:
AsynchronousQueriesTest#test_async_query_reports_failure_after_retries_are_exhausted [test/cases/asynchronous_queries_test.rb:133]:
Expected 0 to be > 1.
```

Follow up to #58049, which added these retry tests.

### Detail

Three TrilogyAdapterTest tests (`#begin_db_transaction raises error`, `#commit_db_transaction raises error` and `#rollback_db_transaction raises error`) stub `perform_query` on the pooled connection. Minitest's stub restores the original method by aliasing it into the instance's singleton class, so after the stub block the connection carries a permanent singleton `perform_query`. Later class-level redefinitions of `perform_query` — such as the ones the retry tests install to inject failures — never reach that instance. Everything else behaves normally, so the leftover method stays invisible until a test relies on a class-level redefinition.

Which tests fail depends on which thread ends up with the affected connection: on CI the background executor picked it up and the four background retry tests failed; in the minimal reproduction below the main thread holds it and the foreground fallback test fails.

Remove the leftover singleton method in an `ensure` block in each of the three stubbing tests, so the connection returns to the pool clean.

### Additional information

Minimal reproduction, running only the stubbing test followed by one retry test. It fails on seeds that order TrilogyAdapterTest first (for example 6, 7, 8 and 10) and passes in the reverse order:

```
$ ARCONN=trilogy bin/test \
    test/cases/adapters/trilogy/trilogy_adapter_test.rb \
    test/cases/asynchronous_queries_test.rb \
    -i "/^(?:TrilogyAdapterTest#(?:test_#begin_db_transaction_raises_error)|AsynchronousQueriesTest#(?:test_async_query_foreground_fallback_retries_query_failure))$/" \
    --seed 6

Failure:
AsynchronousQueriesTest#test_async_query_foreground_fallback_retries_query_failure [test/cases/asynchronous_queries_test.rb:171]:
Expected: 2
  Actual: 0

2 runs, 3 assertions, 1 failures, 0 errors, 0 skips
```

With this change the reproduction passes on those seeds, and both test files pass in full.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
