### PR TITLE
Add PostgreSQL adapter support for configuring error_verbosity

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Add `error_verbosity` support to the PostgreSQL adapter's `database.yml` configuration.
+
+    Sets the connection's error verbosity via `PG::Connection#set_error_verbosity`,
+    controlling whether `DETAIL`, `HINT`, and `CONTEXT` fields are included on
+    raised errors. This is useful to keep values echoed back by Postgres in the
+    `DETAIL` field of unique/foreign-key violations (which can contain PII) out
+    of exception messages and, from there, out of error trackers and logs.
+
+        production:
+          adapter: postgresql
+          error_verbosity: <%= PG::PQERRORS_TERSE %>
+
+    *Florent Beaurain*
+
 *   Avoid unnecessary association preloader queries for nil foreign keys when
     the foreign key and association primary key have different types.
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -37,6 +37,10 @@ module ActiveRecord
     #   as a string of comma-separated schema names.
     # * <tt>:encoding</tt> - An optional client encoding that is used in a <tt>SET client_encoding TO
     #   <encoding></tt> call on the connection.
+    # * <tt>:error_verbosity</tt> - An optional verbosity level (one of the <tt>PG::PQERRORS_*</tt>
+    #   constants) passed to libpq's <tt>PQsetErrorVerbosity</tt>, controlling whether the
+    #   <tt>DETAIL</tt>, <tt>HINT</tt>, and <tt>CONTEXT</tt> fields are included in raised error
+    #   messages.
     # * <tt>:min_messages</tt> - An optional client min messages that is used in a
     #   <tt>SET client_min_messages TO <min_messages></tt> call on the connection.
     # * <tt>:variables</tt> - An optional hash of additional parameters that
@@ -1147,6 +1151,10 @@ module ActiveRecord
 
           if @config[:encoding]
             @raw_connection.set_client_encoding(@config[:encoding])
+          end
+
+          if @config[:error_verbosity]
+            @raw_connection.set_error_verbosity(@config[:error_verbosity])
           end
 
           @notice_receiver_fatal_error = nil

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -251,6 +251,19 @@ module ActiveRecord
         connection&.disconnect!
       end
 
+      def test_configure_connection_error_verbosity
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+        connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(
+          db_config.configuration_hash.merge(error_verbosity: PG::PQERRORS_TERSE)
+        )
+        connection.connect!
+
+        previous_verbosity = connection.raw_connection.set_error_verbosity(PG::PQERRORS_DEFAULT)
+        assert_equal PG::PQERRORS_TERSE, previous_verbosity
+      ensure
+        connection&.disconnect!
+      end
+
       def test_configure_connection_variables_are_set
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
         connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(


### PR DESCRIPTION
### Motivation / Background

Postgres embeds the literal values that violated a constraint (e.g. an email address or other PII stored in a unique column) in the `DETAIL` field of unique/foreign-key/deadlock errors, and `ruby-pg` relays that text verbatim into the raised exception's message. That means this PII commonly ends up flowing into application logs and error trackers.

libpq already exposes a way to opt out of this via `PQsetErrorVerbosity` (wrapped by `ruby-pg` as `PG::Connection#set_error_verbosity`), but `PostgreSQLAdapter#configure_connection` has no way to configure it, so applications wanting quieter (or more verbose) error messages have had to monkey-patch `configure_connection` themselves.

### Detail

This PR changes `PostgreSQLAdapter#configure_connection` to apply a new `error_verbosity` key from `database.yml`, following the same pattern already used for the existing `encoding` option: only applied when explicitly set, once per connection.

  ```yaml
  production:
    adapter: postgresql
    error_verbosity: <%= PG::PQERRORS_TERSE %>
```

### Additional information

See the [PQsetErrorVerbosity](https://www.postgresql.org/docs/current/libpq-control.html#LIBPQ-PQSETERRORVERBOSITY)[libpq docs](https://www.postgresql.org/docs/current/libpq-control.html#LIBPQ-PQSETERRORVERBOSITY) and [PG::Connection#set_error_verbosity](https://deveiate.org/code/pg/PG/Connection.html#method-i-set_error_verbosity) for the accepted values (`PG::PQERRORS_TERSE`, `PG::PQERRORS_DEFAULT`, `PG::PQERRORS_VERBOSE`, `PG::PQERRORS_SQLSTATE`).

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why. If this PR fixes a.related issue include it in the commit message. Ex: [Fix #issue-number]
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.