### PR TITLE
Preserve fetch_multi key order when local cache is active

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Preserve the requested key order in `ActiveSupport::Cache::Store#fetch_multi`
+    when a local cache is active.
+
+    Previously, if some keys were served from the local cache and others from the
+    underlying store, `fetch_multi` returned the local cache hits first instead of
+    following the order of the requested keys.
+
+    *Mueez Afzal*
+
 *   Return a UTC time from `Time.rfc3339` for strings with the "Z" UTC designator.
 
     ```ruby

--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -141,7 +141,7 @@ module ActiveSupport
             results.merge!(super(*(names - results.keys), options, &block))
           end
 
-          results
+          results.slice(*names)
         end
 
         private

--- a/activesupport/test/cache/behaviors/local_cache_behavior.rb
+++ b/activesupport/test/cache/behaviors/local_cache_behavior.rb
@@ -277,6 +277,22 @@ module LocalCacheBehavior
     end
   end
 
+  def test_local_cache_of_fetch_multi_preserves_order
+    first_key = SecureRandom.uuid
+    cached_key = SecureRandom.uuid
+    last_key = SecureRandom.uuid
+
+    @cache.with_local_cache do
+      # Seed the local cache so that only the middle key is a local hit.
+      @cache.increment(cached_key)
+
+      results = @cache.fetch_multi(first_key, cached_key, last_key) { |key| "yielded-#{key}" }
+
+      assert_equal [first_key, cached_key, last_key], results.keys
+      assert_not_equal "yielded-#{cached_key}", results[cached_key]
+    end
+  end
+
   def test_local_cache_of_read_multi
     key = SecureRandom.uuid
     value = SecureRandom.alphanumeric


### PR DESCRIPTION
### Motivation / Background

`ActiveSupport::Cache::Store#fetch_multi` is documented to return values in the order the keys were requested (introduced in #34700). When a local cache is active this guarantee is broken: `Strategy::LocalCache#fetch_multi` builds the result from the local-cache hits first and then merges in the keys fetched from the underlying store, so the returned order depends on which keys happen to be in the local cache.

Fixes #58637.

### Detail

The `Strategy::LocalCache#fetch_multi` override collects the local-cache hits into `results`, then merges the remaining keys (fetched via `super`) on top. Each step preserves its own order, but the "hits, then misses" concatenation does not match the order the caller requested.

Reorder the merged result to match the requested keys with `slice`, mirroring the guarantee the base `Store#fetch_multi` already provides. `slice` preserves exactly which keys are present, so `skip_nil` and recorded-miss semantics are unaffected.

```ruby
cache.with_local_cache do
  cache.increment("bar")
  cache.fetch_multi("foo", "bar") { 0 }.keys
  # before: ["bar", "foo"]
  # after:  ["foo", "bar"]
end
```

### Additional information

The issue's second example expects `fetch_multi` to return a stale value after `write_multi` — that is expected behavior (writing `bar => 1` and then fetching correctly returns `1`), so only the ordering is addressed here.

The regression test is added to the shared `LocalCacheBehavior` module, so it runs against every store that mixes it in (Redis and MemCache). It seeds the local cache with `increment` (the store-agnostic path into the local store) so that only the middle requested key is a local hit, then asserts the returned key order.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
