### PR TITLE
Allow to access view paths in a Ractor

### DIFF
--- a/actionview/lib/action_view/path_registry.rb
+++ b/actionview/lib/action_view/path_registry.rb
@@ -53,5 +53,16 @@ module ActionView # :nodoc:
     def self.all_file_system_resolvers
       @file_system_resolvers.values
     end
+
+    def self.make_shareable! # :nodoc:
+      view = ActionView::LookupContext.view_context_class.new(ActionView::LookupContext.new([]), {}, nil)
+      all_file_system_resolvers.each do |resolver|
+        resolver.eager_load_templates(view)
+        resolver.freeze
+      end
+
+      @file_system_resolver_mutex.synchronize { Ractor.make_shareable(@file_system_resolvers) }
+      Ractor.make_shareable(@view_paths_by_class)
+    end
   end
 end

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -673,13 +673,7 @@ module Rails
 
       @autoloaders, @reloaders, @routes_reloader = nil, nil, nil
 
-      if defined?(ActionView::PathRegistry)
-        view = ActionView::LookupContext.view_context_class.new(ActionView::LookupContext.new([]), {}, nil)
-        ActionView::PathRegistry.all_file_system_resolvers.each do |resolver|
-          resolver.eager_load_templates(view)
-          resolver.freeze
-        end
-      end
+      ActionView::PathRegistry.make_shareable! if defined?(ActionView::PathRegistry)
 
       if defined?(AbstractController::Base)
         [AbstractController::Base, *AbstractController::Base.descendants].each do |controller|

--- a/railties/test/application/ractors_test.rb
+++ b/railties/test/application/ractors_test.rb
@@ -66,6 +66,22 @@ if RUBY_VERSION >= "4.0" && ENV["RACK"] == "head"
         assert_predicate Rails.application, :initialized?
       end
 
+      test "controller view paths are readable from a non-main Ractor" do
+        app_file "app/controllers/greetings_controller.rb", <<~RUBY
+          class GreetingsController < ApplicationController
+          end
+        RUBY
+        app_file "app/views/greetings/index.html.erb", "Hello from a view"
+
+        app "production"
+
+        ractorize!
+
+        main_size = GreetingsController._view_paths.size
+        assert_operator main_size, :>, 0
+        assert_equal main_size, on_ractor { GreetingsController._view_paths.size }
+      end
+
       test "error reporting works after the application is ractorized" do
         app "production"
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because looking up templates isn't possible in a Ractor. This is due to some caches that needs to be made shareable.

### Detail

There are two view related caches that aren't shareable and therefore can't be accessed within a Ractor. Those caches get read when looking up view templates.

I'm going with a pragmatic solution in this patch and freezes the cache when we ractorize the application. This can only work in a eager loaded environment, but there is so much more issues to fix in a non eager loaded environment, that I don't think it makes sense to optimize for it yet.

The reason it can only work in a eagerloaded environment is because a controller can mutate the cache during autoload

```ruby
class MyController < ApplicationController
  append_view_paths("some/folder") # << This mutate the cache
end
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc/ @etiennebarrie @gmcgibbon @skipkayhil 
