### PR TITLE
Raise when a has_one association fails to destroy the replaced record

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Raise `ActiveRecord::RecordNotDestroyed` when a `has_one` association fails to
+    destroy the record it replaces.
+
+    Both `has_one dependent: :destroy` and `has_one :through` discarded the result
+    of destroying the previous record, so a record that halted its own destruction
+    was left in place with no error: the first ended up with two rows pointing at
+    the owner, and the second reported `nil` while its join record survived. The
+    equivalent `has_many` association already raises in that case.
+
+    *Carlos Daniel Pohlod*
+
 *   Avoid unnecessary association preloader queries for nil foreign keys when
     the foreign key and association primary key have different types.
 

--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -99,7 +99,7 @@ module ActiveRecord
           when :destroy
             target.destroyed_by_association = reflection
             if target.persisted?
-              target.destroy
+              target.destroy!
             end
           else
             nullify_owner_attributes(target)

--- a/activerecord/lib/active_record/associations/has_one_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_through_association.rb
@@ -19,7 +19,7 @@ module ActiveRecord
           through_record = through_proxy.load_target
 
           if through_record && !record
-            through_record.destroy
+            through_record.destroy!
           elsif record
             attributes = construct_join_attributes(record)
 

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -1012,6 +1012,18 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_replacing_an_undestroyable_child_raises_record_not_destroyed
+    author = DestroyableAuthor.create!(name: "Test")
+    original_child = UndestroyableBook.create!(author: author)
+
+    error = assert_raises(ActiveRecord::RecordNotDestroyed) do
+      author.book = UndestroyableBook.create!
+    end
+
+    assert_equal original_child, error.record
+    assert_equal [original_child], UndestroyableBook.where(author_id: author.id).to_a
+  end
+
   class SpecialCar < ActiveRecord::Base
     self.table_name = "cars"
     has_one :special_bulb, inverse_of: :car, dependent: :destroy, class_name: "SpecialBulb", foreign_key: "car_id"

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -155,6 +155,34 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
     assert_nil @member.club
   end
 
+  class UndestroyableMembership < ActiveRecord::Base
+    self.table_name = "memberships"
+    belongs_to :club
+    before_destroy :dont
+
+    def dont
+      throw(:abort)
+    end
+  end
+
+  class MemberWithUndestroyableMembership < ActiveRecord::Base
+    self.table_name = "members"
+    has_one :undestroyable_membership, class_name: "UndestroyableMembership", foreign_key: "member_id"
+    has_one :club, through: :undestroyable_membership
+  end
+
+  def test_assigning_nil_raises_when_the_through_record_cannot_be_destroyed
+    member = MemberWithUndestroyableMembership.create!(name: "Bob")
+    club = Club.create!(name: "Moustache")
+    UndestroyableMembership.create!(member_id: member.id, club: club)
+
+    assert_raises(ActiveRecord::RecordNotDestroyed) do
+      member.club = nil
+    end
+
+    assert_equal club, member.reload.club
+  end
+
   def test_set_record_after_delete_association
     @member.club = nil
     @member.club = clubs(:moustache_club)


### PR DESCRIPTION
### Motivation / Background

Replacing the record of a `has_one dependent: :destroy` association discards the result of destroying the previous one. When the old record halts its own destruction, it stays in the database with its foreign key intact, so the owner ends up with two rows pointing at it and nothing is raised:

```ruby
class Book < ApplicationRecord
  belongs_to :author
  before_destroy { throw :abort }
end

class Author < ApplicationRecord
  has_one :book, dependent: :destroy
end

author.book = Book.create!
Book.where(author_id: author.id).count # => 2
```

`has_one :through` has the same problem when assigning nil. The join record survives while the association reports `nil`, so the value changes back after a reload:

```ruby
member.club = nil
member.club          # => nil
member.reload.club   # => #<Club ...>
```

The equivalent `has_many` association already raises `ActiveRecord::RecordNotDestroyed` here. That was fixed in #12812, whose report describes the same symptom ("will end up returning 2 comments").

### Detail

Two call sites now use `destroy!`:

* `HasOneAssociation#remove_target!`, the `:destroy` branch
* `HasOneThroughAssociation#create_through_record`, the branch that runs when the association is assigned nil

The owner destruction path in `HasOneAssociation#delete` is deliberately left alone. There, `target.destroy` is followed by `throw(:abort) unless target.destroyed?`, so `owner.destroy` returns false rather than raising, which is the right behavior for that path.

I believe raising is the correct approach rather than, say, returning false or leaving the record in place. The failure means the association cannot reach the state the caller asked for, and silently keeping the old row corrupts the data the association is supposed to describe. It also matches what `has_many` has done for years, and the raised `RecordNotDestroyed` carries the offending record in `#record`, along with any errors its callback added, so the caller can tell which record refused and why.

The `has_one` file already checked the result of every other destroy and save it performed. `remove_target!` raises `RecordNotSaved` in its `nullify` branch, and `delete` aborts when the target survives. The `:destroy` branch was the only one that ignored the outcome.

### Note on the behavior change

Applications where a `has_one` child halts its own destruction will now see an exception where the failure used to pass unnoticed. There is no deprecation cycle here for the same reason there was none in #12812: the previous behavior left the database in a state the association contradicts, so there is no working behavior to preserve. Recent Active Record changes have taken the same route, for example `connected_to_all_shards` now raising `ArgumentError` instead of silently doing nothing.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
