### PR TITLE
Freeze Active Record time zone related configuration

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -101,7 +101,7 @@ module ActiveRecord
     initializer "active_record.postgresql_time_zone_aware_types" do
       ActiveSupport.on_load(:active_record_postgresqladapter) do
         ActiveSupport.on_load(:active_record) do
-          ActiveRecord::Base.time_zone_aware_types << :timestamptz
+          (ActiveRecord::Base.time_zone_aware_types += [:timestamptz]).freeze
         end
       end
     end
@@ -461,6 +461,11 @@ To keep using the current cache store, you can turn off cache versioning entirel
     initializer "active_record.share_configs" do
       config.after_initialize do
         ActiveSupport::Ractors.make_shareable(ActiveRecord.query_transformers)
+
+        ActiveSupport.on_load(:active_record) do
+          ActiveRecord::Base.time_zone_aware_types.freeze
+          ActiveRecord::Base.skip_time_zone_conversion_for_attributes.freeze
+        end
       end
     end
   end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -5495,6 +5495,8 @@ module ApplicationTests
         app "development"
 
         assert_ractor_shareable(ActiveRecord.query_transformers)
+        assert_ractor_shareable(ActiveRecord::Base.time_zone_aware_types)
+        assert_ractor_shareable(ActiveRecord::Base.skip_time_zone_conversion_for_attributes)
       end
     end
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because building the attribute set now introduce a Ractor isolation issues with the introduction of https://github.com/rails/rails/pull/58578

### Detail

Prior to #58578, the attribute set was loaded eagerly during `load_schema`. Now, the attribute set is built lazily *per ractor*. A code that used to look like this: 
```ruby
Post.create!

Ractor.new do
  Post.create!
end
```

No longer works, because the attribute set inside the Ractor is rebuilt and therefore those configuration accessed.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc/ @gmcgibbon @skipkayhil @etiennebarrie 