### PR TITLE
Store the AssetTagHelper settings in singleton class attributes

### DIFF
--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -22,12 +22,16 @@ module ActionView
       include AssetUrlHelper
       include TagHelper
 
-      mattr_accessor :image_loading
-      mattr_accessor :image_decoding
-      mattr_accessor :preload_links_header
-      mattr_accessor :apply_stylesheet_media_default
-      mattr_accessor :auto_include_nonce_for_scripts
-      mattr_accessor :auto_include_nonce_for_styles
+      settings = [
+        :image_loading,
+        :image_decoding,
+        :preload_links_header,
+        :apply_stylesheet_media_default,
+        :auto_include_nonce_for_scripts,
+        :auto_include_nonce_for_styles,
+      ]
+      singleton_class.attr_accessor(*settings)
+      delegate(*settings, to: AssetTagHelper)
 
       # Returns an HTML script tag for each of the +sources+ provided.
       #

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "abstract_unit"
+require "active_support/testing/ractors_assertions"
 require "active_support/ordered_options"
 
 require "action_dispatch"
@@ -1274,5 +1275,32 @@ class AssetUrlHelperEmptyModuleTest < ActionView::TestCase
 
     assert @module.config.asset_host
     assert_equal "http://custom.example.com/foo", @module.asset_url("foo", host: "http://custom.example.com")
+  end
+end
+
+class AssetTagHelperSettingsRactorTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::RactorsAssertions
+
+  test "the settings are readable from a non-main Ractor" do
+    expected = [
+      ActionView::Helpers::AssetTagHelper.image_loading,
+      ActionView::Helpers::AssetTagHelper.image_decoding,
+      ActionView::Helpers::AssetTagHelper.preload_links_header,
+      ActionView::Helpers::AssetTagHelper.apply_stylesheet_media_default,
+      ActionView::Helpers::AssetTagHelper.auto_include_nonce_for_scripts,
+      ActionView::Helpers::AssetTagHelper.auto_include_nonce_for_styles,
+    ]
+
+    assert_equal expected, on_ractor {
+      helper = ActionView::Helpers::AssetTagHelper
+      [
+        helper.image_loading,
+        helper.image_decoding,
+        helper.preload_links_header,
+        helper.apply_stylesheet_media_default,
+        helper.auto_include_nonce_for_scripts,
+        helper.auto_include_nonce_for_styles,
+      ]
+    }
   end
 end


### PR DESCRIPTION
Similar to https://github.com/rails/rails/pull/58627, I also removed the instance writers writing the global value.

---

The six settings were class variables, which non-main Ractors cannot read on Ruby 4.0.

Use instance variables on the module directly, and add delegating readers for the asset tag helpers to use the settings. The instance writers are removed.
