### PR TITLE
Fix TypeCaster sometimes leaking connection

### DIFF
--- a/activerecord/lib/active_record/type_caster/connection.rb
+++ b/activerecord/lib/active_record/type_caster/connection.rb
@@ -20,7 +20,7 @@ module ActiveRecord
           column = schema_cache.columns_hash(table_name)[attr_name.to_s]
           if column
             # TODO: Remove fetch_cast_type and the need for connection after we release 8.1.
-            type = column.fetch_cast_type(@klass.lease_connection)
+            type = @klass.with_connection { |c| column.fetch_cast_type(c) }
           end
         end
 


### PR DESCRIPTION
Fixes #58644

It should use with_connection to immediately check the connection back in instead of relying on Executor cleanup to handle it (which apparently isn't reliable in Live actions?)