### PR TITLE
Fix "try" on subclasses of DelegateClass

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Fix `try` / `try!` on subclasses of `DelegateClass(x)`.
+
+    `DelegateClass` was copying `try` from the target class as a forwarding
+    method, so overrides on the subclass were skipped. `try` and `try!` are now
+    treated as part of `Delegator`'s public API and are no longer forwarded.
+
+    Fixes #31045.
+
+    *Edil Talantbek uulu*
+
 *   Return a UTC time from `Time.rfc3339` for strings with the "Z" UTC designator.
 
     ```ruby

--- a/activesupport/lib/active_support/core_ext/object/try.rb
+++ b/activesupport/lib/active_support/core_ext/object/try.rb
@@ -153,6 +153,18 @@ class Delegator
   #   try!(*args, &block)
   #
   # See Object#try!
+
+  # +DelegateClass+ copies public methods from the target class onto the
+  # generated subclass, except those listed in +Delegator.public_api+. Without
+  # listing +try+ / +try!+ here, they would be forwarded to the target and
+  # overrides on the subclass would be skipped (see #31045).
+  class << self
+    alias_method :active_support_original_public_api, :public_api
+
+    def public_api # :nodoc:
+      active_support_original_public_api | ActiveSupport::Tryable.public_instance_methods
+    end
+  end
 end
 
 class NilClass

--- a/activesupport/test/core_ext/object/try_test.rb
+++ b/activesupport/test/core_ext/object/try_test.rb
@@ -157,4 +157,22 @@ class ObjectTryTest < ActiveSupport::TestCase
       Decorator.new(klass.new).try!(:private_method)
     end
   end
+
+  class ObjectDelegate < DelegateClass(Object)
+    def to_s
+      "object delegate"
+    end
+  end
+
+  def test_try_with_overridden_method_on_delegate_class
+    assert_equal "object delegate", ObjectDelegate.new(@string).try(:to_s)
+  end
+
+  def test_try_bang_with_overridden_method_on_delegate_class
+    assert_equal "object delegate", ObjectDelegate.new(@string).try!(:to_s)
+  end
+
+  def test_try_with_method_on_delegate_class_target
+    assert_equal 5, ObjectDelegate.new(@string).try(:size)
+  end
 end


### PR DESCRIPTION
### Motivation / Background

Fixes #31045.

`try` works correctly with `SimpleDelegator` subclasses, but not with
`DelegateClass(x)` subclasses. Calling an overridden method via `try` hits the
target object instead of the subclass.

```ruby
class Dog
  def bark; :woof; end
end

class DogDelegate < DelegateClass(Dog)
  def bark; :meow; end
end

DogDelegate.new(Dog.new).bark      # => :meow
DogDelegate.new(Dog.new).try(:bark) # => :woof (bug)
```

### Detail

`DelegateClass` copies public methods from the target class onto the generated
subclass, except methods listed in `Delegator.public_api`. Because `Object`
includes `ActiveSupport::Tryable`, `try` / `try!` were copied as forwarding
methods and never reached the subclass override.

This PR extends `Delegator.public_api` so `try` and `try!` are treated as part of
`Delegator`'s API and are no longer forwarded. That matches how `SimpleDelegator`
already behaves (it inherits `Tryable` without method copying).

### Additional information

Prior attempt: #31047 (went stale after maintainer feedback; same approach of
extending `Delegator.public_api`).

### Checklist

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue, include it in the commit message. Ex: `[Fix #issue-number]`
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
