### PR TITLE
Make the controller configs shareable in ractorize!

### DIFF
--- a/activesupport/test/ordered_options_test.rb
+++ b/activesupport/test/ordered_options_test.rb
@@ -382,4 +382,14 @@ class OrderedOptionsTest < ActiveSupport::TestCase
     assert_not object.overridden?(:one)
     assert_not object.overridden?(:three)
   end
+
+  def test_new_child_over_a_frozen_parent
+    parent = ActiveSupport::InheritableOptions.new(one: "first value")
+    parent.freeze
+    child = ActiveSupport::InheritableOptions.new(parent)
+    child.two = "second value"
+
+    assert_equal "first value", child.one
+    assert_equal "second value", child.two
+  end
 end

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -681,6 +681,12 @@ module Rails
         end
       end
 
+      if defined?(AbstractController::Base)
+        [AbstractController::Base, *AbstractController::Base.descendants].each do |controller|
+          Ractor.make_shareable(controller.config)
+        end
+      end
+
       Ractor.make_shareable(self)
       Ractor.make_shareable(Rails.event)
       Ractor.make_shareable(Rails.error)

--- a/railties/test/application/ractors_test.rb
+++ b/railties/test/application/ractors_test.rb
@@ -36,6 +36,15 @@ if RUBY_VERSION >= "4.0" && ENV["RACK"] == "head"
         assert_ractor_shareable Rails.backtrace_cleaner
       end
 
+      test "ractorize! makes the controller configs shareable" do
+        app "production"
+
+        ractorize!
+
+        assert_ractor_shareable ActionController::Base.config
+        assert_ractor_shareable Rails::HealthController.config
+      end
+
       test "ractorize! eager loads and compiles view templates" do
         app "production"
 


### PR DESCRIPTION
This makes sure the controller configs are shareable. I didn't go with freeze+copy on write because it adds a bunch of complexity and doesn't bring anything at the moment, but it does seem that controller-level configs shouldn't be mutated once the app has booted. Especially since controller instances have their own inherited copy of the config to mutate.