### PR TITLE
Run Live actions inside the application executor on the streaming thread

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Run `ActionController::Live` actions inside the application executor on the
+    streaming thread.
+
+    The streaming thread comes from a pool and outlives the request, and the
+    request thread's executor cannot release state established on another
+    thread. Any per-request state set up on the streaming thread, such as an
+    Active Record connection leased there, was left pinned to the pooled thread
+    after the action finished, which could exhaust the connection pool. The
+    action now runs in `ActionController::Live.executor`, which the railtie sets
+    to `Rails.application.executor`, so the usual completion hooks clean it up.
+
+    *Antony Sastre*
+
 *   Allow `translate`'s (and `t`'s) `scope:` option to be resolved relative to
     the current controller and action when it starts with a period,
     mirroring the existing behavior for the key argument.

--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -91,11 +91,20 @@ module ActionController
   # - `:active_record_prohibit_shard_swapping` - Shard swapping restrictions
   #
   # By default, no keys are excluded to maintain backward compatibility.
+  #
+  # The streaming thread runs the action inside `ActionController::Live.executor`,
+  # which the railtie sets to the application's executor. That way any per-request
+  # state established on the streaming thread, such as Active Record connections
+  # leased there, is cleaned up when the action finishes rather than staying pinned
+  # to the pooled thread.
   module Live
     extend ActiveSupport::Concern
 
     @live_streaming_excluded_keys = []
     singleton_class.attr_accessor :live_streaming_excluded_keys
+
+    @executor = ActiveSupport::Executor
+    singleton_class.attr_accessor :executor
 
     included do
       class_attribute :live_streaming_excluded_keys, instance_accessor: false, default: Live.live_streaming_excluded_keys
@@ -420,7 +429,7 @@ module ActionController
         ActionController::Live.live_thread_pool_executor.post do
           t2 = Thread.current
           t2.abort_on_exception = true
-          yield
+          ActionController::Live.executor.wrap(source: "application.action_controller.live", &block)
         end
       end
 

--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -41,6 +41,12 @@ module ActionController
       end
     end
 
+    initializer "action_controller.live_executor" do |app|
+      ActiveSupport.on_load(:action_controller_live) do
+        ActionController::Live.executor = app.executor
+      end
+    end
+
     initializer "action_controller.parameters_config" do |app|
       options = app.config.action_controller
 

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -156,6 +156,12 @@ module ActionController
         response.stream.close
       end
 
+      def streaming_thread
+        response.headers["Content-Type"] = "text/plain"
+        response.stream.write Thread.current.object_id.to_s
+        response.stream.close
+      end
+
       def basic_send_stream
         send_stream(filename: "my.csv") do |stream|
           stream.write "name,age\ndavid,41"
@@ -381,6 +387,25 @@ module ActionController
       get :basic_stream
       assert_equal "helloworld", @response.body
       assert_equal "text/event-stream", @response.headers["Content-Type"]
+    end
+
+    def test_action_runs_inside_the_executor_on_the_streaming_thread
+      executor = Class.new(ActiveSupport::Executor)
+      completed = Concurrent::CountDownLatch.new
+      completed_on = nil
+      executor.to_complete do
+        completed_on = Thread.current
+        completed.count_down
+      end
+
+      original_executor, ActionController::Live.executor = ActionController::Live.executor, executor
+      get :streaming_thread
+
+      assert completed.wait(2), "executor did not complete on the streaming thread"
+      assert_equal @response.body, completed_on.object_id.to_s
+      assert_not_equal Thread.current, completed_on
+    ensure
+      ActionController::Live.executor = original_executor
     end
 
     def test_write_lines_to_stream


### PR DESCRIPTION
### Motivation / Background

Follow-up to #58644 / #58645.

`ActionController::Live#process` runs the action on a thread from `live_thread_pool_executor`. That thread is not wrapped in an executor, it outlives the request, and the request thread's own executor cannot release state established on another thread: connection leases are keyed by `IsolatedExecutionState.context`, i.e. the thread, and `share_with` only copies the state hash. The pool's reaper does not help either, since it only reclaims connections whose owner thread is dead and `CachedThreadPool` keeps workers alive between requests.

So any `lease_connection` reached from a streamed action left a connection pinned to the pooled thread after the action finished. #58645 removed the one call in Active Record that did this (`TypeCaster::Connection`), but the same thing happens with any other sticky lease taken on the streaming thread, in Rails or in application code. In production this looked like five concurrent Active Storage proxy requests pinning a five-connection pool and every other request failing with `ActiveRecord::ConnectionTimeoutError` until the idle pool threads expired.

### Detail

This Pull Request changes `ActionController::Live#new_controller_thread` to run the posted task inside `ActionController::Live.executor`, and adds an `action_controller.live_executor` initializer that sets it to `app.executor`, the same way Action Cable wraps its worker pool and Active Job wraps job execution. The default is `ActiveSupport::Executor`, which has no hooks and is a no-op outside a Rails application.

The wrap happens before `share_with`, on the worker's own execution state, so the request thread's executor is not affected and the completion hooks (`clear_active_connections!`, query cache reset, interlock) run on the streaming thread when the action finishes.

The added test swaps in an executor with a `to_complete` hook and asserts the hook runs on the thread that ran the action. It fails on main.

### Additional information

Verified against main with a standalone script (the #58644 reproduction with `Author.lease_connection` in the streamed action, since main no longer leases in the type caster): the pooled worker keeps the connection on main and releases it with this change.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.