### PR TITLE
SchemaContext#attributes: preload schemas to prevent deadlock

### DIFF
--- a/activerecord/lib/active_record/model_schema/schema_context.rb
+++ b/activerecord/lib/active_record/model_schema/schema_context.rb
@@ -46,19 +46,7 @@ module ActiveRecord
       end
 
       def attributes
-        # Preload schemas from the class hierarchy to ensure `Attributes.new`
-        # (below) doesn't call a nested `store_if_absent`, which would deadlock.
-        # `load_schema` will return immediately is the schema has already been
-        # loaded, so there should be no performance hit here.
-        klass = @model_class.superclass
-        while klass < ActiveRecord::Base
-          klass.load_schema if !klass.abstract_class?
-          klass = klass.superclass
-        end
-
-        ActiveSupport::Ractors.store_if_absent(@attributes_key) do
-          Attributes.new(self)
-        end
+        ActiveSupport::Ractors[@attributes_key] ||= Attributes.new(self)
       end
 
       def table_name

--- a/activerecord/lib/active_record/model_schema/schema_context.rb
+++ b/activerecord/lib/active_record/model_schema/schema_context.rb
@@ -46,6 +46,16 @@ module ActiveRecord
       end
 
       def attributes
+        # Preload schemas from the class hierarchy to ensure `Attributes.new`
+        # (below) doesn't call a nested `store_if_absent`, which would deadlock.
+        # `load_schema` will return immediately is the schema has already been
+        # loaded, so there should be no performance hit here.
+        klass = @model_class.superclass
+        while klass < ActiveRecord::Base
+          klass.load_schema if !klass.abstract_class?
+          klass = klass.superclass
+        end
+
         ActiveSupport::Ractors.store_if_absent(@attributes_key) do
           Attributes.new(self)
         end

--- a/activerecord/test/cases/attributes_test.rb
+++ b/activerecord/test/cases/attributes_test.rb
@@ -471,6 +471,23 @@ module ActiveRecord
       end
     end
 
+    class RactorSchemaContextDeadlockTest < ActiveRecord::TestCase
+      include ActiveSupport::Testing::Isolation unless in_memory_db?
+
+      test "SchemaContext#attributes avoids recursive locking deadlocks when initializing modifiers" do
+        base_model = Class.new(ActiveRecord::Base) do
+          self.table_name = "topics"
+          encrypts :title # We use the encrypts modifier to demonstrate
+        end
+
+        child_model = Class.new(base_model)
+
+        assert_nothing_raised do
+          child_model.schema_context.attributes
+        end
+      end
+    end
+
     private
       def with_immutable_strings
         old_value = ActiveRecord::Base.immutable_strings_by_default


### PR DESCRIPTION
`SchemaContext#attributes` uses `Ractor.store_if_absent` to initialize an `Attributes` object. However, `Attributes.new` calls `AttributeRegistration#apply_pending_attribute_modifications`, which walks up the superclass chain and applies attribute modifiers from them (e.g. from `EncryptableRecord`). Those modifiers call `columns_hash` on the superclass, which triggers `load_schema`, which calls `SchemaContext#attributes` again, thus calling `Ractor.store_if_absent`, causing a deadlock.

This PR fixes #58650 by removing that lock entirely, thereby preventing the potential deadlock.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
