### PR TITLE
Freeze Active Record specific `on` callbacks

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -325,7 +325,7 @@ module ActiveRecord
         filter_list << options
 
         if name.in?([:commit, :rollback]) && options[:on]
-          fire_on = Array(options[:on])
+          fire_on = Array(options[:on]).freeze
           assert_valid_transaction_action(fire_on)
           options[:if] = [
             -> { transaction_include_any_action?(fire_on) },
@@ -346,7 +346,7 @@ module ActiveRecord
           args << options
 
           if options[:on]
-            fire_on = Array(options[:on])
+            fire_on = Array(options[:on]).freeze
             assert_valid_transaction_action(fire_on)
             options[:if] = [
               -> { transaction_include_any_action?(fire_on) },

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "cases/helper"
+require "active_support/core_ext/object/with"
 require "models/owner"
 require "models/pet"
 require "models/topic"
@@ -1085,5 +1086,23 @@ class SetCallbackTest < ActiveRecord::TestCase
     expected_history << :after_commit_on_update_2
     expected_history << :after_commit_on_update_1
     assert_equal expected_history, TopicWithCallbacksOnUpdate.history
+  end
+
+  if RUBY_VERSION >= "4.0"
+    def test_transaction_callbacks_with_on_option_are_ractor_shareable
+      ActiveSupport::Ractors.with(unshareable_proc_action: :raise) do
+        assert_nothing_raised do
+          klass = Class.new do
+            include ActiveSupport::Callbacks
+            include ActiveRecord::Transactions
+
+            def noop; end
+          end
+
+          klass.after_commit :noop, on: [:create, :update]
+          klass.after_rollback :noop, on: :destroy
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because a model with transactional callbacks can't be called in a Ractor. The callback can't be made shareable.

### Detail

```ruby
class Post < ApplicationRecord
  after_create_commit :foo
end
```

This callback isn't shareable, and the application will crash at boot time when the Ractor mode is set to :raise (given that the application is eager loaded).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc/ @gmcgibbon @skipkayhil @etiennebarrie 