### PR TITLE
Fix a Ractor unsafe callback registered at boot time

### DIFF
--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -674,8 +674,9 @@ module Rails
     end
 
     initializer :wrap_reloader_around_load_seed do |app|
+      reloader = app.reloader
       self.class.set_callback(:load_seed, :around) do |engine, seeds_block|
-        app.reloader.wrap(&seeds_block)
+        reloader.wrap(&seeds_block)
       end
     end
 

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -1157,6 +1157,19 @@ en:
       assert Bukkits::Engine.config.bukkits_seeds_loaded
     end
 
+    if RUBY_VERSION >= "4.0"
+      test "the load_seed reloader callback is Ractor-shareable" do
+        boot_rails
+
+        around = Rails.application.class.send(:get_callbacks, :load_seed).find { |c| c.kind == :around }
+        assert_not_nil around, "expected an around :load_seed callback"
+
+        assert_nothing_raised do
+          Ractor.shareable_proc(&around.filter)
+        end
+      end
+    end
+
     test "loading seed data is wrapped by the executor" do
       app_file "db/seeds.rb", <<-RUBY
         Rails.application.config.seeding_wrapped_by_executor = Rails.application.executor.active?


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because a callback defined in a initializer prevent the app from booting when `ActiveSupport::Ractors` is configured to raise when attempting to make procs shareable.

### Detail

This callback prevent the app from booting when the AS::Ractors mode is set to `:raise`.

This is because the callback creates a proc that tries to access the outer variable `app` which is at this moment not shareable.

The fix in this patch is to store the `reloader` outside of the proc , which allows to make the proc shareable. The reason the proc succeeds to be shareable is because `reloader` is an instance of `Class` and an instance of Class is always Ractor shareable.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc/ @gmcgibbon @skipkayhil @etiennebarrie 