### PR TITLE
Prevent freezing Action Dispatch default headers config itself

### DIFF
--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -88,7 +88,7 @@ module ActionDispatch
 
       ActiveSupport.on_load(:action_dispatch_response) do
         self.default_charset = app.config.action_dispatch.default_charset || app.config.encoding
-        self.default_headers = ActiveSupport::Ractors.make_shareable(app.config.action_dispatch.default_headers)
+        self.default_headers = ActiveSupport::Ractors.make_shareable(app.config.action_dispatch.default_headers, copy: true)
       end
 
       ActionDispatch::ExceptionWrapper.rescue_responses = ActionDispatch::ExceptionWrapper.rescue_responses.merge(config.action_dispatch.rescue_responses)

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2095,6 +2095,17 @@ module ApplicationTests
 
         assert_includes File.read(app_path("log/ractor.log")), "[request-id] hello"
       end
+
+      test "config.action_dispatch.default_headers can still be mutated after ActionDispatch::Response is loaded" do
+        app "development"
+
+        assert_predicate(ActionDispatch::Response.default_headers, :frozen?)
+        assert_not Rails.application.config.action_dispatch.default_headers.frozen?
+
+        assert_nothing_raised do
+          Rails.application.config.action_dispatch.default_headers["X-Custom-Header"] = "custom"
+        end
+      end
     end
 
     test "respond_to? accepts include_private" do


### PR DESCRIPTION
### Motivation / Background

#### Context

In 56d19e536b409b17d8f89545ff5281c4e1c3eaf6, I made a fix to freeze Action Dispatch default headers (for Ractor safety reasons). This commit also freezes the config used by users to temporarly store the values until ActionDispatch Response is loaded.

### Problem

Freezing the config itself can create issues for libraries (that admittedly do wrong thing) that attempts to mutate the config after Action Dispatch loads.

For instance in this case:

```ruby
initializer :mutation do
  ActiveSupport.on_load(:action_controller) do
    Rails.application.config.action_dispatch.default_headers.clear
  end
end
```

With this code, if something loads `ActionController::Base` (which itself loads ActionDispatch::Response) **and then** load `ActionController::API` then the crash will happen. The load hook will get called twice, and the second time the config will be frozen already.

### Solution

I admittedly think that we should offer a fix in the gem upstream as it make no sense to edit `Rails.application.config` in a load hook in the first place. But considering this code used to work for the past 10 years I find strange to break it now.

This patch copy the the headers config before freezing. Users can still mutate the config (although it will have no effect, but that's nothing new).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in sepxrate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc/ @gmcgibbon @skipkayhil @etiennebarrie @andrewn617 