### PR TITLE
Fix Ractor unshareable procs at boot

### DIFF
--- a/actioncable/lib/action_cable/engine.rb
+++ b/actioncable/lib/action_cable/engine.rb
@@ -77,8 +77,9 @@ module ActionCable
 
     initializer "action_cable.set_work_hooks" do |app|
       ActiveSupport.on_load(:action_cable) do
+        executor = app.executor
         ActionCable::Server::Worker.set_callback :work, :around, prepend: true do |_, inner|
-          app.executor.wrap(source: "application.action_cable") do
+          executor.wrap(source: "application.action_cable") do
             # If we took a while to get the lock, we may have been halted in the meantime.
             # As we haven't started doing any real work yet, we should pretend that we never
             # made it off the queue.
@@ -94,8 +95,9 @@ module ActionCable
       end
 
       ActiveSupport.on_load(:action_cable_channel) do
+        executor = app.executor
         wrap = lambda do |_, inner|
-          app.executor.wrap(source: "application.action_cable", &inner)
+          executor.wrap(source: "application.action_cable", &inner)
         end
         ActionCable::Channel::Base.set_callback :subscribe, :around, prepend: true, &wrap
         ActionCable::Channel::Base.set_callback :unsubscribe, :around, prepend: true, &wrap

--- a/activejob/lib/active_job/railtie.rb
+++ b/activejob/lib/active_job/railtie.rb
@@ -88,8 +88,9 @@ module ActiveJob
 
     initializer "active_job.set_reloader_hook" do |app|
       ActiveSupport.on_load(:active_job) do
+        reloader = app.reloader
         ActiveJob::Callbacks.singleton_class.set_callback(:execute, :around, prepend: true) do |_, inner|
-          app.reloader.wrap do
+          reloader.wrap do
             inner.call
           end
         end

--- a/activerecord/lib/active_record/associations/builder/association.rb
+++ b/activerecord/lib/active_record/associations/builder/association.rb
@@ -150,7 +150,8 @@ module ActiveRecord::Associations::Builder # :nodoc:
         end
       end
 
-      model.before_destroy(->(o) { o.association(reflection.name).handle_dependency })
+      name = reflection.name
+      model.before_destroy(->(o) { o.association(name).handle_dependency })
     end
 
     def self.add_after_commit_jobs_callback(model, dependent)

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -28,8 +28,9 @@ module ActiveRecord::Associations::Builder # :nodoc:
     def self.add_counter_cache_callbacks(model, reflection)
       cache_column = reflection.counter_cache_column
 
+      name = reflection.name
       model.after_update lambda { |record|
-        association = association(reflection.name)
+        association = association(name)
 
         if association.saved_change_to_target?
           association.increment_counters
@@ -110,8 +111,10 @@ module ActiveRecord::Associations::Builder # :nodoc:
     end
 
     def self.add_default_callbacks(model, reflection)
+      name = reflection.name
+      default = reflection.options[:default]
       model.before_validation lambda { |o|
-        o.association(reflection.name).default(&reflection.options[:default])
+        o.association(name).default(&default)
       }
     end
 
@@ -144,15 +147,17 @@ module ActiveRecord::Associations::Builder # :nodoc:
         if ActiveRecord.belongs_to_required_validates_foreign_key
           model.validates_presence_of reflection.name, message: :required
         else
+          name = reflection.name
+          polymorphic = reflection.polymorphic?
           condition = lambda { |record|
-            association = record.association(reflection.name)
+            association = record.association(name)
 
             fk_missing_or_changed = association.foreign_key.any? do |fk|
               record.read_attribute(fk).nil? || record.attribute_changed?(fk)
             end
 
             fk_missing_or_changed ||
-              (reflection.polymorphic? && (record.read_attribute(association.foreign_type).nil? || record.attribute_changed?(association.foreign_type)))
+              (polymorphic && (record.read_attribute(association.foreign_type).nil? || record.attribute_changed?(association.foreign_type)))
           }
 
           model.validates_presence_of reflection.name, message: :required, if: condition

--- a/activerecord/lib/active_record/secure_token.rb
+++ b/activerecord/lib/active_record/secure_token.rb
@@ -55,17 +55,19 @@ module ActiveRecord
           raise MinimumLengthError, "Token requires a minimum length of #{MINIMUM_TOKEN_LENGTH} characters."
         end
 
-        prefix = "#{attribute}_" if prefix == true
+        token_length = length
+        token_prefix = prefix == true ? "#{attribute}_" : prefix
 
         if prefix
-          generate_token = -> do
-            token = self.generate_unique_secure_token(length: length)
+          token_generator = -> do
+            token = self.generate_unique_secure_token(length: token_length)
 
-            "#{prefix}#{token}"
+            "#{token_prefix}#{token}"
           end
         else
-          generate_token = -> { self.generate_unique_secure_token(length: length) }
+          token_generator = -> { self.generate_unique_secure_token(length: token_length) }
         end
+        generate_token = ActiveSupport::Ractors.try_shareable_proc(token_generator)
 
         # Load securerandom only when has_secure_token is used.
         require "active_support/core_ext/securerandom"

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -162,6 +162,8 @@ module Rails
         reloader.eager_load = app.config.eager_load
         reloaders << reloader
 
+        app.reloader.singleton_class.attr_accessor :routes_reloader
+        app.reloader.routes_reloader = reloader
         app.reloader.to_run do
           # We configure #execute rather than #execute_if_updated because if
           # autoloaded constants are cleared we need to reload routes also in
@@ -173,7 +175,7 @@ module Rails
           # might not be necessary, but in order to be more precise we need
           # some sort of reloaders dependency support, to be added.
           require_unload_lock!
-          reloader.execute
+          self.class.routes_reloader.execute
           ActiveSupport.run_load_hooks(:after_routes_loaded, self)
         end
 

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -674,8 +674,9 @@ module Rails
     end
 
     initializer :wrap_reloader_around_load_seed do |app|
+      reloader = app.reloader
       self.class.set_callback(:load_seed, :around) do |engine, seeds_block|
-        app.reloader.wrap(&seeds_block)
+        reloader.wrap(&seeds_block)
       end
     end
 

--- a/railties/test/application/ractors_test.rb
+++ b/railties/test/application/ractors_test.rb
@@ -58,6 +58,14 @@ if RUBY_VERSION >= "4.0" && ENV["RACK"] == "head"
         end
       end
 
+      test "the application boots with unshareable_proc_action :raise" do
+        add_to_env_config "production", "ActiveSupport::Ractors.unshareable_proc_action = :raise"
+
+        app "production"
+
+        assert_predicate Rails.application, :initialized?
+      end
+
       test "error reporting works after the application is ractorized" do
         app "production"
 


### PR DESCRIPTION
This includes the commit from #58655 (or the test wouldn't pass). I can rebase once that is merged. The test also relies on 88f486fc18, so I couldn't just build it on top of the other PR.

This uses the same pattern of extracting the locals we care about to avoid capturing values that are not shareable in the proc, which allows the proc to be made shareable.

In all of the cases but the routes reloader, we can just store the shareable value as a local and access it from the lambda and then the lambda can be made shareable too.

For the routes reloader, we need to store it on the reloader since it's an unshareable value, so there's no way to capture it in a shareable proc. It would still raise an IsolationError if the block was called from a non-main Ractor (as it would normally be, called from the reloader middleware), but for now only apps that don't enable reloading are supported for Ractor workers, and those don't mount the reloader middleware at all.

cc @Edouard-chin @gmcgibbon @skipkayhil 