### PR TITLE
Fix ancestors when including a Concern dependency

### DIFF
--- a/activesupport/lib/active_support/concern.rb
+++ b/activesupport/lib/active_support/concern.rb
@@ -141,7 +141,7 @@ module ActiveSupport
     def append_features(base) # :nodoc:
       if base.instance_variable_defined?(:@_dependencies)
         base.instance_variable_get(:@_dependencies) << self
-        false
+        super
       else
         return false if base < self
         @_dependencies.each { |dep| base.include(dep) }

--- a/activesupport/test/concern_test.rb
+++ b/activesupport/test/concern_test.rb
@@ -127,6 +127,13 @@ class ConcernTest < ActiveSupport::TestCase
     assert_nil @klass.prepended_ran
   end
 
+  def test_dependencies_are_added_to_ancestors_immediately
+    assert_includes Bar.ancestors, ConcernTest::Baz
+    # Recorded as a dependency, but the hook processing has not run yet."
+    assert_includes Bar.instance_variable_get(:@_dependencies), ConcernTest::Baz
+    assert_not_respond_to Bar, :included_ran
+  end
+
   def test_modules_dependencies_are_met
     @klass.include(Bar)
     assert_equal "bar", @klass.new.bar


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This pull request fixes an issue where `ancestors` is not correctly updated when an `ActiveSupport::Concern` depends on another Concern.

When one Concern was included into another, the dependency was only recorded (appended to `@_dependencies`).
Ruby's actual `include` machinery (calling `super`) was never invoked, so the dependency was never reflected in `ancestors`.

Fixes [#47699](https://github.com/rails/rails/issues/47699)

### Detail

As discussed in the issue, this pull request changes `false` to `super`.

Calling `super` causes the dependent Concern to be inserted into the real, Ruby-level `ancestors` chain immediately. 
This branch still doesn't extend `ClassMethods` or run the `included` block, so hooks still only fire on the final host class, not on an intermediate Concern. The original design intent is unchanged.

### Additional information

The issue discusses why the current implementation `returns false` instead of calling `super`, but no clear conclusion was reached.

I went back through past PRs and commit messages, but found no explanation for it.

I also ran the existing test suite after switching to `super` and confirmed that no other tests failed, so I decided to try this fix.

For reference, here are some additional historical commits I found while digging through the history:

- https://github.com/rails/rails/commit/2854535b02bcee3668bda02c76c3105fc24730d3 — introduced depends_on
- https://github.com/rails/rails/commit/669fd84910586d4c791b6f5bf4320f68ac7845aa — aliased include to depends_on to make it lazy

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
