### PR TITLE
LazyAttributeSet: Use a mutable indexed row for casted values

### DIFF
--- a/activemodel/lib/active_model.rb
+++ b/activemodel/lib/active_model.rb
@@ -64,6 +64,7 @@ module ActiveModel
     autoload :StrictValidationFailed, "active_model/errors"
     autoload :UnknownAttributeError, "active_model/errors"
     autoload :ValidationError, "active_model/validations"
+    autoload :IndexedRow
   end
 
   module Serializers

--- a/activemodel/lib/active_model/attribute_set/builder.rb
+++ b/activemodel/lib/active_model/attribute_set/builder.rb
@@ -25,7 +25,7 @@ module ActiveModel
       @types = types
       @additional_types = additional_types
       @default_attributes = default_attributes
-      @casted_values = {}
+      @casted_values = values.is_a?(IndexedRow) ? values.new_empty_mutable_row : {}
       @materialized = false
     end
 

--- a/activemodel/lib/active_model/indexed_row.rb
+++ b/activemodel/lib/active_model/indexed_row.rb
@@ -36,6 +36,15 @@ module ActiveModel
       @row.dup
     end
 
+    def values_at(*columns)
+      columns.map! do |column|
+        if index = @indexes[column]
+          @row[index]
+        end
+      end
+      columns
+    end
+
     def ==(other)
       if other.is_a?(Hash)
         to_hash == other
@@ -98,6 +107,16 @@ module ActiveModel
 
       def values
         @row.reject { |v| UNSET.equal?(v) }
+      end
+
+      def values_at(*columns)
+        columns.map! do |column|
+          if index = @indexes[column]
+            value = @row[index]
+            UNSET.equal?(value) ? nil : value
+          end
+        end
+        columns
       end
 
       def [](column)

--- a/activemodel/lib/active_model/indexed_row.rb
+++ b/activemodel/lib/active_model/indexed_row.rb
@@ -12,7 +12,14 @@ module ActiveModel
         column_indexes = hash.transform_values { index += 1 }.freeze
         new(column_indexes, hash.values.freeze)
       end
+
+      def build_indexes(columns)
+        index = -1
+        columns.index_with { index += 1 }
+      end
     end
+
+    attr_reader :indexes, :row
 
     def initialize(indexes, row)
       @indexes = indexes
@@ -57,8 +64,6 @@ module ActiveModel
       [IndexedRow, @indexes, @row].hash
     end
 
-    protected attr_reader :indexes, :row
-
     def eql?(other)
       other.is_a?(IndexedRow) &&
         @indexes == other.indexes &&
@@ -92,6 +97,24 @@ module ActiveModel
 
     def new_empty_mutable_row
       Mutable.new(@indexes)
+    end
+
+    class Remapper
+      def initialize(initial_indexes, old_columns, new_columns = old_columns)
+        @initial_indexes = initial_indexes
+
+        # Handle duplicate keys
+        pairs = new_columns.zip(old_columns).to_h
+        new_columns = pairs.keys
+        old_columns = pairs.values
+
+        @new_indexes = IndexedRow.build_indexes(new_columns)
+        @indexes_to_extract = old_columns.map { |column| @initial_indexes.fetch(column) }
+      end
+
+      def build(original_row)
+        IndexedRow.new(@new_indexes, original_row.row.values_at(*@indexes_to_extract).freeze)
+      end
     end
 
     class Mutable < self

--- a/activemodel/lib/active_model/indexed_row.rb
+++ b/activemodel/lib/active_model/indexed_row.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+# :markup: markdown
+
+module ActiveModel
+  class IndexedRow # :nodoc:
+    class << self
+      def [](hash)
+        return hash if hash.is_a?(self)
+
+        index = -1
+        column_indexes = hash.transform_values { index += 1 }.freeze
+        new(column_indexes, hash.values.freeze)
+      end
+    end
+
+    attr_reader :indexes
+
+    def initialize(indexes, row)
+      @indexes = indexes
+      @row = row
+    end
+
+    def size
+      @indexes.size
+    end
+    alias_method :length, :size
+
+    def each_key(&block)
+      @indexes.each_key(&block)
+    end
+
+    def keys
+      @indexes.keys
+    end
+
+    def ==(other)
+      if other.is_a?(Hash)
+        to_hash == other
+      else
+        super
+      end
+    end
+
+    def key?(column)
+      @indexes.key?(column)
+    end
+
+    def fetch(column)
+      if index = @indexes[column]
+        @row[index]
+      elsif block_given?
+        yield
+      else
+        raise KeyError, "key not found: #{column.inspect}"
+      end
+    end
+
+    def [](column)
+      if index = @indexes[column]
+        @row[index]
+      end
+    end
+
+    def to_h
+      @indexes.transform_values { |index| @row[index] }
+    end
+    alias_method :to_hash, :to_h
+  end
+end

--- a/activemodel/lib/active_model/indexed_row.rb
+++ b/activemodel/lib/active_model/indexed_row.rb
@@ -53,6 +53,18 @@ module ActiveModel
       end
     end
 
+    def hash
+      [IndexedRow, @indexes, @row].hash
+    end
+
+    protected attr_reader :indexes, :row
+
+    def eql?(other)
+      other.is_a?(IndexedRow) &&
+        @indexes == other.indexes &&
+        @row == other.row
+    end
+
     def key?(column)
       @indexes.key?(column)
     end

--- a/activemodel/lib/active_model/indexed_row.rb
+++ b/activemodel/lib/active_model/indexed_row.rb
@@ -14,8 +14,6 @@ module ActiveModel
       end
     end
 
-    attr_reader :indexes
-
     def initialize(indexes, row)
       @indexes = indexes
       @row = row
@@ -32,6 +30,10 @@ module ActiveModel
 
     def keys
       @indexes.keys
+    end
+
+    def values
+      @row.dup
     end
 
     def ==(other)
@@ -66,5 +68,75 @@ module ActiveModel
       @indexes.transform_values { |index| @row[index] }
     end
     alias_method :to_hash, :to_h
+
+    def new_empty_mutable_row
+      Mutable.new(@indexes)
+    end
+
+    class Mutable < self
+      UNSET = Object.new.freeze
+      private_constant :UNSET
+
+      def initialize(indexes, row = nil)
+        @indexes = indexes
+        @row = row || Array.new(indexes.size, UNSET)
+      end
+
+      def size
+        @indexes.size - @row.count(UNSET)
+      end
+      alias_method :length, :size
+
+      def keys
+        @indexes.reject { |k, v| UNSET.equal?(@row[v]) }.keys
+      end
+
+      def key?(column)
+        index = @indexes[column]
+        index && !UNSET.equal?(@row[index])
+      end
+
+      def values
+        @row.reject { |v| UNSET.equal?(v) }
+      end
+
+      def [](column)
+        if index = @indexes[column]
+          value = @row[index]
+          return if UNSET.equal?(value)
+          value
+        end
+      end
+
+      def []=(column, value)
+        if index = @indexes[column]
+          @row[index] = value
+        else
+          raise KeyError, "key not found: #{column.inspect}"
+        end
+      end
+
+      def fetch(column)
+        if index = @indexes[column]
+          value = @row[index]
+          if UNSET.equal?(value)
+            if block_given?
+              yield
+            else
+              raise KeyError, "key not found: #{column.inspect}"
+            end
+          else
+            value
+          end
+        else
+          raise KeyError, "key not found: #{column.inspect}"
+        end
+      end
+
+      def to_h
+        @indexes.transform_values { |index| @row[index] }.reject { |k, v| UNSET.equal?(v) }
+      end
+      alias_method :to_hash, :to_h
+    end
   end
 end

--- a/activemodel/lib/active_model/indexed_row.rb
+++ b/activemodel/lib/active_model/indexed_row.rb
@@ -147,6 +147,8 @@ module ActiveModel
           else
             value
           end
+        elsif block_given?
+          yield
         else
           raise KeyError, "key not found: #{column.inspect}"
         end

--- a/activemodel/lib/active_model/indexed_row.rb
+++ b/activemodel/lib/active_model/indexed_row.rb
@@ -118,7 +118,7 @@ module ActiveModel
     end
 
     class Mutable < self
-      UNSET = Object.new.freeze
+      UNSET = Module.new.freeze
       private_constant :UNSET
 
       def initialize(indexes, row = nil)

--- a/activemodel/test/cases/indexed_row_test.rb
+++ b/activemodel/test/cases/indexed_row_test.rb
@@ -35,6 +35,10 @@ class IndexedRowTest < ActiveModel::TestCase
     assert_equal @hash, @row
   end
 
+  test "#hash" do
+    assert_equal 1, [@row, @row.dup].uniq.size
+  end
+
   test "#key?" do
     assert_equal true, @row.key?("first_name")
     assert_equal true, @row.key?("last_name")

--- a/activemodel/test/cases/indexed_row_test.rb
+++ b/activemodel/test/cases/indexed_row_test.rb
@@ -27,6 +27,10 @@ class IndexedRowTest < ActiveModel::TestCase
     assert_equal @hash.values, @row.values
   end
 
+  test "#values_at" do
+    assert_equal @hash.values_at("age", "first_name", "missing"), @row.values_at("age", "first_name", "missing")
+  end
+
   test "#==" do
     assert_equal @hash, @row
   end
@@ -97,6 +101,12 @@ class EmptyMutableIndexedRowTest < ActiveModel::TestCase
     assert_equal [42], @row.values
     @row["first_name"] = "George"
     assert_equal ["George", 42], @row.values
+  end
+
+  test "#values_at" do
+    assert_equal [nil, nil], @row.values_at("age", "first_name")
+    @row["age"] = 42
+    assert_equal [42, nil, nil], @row.values_at("age", "first_name", "missing")
   end
 
   test "#fetch" do

--- a/activemodel/test/cases/indexed_row_test.rb
+++ b/activemodel/test/cases/indexed_row_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+class IndexedRowTest < ActiveModel::TestCase
+  setup do
+    @hash = { "first_name" => "George", "last_name" => "Abitbol", "age" => 42 }.freeze
+    @row = ActiveModel::IndexedRow[@hash]
+  end
+
+  test "#[]" do
+    assert_equal "George", @row["first_name"]
+    assert_equal "Abitbol", @row["last_name"]
+    assert_equal 42, @row["age"]
+    assert_nil @row["missing"]
+  end
+
+  test "#size" do
+    assert_equal @hash.size, @row.size
+  end
+
+  test "#keys" do
+    assert_equal @hash.keys, @row.keys
+  end
+
+  test "#==" do
+    assert_equal @hash, @row
+  end
+
+  test "#key?" do
+    assert_equal true, @row.key?("first_name")
+    assert_equal true, @row.key?("last_name")
+    assert_equal true, @row.key?("age")
+    assert_equal false, @row.key?("missing")
+  end
+
+  test "#fetch" do
+    assert_equal 42, @row.fetch("age")
+    assert_raises(KeyError) do
+      @row.fetch("missing")
+    end
+    assert_equal(1, @row.fetch("missing") { 1 })
+  end
+
+  test "#to_h" do
+    assert_equal @hash, @row.to_h
+  end
+end

--- a/activemodel/test/cases/indexed_row_test.rb
+++ b/activemodel/test/cases/indexed_row_test.rb
@@ -114,5 +114,8 @@ class EmptyMutableIndexedRowTest < ActiveModel::TestCase
     assert_equal(4, @row.fetch("age") { 4 })
     @row["age"] = 42
     assert_equal 42, @row.fetch("age")
+
+    assert_raises(KeyError) { @row.fetch("missing") }
+    assert_equal(5, @row.fetch("missing") { 5 })
   end
 end

--- a/activemodel/test/cases/indexed_row_test.rb
+++ b/activemodel/test/cases/indexed_row_test.rb
@@ -8,6 +8,11 @@ class IndexedRowTest < ActiveModel::TestCase
     @row = ActiveModel::IndexedRow[@hash]
   end
 
+  test ".build_indexes" do
+    assert_equal({ a: 0, b: 1, c: 2, d: 3 }, ActiveModel::IndexedRow.build_indexes(%i(a b c d)))
+    assert_equal({ a: 0, b: 5, c: 2, d: 6 }, ActiveModel::IndexedRow.build_indexes(%i(a b c b b b d)))
+  end
+
   test "#[]" do
     assert_equal "George", @row["first_name"]
     assert_equal "Abitbol", @row["last_name"]
@@ -121,5 +126,36 @@ class EmptyMutableIndexedRowTest < ActiveModel::TestCase
 
     assert_raises(KeyError) { @row.fetch("missing") }
     assert_equal(5, @row.fetch("missing") { 5 })
+  end
+end
+
+class RemapperTest < ActiveModel::TestCase
+  test "#build" do
+    row = ActiveModel::IndexedRow["_first_name" => "George", "_last_name" => "Abitbol", "_age" => 42]
+    remapper = ActiveModel::IndexedRow::Remapper.new(
+      row.indexes,
+      %w(_age _first_name),
+      %w(age name),
+    )
+    remapped_row = remapper.build(row)
+    assert_equal({ "age" => 42, "name" => "George" }, remapped_row.to_h)
+  end
+
+  test "#build with duplicated keys" do
+    columns = ["id", "author_id", "name", "author_id"].freeze
+    values = [1, 2, "George", 4].freeze
+    indexes = ActiveModel::IndexedRow.build_indexes(columns)
+    row = ActiveModel::IndexedRow.new(indexes, values)
+
+    remapper = ActiveModel::IndexedRow::Remapper.new(
+      row.indexes,
+      ["author_id", "name", "author_id"],
+      ["author_id", "first_name", "author_id"],
+    )
+    remapped_row = remapper.build(row)
+    assert_equal row["author_id"], remapped_row["author_id"]
+    assert_equal row["name"], remapped_row["first_name"]
+
+    assert_equal(2, remapped_row.values.size)
   end
 end

--- a/activemodel/test/cases/indexed_row_test.rb
+++ b/activemodel/test/cases/indexed_row_test.rb
@@ -23,6 +23,10 @@ class IndexedRowTest < ActiveModel::TestCase
     assert_equal @hash.keys, @row.keys
   end
 
+  test "#values" do
+    assert_equal @hash.values, @row.values
+  end
+
   test "#==" do
     assert_equal @hash, @row
   end
@@ -44,5 +48,61 @@ class IndexedRowTest < ActiveModel::TestCase
 
   test "#to_h" do
     assert_equal @hash, @row.to_h
+  end
+end
+
+class EmptyMutableIndexedRowTest < ActiveModel::TestCase
+  setup do
+    @hash = { "first_name" => "George", "last_name" => "Abitbol", "age" => 42 }.freeze
+    @reference = ActiveModel::IndexedRow[@hash]
+    @row = @reference.new_empty_mutable_row
+  end
+
+  test "#[]" do
+    assert_nil @row["first_name"]
+    assert_nil @row["last_name"]
+    assert_nil @row["age"]
+    assert_nil @row["missing"]
+  end
+
+  test "#[]=" do
+    assert_nil @row["age"]
+    @row["age"] = 42
+    assert_equal 42, @row["age"]
+
+    assert_raises KeyError do
+      @row["missing"] = true
+    end
+  end
+
+  test "#size" do
+    assert_equal 0, @row.size
+    @row["age"] = 42
+    assert_equal 1, @row.size
+    @row["first_name"] = "George"
+    assert_equal 2, @row.size
+  end
+
+  test "#keys" do
+    assert_equal [], @row.keys
+    @row["age"] = 42
+    assert_equal ["age"], @row.keys
+    @row["first_name"] = "George"
+    assert_equal ["first_name", "age"], @row.keys
+  end
+
+  test "#values" do
+    assert_equal [], @row.values
+    @row["age"] = 42
+    assert_equal [42], @row.values
+    @row["first_name"] = "George"
+    assert_equal ["George", 42], @row.values
+  end
+
+  test "#fetch" do
+    assert_raises(KeyError) { @row.fetch("age") }
+    assert_equal(4, @row.fetch("age") { 4 })
+    @row["age"] = 42
+    assert_equal 42, @row.fetch("age")
   end
 end

--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -140,10 +140,10 @@ module ActiveRecord
         }
 
         message_bus.instrument("instantiation.active_record", payload) do
-          result_set.each { |row_hash|
-            parent_key = primary_key.empty? ? row_hash : row_hash.values_at(*primary_key)
-            parent = parents[parent_key] ||= join_root.instantiate(row_hash, column_aliases, column_types, &block)
-            construct(parent, join_root, row_hash, seen, model_cache, strict_loading_value)
+          result_set.indexed_rows.each { |row|
+            parent_key = primary_key.empty? ? row : row.values_at(*primary_key)
+            parent = parents[parent_key] ||= join_root.instantiate(row, column_aliases, column_types, &block)
+            construct(parent, join_root, row, seen, model_cache, strict_loading_value)
           }
         end
 

--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -72,6 +72,7 @@ module ActiveRecord
         tree = self.class.make_tree associations
         @join_root = JoinBase.new(base, table, build(tree, base))
         @join_type = join_type
+        @remappers = {}
       end
 
       def base_klass
@@ -139,12 +140,17 @@ module ActiveRecord
           class_name: join_root.base_klass.name
         }
 
+        primary_key_indexes = primary_key.map { |name| result_set.column_indexes.fetch(name) }.freeze
+        remapper = ActiveModel::IndexedRow::Remapper.new(result_set.column_indexes, column_aliases.map(&:alias), column_aliases.map(&:name))
+
         message_bus.instrument("instantiation.active_record", payload) do
-          result_set.indexed_rows.each { |row|
-            parent_key = primary_key.empty? ? row : row.values_at(*primary_key)
-            parent = parents[parent_key] ||= join_root.instantiate(row, column_aliases, column_types, &block)
-            construct(parent, join_root, row, seen, model_cache, strict_loading_value)
-          }
+          result_set.indexed_rows.each do |indexed_row|
+            row = indexed_row.row
+            parent_key = primary_key_indexes.empty? ? row : row.values_at(*primary_key_indexes)
+
+            parent = parents[parent_key] ||= join_root.instantiate(remapper.build(indexed_row), column_types, &block)
+            construct(parent, join_root, indexed_row, seen, model_cache, strict_loading_value)
+          end
         end
 
         parents.values
@@ -276,11 +282,18 @@ module ActiveRecord
           end
         end
 
+        def remapper(node, indexes)
+          @remappers[node] ||= begin
+            column_aliases = aliases.column_aliases(node)
+            ActiveModel::IndexedRow::Remapper.new(indexes, column_aliases.map(&:alias), column_aliases.map(&:name))
+          end
+        end
+
         def construct_model(record, node, row, model_cache, id, strict_loading_value)
           other = record.association(node.reflection.name)
 
           unless model = model_cache[node][id]
-            model = node.instantiate(row, aliases.column_aliases(node)) do |m|
+            model = node.instantiate(remapper(node, row.indexes).build(row)) do |m|
               m.strict_loading! if strict_loading_value
               other.set_inverse_instance(m)
             end

--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -103,6 +103,9 @@ module ActiveRecord
         }
       end
 
+      EMPTY_HASH = {}.freeze
+      private_constant :EMPTY_HASH
+
       def instantiate(result_set, strict_loading_value, &block)
         primary_key = Array(join_root.primary_key).map { |column| aliases.column_alias(join_root, column) }
 
@@ -116,19 +119,19 @@ module ActiveRecord
         parents = model_cache[join_root]
 
         column_aliases = aliases.column_aliases(join_root)
-        column_names = []
 
-        result_set.columns.each do |name|
-          column_names << name unless /\At\d+_r\d+\z/.match?(name)
+        column_names = result_set.columns.reject do |name|
+          /\At\d+_r\d+\z/.match?(name)
         end
 
         if column_names.empty?
-          column_types = {}
+          column_types = EMPTY_HASH
         else
           column_types = result_set.column_types
           unless column_types.empty?
             attribute_types = join_root.attribute_types
-            column_types = column_types.slice(*column_names).delete_if { |k, _| attribute_types.key?(k) }
+            column_types = column_types.slice(*column_names).delete_if { |k, _| attribute_types.key?(k) }.freeze
+            column_types = EMPTY_HASH if column_types.empty?
           end
           column_aliases += column_names.map! { |name| Aliases::Column.new(name, name) }
         end

--- a/activerecord/lib/active_record/associations/join_dependency/join_part.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_part.rb
@@ -45,25 +45,8 @@ module ActiveRecord
           raise NotImplementedError
         end
 
-        def extract_record(row, column_names_with_alias)
-          # This code is performance critical as it is called per row.
-          # see: https://github.com/rails/rails/pull/12185
-          hash = {}
-
-          index = 0
-          length = column_names_with_alias.length
-
-          while index < length
-            column = column_names_with_alias[index]
-            hash[column.name] = row[column.alias]
-            index += 1
-          end
-
-          hash
-        end
-
-        def instantiate(row, aliases, column_types = {}, &block)
-          base_klass.instantiate(extract_record(row, aliases), column_types, &block)
+        def instantiate(row, column_types = {}, &block)
+          base_klass.instantiate(row, column_types, &block)
         end
       end
     end

--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -186,10 +186,7 @@ module ActiveRecord
     end
 
     def column_indexes # :nodoc:
-      @column_indexes ||= begin
-        index = -1
-        columns.to_h { |c| [c, index += 1] }.freeze # rubocop:disable Rails/IndexWith
-      end
+      @column_indexes ||= ActiveModel::IndexedRow.build_indexes(columns)
     end
 
     def indexed_rows # :nodoc:

--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -41,59 +41,6 @@ module ActiveRecord
   class Result
     include Enumerable
 
-    class IndexedRow
-      def initialize(column_indexes, row)
-        @column_indexes = column_indexes
-        @row = row
-      end
-
-      def size
-        @column_indexes.size
-      end
-      alias_method :length, :size
-
-      def each_key(&block)
-        @column_indexes.each_key(&block)
-      end
-
-      def keys
-        @column_indexes.keys
-      end
-
-      def ==(other)
-        if other.is_a?(Hash)
-          to_hash == other
-        else
-          super
-        end
-      end
-
-      def key?(column)
-        @column_indexes.key?(column)
-      end
-
-      def fetch(column)
-        if index = @column_indexes[column]
-          @row[index]
-        elsif block_given?
-          yield
-        else
-          raise KeyError, "key not found: #{column.inspect}"
-        end
-      end
-
-      def [](column)
-        if index = @column_indexes[column]
-          @row[index]
-        end
-      end
-
-      def to_h
-        @column_indexes.transform_values { |index| @row[index] }
-      end
-      alias_method :to_hash, :to_h
-    end
-
     attr_reader :columns, :rows, :affected_rows
 
     def self.empty(async: false, affected_rows: nil) # :nodoc:
@@ -240,21 +187,15 @@ module ActiveRecord
 
     def column_indexes # :nodoc:
       @column_indexes ||= begin
-        index = 0
-        hash = {}
-        length = columns.length
-        while index < length
-          hash[columns[index]] = index
-          index += 1
-        end
-        hash.freeze
+        index = -1
+        columns.to_h { |c| [c, index += 1] }.freeze # rubocop:disable Rails/IndexWith
       end
     end
 
     def indexed_rows # :nodoc:
       @indexed_rows ||= begin
         columns = column_indexes
-        @rows.map { |row| IndexedRow.new(columns, row) }.freeze
+        @rows.map { |row| ActiveModel::IndexedRow.new(columns, row) }.freeze
       end
     end
 

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -85,15 +85,11 @@ module Enumerable
   # ```
   def index_with(default = (no_default = true))
     if block_given?
-      result = {}
-      each { |elem| result[elem] = yield(elem) }
-      result
+      to_h { |elem| [elem, yield(elem)] } # rubocop:disable Rails/IndexWith
     elsif no_default
       to_enum(:index_with) { size if respond_to?(:size) }
     else
-      result = {}
-      each { |elem| result[elem] = default }
-      result
+      to_h { |elem| [elem, default] } # rubocop:disable Rails/IndexWith
     end
   end
 


### PR DESCRIPTION
This is a followup on https://github.com/rails/rails/pull/51744

`@casted_values` starts empty, but eventually it shares all the same keys as `@values`.

As such using a Hash is wasteful if `@values` is an IndexedRow as we can re-use the same index to store the casted values in a much more compact fashion.

Unfortunately there's still a few codepaths that create `LazyAttributeSet` with an actual Hash, ideally they're be eliminated, but in the meantime we can enable that optimisation most of the time.

cc @ilianah 