### PR TITLE
Reset the autosave callbacks guard on a duplicated record

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,29 @@
+*   Reset the autosave callbacks guard on a duplicated record.
+
+    The autosave callbacks share `@_already_called`, which says which of them are
+    running on a given record. `ActiveRecord::Core#initialize_dup` resets a few
+    instance variables by hand rather than going through `init_internals`, where
+    that guard is reset, so a record duplicated while the record it was copied
+    from was inside its own autosave started life with the guard already raised
+    and skipped that association: no `INSERT` was issued and nothing was raised.
+
+    ```ruby
+    class Bird < ActiveRecord::Base
+      belongs_to :pirate
+
+      after_update do
+        copy = pirate.dup            # taken inside the pirate's own autosave
+        copy.birds = [Bird.new(name: "Cockatoo")]
+        copy.save!
+        copy.birds # => [] before this fix, and no INSERT was attempted
+      end
+    end
+
+    pirate.update!(birds_attributes: [{ id: bird.id, name: "Canary" }])
+    ```
+
+    *Anton Hetmanov*
+
 *   Re-enable PostgreSQL triggers when the block given to `disable_referential_integrity` raises.
 
     On PostgreSQL versions without `NOT ENFORCED` constraints (before 18.4), the

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -281,6 +281,16 @@ module ActiveRecord
       new_record? || has_changes_to_save? || marked_for_destruction? || nested_records_changed_for_autosave?
     end
 
+    def initialize_dup(other) # :nodoc:
+      super
+      # +@_already_called+ says which of these callbacks are running on this very
+      # record. #initialize_dup does not go through #init_internals, where it is
+      # reset, so without this a record duplicated while the record it was copied
+      # from is inside its own autosave would start with the guard already raised
+      # and skip that association without saving it or raising.
+      @_already_called = nil
+    end
+
     def validating_belongs_to_for?(association)
       @validating_belongs_to_for ||= {}
       @validating_belongs_to_for[association]

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -2574,3 +2574,43 @@ class AutosavePolymorphicShardedPrimaryKeyTest < ActiveRecord::TestCase
     assert_equal shipment, adjustment.reload.adjustable
   end
 end
+
+class TestAutosaveAssociationOnADuplicatedRecord < ActiveRecord::TestCase
+  def test_dup_does_not_inherit_the_autosave_callbacks_guard
+    pirate = Pirate.create!(catchphrase: "Aye")
+    pirate.instance_variable_set(:@_already_called, { autosave_associated_records_for_birds: true })
+
+    assert_nil pirate.dup.instance_variable_get(:@_already_called)
+  end
+
+  def test_dup_saves_the_records_staged_on_it_while_the_original_guard_is_raised
+    pirate = Pirate.create!(catchphrase: "Aye")
+    pirate.instance_variable_set(:@_already_called, { autosave_associated_records_for_birds: true })
+
+    copy = pirate.dup
+    copy.birds = [Bird.new(name: "Bluebird")]
+    copy.save!
+
+    assert_equal ["Bluebird"], copy.reload.birds.map(&:name)
+  end
+
+  def test_dup_taken_from_inside_the_autosave_callback_saves_its_own_records
+    pirate = Pirate.create!(catchphrase: "Aye")
+    bird = pirate.birds.create!(name: "Bluebird")
+    copy = nil
+
+    Bird.define_method(:duplicate_the_pirate) do
+      copy = pirate.dup
+      copy.birds = [Bird.new(name: "Cockatoo")]
+      copy.save!
+    end
+    Bird.set_callback(:update, :after, :duplicate_the_pirate)
+
+    pirate.update!(birds_attributes: [{ id: bird.id, name: "Canary" }])
+
+    assert_equal ["Cockatoo"], copy.reload.birds.map(&:name)
+  ensure
+    Bird.skip_callback(:update, :after, :duplicate_the_pirate, raise: false)
+    Bird.remove_method(:duplicate_the_pirate) if Bird.method_defined?(:duplicate_the_pirate)
+  end
+end


### PR DESCRIPTION
### Motivation / Background

The autosave callbacks share `@_already_called`, a hash saying which of them are
currently running on a record. `ActiveRecord::Core#initialize_dup` resets a few
instance variables by hand instead of going through `init_internals`, which is
where `AutosaveAssociation` resets that guard:

```ruby
# activerecord/lib/active_record/core.rb
def initialize_dup(other)
  @attributes = init_attributes(other)
  _run_initialize_callbacks
  @new_record               = true
  @previously_new_record    = false
  @destroyed                = false
  @_start_transaction_state = nil
  super
end

# activerecord/lib/active_record/autosave_association.rb
def init_internals
  super
  @_already_called = nil
end
```

`dup` copies instance variables, so a record duplicated while the record it was
copied from is inside its own autosave starts life with that guard already
raised, and the method built by `define_non_cyclic_method` returns `true` for
that association without doing anything. The copy is inserted, its other
associations are inserted, and the guarded one is not: no `INSERT` is issued,
nothing is raised, and `save!` reports success.

Reproduction on plain Active Record, in-memory sqlite, no application:

```ruby
require "active_record"
require "sqlite3"

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Schema.verbose = false
ActiveRecord::Schema.define do
  create_table(:parents, force: true) { |t| t.string :name }
  create_table(:children, force: true) do |t|
    t.integer :parent_id
    t.string :name
  end
end

class Parent < ActiveRecord::Base
  has_many :children
  accepts_nested_attributes_for :children
end

class Child < ActiveRecord::Base
  belongs_to :parent, optional: true

  after_update do
    copy = parent.dup
    copy.children = [Child.new(name: "child of the copy")]
    copy.save!
    $copy_id = copy.id
  end
end

parent = Parent.create!(name: "source", children: [Child.new(name: "original child")])
child = parent.children.first

# The child is changed through its parent, so the child's save runs inside
# Parent#autosave_associated_records_for_children.
parent.update!(children_attributes: [{ "id" => child.id, "name" => "renamed" }])

Parent.find($copy_id).children.count # => 0, and no INSERT INTO "children" was issued
```

How it turned up: a delivery application transfers a task to a partner
organization from an `after_update` callback on the task's child record, and the
transfer duplicates the task. One screen submits the child's change as nested
attributes on the parent, so the child is saved by the parent's autosave and the
duplication happens inside it. Twenty tasks were created over nine days with all
of their children missing, with no exception anywhere and no gap in the
children's id sequence, because the inserts were never attempted. They were only
noticed when unrelated code raised `NoMethodError` on the missing child.

### Detail

This Pull Request resets `@_already_called` in `initialize_dup`, next to the
`init_internals` that already does it for a newly instantiated record:

```ruby
def initialize_dup(other) # :nodoc:
  super
  @_already_called = nil
end
```

The guard means "this callback is currently running on this record". A copy is a
different record with its own association graph, so inheriting a raised guard
cannot prevent a cycle on the copy; it can only stop the copy from saving what
was staged on it. `Associations#initialize_dup` already resets
`@association_cache`, so `initialize_dup` is the established place for this kind
of per-instance state, and `@_already_called` was never added to that path.

Outside a save the variable is either `nil` or a hash whose values are all
`false`, so resetting it changes nothing for a record duplicated at any other
moment.

Three tests are added to `activerecord/test/cases/autosave_association_test.rb`:
the invariant, its consequence, and the end-to-end case where the copy is taken
from inside the callback. All three fail before the change:

```
1) Expected {:autosave_associated_records_for_birds=>true} to be nil.
2) Expected: ["Bluebird"]  Actual: []
3) Expected: ["Cockatoo"]  Actual: []
```

### Additional information

Measured on `main` (8.2.0.alpha), 7.2.3.2 and 7.1.6: the copy keeps none of its
staged records and no `INSERT` is attempted. With this change all three save the
record and issue one `INSERT`. 7.0 and 6.1 were not tried (their Active Support
does not load on Ruby 3.3), but the same gap is visible in their source.

`@validating_belongs_to_for` and `@autosaving_belongs_to_for` are the same kind
of in-flight, this-record-only state: raised around a `belongs_to` validation or
save, lowered in an `ensure`, and read to skip work. They are not reset by
`initialize_dup` either, and unlike `@_already_called` they are not reset in
`init_internals` at all. I left them alone rather than change behaviour I have no
test for, and I am happy to add both with tests if you would prefer that.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
