### PR TITLE
Use equality comparison when fetching information about a single table

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -760,7 +760,7 @@ module ActiveRecord
               SELECT table_name AS 'table', table_collation AS 'collation'
               FROM information_schema.tables
               WHERE table_schema = #{schema}
-                AND table_name IN (#{quoted_table_names(group)})
+                AND table_name #{table_name_predicate(group)}
             SQL
 
             group.index_with { |table| by_name[bare_table_name(table)] }
@@ -769,8 +769,6 @@ module ActiveRecord
 
         def fetch_foreign_keys(tables)
           fetch_by_schema(tables) do |schema, group|
-            names = quoted_table_names(group)
-
             # MySQL returns 1 row for each column of composite foreign keys.
             by_name = query_all(<<~SQL).group_by { |row| row["from_table"] }
               SELECT fk.table_name AS 'from_table',
@@ -787,7 +785,7 @@ module ActiveRecord
               WHERE fk.referenced_column_name IS NOT NULL
                 AND fk.table_schema = #{schema}
                 AND rc.constraint_schema = #{schema}
-                AND fk.table_name IN (#{names}) AND rc.table_name IN (#{names})
+                AND fk.table_name #{table_name_predicate(group)} AND rc.table_name #{table_name_predicate(group)}
             SQL
 
             group.index_with { |table| build_foreign_keys(table, rows_for(by_name, table)) }
@@ -798,8 +796,6 @@ module ActiveRecord
           raise NotImplementedError unless supports_check_constraints?
 
           fetch_by_schema(tables) do |schema, group|
-            names = quoted_table_names(group)
-
             sql = +<<~SQL
               SELECT tc.table_name AS 'table',
                      cc.constraint_name AS 'name',
@@ -808,10 +804,10 @@ module ActiveRecord
               JOIN information_schema.table_constraints tc
               USING (constraint_schema, constraint_name)
               WHERE tc.table_schema = #{schema}
-                AND tc.table_name IN (#{names})
+                AND tc.table_name #{table_name_predicate(group)}
                 AND cc.constraint_schema = #{schema}
             SQL
-            sql << " AND cc.table_name IN (#{names})" if mariadb?
+            sql << " AND cc.table_name #{table_name_predicate(group)}" if mariadb?
 
             by_name = query_all(sql).group_by { |row| row["table"] }
 
@@ -826,7 +822,7 @@ module ActiveRecord
               FROM information_schema.statistics
               WHERE index_name = 'PRIMARY'
                 AND table_schema = #{schema}
-                AND table_name IN (#{quoted_table_names(group)})
+                AND table_name #{table_name_predicate(group)}
               ORDER BY table_name, seq_in_index
             SQL
 
@@ -1075,7 +1071,7 @@ module ActiveRecord
                      collation_name AS 'Collation', column_comment AS 'Comment'
               FROM information_schema.columns
               WHERE table_schema = #{schema}
-                AND table_name IN (#{quoted_table_names(group)})
+                AND table_name #{table_name_predicate(group)}
               ORDER BY table_name, ordinal_position
             SQL
 

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -104,7 +104,7 @@ module ActiveRecord
                        index_comment AS 'Index_comment'#{optional_columns}
                 FROM information_schema.statistics
                 WHERE table_schema = #{schema}
-                  AND table_name IN (#{quoted_table_names(group)})
+                  AND table_name #{table_name_predicate(group)}
                   AND index_name != 'PRIMARY'
                 ORDER BY table_name, index_name, seq_in_index
               SQL
@@ -297,6 +297,10 @@ module ActiveRecord
             scope[:name] = quote(name) if name
             scope[:type] = quote(type) if type
             scope
+          end
+
+          def table_name_predicate(table_names)
+            table_names.one? ? "= #{quoted_table_names(table_names)}" : "IN (#{quoted_table_names(table_names)})"
           end
 
           def bare_table_name(table)


### PR DESCRIPTION
Since https://github.com/rails/rails/pull/58421 MySQL schema readers answer for a list of tables, and filter with `table_name IN (...)` even when asked about one table.


A single database in Vitess can have multiple keyspaces, with each keyspace running its own MySQL instances, so there is no global `information_schema` table that holds information for all of them.
This means that Vitess is not able to correctly determine which keyspace an IN query to `information_schema` should be sent to. The query is resolved to no keyspace, so Vitess just ends up routing it to the default one.
This is ok for applications only using a single keyspace, or if the table from the query happens to be in the default one, but otherwise the query returns an empty result.

This is a problem any time an application running Vitess uses any schema reader, but more notably it's an issue for `remove_index` migrations. `remove_index` ends up calling `fetch_indexes` for the table in the migration, which generates an `IN` query for a single table that Vitess doesn't know how to route, which results in `No indexes found on #{table_name} with the options provided.` error for any table not in the default keyspace. 

We've reported this to Vitess and they are shipping a fix for it (https://github.com/vitessio/vitess/pull/20973) but the fix is not going to be backported further back than v23. 

With this change, `IN` queries for single tables are converted to equality comparison, which will work on any Vitess version. (This restores the single-table statment used before #58421)
Queries for multiple tables remain the same. They still can't be routed in Vitess, and end up being issued against the default keyspace.
