### PR TITLE
Apply has_many default_order: when the association is preloaded

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -494,6 +494,16 @@ module ActiveRecord
     # Holds all the metadata about an association as it was specified in the
     # Active Record class.
     class AssociationReflection < MacroReflection # :nodoc:
+      def join_scopes(table, predicate_builder = nil, klass = self.klass, record = nil) # :nodoc:
+        scopes = super
+
+        if options[:default_order].present?
+          scopes += [build_scope(table, predicate_builder, klass).default_order!(options[:default_order])]
+        end
+
+        scopes
+      end
+
       def compute_class(name)
         if polymorphic?
           raise ArgumentError, "Polymorphic associations do not support computing the class."

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -698,6 +698,14 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal [6, 5, 4, 2, 1], author.posts_with_default_order.reload.map(&:id)
   end
 
+  def test_default_order_is_applied_when_the_association_is_preloaded
+    id = authors(:david).id
+    expected = [1, 2, 4, 5, 6]
+
+    assert_equal expected, Author.preload(:posts_with_ascending_default_order).find(id).posts_with_ascending_default_order.map(&:id)
+    assert_equal expected, Author.includes(:posts_with_ascending_default_order).find(id).posts_with_ascending_default_order.map(&:id)
+  end
+
   def test_default_order_keeps_using_the_statement_cache
     author = authors(:david)
     association = author.association(:posts_with_default_order)

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -11,6 +11,7 @@ class Author < ActiveRecord::Base
   has_many :posts_sorted_by_id, -> { order(:id) }, class_name: "Post"
   has_many :posts_sorted_by_id_limited, -> { order("posts.id").limit(1) }, class_name: "Post"
   has_many :posts_with_default_order, class_name: "Post", default_order: "posts.id DESC"
+  has_many :posts_with_ascending_default_order, class_name: "Post", default_order: "posts.id ASC"
   has_many :posts_with_categories, -> { includes(:categories) }, class_name: "Post"
   has_many :posts_with_comments_and_categories, -> { includes(:comments, :categories).order("posts.id") }, class_name: "Post"
   has_many :posts_with_special_categorizations, class_name: "PostWithSpecialCategorization"


### PR DESCRIPTION
### Motivation / Background

`default_order:` is applied when the association is loaded lazily, but not when it's preloaded:

```ruby
class Author < ApplicationRecord
  has_many :posts, default_order: "posts.id ASC"
end

author.posts.map(&:id)                                     # => [1, 2, 4, 5, 6]
Author.preload(:posts).find(author.id).posts.map(&:id)     # => [6, 5, 4, 2, 1]
```

The lambda form (`-> { default_order(...) }`) is applied on both paths, so the two forms the CHANGELOG presents as equivalent aren't.

Same class of gap as #57632 and #57538.

### Detail

`AssociationReflection#join_scopes` only returned a scope when the association had a lambda, so the option never reached the preloader. It now returns one carrying the option too. `:default_order` is in `Relation::VALUE_METHODS`, so the merges in `Preloader::Association` and `Preloader::Branch` pick it up.

The override is on `AssociationReflection` and not `AbstractReflection` because `PolymorphicReflection` inherits from the latter and has no `options`.

### Additional information

Ordering is still not applied on the JOIN path, but that's true of the lambda form as well, so both forms now behave the same. `has_many :through` with `default_order:` on the source is also still unordered when preloaded, unchanged here.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
