### PR TITLE
Introduce CoW when adding Active Record reflections

### DIFF
--- a/activerecord/lib/active_record/associations/builder/association.rb
+++ b/activerecord/lib/active_record/associations/builder/association.rb
@@ -52,7 +52,8 @@ module ActiveRecord::Associations::Builder # :nodoc:
 
     def self.build_scope(scope)
       if scope && scope.arity == 0
-        proc { instance_exec(&scope) }
+        scope_body = ActiveSupport::Ractors.try_shareable_proc(scope)
+        proc { instance_exec(&scope_body) }
       else
         scope
       end

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -578,6 +578,12 @@ module ActiveRecord
         end
       end
 
+      def make_reflections_shareable! # :nodoc:
+        ActiveSupport::Ractors.try_make_shareable(aggregate_reflections)
+        ActiveSupport::Ractors.try_make_shareable(_reflections)
+        normalized_reflections
+      end
+
       protected
         def initialize_load_schema_monitor
           @load_schema_monitor = Monitor.new

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -8,8 +8,8 @@ module ActiveRecord
     extend ActiveSupport::Concern
 
     included do
-      class_attribute :_reflections, instance_writer: false, default: {}
-      class_attribute :aggregate_reflections, instance_writer: false, default: {}
+      class_attribute :_reflections, instance_writer: false, default: {}.freeze
+      class_attribute :aggregate_reflections, instance_writer: false, default: {}.freeze
       class_attribute :automatic_scope_inversing, instance_writer: false, default: false
       class_attribute :automatically_invert_plural_associations, instance_writer: false, default: false
     end
@@ -23,11 +23,11 @@ module ActiveRecord
       def add_reflection(ar, name, reflection)
         ar.clear_reflections_cache
         name = name.to_sym
-        ar._reflections = ar._reflections.except(name).merge!(name => reflection)
+        ar._reflections = ar._reflections.except(name).merge!(name => reflection).freeze
       end
 
       def add_aggregate_reflection(ar, name, reflection)
-        ar.aggregate_reflections = ar.aggregate_reflections.merge(name.to_sym => reflection)
+        ar.aggregate_reflections = ar.aggregate_reflections.merge(name.to_sym => reflection).freeze
       end
 
       private
@@ -163,7 +163,6 @@ module ActiveRecord
     class AbstractReflection # :nodoc:
       def initialize
         @class_name = nil
-        @counter_cache_column = nil
         @inverse_of = nil
         @inverse_which_updates_counter_cache_defined = false
         @inverse_which_updates_counter_cache = nil
@@ -245,9 +244,10 @@ module ActiveRecord
       end
 
       def counter_cache_column
-        @counter_cache_column ||= begin
-          counter_cache = options[:counter_cache]
+        return @counter_cache_column if defined?(@counter_cache_column)
 
+        counter_cache = options[:counter_cache]
+        @counter_cache_column =
           if belongs_to?
             if counter_cache
               counter_cache[:column] || -"#{active_record.name.demodulize.underscore.pluralize}_count"
@@ -255,7 +255,6 @@ module ActiveRecord
           else
             -((counter_cache && counter_cache[:column]) || "#{name}_count")
           end
-        end
       end
 
       def inverse_of
@@ -423,19 +422,21 @@ module ActiveRecord
       # a new association object. Use +build_association+ or +create_association+
       # instead. This allows plugins to hook into association object creation.
       def klass
-        @klass ||= _klass(class_name)
+        _klass(class_name)
       end
 
       def _klass(class_name) # :nodoc:
-        if active_record.name.demodulize == class_name
-          begin
-            return compute_class("::#{class_name}")
-          rescue
-            # Ignored
+        @klass ||= begin
+          if active_record.name.demodulize == class_name
+            begin
+              return compute_class("::#{class_name}")
+            rescue
+              # Ignored
+            end
           end
-        end
 
-        compute_class(class_name)
+          compute_class(class_name)
+        end
       end
 
       def compute_class(name)
@@ -488,6 +489,12 @@ module ActiveRecord
       def mapping
         mapping = options[:mapping] || [name, name]
         mapping.first.is_a?(Array) ? mapping : [mapping]
+      end
+
+      def freeze
+        klass
+
+        super
       end
     end
 
@@ -552,6 +559,27 @@ module ActiveRecord
         @deprecated = !!options[:deprecated]
 
         ensure_option_not_given_as_class!(:class_name)
+      end
+
+      def freeze
+        return self if frozen?
+
+        unless polymorphic?
+          klass
+          join_primary_key
+          inverse_of
+          inverse_which_updates_counter_cache
+        end
+
+        join_foreign_key
+        active_record_primary_key
+        association_foreign_key
+        counter_cache_column
+        foreign_key
+        check_validity!
+        @scope = ActiveSupport::Ractors.try_shareable_proc(@scope) if @scope
+
+        super
       end
 
       def association_scope_cache(klass, owner, &block)
@@ -1009,6 +1037,22 @@ module ActiveRecord
 
       def klass
         @klass ||= delegate_reflection._klass(class_name)
+      end
+
+      def freeze
+        return self if frozen?
+
+        klass
+        source_reflection_name
+        association_primary_key
+        foreign_key
+        active_record_primary_key
+        association_foreign_key
+        inverse_which_updates_counter_cache
+        deprecated_nested_reflections
+        check_validity!
+
+        super
       end
 
       # Returns the source of the through reflection. It checks both a singularized

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "cases/helper"
+require "active_support/core_ext/object/with"
 require "models/topic"
 require "models/customer"
 require "models/comment"
@@ -14,6 +15,7 @@ require "models/author"
 require "models/organization"
 require "models/post"
 require "models/tagging"
+require "models/categorization"
 require "models/category"
 require "models/book"
 require "models/subscriber"
@@ -260,6 +262,75 @@ class ReflectionTest < ActiveRecord::TestCase
     assert_equal Address, Customer.reflect_on_aggregation(:address).klass
 
     assert_equal Money, Customer.reflect_on_aggregation(:balance).klass
+  end
+
+  def test_reflection_hashes_are_frozen
+    assert_predicate Topic.aggregate_reflections, :frozen?
+    assert_predicate Customer.aggregate_reflections, :frozen?
+    assert_predicate Topic._reflections, :frozen?
+  end
+
+  if RUBY_VERSION >= "4.0"
+    def test_association_reflections_can_be_read_from_a_ractor_in_ractor_mode
+      ActiveSupport::Ractors.with(unshareable_proc_action: :raise) do
+        Categorization.make_reflections_shareable!
+
+        assert Ractor.shareable?(Categorization._reflections)
+
+        result = Ractor.new do
+          belongs_to = Categorization.reflect_on_association(:category)
+          through = Categorization.reflect_on_association(:post_taggings)
+
+          [
+            belongs_to.klass.name,
+            belongs_to.foreign_key,
+            belongs_to.inverse_of.name,
+            belongs_to.counter_cache_column,
+            through.through_reflection?,
+            through.klass.name,
+          ]
+        end.value
+
+        assert_equal(
+          ["Category", "category_id", :categorizations, "categorizations_count", true, "Tagging"],
+          result
+        )
+      end
+    ensure
+      Categorization.reset_column_information
+    end
+
+    def test_aggregate_reflections_can_be_read_from_a_ractor_in_ractor_mode
+      ActiveSupport::Ractors.with(unshareable_proc_action: :raise) do
+        Customer.make_reflections_shareable!
+
+        assert Ractor.shareable?(Customer.aggregate_reflections)
+
+        mapping, klass_name = Ractor.new do
+          reflection = Customer.reflect_on_aggregation(:balance)
+          [reflection.mapping, reflection.klass.name]
+        end.value
+
+        assert_equal [[:balance, :amount]], mapping
+        assert_equal "Money", klass_name
+      end
+    ensure
+      Customer.reset_column_information
+    end
+
+    def test_association_scopes_are_shareable_and_readable_from_a_ractor_in_ractor_mode
+      model = Class.new(ActiveRecord::Base) do
+        set_temporary_name "ractor_scoped_model"
+        self.table_name = "posts"
+        belongs_to :parent, ->(record) { order(:id) }, anonymous_class: self, foreign_key: "author_id", optional: true
+      end
+
+      ActiveSupport::Ractors.with(unshareable_proc_action: :raise) do
+        model.make_reflections_shareable!
+
+        assert Ractor.shareable?(model.reflect_on_association(:parent).scope)
+      end
+    end
   end
 
   def test_reflect_on_all_autosave_associations

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -681,6 +681,10 @@ module Rails
         end
       end
 
+      if defined?(ActiveRecord::Base)
+        ActiveRecord::Base.descendants.each(&:make_reflections_shareable!)
+      end
+
       Ractor.make_shareable(self)
       Ractor.make_shareable(Rails.event)
       Ractor.make_shareable(Rails.error)

--- a/railties/test/application/ractors_test.rb
+++ b/railties/test/application/ractors_test.rb
@@ -92,6 +92,38 @@ if RUBY_VERSION >= "4.0" && ENV["RACK"] == "head"
         end
       end
 
+      test "ractorize! makes model reflections Ractor-shareable" do
+        app_file "app/models/post.rb", <<~RUBY
+          class Post < ActiveRecord::Base
+            has_one :comment
+          end
+        RUBY
+        app_file "app/models/comment.rb", <<~RUBY
+          class Comment < ActiveRecord::Base
+            belongs_to :post
+          end
+        RUBY
+        app_file "config/initializers/active_record.rb", <<~RUBY
+          ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+          ActiveRecord::Migration.verbose = false
+          ActiveRecord::Schema.define(version: 1) do
+            create_table :posts
+            create_table :comments do |t|
+              t.belongs_to :post
+            end
+          end
+          ActiveRecord::Base.schema_cache.add("posts")
+          ActiveRecord::Base.schema_cache.add("comments")
+        RUBY
+
+        app "production"
+
+        ractorize!
+
+        assert Ractor.shareable?(Post._reflections)
+        assert_equal "Comment", on_ractor { Post.reflect_on_association(:comment).klass.name }
+      end
+
       private
         def ractorize!
           @original_experimental_warning = Warning[:experimental]


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because we can't run `Post.find` , `Post.where`  etc.. inside a Ractor due to the reflection cache that's not frozen.

### Detail

We need to make Reflection ractor safe and freeze the cache that holds those reflections.
This patch deep freeze the reflection and the aggregated reflection one.

The fixes are somewhat similar to other Ractor safety problems we encountered and we need to eager load otherwise lazily memoized values before freezing (there is a lot of them).

There is one memoization that moved from one method to another, and I explained in details why in the commit message.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc/ @gmcgibbon @skipkayhil @etiennebarrie 
