### PR TITLE
Fix broken link to Redirecting Requests in layouts_and_rendering.md

### DIFF
--- a/guides/source/layouts_and_rendering.md
+++ b/guides/source/layouts_and_rendering.md
@@ -517,7 +517,8 @@ header:
 render plain: "Redirecting...", location: root_path, status: :see_other
 ```
 
-WARNING: While this is valid code, using [`redirect_to`](#redirecting-requests)
+WARNING: While this is valid code, using
+[`redirect_to`](action_controller_overview.html#redirecting-requests)
 is the canonical way to send redirect responses in Rails.
 
 #### `status:`


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `rake guides:lint` fails on main since #57152. The rewritten Layouts and Rendering guide links to the `#redirecting-requests` anchor within the same guide, but that section only exists in `action_controller_overview.md`:

```
[WARN] BROKEN LINK(s): layouts_and_rendering.md: #redirecting-requests
```

https://buildkite.com/rails/rails/builds/133214#01a06ba2-b1f3-4495-9fd1-7c950739dc7c

### Detail

This Pull Request changes the link to point at `action_controller_overview.html#redirecting-requests`, matching the existing cross-guide link later in the same file.

### Additional information

Verified locally: `rake guides:lint:check_links` and `rake guides:lint:mdl` both exit 0 with this change.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
