### PR TITLE
Preserve shared primary key columns when nullifying on destroy

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -111,9 +111,12 @@
 
     Previously, assigning `nil` preserved every foreign key column in these
     cases. Shared columns are now preserved only when the foreign key has
-    another column that can be nulled instead.
+    another column that can be nulled instead. The same applies to `has_one`
+    and `has_many` associations declared with `dependent: :nullify` when the
+    owner is destroyed, which nulled the shared columns and left the record
+    with an incomplete primary key.
 
-    *Matthew Draper*
+    *Matthew Draper*, *Carlos Daniel Pohlod*
 
 *   `ActiveRecord::Relation#update` and `#update!` no longer escape the relation
     when given ids.

--- a/activerecord/lib/active_record/associations/foreign_association.rb
+++ b/activerecord/lib/active_record/associations/foreign_association.rb
@@ -13,8 +13,18 @@ module ActiveRecord::Associations
     end
 
     def nullified_owner_attributes
+      primary_key = ActiveRecord::Key.for(reflection.klass.primary_key)
+      foreign_key = ActiveRecord::Key.for(reflection.foreign_key)
+
+      # Preserve shared primary key columns only if another foreign key
+      # column can be cleared to disassociate the record.
+      preserve_primary_key = foreign_key.any? { |key| !primary_key.include?(key) }
+
       Hash.new.tap do |attrs|
-        ActiveRecord::Key.for(reflection.foreign_key).each { |foreign_key| attrs[foreign_key] = nil }
+        foreign_key.each do |foreign_key_column|
+          next if preserve_primary_key && primary_key.include?(foreign_key_column)
+          attrs[foreign_key_column] = nil
+        end
         attrs[reflection.type] = nil if reflection.type.present?
       end
     end

--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -117,18 +117,9 @@ module ActiveRecord
         end
 
         def nullify_owner_attributes(record)
-          primary_key = ActiveRecord::Key.for(record.class.primary_key)
-          foreign_key = ActiveRecord::Key.for(reflection.foreign_key)
-
-          # Preserve shared primary key columns only if another foreign key
-          # column can be cleared to disassociate the record.
-          preserve_primary_key = foreign_key.any? { |key| !primary_key.include?(key) }
-
-          foreign_key.each do |foreign_key_column|
-            next if preserve_primary_key && primary_key.include?(foreign_key_column)
-            record.write_attribute(foreign_key_column, nil)
+          nullified_owner_attributes.each do |attribute, value|
+            record.write_attribute(attribute, value)
           end
-          record.write_attribute(reflection.type, nil) if reflection.type.present?
         end
 
         def transaction_if(value, &block)

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -670,6 +670,18 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal firm.limited_clients.length, firm.limited_clients.count
   end
 
+  def test_nullification_on_cpk_association_with_pk_column_when_owner_is_destroyed
+    chapter = Cpk::Chapter.create!(id: [1, 2])
+    book = Cpk::NullifiedBookWithChapters.create!(id: [1, 3])
+    book.chapters << chapter
+
+    book.destroy
+
+    chapter.reload
+    assert_nil chapter.book_id
+    assert_equal 1, chapter.author_id
+  end
+
   def test_default_order
     post = posts(:welcome)
 

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -221,6 +221,17 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     assert_equal 1, chapter.author_id
   end
 
+  def test_nullification_on_cpk_association_with_pk_column_when_owner_is_destroyed
+    chapter = Cpk::Chapter.create!(id: [1, 2])
+    book = Cpk::NullifiedBook.create!(id: [1, 3], chapter: chapter)
+
+    book.destroy
+
+    chapter.reload
+    assert_nil chapter.book_id
+    assert_equal 1, chapter.author_id
+  end
+
   def test_has_one_for_new_record_owner_with_composite_primary_key_present
     order = Cpk::Order.create!(id: [1, 10])
     book = order.create_book!(id: [1, 100], title: "Some book")

--- a/activerecord/test/models/cpk/book.rb
+++ b/activerecord/test/models/cpk/book.rb
@@ -50,6 +50,10 @@ module Cpk
     has_one :chapter, foreign_key: [:author_id, :book_id], dependent: :nullify
   end
 
+  class NullifiedBookWithChapters < Book
+    has_many :chapters, class_name: "Cpk::Chapter", foreign_key: [:author_id, :book_id], dependent: :nullify
+  end
+
   class BookWithOrderAgreements < Book
     has_many :order_agreements, through: :order
     has_one :order_agreement, through: :order, source: :order_agreements


### PR DESCRIPTION
### Motivation / Background

`dependent: :nullify` nulls every foreign key column, so when the foreign key overlaps the child's own primary key the child is left unfindable:

```ruby
chapter = Cpk::Chapter.create!(id: [1, 2])          # primary key [:author_id, :id]
book = Cpk::NullifiedBook.create!(id: [1, 3], chapter: chapter)

book.destroy
chapter.reload   # ActiveRecord::RecordNotFound
```

cda4a97fa8 fixed this for the assignment path (`book.chapter = other`), putting the guard in `HasOneAssociation#nullify_owner_attributes`. Destroying the owner goes through `ForeignAssociation#nullified_owner_attributes` instead, which had no guard, and which `has_many` uses as well.

### Detail

The guard moves to `nullified_owner_attributes`, and the assignment path delegates to it, so `has_one` on assign, `has_one` on destroy and `has_many` on destroy share one implementation.

`has_many :through` with `dependent: :nullify` nulls source foreign keys through a separate path and still has the same problem. Left out here.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
