### PR TITLE
Fix grouped relation cache versions

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix grouped relation cache versions to count every group and use the newest
+    grouped timestamp.
+
+    *Ousama Benyounes*
+
 *   Re-enable PostgreSQL triggers when the block given to `disable_referential_integrity` raises.
 
     On PostgreSQL versions without `NOT ENFORCED` constraints (before 18.4), the

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -498,7 +498,14 @@ module ActiveRecord
           column = c.visitor.compile(table[timestamp_column])
           select_values = "COUNT(*) AS #{model.adapter_class.quote_column_name("size")}, MAX(%s) AS timestamp"
 
-          if collection.has_limit_or_offset?
+          if collection.group_values.any?
+            query = collection.distinct(false)
+            query = query.unscope(:select, :order) unless collection.has_limit_or_offset?
+            query._select!("MAX(#{column}) AS collection_cache_key_timestamp")
+            subquery_alias = "subquery_for_cache_key"
+            subquery_column = "#{subquery_alias}.collection_cache_key_timestamp"
+            arel = query.build_subquery(subquery_alias, select_values % subquery_column)
+          elsif collection.has_limit_or_offset?
             query = collection.select("#{column} AS collection_cache_key_timestamp")
             query._select!(table[Arel.star]) if distinct_value && collection.select_values.empty?
             subquery_alias = "subquery_for_cache_key"

--- a/activerecord/test/cases/collection_cache_key_test.rb
+++ b/activerecord/test/cases/collection_cache_key_test.rb
@@ -278,6 +278,32 @@ module ActiveRecord
       end
     end
 
+    test "cache_version for grouped relation" do
+      with_collection_cache_versioning do
+        Developer.delete_all
+        developers = %w[Alpha Beta Beta].map { |name| Developer.create!(name: name) }
+        first_developer_timestamp = 1.second.from_now
+        last_developer_timestamp = 2.seconds.from_now
+        developers.first.update!(updated_at: first_developer_timestamp)
+        developers.last.update!(updated_at: last_developer_timestamp)
+
+        relation = Developer.select("name AS developer_name").distinct.group(:name).order("developer_name DESC")
+        cache_version = relation.cache_version
+        match = /(\d+)-(\d+)\z/.match(cache_version)
+
+        assert_not_nil match
+        assert_equal developers.map(&:name).uniq.size.to_s, match[1]
+        assert_equal last_developer_timestamp.to_fs(ActiveRecord::Base.cache_timestamp_format), match[2]
+
+        limited_cache_version = relation.limit(1).cache_version
+        limited_match = /(\d+)-(\d+)\z/.match(limited_cache_version)
+
+        assert_not_nil limited_match
+        assert_equal 1.to_s, limited_match[1]
+        assert_equal last_developer_timestamp.to_fs(ActiveRecord::Base.cache_timestamp_format), limited_match[2]
+      end
+    end
+
     test "reset will reset cache_version" do
       with_collection_cache_versioning do
         developers = Developer.all


### PR DESCRIPTION
### Motivation / Background

This Pull Request fixes grouped relation cache versions for `ActiveRecord::Relation#cache_version` and `cache_key`.

Fix #51399

When an unloaded relation has `GROUP BY`, the cache version query returns one row per group. Active Record was reading only the first row, so the version could report one group and the first group's timestamp instead of the grouped relation's full count and newest timestamp.

### Detail

This Pull Request changes grouped relation cache version calculation to aggregate each group in a subquery, then count and timestamp that subquery.

For grouped relations without `LIMIT` or `OFFSET`, the cache-version subquery removes unrelated `SELECT`, `ORDER`, and `DISTINCT` clauses before aggregating group timestamps. For grouped relations with `LIMIT` or `OFFSET`, it preserves the ordered subset so the cache version still describes the same grouped rows as the relation.

A regression test covers a grouped relation with a selected alias, `DISTINCT`, ordering, duplicate group values, and `LIMIT`.

### Additional information

RED / GREEN verification:

```text
RED on upstream main with the new test:
Failure:
ActiveRecord::CollectionCacheKeyTest#test_cache_version_for_grouped_relation [test/cases/collection_cache_key_test.rb:295]:
--- expected
+++ actual
@@ -1,3 +1 @@
-"2"
+"1"

1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
```

```text
GREEN with this change:
1 runs, 6 assertions, 0 failures, 0 errors, 0 skips
```

Full local suite:

```text
Local Active Record cache-key test file:
34 runs, 85 assertions, 0 failures, 0 errors, 0 skips
```

```text
Baseline on upstream main for the same file:
33 runs, 79 assertions, 0 failures, 0 errors, 0 skips
```

```text
RuboCop:
2 files inspected, no offenses detected
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
