### PR TITLE
Fix docker-entrypoint check to support extra bin/rails server flags

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/docker-entrypoint.tt
+++ b/railties/lib/rails/generators/rails/app/templates/docker-entrypoint.tt
@@ -2,7 +2,7 @@
 
 <% unless skip_active_record? -%>
 # If running the rails server then create or migrate existing database
-if [ "${@: -2:1}" == "./bin/rails" ] && [ "${@: -1:1}" == "server" ]; then
+if [ "${1}" == "./bin/rails" ] && [ "${2}" == "server" ]; then
   ./bin/rails db:prepare
 fi
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1468,6 +1468,23 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_file "bin/docker-entrypoint"
   end
 
+  def test_docker_entrypoint_checks_first_two_arguments_so_extra_server_flags_still_trigger_db_prepare
+    run_generator
+
+    assert_file "bin/docker-entrypoint" do |content|
+      assert_match(/if \[ "\$\{1\}" == "\.\/bin\/rails" \] && \[ "\$\{2\}" == "server" \]; then/, content)
+      assert_no_match(/\$\{@: -2:1\}|\$\{@: -1:1\}/, content)
+    end
+  end
+
+  def test_docker_entrypoint_omits_db_prepare_check_when_skipping_active_record
+    run_generator [destination_root, "--skip-active-record"]
+
+    assert_file "bin/docker-entrypoint" do |content|
+      assert_no_match(/db:prepare/, content)
+    end
+  end
+
   def test_env
     run_generator
 


### PR DESCRIPTION
### Problem

The generated `bin/docker-entrypoint` script only runs `db:prepare` when
`./bin/rails` and `server` are exactly the last two arguments:

    if [ "${@: -2:1}" == "./bin/rails" ] && [ "${@: -1:1}" == "server" ]; then

Passing any additional flag to the server (e.g. `-b 0.0.0.0`, needed to
bind to all interfaces under Docker/Podman) shifts `server` out of that
position, so the check silently fails and the database is never prepared.

### Fix

Check the first two arguments instead of the last two, since Docker's
`CMD ["./bin/rails", "server"]` convention always places them first,
regardless of any flags appended afterward:

    if [ "${1}" == "./bin/rails" ] && [ "${2}" == "server" ]; then

### Tests

Added two tests to `app_generator_test.rb` asserting the generated script
checks the first two arguments (and doesn't regress to the old form), and
that `--skip-active-record` still correctly omits the `db:prepare` check.

Fixes #58652