### PR TITLE
Restrict If-None-Match wildcard matching to standalone values

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Match `If-None-Match` wildcards only when the entire header value is `*`.
+
+    A nonmatching quoted ETag such as `"foo,*,bar"` no longer produces a
+    `304 Not Modified` response.
+
+    *Marcelo Trylesinski*
+
 *   Check `PATCH` and `QUERY` in `assert_recognizes` and `assert_routing` with `method: :all`.
 
     Both assertions only recognized the path for `GET`, `POST`, `PUT` and

--- a/actionpack/lib/action_dispatch/http/cache.rb
+++ b/actionpack/lib/action_dispatch/http/cache.rb
@@ -35,8 +35,7 @@ module ActionDispatch
 
         def etag_matches?(etag)
           if etag
-            validators = if_none_match_etags
-            validators.include?(etag) || validators.include?("*")
+            if_none_match&.strip == "*" || if_none_match_etags.include?(etag)
           end
         end
 

--- a/actionpack/test/controller/api/conditional_get_test.rb
+++ b/actionpack/test/controller/api/conditional_get_test.rb
@@ -64,6 +64,13 @@ class ConditionalGetApiTest < ActionController::TestCase
     assert_response :not_modified
   end
 
+  def test_if_none_match_contains_asterisk_in_quoted_etag
+    @request.if_none_match = '"foo,*,bar"'
+    get :one
+    assert_response :success
+    assert_equal "Hi!", @response.body
+  end
+
   def test_etag_matches
     @request.if_none_match = weak_etag([:foo, 123])
     get :one


### PR DESCRIPTION
Conditional GET requests with `If-None-Match: "foo,*,bar"` currently receive `304 Not Modified` even when the response ETag does not match. Splitting the quoted ETag on commas produces a standalone `*`, which is incorrectly treated as a wildcard and suppresses the response body.

Recognize the wildcard only when the entire header value, after stripping surrounding whitespace, is `*`. This follows [RFC 9110 §13.1.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.2). Add one controller regression test that fails with `304` before the change and passes with `200` and the expected body afterward.

Validation: 217 tests and 726 assertions passed across the conditional GET, caching, request, and Rack cache test files; RuboCop passed for both changed Ruby files. The full Action Pack run was blocked by missing Selenium drivers; a run excluding browser tests hit a Ruby 4.0.5 VM crash (`should have cvar cache entry` in `i18n/config.rb`).

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
