### PR TITLE
Match Rack::BadRequest errors in ActionDispatch::ParamError

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Raise `ActionController::BadRequest` for every `Rack::BadRequest` error raised while parsing request parameters.
+
+    `ActionDispatch::Request#POST` only converted three explicit Rack errors into
+    `ActionController::BadRequest`. Other malformed-body errors that Rack tags with
+    `Rack::BadRequest`, such as `Rack::Multipart::BoundaryTooLongError` or
+    `Rack::Multipart::MultipartPartLimitError`, escaped as 500s instead of 400s.
+
+    *Navid Emad*
+
 *   Check `PATCH` and `QUERY` in `assert_recognizes` and `assert_routing` with `method: :all`.
 
     Both assertions only recognized the path for `GET`, `POST`, `PUT` and

--- a/actionpack/lib/action_dispatch/http/param_error.rb
+++ b/actionpack/lib/action_dispatch/http/param_error.rb
@@ -8,6 +8,9 @@ module ActionDispatch
 
     def self.===(other)
       super || (
+        # Rack >= 3.1 tags every request-parsing error with Rack::BadRequest;
+        # the explicit classes keep Rack 3.0 working.
+        defined?(Rack::BadRequest) && Rack::BadRequest === other ||
         defined?(Rack::Utils::ParameterTypeError) && Rack::Utils::ParameterTypeError === other ||
         defined?(Rack::Utils::InvalidParameterError) && Rack::Utils::InvalidParameterError === other ||
         defined?(Rack::QueryParser::ParamsTooDeepError) && Rack::QueryParser::ParamsTooDeepError === other

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -717,6 +717,44 @@ class RequestParamsParsing < BaseRequestTest
     assert_match "Invalid request parameters:", err.message
   end
 
+  test "request_parameters raises BadRequest when the multipart boundary is too long" do
+    skip "Rack::BadRequest was introduced in Rack 3.1" unless defined?(Rack::BadRequest)
+
+    boundary = "A" * 71
+    input = "--#{boundary}\r\ncontent-disposition: form-data; name=\"foo\"\r\n\r\nbar\r\n--#{boundary}--\r\n"
+    request = stub_request(
+      "CONTENT_TYPE" => "multipart/form-data; boundary=#{boundary}",
+      "CONTENT_LENGTH" => input.bytesize.to_s,
+      "REQUEST_METHOD" => "PUT",
+      :input => input
+    )
+
+    err = assert_raises(ActionController::BadRequest) do
+      request.request_parameters
+    end
+
+    assert_match "Invalid request parameters: multipart boundary size too large", err.message
+  end
+
+  test "request_parameters raises BadRequest when the multipart file limit is exceeded" do
+    skip "Rack::BadRequest was introduced in Rack 3.1" unless defined?(Rack::BadRequest)
+
+    parts = (Rack::Utils.multipart_file_limit + 1).times.map do |i|
+      "--AaB03x\r\ncontent-disposition: form-data; name=\"f#{i}\"; filename=\"f#{i}\"\r\ncontent-type: text/plain\r\n\r\nx\r\n"
+    end
+    input = parts.join + "--AaB03x--\r\n"
+    request = stub_request(
+      "CONTENT_TYPE" => "multipart/form-data; boundary=AaB03x",
+      "CONTENT_LENGTH" => input.bytesize.to_s,
+      "REQUEST_METHOD" => "POST",
+      :input => input
+    )
+
+    assert_raises(ActionController::BadRequest) do
+      request.request_parameters
+    end
+  end
+
   test "request_parameters raises BadRequest when content length is higher than actual data length" do
     request = stub_request(
       "CONTENT_TYPE" => "multipart/form-data; boundary=AaB03x",

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -717,41 +717,40 @@ class RequestParamsParsing < BaseRequestTest
     assert_match "Invalid request parameters:", err.message
   end
 
-  test "request_parameters raises BadRequest when the multipart boundary is too long" do
-    skip "Rack::BadRequest was introduced in Rack 3.1" unless defined?(Rack::BadRequest)
+  # Rack::BadRequest was introduced in Rack 3.1
+  if defined?(Rack::BadRequest)
+    test "request_parameters raises BadRequest when the multipart boundary is too long" do
+      boundary = "A" * 71
+      input = "--#{boundary}\r\ncontent-disposition: form-data; name=\"foo\"\r\n\r\nbar\r\n--#{boundary}--\r\n"
+      request = stub_request(
+        "CONTENT_TYPE" => "multipart/form-data; boundary=#{boundary}",
+        "CONTENT_LENGTH" => input.bytesize.to_s,
+        "REQUEST_METHOD" => "PUT",
+        :input => input
+      )
 
-    boundary = "A" * 71
-    input = "--#{boundary}\r\ncontent-disposition: form-data; name=\"foo\"\r\n\r\nbar\r\n--#{boundary}--\r\n"
-    request = stub_request(
-      "CONTENT_TYPE" => "multipart/form-data; boundary=#{boundary}",
-      "CONTENT_LENGTH" => input.bytesize.to_s,
-      "REQUEST_METHOD" => "PUT",
-      :input => input
-    )
+      err = assert_raises(ActionController::BadRequest) do
+        request.request_parameters
+      end
 
-    err = assert_raises(ActionController::BadRequest) do
-      request.request_parameters
+      assert_match "Invalid request parameters: multipart boundary size too large", err.message
     end
 
-    assert_match "Invalid request parameters: multipart boundary size too large", err.message
-  end
+    test "request_parameters raises BadRequest when the multipart file limit is exceeded" do
+      parts = (Rack::Utils.multipart_file_limit + 1).times.map do |i|
+        "--AaB03x\r\ncontent-disposition: form-data; name=\"f#{i}\"; filename=\"f#{i}\"\r\ncontent-type: text/plain\r\n\r\nx\r\n"
+      end
+      input = parts.join + "--AaB03x--\r\n"
+      request = stub_request(
+        "CONTENT_TYPE" => "multipart/form-data; boundary=AaB03x",
+        "CONTENT_LENGTH" => input.bytesize.to_s,
+        "REQUEST_METHOD" => "POST",
+        :input => input
+      )
 
-  test "request_parameters raises BadRequest when the multipart file limit is exceeded" do
-    skip "Rack::BadRequest was introduced in Rack 3.1" unless defined?(Rack::BadRequest)
-
-    parts = (Rack::Utils.multipart_file_limit + 1).times.map do |i|
-      "--AaB03x\r\ncontent-disposition: form-data; name=\"f#{i}\"; filename=\"f#{i}\"\r\ncontent-type: text/plain\r\n\r\nx\r\n"
-    end
-    input = parts.join + "--AaB03x--\r\n"
-    request = stub_request(
-      "CONTENT_TYPE" => "multipart/form-data; boundary=AaB03x",
-      "CONTENT_LENGTH" => input.bytesize.to_s,
-      "REQUEST_METHOD" => "POST",
-      :input => input
-    )
-
-    assert_raises(ActionController::BadRequest) do
-      request.request_parameters
+      assert_raises(ActionController::BadRequest) do
+        request.request_parameters
+      end
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

`ActionDispatch::Request#POST` converts `ActionDispatch::ParamError` into `ActionController::BadRequest`, but `ParamError.===` only matched three explicit Rack error classes (`ParameterTypeError`, `InvalidParameterError`, `ParamsTooDeepError`). Other malformed-body errors that Rack ≥ 3.1 tags with the `Rack::BadRequest` marker module, such as `Rack::Multipart::BoundaryTooLongError` or `Rack::Multipart::MultipartPartLimitError`, escaped as 500s instead of 400s.

We hit this in production: a `PUT`/`PATCH` `multipart/form-data` request with a boundary longer than 70 characters raises `BoundaryTooLongError` at the first `params` access in the controller. `ExceptionWrapper.rescue_responses` has no entry for it, so the client gets a 500 for what is a malformed request.

### Detail

`ParamError.===` now also matches `Rack::BadRequest` when it is defined. The explicit classes are kept because Rails still supports Rack 3.0, which predates the marker module.

### Additional information

Two tests in `test/dispatch/request_test.rb` (boundary too long on `PUT`, `multipart_file_limit` exceeded), only defined on Rack >= 3.1, where `Rack::BadRequest` exists. Both fail on `main` and pass with this change. `test/dispatch/request*`, `debug_exceptions_test` and `show_exceptions_test`: 298 runs, 0 failures.

Companion Rack change so that `Rack::MethodOverride` stops letting the same errors escape on `POST`: https://github.com/rack/rack/pull/2505.

### Checklist

- [x] This PR is a fix
- [x] Tests are included
- [x] CHANGELOG entry added (actionpack)

