### PR TITLE
Use Regexp#source instead of Regexp#to_s to detect deep filters

### DIFF
--- a/activesupport/lib/active_support/parameter_filter.rb
+++ b/activesupport/lib/active_support/parameter_filter.rb
@@ -111,7 +111,7 @@ module ActiveSupport
         when Proc
           (@blocks ||= []) << item
         when Regexp
-          if item.to_s.include?("\\.")
+          if item.source.include?("\\.")
             (@deep_regexps ||= []) << item
           elsif (literal = extract_exact_string_key(item))
             (@exact_string_keys ||= {})[literal] = true


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

While profiling ruby-bench's railsbench I noticed a non-trivial amount of time is spent in `Regexp#to_s`, which seems unexpected on the fast path.
Using `Regexp#source` is an easy fix, as that just returns an existing String, vs computing a new one.

`Regexp#source` and `Regexp#to_s` both work fine for the purpose of detecting `"\\."`, which is what is done here.

### Detail

The performance difference on micro benchmarks is clear:
benchmark-ips on the two Regexps Rails precompiles for railsbench's `config.filter_parameters`, Ruby 4.0.6 YJIT, both Regexps per iteration:

    Regexp#source:  8781.2k i/s
      Regexp#to_s:   347.3k i/s - 25.29x slower

    source.include?("\\."):  2533.8k i/s
      to_s.include?("\\."):   297.4k i/s - 8.52x slower

On railsbench this means about ~4.2us of each request is spent on `Regexp#to_s`.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
