### PR TITLE
Avoid quadratic lookups when replacing a collection association

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Avoid quadratic lookups when replacing records in a collection association.
+
+    *Denis Levenko*
+
 *   Re-enable PostgreSQL triggers when the block given to `disable_referential_integrity` raises.
 
     On PostgreSQL versions without `NOT ENFORCED` constraints (before 18.4), the

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -422,9 +422,18 @@ module ActiveRecord
 
         def replace_common_records_in_memory(new_target, original_target)
           common_records = intersection(new_target, original_target)
+          return if common_records.empty?
+
+          # Avoid scanning the target for every common record. Keep the first
+          # index for equal records to match Array#index.
+          target_index = {}
+          @target.each_with_index do |record, index|
+            target_index[record] = index unless target_index.key?(record)
+          end
+
           common_records.each do |record|
             skip_callbacks = true
-            replace_on_target(record, skip_callbacks, replace: true)
+            replace_on_target(record, skip_callbacks, replace: true, target_index: target_index)
           end
         end
 
@@ -447,9 +456,13 @@ module ActiveRecord
           records
         end
 
-        def replace_on_target(record, skip_callbacks, replace:, inversing: false)
+        def index_on_target(record, target_index)
+          target_index ? target_index[record] : @target.index(record)
+        end
+
+        def replace_on_target(record, skip_callbacks, replace:, inversing: false, target_index: nil)
           if replace && (!record.new_record? || @replaced_or_added_targets.include?(record))
-            index = @target.index(record)
+            index = index_on_target(record, target_index)
           end
 
           catch(:abort) do
@@ -463,7 +476,7 @@ module ActiveRecord
           yield(record) if block_given?
 
           if !index && @replaced_or_added_targets.include?(record)
-            index = @target.index(record)
+            index = index_on_target(record, target_index)
           end
 
           @replaced_or_added_targets << record if inversing || index || record.new_record?

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2170,6 +2170,51 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal [], firm.public_send("clients=", [])
   end
 
+  def test_replace_with_equal_but_distinct_instances_replaces_them_in_place
+    firm = companies(:first_firm)
+    firm.clients.load
+    originals = firm.clients.to_a
+    assert_operator originals.length, :>, 1
+
+    fresh = originals.map { |client| Client.find(client.id) }
+    firm.clients = fresh
+
+    target = firm.association(:clients).target
+    assert_equal originals.map(&:id), target.map(&:id)
+    target.each_with_index do |record, index|
+      assert_same fresh[index], record
+    end
+  end
+
+  def test_replace_matches_the_first_index_when_the_target_holds_equal_records
+    firm = companies(:first_firm)
+    firm.clients.load
+    association = firm.association(:clients)
+
+    first = association.target.first
+    association.target.unshift(Client.find(first.id))
+    assert_equal association.target[0], association.target[1]
+
+    replacement = Client.find(first.id)
+    association.send(:replace_common_records_in_memory, [replacement], association.target)
+
+    assert_same replacement, association.target[0], "the first equal record should have been replaced"
+    assert_same first, association.target[1], "the later equal record should have been left alone"
+  end
+
+  def test_replace_does_not_overwrite_existing_records_with_a_new_one
+    firm = companies(:first_firm)
+    firm.clients.load
+    existing = firm.clients.to_a
+    new_client = Client.new(name: "New Client")
+
+    firm.clients = existing + [new_client]
+
+    target = firm.association(:clients).target
+    assert_equal existing.map(&:id), target.first(existing.length).map(&:id)
+    assert_same new_client, target.last
+  end
+
   def test_transactions_when_replacing_on_persisted
     good = Client.new(name: "Good")
     bad  = Client.new(name: "Bad", raise_on_save: true)


### PR DESCRIPTION
### Motivation / Background

Replacing a collection association calls `Array#index` once for every record shared
by the old and the new target. Each call scans the target from the start, so
replacing a collection of n records costs `O(n**2)` comparisons.

This shows up when assigning a large collection, and in Active Storage when adding
a file to an existing `has_many_attached` collection, as reported in #50848.
#46652 suggests building a local index instead.

### Detail

`replace_common_records_in_memory` now builds a lookup of the target once and passes
it to `replace_on_target`, which uses it instead of `Array#index`.

The index lives only for that one call. It keeps the first occurrence of equal
records, matching what `Array#index` returns. Replacements assign in place, so
positions do not move, and appends only add after the first matching position, so
the index stays valid for the whole loop.

The lookup relies on Active Record's standard `hash`/`eql?` behavior, which
`intersection` already uses to select the common records, so no new assumption is
introduced. Models that override `==` need to keep `eql?` and `hash` consistent with
it; the `eql?` alias inherited from `ActiveRecord::Core` does not pick up an
override of `==`.

### Additional information

Benchmark for `owner.items = items` on this branch, Ruby 4.0.6 with SQLite, median
of 10 runs after 2 warmups:

| Records | Before | After |
| ---: | ---: | ---: |
| 100 | 5.05 ms | 1.43 ms |
| 1,000 | 381.56 ms | 14.18 ms |

Allocations at 1,000 records: 12,003 before, 12,005 after.

Three tests are added: replacement with equal but distinct instances, a target that
already contains equal records, and adding a new record alongside existing ones. The
second builds the target directly and calls the private method in order to pin down
*which* occurrence is replaced; an index built with `each_with_index.to_h` would keep
the last occurrence, and no other test in the suites listed below catches the
difference. The existing
`NestedThroughAssociationsTest#test_nested_has_many_through_writers_should_raise_error`
also reaches this code with a duplicated target, but its assertions are about
read-only association errors.

The `has_many_associations`, `has_many_through_associations`,
`has_and_belongs_to_many_associations`, `inverse_associations`, and
`nested_through_associations` suites pass with SQLite.

Related: #58533 previously proposed a similar local index for collection
replacement together with an Active Storage attachment lookup optimization.
This PR focuses on the Active Record part and adds regression tests for
replacement behavior.

This partially addresses #50848. The other quadratic lookup, in
`ActiveStorage::Attached::Changes::CreateOneOfMany#find_attachment`, is left for a
separate change.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.