### PR TITLE
Cache ActiveSupport::ParameterFilter instances across requests

### DIFF
--- a/actionpack/lib/action_dispatch/http/filter_parameters.rb
+++ b/actionpack/lib/action_dispatch/http/filter_parameters.rb
@@ -2,6 +2,7 @@
 
 # :markup: markdown
 
+require "concurrent/map"
 require "active_support/parameter_filter"
 
 module ActionDispatch
@@ -21,6 +22,17 @@ module ActionDispatch
       ENV_MATCH = [/RAW_POST_DATA/, "rack.request.form_vars"].freeze
       NULL_PARAM_FILTER = ActiveSupport::ParameterFilter.new
       NULL_ENV_FILTER   = ActiveSupport::ParameterFilter.new ENV_MATCH
+
+      # Cache ParameterFilter's because compiling Regexps is expensive and causes extra GC load
+      @parameter_filters_cache = Concurrent::Map.new
+
+      class << self
+        def parameter_filter_for(filters) # :nodoc:
+          # Guard against unbounded growth if an application generates ever-changing filter lists
+          @parameter_filters_cache.clear if @parameter_filters_cache.size > 100
+          @parameter_filters_cache.compute_if_absent(filters) { ActiveSupport::ParameterFilter.new(filters) }
+        end
+      end
       # :startdoc:
 
       def initialize
@@ -67,7 +79,7 @@ module ActionDispatch
       end
 
       def parameter_filter_for(filters) # :doc:
-        ActiveSupport::ParameterFilter.new(filters)
+        FilterParameters.parameter_filter_for(filters)
       end
 
       def filtered_query_string # :doc:


### PR DESCRIPTION
### Motivation / Background

While profiling ruby-bench's railsbench I noticed that Regexp objects are being created on every request.
Regexp creation is generally slow path (needs parsing, various validations, compilation to Regexp bytecode, etc; a bit like `eval` but for the Regexp language) so I would expect no Regexp to be created per request (to avoid the associated overhead).

`ActiveSupport::ParameterFilter` is what creates those Regexp's, and the obvious fix is to cache them globally, since in general it will be called with the same filters all the time.

### Detail

`ActionDispatch::Request` memoizes its `ParameterFilter` only on the request object itself, which is created anew for every request. So every request before this PR calls `ActiveSupport::ParameterFilter.new` which calls `compile_filters!` and that calls `Regexp.new` (as well as `Regexp.escape`, `Regexp#to_s`, etc).

Such a cache existed before: it was added in 55ae903c3fd2 ("Store compiled parameter filters so we don't have to compile them in each request.", 2010), made thread-safe in 45448a578877, and removed the following day in fa3457dc3b30 ("remove a cache we do not need", 2012) without a stated rationale, so filters have been recompiled per request ever since.

This PR caches compiled `ParameterFilter` instances in a `Concurrent::Map` keyed by the filter list.
A compiled `ParameterFilter` is immutable after construction so sharing it across requests and threads is safe.
The cache is keyed by Array equality, which also caches `env_filter`, that builds a new but equal `Array` of filters per call.

The cache is cleared if it ever exceeds 100 entries, to bound growth for applications generating dynamic filter lists.
Happy to switch to a different strategy there for that case.

### Additional information

With Ruby 4.0.6 and actionpack 8.1.1, constructing the `ParameterFilter` for railsbench's filter list (2 precompiled Regexps) takes 6.1us without JIT and 5.4us with YJIT per call, ~4.2us of which is the two `Regexp#to_s` calls (see https://github.com/rails/rails/pull/58678 about that), vs ~0.9us for the cache hit. On full railsbench (ruby-bench, 2000 requests per iteration, median of the warmed-up half per run, 3 interleaved runs per configuration):

    no JIT stock:   2191 2204 2213 ms/iteration
    no JIT patched: 2188 2188 2198 ms/iteration  (~11ms, ~0.5% faster)
    YJIT   stock:   1234 1228 1230 ms/iteration
    YJIT   patched: 1224 1224 1220 ms/iteration  (~8ms, ~0.65% faster)

Those numbers are with `config.precompile_filter_parameters` enabled (the default since 7.1), which minimizes the per-request compilation cost.
For applications with earlier framework defaults, precompilation is off and each request pays the full compile of the raw filter list (for this application: 19 filters, so 19x Regexp.escape and building two combined Regexps per request, ~38us per `ParameterFilter.new`).
Same methodology, YJIT, with `config.precompile_filter_parameters = false`:

        stock:   1319 1324 1322 ms/iteration
        patched: 1225 1218 1212 ms/iteration  (~104ms, ~7.9% faster)

With the cache, the non-precompiled configuration is as fast as the precompiled one, since compilation happens only once either way.

Applications with more filters save more.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
