### PR TITLE
Pin json and image_processing gems in 8.1 bug templates

### DIFF
--- a/guides/bug_report_templates/action_mailbox.rb
+++ b/guides/bug_report_templates/action_mailbox.rb
@@ -10,6 +10,7 @@ gemfile(true) do
   # gem "rails", github: "rails/rails", branch: "main"
 
   gem "sqlite3"
+  gem "json", "~> 2.0"
 end
 
 require "active_record/railtie"

--- a/guides/bug_report_templates/active_storage.rb
+++ b/guides/bug_report_templates/active_storage.rb
@@ -10,6 +10,8 @@ gemfile(true) do
   # gem "rails", github: "rails/rails", branch: "main"
 
   gem "sqlite3"
+  gem "json", "~> 2.0"
+  gem "image_processing", "~> 1.2"
 end
 
 require "active_record/railtie"


### PR DESCRIPTION
Fix the [failing 8-1-stable CI](https://buildkite.com/rails/rails/builds/133265/list) which tries installing json 3.0 and image_processing 2.0, which break 8-1-stable.

Another option would be pinning these gems in  the gemspec.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
