### PR TITLE
Fix Active Support loading on JRuby without Ractor

### DIFF
--- a/activesupport/lib/active_support/ractors.rb
+++ b/activesupport/lib/active_support/ractors.rb
@@ -94,7 +94,7 @@ module ActiveSupport
         end
       end
 
-      if RUBY_VERSION >= "4.0"
+      if defined?(Ractor) && RUBY_VERSION >= "4.0"
         def on_main(obj = nil, &block)
           if Ractor.main?
             obj.instance_eval(&block)
@@ -146,8 +146,14 @@ module ActiveSupport
         end
 
       else
-        def main?
-          Ractor.current == Ractor.main
+        if defined?(Ractor)
+          def main?
+            Ractor.current == Ractor.main
+          end
+        else
+          def main?
+            true
+          end
         end
 
         def on_main(obj = nil, &block)
@@ -172,39 +178,56 @@ module ActiveSupport
       end
     end
 
-    # Returns the value stored under +key+ in the current Ractor's local
-    # storage. Returns +nil+ when nothing has been stored under +key+ yet.
-    #
-    # Each Ractor has an isolated local storage, so values set in one Ractor
-    # are not visible to any other.
-    def self.[](key)
-      Ractor.current[key]
-    end
-
-    # Stores +value+ under +key+ in the current Ractor's local storage.
-    # The value is only visible to the current Ractor, and other
-    # Ractors have their own independent storage.
-    def self.[]=(key, value)
-      Ractor.current[key] = value
-    end
-
-    if Ractor.respond_to?(:store_if_absent)
+    if defined?(Ractor)
       # Returns the value stored under +key+ in the current Ractor's local
-      # storage, running +block+ to compute and store it on first access, by
-      # delegating to +Ractor.store_if_absent+. Concurrent threads in the
-      # same Ractor initialize the value only once.
-      def self.store_if_absent(key, &block)
-        Ractor.store_if_absent(key, &block)
+      # storage. Returns +nil+ when nothing has been stored under +key+ yet.
+      #
+      # Each Ractor has an isolated local storage, so values set in one Ractor
+      # are not visible to any other.
+      def self.[](key)
+        Ractor.current[key]
+      end
+
+      # Stores +value+ under +key+ in the current Ractor's local storage.
+      # The value is only visible to the current Ractor, and other
+      # Ractors have their own independent storage.
+      def self.[]=(key, value)
+        Ractor.current[key] = value
+      end
+
+      if Ractor.respond_to?(:store_if_absent)
+        # Returns the value stored under +key+ in the current Ractor's local
+        # storage, running +block+ to compute and store it on first access, by
+        # delegating to +Ractor.store_if_absent+. Concurrent threads in the
+        # same Ractor initialize the value only once.
+        def self.store_if_absent(key, &block)
+          Ractor.store_if_absent(key, &block)
+        end
+      else
+        @local_storage_lock = Mutex.new
+
+        # Same contract as +Ractor.store_if_absent+ (Ruby 3.4) on top of the
+        # Ractor-local storage that predates it: the value is initialized at
+        # most once even when the Ractor's threads race, with an unsynchronized
+        # fast path for the common hit.
+        def self.store_if_absent(key, &block)
+          Ractor.current[key] || @local_storage_lock.synchronize { Ractor.current[key] ||= block.call }
+        end
       end
     else
+      @local_storage = {}
       @local_storage_lock = Mutex.new
 
-      # Same contract as +Ractor.store_if_absent+ (Ruby 3.4) on top of the
-      # Ractor-local storage that predates it: the value is initialized at
-      # most once even when the Ractor's threads race, with an unsynchronized
-      # fast path for the common hit.
+      def self.[](key)
+        @local_storage_lock.synchronize { @local_storage[key] }
+      end
+
+      def self.[]=(key, value)
+        @local_storage_lock.synchronize { @local_storage[key] = value }
+      end
+
       def self.store_if_absent(key, &block)
-        Ractor.current[key] || @local_storage_lock.synchronize { Ractor.current[key] ||= block.call }
+        @local_storage_lock.synchronize { @local_storage[key] ||= block.call }
       end
     end
   end

--- a/activesupport/test/ractors_test.rb
+++ b/activesupport/test/ractors_test.rb
@@ -9,13 +9,15 @@ class RactorsTest < ActiveSupport::TestCase
     assert ActiveSupport::Ractors.main?
   end
 
-  def test_main_is_false_on_a_non_main_ractor
-    ractor = Ractor.new do
-      ActiveSupport::Ractors.main?
-    end
-    value = ractor.respond_to?(:value) ? ractor.value : ractor.take
+  if defined?(Ractor)
+    def test_main_is_false_on_a_non_main_ractor
+      ractor = Ractor.new do
+        ActiveSupport::Ractors.main?
+      end
+      value = ractor.respond_to?(:value) ? ractor.value : ractor.take
 
-    assert_not value
+      assert_not value
+    end
   end
 
   def test_store_if_absent_computes_once_and_returns_the_stored_value
@@ -33,7 +35,7 @@ class RactorsTest < ActiveSupport::TestCase
     assert_equal "value", ActiveSupport::Ractors[:as_ractors_test_storage]
   end
 
-  if RUBY_VERSION >= "4.0"
+  if defined?(Ractor) && RUBY_VERSION >= "4.0"
     def test_on_main_runs_block_on_main_ractor
       value = Ractor.new do
         ActiveSupport::Ractors.on_main { Ractor.main? }


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because JRuby 10 reports `RUBY_VERSION` as `4.0.0` but does not define the `Ractor` constant. Active Support selected its Ruby 4.0 Ractor implementation based only on the Ruby version, causing `active_support/core_ext` to fail to load with `NameError: uninitialized constant ActiveSupport::Ractors::Ractor`.

Fixes #58654.

### Detail

This Pull Request changes `ActiveSupport::Ractors` to use Ractor-backed behavior only when the `Ractor` constant is available. On Ruby implementations without Ractor support, it uses thread-safe process-local storage while preserving the existing `[]`, `[]=`, and `store_if_absent` APIs.

The tests now skip Ractor-specific behavior when Ractor is unavailable and cover the fallback implementation. The Active Support changelog has also been updated.

### Additional information

The existing behavior remains unchanged on Ruby implementations that provide Ractor.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.