### PR TITLE
Skip testing Action Mailbox and Active Storage scripts

### DIFF
--- a/guides/test/bug_report_template_test.rb
+++ b/guides/test/bug_report_template_test.rb
@@ -9,6 +9,11 @@ class BugReportTemplatesTest < ActiveSupport::TestCase
   templates = Dir.glob("bug_report_templates/*.rb")
   templates.each do |file|
     test "#{file} can be executed " do
+      case file
+      when "bug_report_templates/action_mailbox.rb", "bug_report_templates/active_storage.rb"
+        skip "activesupport-8.1.3.1 has a compatiblity issue with json 3.0.0"
+      end
+
       success = silence_stream($stdout) do
         Bundler.unbundled_system(Gem.ruby, "-w", file) ||
           puts("+++ 💥 FAILED (exit #{$?.exitstatus})")


### PR DESCRIPTION
They run using `rails 8.1.3` and `json 3.0` which aren't compatible. We can unskip them once `8.1.4` is released.
