### PR TITLE
Upgrade rubocop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem "argon2", "~> 2.3.2", require: false
 gem "terser", ">= 1.1.4", require: false
 
 # Explicitly avoid 1.x that doesn't support Ruby 2.4+
-gem "json", ">= 2.0.0", "!=2.7.0"
+gem "json", ">= 2.0.0", "!=2.7.0", "< 3"
 
 # Workaround until all supported Ruby versions ship with uri version 0.13.1 or higher.
 gem "uri", ">= 0.13.1", require: false
@@ -45,7 +45,7 @@ gem "uri", ">= 0.13.1", require: false
 gem "prism"
 
 group :rubocop do
-  gem "rubocop", "1.79.2", require: false
+  gem "rubocop", "1.90.0", require: false
   gem "rubocop-minitest", require: false
   gem "rubocop-packaging", require: false
   gem "rubocop-performance", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,7 @@ GEM
     argon2 (2.3.2)
       ffi (~> 1.15)
       ffi-compiler (~> 1.0)
-    ast (2.4.2)
+    ast (2.4.3)
     aws-eventstream (1.4.0)
     aws-partitions (1.1150.0)
     aws-sdk-core (3.230.0)
@@ -301,7 +301,7 @@ GEM
     jmespath (1.6.2)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
-    json (2.20.0)
+    json (2.21.2)
     jwt (2.10.1)
       base64
     kamal (2.4.0)
@@ -319,7 +319,7 @@ GEM
       rexml (>= 3.3.9)
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    language_server-protocol (3.17.0.3)
+    language_server-protocol (3.17.0.6)
     launchy (3.0.1)
       addressable (~> 2.8)
       childprocess (~> 5.0)
@@ -397,8 +397,8 @@ GEM
       racc (~> 1.4)
     os (1.1.4)
     ostruct (0.6.1)
-    parallel (1.26.3)
-    parser (3.3.9.0)
+    parallel (2.1.0)
+    parser (3.3.12.0)
       ast (~> 2.4.1)
       racc
     pg (1.6.3)
@@ -409,7 +409,7 @@ GEM
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
-    prism (1.7.0)
+    prism (1.9.0)
     propshaft (1.3.1)
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
@@ -463,7 +463,7 @@ GEM
       connection_pool
     redis-namespace (1.11.0)
       redis (>= 4)
-    regexp_parser (2.10.0)
+    regexp_parser (2.12.0)
     reline (0.6.1)
       io-console (~> 0.5)
     representable (3.2.0)
@@ -483,21 +483,21 @@ GEM
     retriable (3.1.2)
     rexml (3.4.0)
     rouge (4.6.1)
-    rubocop (1.79.2)
-      json (~> 2.3)
+    rubocop (1.90.0)
+      json (>= 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
-      parallel (~> 1.10)
+      parallel (>= 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.46.0, < 2.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.46.0)
+    rubocop-ast (1.50.0)
       parser (>= 3.3.7.2)
-      prism (~> 1.4)
-    rubocop-md (2.0.1)
+      prism (~> 1.7)
+    rubocop-md (2.0.4)
       lint_roller (~> 1.1)
       rubocop (>= 1.72.1)
     rubocop-minitest (0.37.1)
@@ -643,8 +643,8 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
-    unicode-display_width (3.1.4)
-      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
     uri (1.0.3)
     useragent (0.16.11)
@@ -703,7 +703,7 @@ DEPENDENCIES
   importmap-rails (>= 1.2.3)
   jbuilder
   jsbundling-rails
-  json (>= 2.0.0, != 2.7.0)
+  json (>= 2.0.0, < 3, != 2.7.0)
   kamal (>= 2.1.0)
   launchy
   libxml-ruby
@@ -733,7 +733,7 @@ DEPENDENCIES
   resque-scheduler
   rexml
   rouge
-  rubocop (= 1.79.2)
+  rubocop (= 1.90.0)
   rubocop-md
   rubocop-minitest
   rubocop-packaging
@@ -783,7 +783,7 @@ CHECKSUMS
   addressable (2.8.7) sha256=462986537cf3735ab5f3c0f557f14155d778f4b43ea4f485a9deb9c8f7c58232
   amq-protocol (2.3.2) sha256=3d155ef8f2aed26b2f3fafd6d7ab57e5105865d409c3d9c43e72a40b73dda816
   argon2 (2.3.2) sha256=62b04170af37ca8d9975bc6e24dd3b74794e82a98e6d8cfa9ae95a76804a6f89
-  ast (2.4.2) sha256=1e280232e6a33754cde542bc5ef85520b74db2aac73ec14acef453784447cc12
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   aws-eventstream (1.4.0) sha256=116bf85c436200d1060811e6f5d2d40c88f65448f2125bc77ffce5121e6e183b
   aws-partitions (1.1150.0) sha256=b9411943748b9ca4e78f83242c746ce183ab6428b3ec039c862d0a22d55b0f66
   aws-sdk-core (3.230.0) sha256=4621204bc1893f6364c4ab61080d30b5906833c428984b7797705c2ab70301aa
@@ -866,12 +866,12 @@ CHECKSUMS
   jbuilder (2.13.0) sha256=7200a38a1c0081aa81b7a9757e7a299db75bc58cf1fd45ca7919a91627d227d6
   jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
   jsbundling-rails (1.3.1) sha256=0fa03f6d051c694cbf55a022d8be53399879f2c4cf38b2968f86379c62b1c2ca
-  json (2.20.0) sha256=9362bc6e55a952b056abf9167cf053358181c904cb70cd6eee0808ea830fc32b
+  json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   jwt (2.10.1) sha256=e6424ae1d813f63e761a04d6284e10e7ec531d6f701917fadcd0d9b2deaf1cc5
   kamal (2.4.0) sha256=5f62f1858cc15c1506e55b60b075c89a1e7ef9c6bb0a7e3c01b54af190f85181
   kramdown (2.5.1) sha256=87bbb6abd9d3cebe4fc1f33e367c392b4500e6f8fa19dd61c0972cf4afe7368c
   kramdown-parser-gfm (1.1.0) sha256=fb39745516427d2988543bf01fc4cf0ab1149476382393e0e9c48592f6581729
-  language_server-protocol (3.17.0.3) sha256=3d5c58c02f44a20d972957a9febe386d7e7468ab3900ce6bd2b563dd910c6b3f
+  language_server-protocol (3.17.0.6) sha256=5ef2c0c138f8267e1bc631d3328347d354f96724b0af22f2c79516120443b7f0
   launchy (3.0.1) sha256=b7fa60bda0197cf57614e271a250a8ca1f6a34ab889a3c73f67ec5d57c8a7f2c
   libxml-ruby (6.0.0) sha256=a9d9458d018dee591d0995fdc1110cd67ec32b7be67d36fdb9e0b01a4ca9dac4
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
@@ -913,8 +913,8 @@ CHECKSUMS
   nokogiri (1.19.1-x86_64-linux-gnu) sha256=1a4902842a186b4f901078e692d12257678e6133858d0566152fe29cdb98456a
   os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
   ostruct (0.6.1) sha256=09a3fb7ecc1fa4039f25418cc05ae9c82bd520472c5c6a6f515f03e4988cb817
-  parallel (1.26.3) sha256=d86babb7a2b814be9f4b81587bf0b6ce2da7d45969fab24d8ae4bf2bb4d4c7ef
-  parser (3.3.9.0) sha256=94d6929354b1a6e3e1f89d79d4d302cc8f5aa814431a6c9c7e0623335d7687f2
+  parallel (2.1.0) sha256=b35258865c2e31134c5ecb708beaaf6772adf9d5efae28e93e99260877b09356
+  parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
   pg (1.6.3) sha256=1388d0563e13d2758c1089e35e973a3249e955c659592d10e5b77c468f628a99
   pg (1.6.3-aarch64-linux) sha256=0698ad563e02383c27510b76bf7d4cd2de19cd1d16a5013f375dd473e4be72ea
   pg (1.6.3-arm64-darwin) sha256=7240330b572e6355d7c75a7de535edb5dfcbd6295d9c7777df4d9dddfb8c0e5f
@@ -922,7 +922,7 @@ CHECKSUMS
   pg (1.6.3-x86_64-linux) sha256=5d9e188c8f7a0295d162b7b88a768d8452a899977d44f3274d1946d67920ae8d
   pp (0.6.2) sha256=947ec3120c6f92195f8ee8aa25a7b2c5297bb106d83b41baa02983686577b6ff
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
-  prism (1.7.0) sha256=10062f734bf7985c8424c44fac382ac04a58124ea3d220ec3ba9fe4f2da65103
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   propshaft (1.3.1) sha256=9acc664ef67e819ffa3d95bd7ad4c3623ea799110c5f4dee67fa7e583e74c392
   psych (5.2.6) sha256=814328aa5dcb6d604d32126a20bc1cbcf05521a5b49dbb1a8b30a07e580f316e
   public_suffix (6.0.1) sha256=61d44e1cab5cbbbe5b31068481cf16976dd0dc1b6b07bd95617ef8c5e3e00c6f
@@ -951,7 +951,7 @@ CHECKSUMS
   redis (5.4.1) sha256=b5e675b57ad22b15c9bcc765d5ac26f60b675408af916d31527af9bd5a81faae
   redis-client (0.28.0) sha256=888892f9cd8787a41c0ece00bdf5f556dfff7770326ce40bb2bc11f1bfec824b
   redis-namespace (1.11.0) sha256=e91a1aa2b2d888b6dea1d4ab8d39e1ae6fac3426161feb9d91dd5cca598a2239
-  regexp_parser (2.10.0) sha256=cb6f0ddde88772cd64bff1dbbf68df66d376043fe2e66a9ef77fcb1b0c548c61
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
   releaser (1.0.0)
   reline (0.6.1) sha256=1afcc9d7cb1029cdbe780d72f2f09251ce46d3780050f3ec39c3ccc6b60675fb
   representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace
@@ -960,9 +960,9 @@ CHECKSUMS
   retriable (3.1.2) sha256=0a5a5d0ca4ba61a76fb31a17ab8f7f80281beb040c329d34dfc137a1398688e0
   rexml (3.4.0) sha256=efbea1efba7fa151158e0ee1e643525834da2d8eb4cf744aa68f6480bc9804b2
   rouge (4.6.1) sha256=5075346d5797d6864be93f7adc75a16047a7dbfa572c63c502419ffa582c77de
-  rubocop (1.79.2) sha256=d3f42a7d197952c2a163719c5462fea827710a435b18bfb7070c6eedd2e90391
-  rubocop-ast (1.46.0) sha256=0da7f6ad5b98614f89b74f11873c191059c823eae07d6ffd40a42a3338f2232b
-  rubocop-md (2.0.1) sha256=20eb3afa544389de5de5064ed3fa767ad4dc6b9ab0e050d7cee7dbfd6e08b19b
+  rubocop (1.90.0) sha256=9eb4c065b5c5154e4ef554c547972f3905a9eb6b53e657e580b6796b54bf8242
+  rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
+  rubocop-md (2.0.4) sha256=0d076b6b5e99dea2ddc928c4bd702497decb9a8400da7808091e02ebcafcfb93
   rubocop-minitest (0.37.1) sha256=dcdcc2c835a859193e50bc67296daaf95ac99f6410838119374df31490460d36
   rubocop-packaging (0.6.0) sha256=fb92bd0fb48e6f8cdb1648d2249b0cd51c2497dcc87340132d22f01edbf558a7
   rubocop-performance (1.24.0) sha256=e5bd39ff3e368395b9af886927cc37f5892f43db4bd6c8526594352d5b4440b5
@@ -1024,7 +1024,7 @@ CHECKSUMS
   turbo-rails (2.0.11) sha256=fc47674736372780abd2a4dc0d84bef242f5ca156a457cd7fa6308291e397fcf
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
   uber (0.1.0) sha256=5beeb407ff807b5db994f82fa9ee07cfceaa561dad8af20be880bc67eba935dc
-  unicode-display_width (3.1.4) sha256=8caf2af1c0f2f07ec89ef9e18c7d88c2790e217c482bfc78aaa65eadd5415ac1
+  unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
   uri (1.0.3) sha256=e9f2244608eea2f7bc357d954c65c910ce0399ca5e18a7a29207ac22d8767011
   useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844

--- a/actionpack/lib/action_dispatch/testing/test_helpers/page_dump_helper.rb
+++ b/actionpack/lib/action_dispatch/testing/test_helpers/page_dump_helper.rb
@@ -8,7 +8,7 @@ module ActionDispatch
       # Saves the content of response body to a file and tries to open it in your browser.
       # Launchy must be present in your Gemfile for the page to open automatically.
       def save_and_open_page(path = html_dump_default_path)
-        save_page(path).tap { |s_path| open_file(s_path) }
+        save_page(path).tap { |s_path| open_file(s_path) } # rubocop:disable Lint/Debugger
       end
 
       private

--- a/actionpack/test/controller/parameters/mutators_test.rb
+++ b/actionpack/test/controller/parameters/mutators_test.rb
@@ -232,26 +232,20 @@ class ParametersMutatorsTest < ActiveSupport::TestCase
     assert_instance_of ActiveSupport::HashWithIndifferentAccess, params_hash
   end
 
-  # rubocop:disable Style/HashTransformKeys
   test "to_h receives a block and transforms keys" do
-    params = ActionController::Parameters.new(name: "Alex", age: "40", location: "Beijing")
-    params.permit!
-    params_hash = params.to_h { |key, value| [:"#{key}_modified", value] }
-    assert_equal %w(name_modified age_modified location_modified), params_hash.keys
-  end
-  # rubocop:enable Style/HashTransformKeys
-
-  # rubocop:disable Style/HashTransformValues
+  params = ActionController::Parameters.new(name: "Alex", age: "40", location: "Beijing")
+  params.permit!
+  params_hash = params.to_h { |key, value| [:"#{key}_modified", value] }
+  assert_equal %w(name_modified age_modified location_modified), params_hash.keys
+end
   test "to_h receives a block and transforms values" do
-    params = ActionController::Parameters.new(name: "Alex", age: "40", location: "Beijing")
-    params.permit!
-    params_hash = params.to_h { |key, value| [key, value.is_a?(String) ? "#{value}_modified" : value] }
-    assert_equal %w(Alex_modified 40_modified Beijing_modified), params_hash.values
-  end
-  # rubocop:enable Style/HashTransformValues
-
+  params = ActionController::Parameters.new(name: "Alex", age: "40", location: "Beijing")
+  params.permit!
+  params_hash = params.to_h { |key, value| [key, value.is_a?(String) ? "#{value}_modified" : value] }
+  assert_equal %w(Alex_modified 40_modified Beijing_modified), params_hash.values
+end
   test "to_h does not include unpermitted params" do
-    params = ActionController::Parameters.new(name: "Alex", age: "40", location: "Beijing")
-    assert_raises(ActionController::UnfilteredParameters) { params.to_h { |key, value| [key, value] } }
-  end
+  params = ActionController::Parameters.new(name: "Alex", age: "40", location: "Beijing")
+  assert_raises(ActionController::UnfilteredParameters) { params.to_h { |key, value| [key, value] } }
+end
 end

--- a/actiontext/lib/action_text/attachments/conversion.rb
+++ b/actiontext/lib/action_text/attachments/conversion.rb
@@ -31,9 +31,9 @@ module ActionText
       private
         def editor_attachment_content
           if partial_path = (
-              attachable.try(:to_editor_content_attachment_partial_path) ||
-              ActionText.deprecator.silence { attachable.try(:to_trix_content_attachment_partial_path) }
-            )
+            attachable.try(:to_editor_content_attachment_partial_path) ||
+            ActionText.deprecator.silence { attachable.try(:to_trix_content_attachment_partial_path) }
+          )
             ActionText::Content.render(partial: partial_path, formats: :html, object: self, as: model_name.element)
           end
         end

--- a/actionview/test/template/dependency_tracker_test.rb
+++ b/actionview/test/template/dependency_tracker_test.rb
@@ -276,9 +276,7 @@ module SharedTrackerTests
   def test_dependencies_with_interpolation_are_resolved_with_view_paths
     view_paths = ActionView::PathSet.new([File.expand_path("../fixtures/digestor", __dir__)])
 
-    template = FakeTemplate.new(%q{
-      <%= render "events/#{quote}" %>
-    }, :erb)
+    template = FakeTemplate.new('<%= render "events/#{quote}" %>', :erb)
 
     tracker = make_tracker("interpolation/_string", template, view_paths)
 
@@ -288,9 +286,7 @@ module SharedTrackerTests
   def test_dependencies_with_interpolation_non_trailing
     view_paths = ActionView::PathSet.new([File.expand_path("../fixtures/digestor", __dir__)])
 
-    template = FakeTemplate.new(%q{
-      <%= render "#{type}/comments" %>
-    }, :erb)
+    template = FakeTemplate.new('<%= render "#{type}/comments" %>', :erb)
 
     tracker = make_tracker("interpolation/_string", template, view_paths)
 
@@ -300,9 +296,7 @@ module SharedTrackerTests
   def test_dependencies_with_interpolation_expr
     view_paths = ActionView::PathSet.new([File.expand_path("../fixtures/digestor", __dir__)])
 
-    template = FakeTemplate.new(%q{
-      <%= render "orders/#{variable || "default"}" %>
-    }, :erb)
+    template = FakeTemplate.new('<%= render "orders/#{variable || "default"}" %>', :erb)
 
     tracker = make_tracker("interpolation/_string", template, view_paths)
 

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -456,15 +456,15 @@ module ActiveRecord
         relation = except(:includes, :eager_load, :preload).joins!(join_dependency)
 
         if eager_loading && has_limit_or_offset? && !(
-            using_limitable_reflections?(join_dependency.reflections) &&
-            using_limitable_reflections?(
-              construct_join_dependency(
-                select_association_list(joins_values).concat(
-                  select_association_list(left_outer_joins_values)
-                ), nil
-              ).reflections
-            )
+          using_limitable_reflections?(join_dependency.reflections) &&
+          using_limitable_reflections?(
+            construct_join_dependency(
+              select_association_list(joins_values).concat(
+                select_association_list(left_outer_joins_values)
+              ), nil
+            ).reflections
           )
+        )
           relation = skip_query_cache_if_necessary do
             model.with_connection do |c|
               c.distinct_relation_for_primary_key(relation)

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -1110,7 +1110,7 @@ class EnumTest < ActiveRecord::TestCase
     ActiveRecord::Base.logger = logger
 
     Class.new(ActiveRecord::Base) do
-      def self.name
+      def self.name # rubocop:disable Lint/DuplicateMethods
         "Book"
       end
       enum :status, [:not_sent]
@@ -1128,7 +1128,7 @@ class EnumTest < ActiveRecord::TestCase
     ActiveRecord::Base.logger = logger
 
     Class.new(ActiveRecord::Base) do
-      def self.name
+      def self.name # rubocop:disable Lint/DuplicateMethods
         "Book"
       end
       silence_warnings do
@@ -1143,9 +1143,9 @@ class EnumTest < ActiveRecord::TestCase
 
   test "raises for attributes with undeclared type" do
     klass = Class.new(Book) do
-    def self.name; "Book"; end
-    enum :typeless_genre, [:adventure, :comic]
-  end
+      def self.name; "Book"; end
+      enum :typeless_genre, [:adventure, :comic]
+    end
 
     error = assert_raises(RuntimeError) do
       klass.type_for_attribute(:typeless_genre)

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1324,7 +1324,7 @@ ActiveRecord::Schema.define do
   end
 
   create_table :humans, force: true do |t|
-    t.string  :name
+    t.string :name
   end
 
   create_table :faces, force: true do |t|

--- a/activesupport/test/callbacks_test.rb
+++ b/activesupport/test/callbacks_test.rb
@@ -1343,27 +1343,27 @@ module CallbacksTest
     end
 
     def before_save_2
-      @history <<  __method__.to_s
+      @history << __method__.to_s
     end
 
     def around_save_1
-      @history <<  __method__.to_s + "_before"
+      @history << __method__.to_s + "_before"
       yield
-      @history <<  __method__.to_s + "_after"
+      @history << __method__.to_s + "_after"
     end
 
     def around_save_2
-      @history <<  __method__.to_s + "_before"
+      @history << __method__.to_s + "_before"
       yield
-      @history <<  __method__.to_s + "_after"
+      @history << __method__.to_s + "_after"
     end
 
     def after_save_1
-      @history <<  __method__.to_s
+      @history << __method__.to_s
     end
 
     def after_save_2
-      @history <<  __method__.to_s
+      @history << __method__.to_s
     end
   end
 

--- a/activesupport/test/notifications/evented_notification_test.rb
+++ b/activesupport/test/notifications/evented_notification_test.rb
@@ -100,12 +100,12 @@ module ActiveSupport
         notifier.subscribe nil, listener
 
         error = assert_raises InstrumentationSubscriberError do
-          notifier.start  "hello", 1, {}
+          notifier.start "hello", 1, {}
         end
         assert_instance_of BadListenerException, error.cause
 
         error = assert_raises InstrumentationSubscriberError do
-          notifier.start  "world", 1, {}
+          notifier.start "world", 1, {}
         end
         assert_instance_of BadListenerException, error.cause
 
@@ -134,13 +134,13 @@ module ActiveSupport
         notifier.start  "hello", 1, {}
         notifier.start  "world", 1, {}
         error = assert_raises InstrumentationSubscriberError do
-          notifier.finish  "world", 1, {}
+          notifier.finish "world", 1, {}
         end
         assert_equal 5, error.exceptions.count
         assert_instance_of BadListenerException, error.cause
 
         error = assert_raises InstrumentationSubscriberError do
-          notifier.finish  "hello", 1, {}
+          notifier.finish "hello", 1, {}
         end
         assert_equal 5, error.exceptions.count
         assert_instance_of BadListenerException, error.cause

--- a/railties/test/application/generators_test.rb
+++ b/railties/test/application/generators_test.rb
@@ -120,7 +120,7 @@ module ApplicationTests
     test "generators with string and hash for options should generate symbol keys" do
       with_bare_config do |c|
         c.generators do |g|
-          g.orm    "data_mapper", migration: false
+          g.orm "data_mapper", migration: false
         end
 
         expected = {


### PR DESCRIPTION
And lock `json < 3.0` temporarily (everything works with it except for the resque test suite that need a new `multi_json` release).
