### PR TITLE
Update json to 3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem "argon2", "~> 2.3.2", require: false
 gem "terser", ">= 1.1.4", require: false
 
 # Explicitly avoid 1.x that doesn't support Ruby 2.4+
-gem "json", ">= 2.0.0", "!=2.7.0", "< 3"
+gem "json", ">= 2.0.0", "!=2.7.0"
 
 # Workaround until all supported Ruby versions ship with uri version 0.13.1 or higher.
 gem "uri", ">= 0.13.1", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,7 +301,7 @@ GEM
     jmespath (1.6.2)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
-    json (2.21.2)
+    json (3.0.1)
     jwt (2.10.1)
       base64
     kamal (2.4.0)
@@ -362,7 +362,7 @@ GEM
       chef-utils
     mono_logger (1.1.2)
     msgpack (1.7.5)
-    multi_json (1.15.0)
+    multi_json (1.21.2)
     mustermann (3.0.4)
       ruby2_keywords (~> 0.0.1)
     mutex_m (0.3.0)
@@ -703,7 +703,7 @@ DEPENDENCIES
   importmap-rails (>= 1.2.3)
   jbuilder
   jsbundling-rails
-  json (>= 2.0.0, < 3, != 2.7.0)
+  json (>= 2.0.0, != 2.7.0)
   kamal (>= 2.1.0)
   launchy
   libxml-ruby
@@ -866,7 +866,7 @@ CHECKSUMS
   jbuilder (2.13.0) sha256=7200a38a1c0081aa81b7a9757e7a299db75bc58cf1fd45ca7919a91627d227d6
   jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
   jsbundling-rails (1.3.1) sha256=0fa03f6d051c694cbf55a022d8be53399879f2c4cf38b2968f86379c62b1c2ca
-  json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
+  json (3.0.1) sha256=c80f74a3570c3a310cd41c526904e7ef8363abdece4432f31fe97d812bc4a39e
   jwt (2.10.1) sha256=e6424ae1d813f63e761a04d6284e10e7ec531d6f701917fadcd0d9b2deaf1cc5
   kamal (2.4.0) sha256=5f62f1858cc15c1506e55b60b075c89a1e7ef9c6bb0a7e3c01b54af190f85181
   kramdown (2.5.1) sha256=87bbb6abd9d3cebe4fc1f33e367c392b4500e6f8fa19dd61c0972cf4afe7368c
@@ -893,7 +893,7 @@ CHECKSUMS
   mixlib-shellout (3.3.4) sha256=f7dbde9f69612e431aac7dbd0cf5c9ec6895fe272092ef67dbb08b7a6868378b
   mono_logger (1.1.2) sha256=2e359def7007f5c908aadd953687991fe667995d14ae5f0d10dda76e3e8670f7
   msgpack (1.7.5) sha256=ffb04979f51e6406823c03abe50e1da2c825c55a37dee138518cdd09d9d3aea8
-  multi_json (1.15.0) sha256=1fd04138b6e4a90017e8d1b804c039031399866ff3fbabb7822aea367c78615d
+  multi_json (1.21.2) sha256=245531eaf54bdba57aba515ff08b4503505c5e09911daa89c5a561e2f85bea8e
   mustermann (3.0.4) sha256=85fadcb6b3c6493a8b511b42426f904b7f27b282835502233dd154daab13aa22
   mutex_m (0.3.0) sha256=cfcb04ac16b69c4813777022fdceda24e9f798e48092a2b817eb4c0a782b0751
   mysql2 (0.5.6) sha256=70f447d45d6b3cc16b00f7dd30366f708a81b4093a35d026ff7135d778d8da33


### PR DESCRIPTION
Currently blocked by resque -> mutli_json which need a new release cut: https://github.com/sferik/multi_json/pull/67

```
ArgumentError: wrong number of arguments (given 2, expected 1)
    /usr/local/bundle/gems/json-3.0.0/lib/json/common.rb:296:in 'JSON.parse'
    /usr/local/bundle/gems/multi_json-1.21.1/lib/multi_json/adapters/json_gem.rb:47:in 'MultiJSON::Adapters::JsonGem#load'
    /usr/local/bundle/gems/multi_json-1.21.1/lib/multi_json/adapter.rb:100:in 'MultiJSON::Adapter.load'
    /usr/local/bundle/gems/multi_json-1.21.1/lib/multi_json.rb:182:in 'MultiJSON.parse'
    /usr/local/bundle/gems/resque-3.0.2/lib/resque.rb:57:in 'Resque#decode'
    /usr/local/bundle/gems/resque-3.0.2/lib/resque/job.rb:49:in 'Resque::Job.decode'
```