### PR TITLE
fix erb syntax error line numbers

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Report the original ERB line for template syntax errors instead of the
+    corresponding line in the generated Ruby source.
+
+    *aouxwoux*
+
 *   Allow `translate`'s (and `t`'s) `scope:` option to be resolved relative to
     the current template when it starts with a period, mirroring the existing
     behavior for the key argument.

--- a/actionview/lib/action_view/template/error.rb
+++ b/actionview/lib/action_view/template/error.rb
@@ -269,6 +269,14 @@ module ActionView
       end
     end
 
+    def line_number
+      if template.handler.respond_to?(:syntax_error_line)
+        template.handler.syntax_error_line(@offending_code_string)&.to_s || super
+      else
+        super
+      end
+    end
+
     def annotated_source_code
       @offending_code_string.split("\n").map.with_index(1) { |line, index|
         indentation = " " * 4

--- a/actionview/lib/action_view/template/handlers/erb.rb
+++ b/actionview/lib/action_view/template/handlers/erb.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "strscan"
+require "ripper"
 require "active_support/core_ext/erb/util"
 
 module ActionView
@@ -27,8 +28,20 @@ module ActionView
 
         LocationParsingError = Class.new(StandardError) # :nodoc:
 
+        class SyntaxErrorParser < Ripper # :nodoc:
+          attr_reader :line_number
+
+          def on_parse_error(*)
+            @line_number ||= lineno
+          end
+        end
+
         def self.call(template, source)
           new.call(template, source)
+        end
+
+        def self.syntax_error_line(source)
+          new.syntax_error_line(source)
         end
 
         def supports_streaming?
@@ -92,6 +105,31 @@ module ActionView
           end
 
           self.class.erb_implementation.new(erb, options).src
+        end
+
+        def syntax_error_line(source)
+          code = +""
+          code.force_encoding(source.encoding)
+          executable = false
+
+          ::ERB::Util.tokenize(source).each do |type, value|
+            case type
+            when :OPEN
+              executable = !value.start_with?("<%#", "<%%")
+              code << value.gsub(/[^\r\n]/, " ")
+            when :CODE
+              code << (executable ? value : value.gsub(/[^\r\n]/, " "))
+            else
+              code << value.gsub(/[^\r\n]/, " ")
+              executable = false if type == :CLOSE
+            end
+          end
+
+          parser = SyntaxErrorParser.new(code)
+          parser.parse
+          parser.line_number
+        rescue NotImplementedError
+          nil
         end
 
       private

--- a/actionview/test/fixtures/test/syntax_error_on_later_line.html.erb
+++ b/actionview/test/fixtures/test/syntax_error_on_later_line.html.erb
@@ -1,0 +1,8 @@
+<h1>Posts</h1>
+
+<div id="posts">
+  <%# @posts.each do |post| %>
+    <%#= render post %>
+    <p>post</p>
+  <% end %>
+</div>

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -216,6 +216,15 @@ module RenderTestCases
     assert_equal "1:    <%= foo(", e.annotated_source_code[0].strip
   end
 
+  def test_render_template_with_syntax_error_on_later_line
+    e = assert_raises(ActionView::Template::Error) do
+      silence_warnings { @view.render(template: "test/syntax_error_on_later_line") }
+    end
+
+    assert_equal "7", e.line_number
+    assert_includes e.annotated_source_code.map(&:strip), "7:      <% end %>"
+  end
+
   def test_render_runtime_error
     ex = assert_raises(ActionView::Template::Error) {
       @view.render(template: "test/runtime_error")


### PR DESCRIPTION
reports the original erb line for template syntax errors instead of the generated ruby line.

tested the added fixture through the erb handler and checked ruby syntax.
