### PR TITLE
Exclude generated error pages from GitHub language stats

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Mark the generated `public/*.html` error pages as `linguist-generated` in
+    the default `.gitattributes`.
+
+    The five error pages generated since Rails 8.0 total about 36 KB of HTML,
+    more than the Ruby in a freshly generated application, so GitHub reported
+    new Rails applications as HTML repositories. Marking the pages as generated
+    excludes them from language statistics, as is already done for
+    `db/schema.rb`.
+
+    *Irina Nazarova*
+
 *   A generated application's ci.yml file now sets `timeout-minutes: 15` for
     each job to prevent transisent network errors, etc. from hanging the
     action until the default 360 minutes kicks in and potentially eat up an

--- a/railties/lib/rails/generators/rails/app/templates/gitattributes.tt
+++ b/railties/lib/rails/generators/rails/app/templates/gitattributes.tt
@@ -5,5 +5,12 @@
 db/schema.rb linguist-generated
 <% end -%>
 
+# Mark the static error pages as having been generated.
+public/400.html linguist-generated
+public/404.html linguist-generated
+public/406-unsupported-browser.html linguist-generated
+public/422.html linguist-generated
+public/500.html linguist-generated
+
 # Mark any vendored files as having been vendored.
 vendor/* linguist-vendored

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -530,6 +530,15 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file ".gitattributes", /\.enc diff=/
   end
 
+  def test_generator_marks_error_pages_as_generated
+    run_generator
+    assert_file ".gitattributes" do |content|
+      %w[400 404 406-unsupported-browser 422 500].each do |page|
+        assert_match(/^public\/#{Regexp.escape(page)}\.html linguist-generated$/, content)
+      end
+    end
+  end
+
   def test_generator_does_not_configure_decrypted_diffs_when_skip_decrypted_diffs_is_given
     run_generator [destination_root, "--skip-decrypted-diffs"]
     assert_file ".gitattributes" do |content|


### PR DESCRIPTION
### Motivation

Every new Rails application since Rails 8 is reported as an **HTML** repository on Github (instead of Ruby). This misattribution affects on a rough estimate, around a thousand Rails repositories a month. Any statistic derived from GitHub language data, such as new Rails applications or new Ruby developers, undercounts Ruby.

`rails new` writes five static error pages (`400.html`, `404.html`, etc). Github's Linguist picks a repository's primary language by byte count, hence it attributes the new Rails application to **HTML** language. If we mark these pages as generated, the repository gets attributed as Ruby.

### Reproduction

Before: https://github.com/irinanazarova/rails-new is the unmodified output of `rails _8.1.3.1_ new rails-new --skip-bundle`. Github reports it as HTML. 

After: https://github.com/irinanazarova/rails-new-amended is the same application with only these five lines added to `.gitattributes`. Github reports it as Ruby.

### Detail

Adds `linguist-generated` for the five error pages to the generated `.gitattributes`, next to the existing entry for `db/schema.rb`. Linguist then excludes them from language statistics (and collapses them in diffs, as it already does for `db/schema.rb`). The pages are generator boilerplate, so the attribute is accurate.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.