### PR TITLE
Allow exception backtraces from Ractor workers

### DIFF
--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -1138,6 +1138,7 @@ class CachedCollectionViewRenderTest < ActiveSupport::TestCase
       ActionView::Template::Handlers::ERB.escape_ignore_list.freeze
       ActiveSupport::Ractors.unshareable_proc_action = :raise
       ActiveSupport::Notifications.send(:record_subscriptions)
+      Ractor.make_shareable(ActiveSupport.event_reporter)
 
       I18n::Config.prepend(Module.new do
         def available_locales = [:en].freeze

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -117,13 +117,7 @@ module ActiveSupport
   singleton_class.attr_accessor :error_reporter # :nodoc:
 
   @event_reporter = ActiveSupport::EventReporter.new
-  singleton_class.attr_writer :event_reporter # :nodoc:
-
-  def self.event_reporter # :nodoc:
-    return @event_reporter if ActiveSupport::Ractors.main?
-
-    Ractor[:__event_reporter] ||= ActiveSupport::EventReporter.new
-  end
+  singleton_class.attr_accessor :event_reporter # :nodoc:
 
   cattr_accessor :filter_parameters, default: [] # :nodoc:
 

--- a/activesupport/lib/active_support/backtrace_cleaner.rb
+++ b/activesupport/lib/active_support/backtrace_cleaner.rb
@@ -214,7 +214,8 @@ module ActiveSupport
       end
 
       def add_stdlib_silencer
-        add_silencer(&Ractors.shareable_proc  { |line| line.start_with?(RbConfig::CONFIG["rubylibdir"]) })
+        rubylibdir = -RbConfig::CONFIG["rubylibdir"]
+        add_silencer(&Ractors.shareable_proc { |line| line.start_with?(rubylibdir) })
       end
 
       def filter_backtrace(backtrace)

--- a/activesupport/test/event_reporter_test.rb
+++ b/activesupport/test/event_reporter_test.rb
@@ -701,18 +701,17 @@ module ActiveSupport
     include ActiveSupport::Testing::RactorsAssertions
 
     if RUBY_VERSION >= "4.0"
-      test "each Ractor gets its own event reporter" do
-        main_subscriber_count = ActiveSupport.event_reporter.subscribers.size
+      test "a shareable event reporter notifies its subscribers from other Ractors" do
+        reporter = ActiveSupport::EventReporter.new
+        reporter.subscribe(Class.new { def emit(event); end }.new)
+        Ractor.make_shareable(reporter)
 
-        event_names = on_ractor do
-          subscriber = EventReporter::TestHelper::EventSubscriber.new
-          ActiveSupport.event_reporter.subscribe(subscriber)
-          ActiveSupport.event_reporter.notify("ractor_event")
-          subscriber.events.map { |event| event[:name] }
+        subscriber_count = on_ractor(reporter) do |reporter|
+          reporter.notify("ractor_event")
+          reporter.subscribers.size
         end
 
-        assert_equal ["ractor_event"], event_names
-        assert_equal main_subscriber_count, ActiveSupport.event_reporter.subscribers.size
+        assert_equal 1, subscriber_count
       end
     end
   end

--- a/activesupport/test/ractors_test.rb
+++ b/activesupport/test/ractors_test.rb
@@ -56,6 +56,17 @@ class RactorsTest < ActiveSupport::TestCase
       assert_equal :bar, object.foo
     end
 
+    def test_non_main_ractors_cannot_read_the_event_reporter_before_it_is_shareable
+      error = Ractor.new do
+        ActiveSupport.event_reporter
+        nil
+      rescue Ractor::IsolationError => e
+        e
+      end.value
+
+      assert_kind_of Ractor::IsolationError, error
+    end
+
     def test_ractor_make_shareable_returns_a_shareable_object
       string = +"hello"
       assert_not ActiveSupport::Ractors.shareable?(string)

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -682,6 +682,7 @@ module Rails
       end
 
       Ractor.make_shareable(self)
+      Ractor.make_shareable(Rails.env)
       Ractor.make_shareable(Rails.event)
       Ractor.make_shareable(Rails.error)
       Ractor.make_shareable(Rails.backtrace_cleaner)

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -683,6 +683,7 @@ module Rails
 
       Ractor.make_shareable(self)
       Ractor.make_shareable(Rails.env)
+      Ractor.make_shareable(Rails.logger)
       Ractor.make_shareable(Rails.event)
       Ractor.make_shareable(Rails.error)
       Ractor.make_shareable(Rails.backtrace_cleaner)

--- a/railties/lib/rails/backtrace_cleaner.rb
+++ b/railties/lib/rails/backtrace_cleaner.rb
@@ -9,7 +9,7 @@ module Rails
 
     class << self
       def root
-        @root ||= Rails.root && "#{Rails.root}/"
+        @root ||= Rails.root && "#{Rails.root}/".freeze
       end
     end
 

--- a/railties/lib/rails/gem_version.rb
+++ b/railties/lib/rails/gem_version.rb
@@ -12,6 +12,6 @@ module Rails
     TINY  = 0
     PRE   = "alpha"
 
-    STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")
+    STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".").freeze
   end
 end

--- a/railties/test/application/ractors_test.rb
+++ b/railties/test/application/ractors_test.rb
@@ -53,6 +53,14 @@ if RUBY_VERSION >= "4.0" && ENV["RACK"] == "head"
         assert_ractor_shareable Rails::HealthController.config
       end
 
+      test "ractorize! makes Rails.logger shareable" do
+        app "production"
+
+        ractorize!
+
+        assert_ractor_shareable Rails.logger
+      end
+
       test "ractorize! eager loads and compiles view templates" do
         app "production"
 

--- a/railties/test/application/ractors_test.rb
+++ b/railties/test/application/ractors_test.rb
@@ -36,6 +36,14 @@ if RUBY_VERSION >= "4.0" && ENV["RACK"] == "head"
         assert_ractor_shareable Rails.backtrace_cleaner
       end
 
+      test "ractorize! makes Rails.env shareable" do
+        app "production"
+
+        ractorize!
+
+        assert_ractor_shareable Rails.env
+      end
+
       test "ractorize! makes the controller configs shareable" do
         app "production"
 

--- a/railties/test/backtrace_cleaner_test.rb
+++ b/railties/test/backtrace_cleaner_test.rb
@@ -96,4 +96,18 @@ class BacktraceCleanerTest < ActiveSupport::TestCase
   test "backtrace cleaner can be made Ractor shareable" do
     assert_ractor_make_shareable @cleaner
   end
+
+  test "backtrace cleaner cleans from a non-main Ractor" do
+    assert_ractor_make_shareable @cleaner
+
+    backtrace = [ "#{Rails::BacktraceCleaner.root}app/models/post.rb:4:in 'boom'",
+                  "#{RbConfig::CONFIG["rubylibdir"]}/net/http.rb:12:in 'get'" ]
+    original_experimental_warning = Warning[:experimental]
+    Warning[:experimental] = false
+    result = on_ractor(@cleaner, backtrace) { |cleaner, lines| cleaner.clean(lines) }
+
+    assert_equal ["app/models/post.rb:4:in 'boom'"], result
+  ensure
+    Warning[:experimental] = original_experimental_warning
+  end
 end

--- a/railties/test/version_test.rb
+++ b/railties/test/version_test.rb
@@ -7,6 +7,10 @@ class VersionTest < ActiveSupport::TestCase
     assert Rails.version.is_a? String
   end
 
+  def test_rails_version_string_is_frozen
+    assert_predicate Rails::VERSION::STRING, :frozen?
+  end
+
   def test_rails_gem_version_returns_a_correct_gem_version_object
     assert Rails.gem_version.is_a? Gem::Version
     assert_equal Rails.version, Rails.gem_version.to_s


### PR DESCRIPTION
There are a few missing pieces which means that a Ractor worker serving a request that raises an exception doesn't log properly, this addresses them.

* The error reporter uses a few values that were not shareable, `Rails::VERSION::STRING`, `Rails.env`.
* The logger is wrapped with a `BroadcastLogger` which isn't shareable.
* The event reporter was ractor-safe, but since it was a Ractor-local new instance (from https://github.com/rails/rails/pull/58599), it wasn't subscribed to any event from the LogSubscribers.
* The backtrace cleaner refers to `RbConfig::CONFIG["rubylibdir"]` and `Rails::BacktraceCleaner.root`, both of which were unfrozen strings which were not shareable.

Here's a new Rails app (disabling a few frameworks) that adds a ractor environment: https://github.com/etiennebarrie/rails-app/commit/db51ca33b4702112bc04fb118c94c35d0083a44f

From which we can get a backtrace:

```console
$ bin/rails server -e ractor & until nc -z localhost 3000 2>/dev/null; do :; done
[1] 5496
=> Booting Cougar
=> Rails 8.2.0.alpha application starting in ractor http://0.0.0.0:3000
=> Run `bin/rails server --help` for more startup options
config.ru:10: warning: Ractor support in Rails is experimental and subject to change.
Cougar listening on 0.0.0.0:3000 with 8 workers
$ curl http://127.0.0.1:3000/up &>/dev/null
Started GET "/up" for 127.0.0.1 at 2026-09-08 17:03:18 +0200
Processing by Rails::HealthController#show as */*
Completed 200 OK in 2ms (Views: 0.8ms | GC: 0.0ms)
$ curl http://127.0.0.1:3000/500 &>/dev/null
Started GET "/500" for 127.0.0.1 at 2026-09-08 17:03:20 +0200
Processing by BoomController#show as */*
Completed 500 Internal Server Error in 1ms (GC: 0.0ms)
  
RuntimeError (boom):
  
app/controllers/boom_controller.rb:3:in 'BoomController#show'
```

cc @gmcgibbon @andrewn617 @Edouard-chin @skipkayhil 