### PR TITLE
Add on_load args with default params (1 for 2 ArgumentError)

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `on_load: nil` to `ActiveSupport::JSON.decode` to prevent automatic object creation.
+
+    *Rodrigo Argumedo*
+
 *   Preserve the requested key order in `ActiveSupport::Cache::Store#fetch_multi`
     when a local cache is active.
 

--- a/activesupport/lib/active_support/json/decoding.rb
+++ b/activesupport/lib/active_support/json/decoding.rb
@@ -23,7 +23,7 @@ module ActiveSupport
       # # => 2.39
       # ```
       def decode(json, options = {})
-        data = ::JSON.parse(json, **options)
+        data = ::JSON.parse(json, on_load: nil, **options)
 
         if ActiveSupport.parse_json_times
           convert_dates_from(data)


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because it has a breaking change as a result of the JSON 3.0.0 update.

### Detail

This Pull Request changes the `decode` mechanism. Previously, JSON used to only require 1 argument. As of the version 3.0.0, `::JSON.parse(...)` now requires two arguments instead of one.

### Additional information

No additional information available.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
