### PR TITLE
Remove stale Active Record encryption performance tasks

### DIFF
--- a/activerecord/RUNNING_UNIT_TESTS.rdoc
+++ b/activerecord/RUNNING_UNIT_TESTS.rdoc
@@ -38,14 +38,6 @@ There should be tests available for each database backend listed in the {Config
 File}[rdoc-label:label-Config+File]. (the exact set of available tests is
 defined in +Rakefile+)
 
-There are some performance tests for the encryption system that can be run with.
-
-  $ rake test:encryption:performance:mysql2
-  $ rake test:integration:active_job:postgresql
-  $ rake test:encryption:performance:sqlite3
-
-These performance tests are not executed as part of the regular testing tasks.
-
 == Config File
 
 If +test/config.yml+ is present, then its parameters are obeyed; otherwise, the

--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -105,23 +105,6 @@ adapters.each do |adapter|
         end
       end
     end
-
-    namespace :encryption do
-      namespace :performance do
-        Rake::TestTask.new(adapter => "#{adapter}:env") do |t|
-          t.description = "Encryption performance tests for #{adapter}"
-          t.libs << "test"
-          t.test_files = FileList["test/cases/encryption/performance/*_test.rb"]
-
-          t.warning = true
-          if ENV["CI"]
-            t.verbose = true
-            t.options = "--profile --defer-output"
-          end
-          t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
-        end
-      end
-    end
   end
 
   namespace adapter do

--- a/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb
+++ b/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb
@@ -30,10 +30,6 @@ module ActiveRecord
         ActiveRecord::Encryption::EncryptedAttributeType.prepend(ExtendedEncryptableType)
       end
 
-      # When modifying this file run performance tests in
-      # +activerecord/test/cases/encryption/performance/extended_deterministic_queries_performance_test.rb+
-      # to make sure performance overhead is acceptable.
-      #
       # @TODO We will extend this to support previous "encryption context" versions in future iterations
       # @TODO Experimental. Support for every kind of query is pending
       # @TODO It should not patch anything if not needed (no previous schemes or no support for previous encryption schemes)


### PR DESCRIPTION
Active Record defines and documents encryption performance tasks that do nothing.

[rails/rails#50986](https://github.com/rails/rails/pull/50986) deleted the encryption performance tests in February 2024.

The Rake tasks, test documentation, and a source comment remained after that deletion. Each `test:encryption:performance:<adapter>` task matched an empty file list. The task returned success without doing anything.

This change removes:

- The empty encryption performance Rake tasks.
- The obsolete commands from `RUNNING_UNIT_TESTS.rdoc`.
- The obsolete test reference from `extended_deterministic_queries.rb`.