### PR TITLE
Allow `wait:` to call an instance method

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   Allow `retry_on`'s `wait:` option to name an instance method on the job.
+
+    Any symbol other than `:polynomially_longer` is treated as a method name and
+    called on the job to compute the delay. Like a proc, the method receives the
+    number of executions so far (and optionally the error) as arguments.
+
+    ```ruby
+    class RemoteServiceJob < ApplicationJob
+      retry_on CustomAppException, wait: :custom_wait
+
+      private
+        def custom_wait(executions, error)
+          error.retry_after || executions * 2
+        end
+    end
+    ```
+
+    *Dennis Paagman*
+
 *   Fix continuation step cursors losing their type when a job is interrupted
     and resumed.
 

--- a/activejob/lib/active_job/exceptions.rb
+++ b/activejob/lib/active_job/exceptions.rb
@@ -27,9 +27,11 @@ module ActiveJob
       # ==== Options
       # * <tt>:wait</tt> - Re-enqueues the job with a delay specified either in seconds (default: 3 seconds),
       #   as a computing proc that takes the number of executions so far as an argument (and optionally the error),
-      #   or as a symbol reference of
+      #   as a symbol reference of
       #   <tt>:polynomially_longer</tt>, which applies the wait algorithm of <tt>((executions**4) + (Kernel.rand * (executions**4) * jitter)) + 2</tt>
-      #   (first wait ~3s, then ~18s, then ~83s, etc)
+      #   (first wait ~3s, then ~18s, then ~83s, etc), or as any other symbol naming an instance method on the job
+      #   that computes the delay. Like a proc, the method takes the number of executions so far as an argument
+      #   (and optionally the error).
       # * <tt>:attempts</tt> - Enqueues the job the specified number of times (default: 5 attempts) or a symbol reference of <tt>:unlimited</tt>
       #   to retry the job until it succeeds. The number of attempts includes the original job execution.
       # * <tt>:queue</tt> - Re-enqueues the job on a different queue
@@ -43,6 +45,7 @@ module ActiveJob
       #    retry_on CustomAppException # defaults to ~3s wait, 5 attempts
       #    retry_on AnotherCustomAppException, wait: ->(executions) { executions * 2 }
       #    retry_on ThirdCustomAppException, wait: ->(executions, error) { error.retry_after || executions * 2 }
+      #    retry_on FourthCustomAppException, wait: :custom_wait # calls the custom_wait instance method below
       #    retry_on CustomInfrastructureException, wait: 5.minutes, attempts: :unlimited
       #
       #    retry_on ActiveRecord::Deadlocked, wait: 5.seconds, attempts: 3
@@ -62,14 +65,19 @@ module ActiveJob
       #      # Might raise ActiveRecord::Deadlocked when a local db deadlock is detected
       #      # Might raise Net::OpenTimeout or Timeout::Error when the remote service is down
       #    end
+      #
+      #    private
+      #      def custom_wait(executions, error)
+      #        error.retry_after || executions * 2
+      #      end
       #  end
       def retry_on(*exceptions, wait: 3.seconds, attempts: 5, queue: nil, priority: nil, jitter: JITTER_DEFAULT, report: false)
         case wait
-        when :polynomially_longer, Integer, Float, ActiveSupport::Duration, Proc
+        when Symbol, Integer, Float, ActiveSupport::Duration, Proc
           # Supported wait type, continue.
         else
           raise ArgumentError, "Unsupported argument type for :wait, expected an Integer, Float, " \
-            "ActiveSupport::Duration, Proc, or :polynomially_longer, but got #{wait.inspect}"
+            "ActiveSupport::Duration, Proc, or Symbol, but got #{wait.inspect}"
         end
 
         rescue_from(*exceptions) do |error|
@@ -191,12 +199,21 @@ module ActiveJob
           delay = seconds_or_duration_or_algorithm.to_f
           delay_jitter = determine_jitter_for_delay(delay, jitter)
           delay + delay_jitter
-        when Proc
-          algorithm = seconds_or_duration_or_algorithm
+        when Proc, Symbol
+          algorithm = seconds_or_duration_or_algorithm.is_a?(Symbol) ? wait_method(seconds_or_duration_or_algorithm) : seconds_or_duration_or_algorithm
           algorithm.arity == 2 || algorithm.arity < -1 ? algorithm.call(executions, error) : algorithm.call(executions)
         else
           raise "Couldn't determine a delay based on #{seconds_or_duration_or_algorithm.inspect}"
         end
+      end
+
+      def wait_method(name)
+        unless respond_to?(name, true)
+          raise ArgumentError, "Unsupported argument for :wait, expected :polynomially_longer or the name of " \
+            "an instance method on #{self.class.name}, but got #{name.inspect}"
+        end
+
+        method(name)
       end
 
       def determine_jitter_for_delay(delay, jitter)

--- a/activejob/test/cases/exceptions_test.rb
+++ b/activejob/test/cases/exceptions_test.rb
@@ -4,6 +4,7 @@ require "helper"
 require "jobs/retry_job"
 require "jobs/retries_job"
 require "jobs/after_discard_retry_job"
+require "jobs/missing_wait_method_job"
 require "models/person"
 require "minitest/mock"
 
@@ -309,6 +310,34 @@ class ExceptionsTest < ActiveSupport::TestCase
       ], JobBuffer.values
     end
 
+    test "custom wait method retrying job" do
+      travel_to Time.now
+
+      RetryJob.perform_later "MethodWaitError", 3, :log_scheduled_at
+
+      assert_equal [
+        "Raised MethodWaitError for the 1st time",
+        "Next execution scheduled at #{(Time.now + 3.seconds).to_f}",
+        "Raised MethodWaitError for the 2nd time",
+        "Next execution scheduled at #{(Time.now + 6.seconds).to_f}",
+        "Successfully completed job"
+      ], JobBuffer.values
+    end
+
+    test "custom wait method can use the error" do
+      travel_to Time.now
+
+      RetryJob.perform_later "MethodWaitWithErrorError", 3, :log_scheduled_at
+
+      assert_equal [
+        "Raised MethodWaitWithErrorError for the 1st time",
+        "Next execution scheduled at #{(Time.now + 11.seconds).to_f}",
+        "Raised MethodWaitWithErrorError for the 2nd time",
+        "Next execution scheduled at #{(Time.now + 12.seconds).to_f}",
+        "Successfully completed job"
+      ], JobBuffer.values
+    end
+
     test "use individual execution timers when calculating retry delay" do
       travel_to Time.now
 
@@ -453,6 +482,12 @@ class ExceptionsTest < ActiveSupport::TestCase
     assert_match(/Unsupported argument type for :wait/, error.message)
   end
 
+  test "retry_on raises ArgumentError when the wait method is not defined on the job" do
+    error = assert_raises(ArgumentError) { MissingWaitMethodJob.perform_now }
+    assert_equal "Unsupported argument for :wait, expected :polynomially_longer or the name of " \
+      "an instance method on MissingWaitMethodJob, but got :missing_wait", error.message
+  end
+
   test "retry_on accepts all supported wait types" do
     assert_nothing_raised do
       Class.new(ActiveJob::Base) do
@@ -461,6 +496,7 @@ class ExceptionsTest < ActiveSupport::TestCase
         retry_on StandardError, wait: 5.minutes
         retry_on StandardError, wait: :polynomially_longer
         retry_on StandardError, wait: ->(executions) { executions * 2 }
+        retry_on StandardError, wait: :custom_wait
       end
     end
   end

--- a/activejob/test/jobs/missing_wait_method_job.rb
+++ b/activejob/test/jobs/missing_wait_method_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class MissingWaitMethodJob < ActiveJob::Base
+  retry_on StandardError, wait: :missing_wait
+
+  def perform
+    raise "boom"
+  end
+end

--- a/activejob/test/jobs/retry_job.rb
+++ b/activejob/test/jobs/retry_job.rb
@@ -14,6 +14,12 @@ class ShortWaitTenAttemptsError < StandardError; end
 class PolynomialWaitTenAttemptsError < StandardError; end
 class CustomWaitTenAttemptsError < StandardError; end
 class OptionalArgWaitError < StandardError; end
+class MethodWaitError < StandardError; end
+class MethodWaitWithErrorError < StandardError
+  def retry_after
+    10
+  end
+end
 class RetryWaitIncludedInError < StandardError
   def retry_after
     10
@@ -40,6 +46,8 @@ class RetryJob < ActiveJob::Base
   retry_on CustomWaitTenAttemptsError, wait: ->(executions) { executions * 2 }, attempts: 10
   retry_on OptionalArgWaitError, wait: ->(executions = 0) { executions * 2 }, attempts: 10
   retry_on RetryWaitIncludedInError, wait: ->(executions, error) { error.retry_after + executions }
+  retry_on MethodWaitError, wait: :custom_wait, attempts: 10
+  retry_on MethodWaitWithErrorError, wait: :custom_wait_with_error
   retry_on(CustomCatchError) { |job, error| JobBuffer.add("Dealt with a job that failed to retry in a custom way after #{job.arguments.second} attempts. Message: #{error.message}") }
   retry_on(ActiveJob::DeserializationError) { |job, error| JobBuffer.add("Raised #{error.class} for the #{job.executions} time") }
   retry_on UnlimitedRetryError, attempts: :unlimited
@@ -65,4 +73,13 @@ class RetryJob < ActiveJob::Base
       JobBuffer.add("Successfully completed job")
     end
   end
+
+  private
+    def custom_wait(executions)
+      executions * 3
+    end
+
+    def custom_wait_with_error(executions, error)
+      error.retry_after + executions
+    end
 end


### PR DESCRIPTION
### Motivation / Background

I wanted to customize the wait algorithm on a job and found that I could only do this via a Proc. The main pattern all over Rails is that these kind of options also accept the symbol name for a method which is then called.

### Detail

This implements calling methods as symbols with the same arguments as you would a Proc.

### Additional information

A small potential down side is that it moves a bit more of the logic to run time, https://github.com/rails/rails/pull/57765 introduced some checks that blow up for invalid values. Since now every symbol is allowed, it's a bit less strict.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
