### PR TITLE
Reduce Action View renderable allocations

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Only attach `ActionView::StructuredEventSubscriber` to `action_view` notifications when `Rails.event.debug_mode?` is true, avoiding unnecessary instrumentation overhead in non-debug apps.
+
+    *Joel Hawksley*
+
 *   Allow `translate`'s (and `t`'s) `scope:` option to be resolved relative to
     the current template when it starts with a period, mirroring the existing
     behavior for the key argument.
@@ -110,7 +114,9 @@
 
     *Kenta Ishizaki*
 
-*   Pass render options and block to calls to `#render_in`
+*   Pass render options and block to calls to `#render_in`.
+
+    `#render_in` must now accept a `locals:` keyword argument.
 
     ```ruby
     class Greeting
@@ -131,7 +137,7 @@
     render(Greeting.new) { "Hello, Block" }                     # => "Hello, Block"
     ```
 
-    *Sean Doyle*
+    *Sean Doyle, Joel Hawksley*
 
 *   Add `f.datalist` to `FormBuilder`
 

--- a/actionview/lib/action_view/helpers/rendering_helper.rb
+++ b/actionview/lib/action_view/helpers/rendering_helper.rb
@@ -142,16 +142,20 @@ module ActionView
       def render(options = {}, locals = {}, &block)
         case options
         when Hash
-          in_rendering_context(options) do |renderer|
-            if block_given? && !options.key?(:renderable)
-              view_renderer.render_partial(self, options.merge(partial: options[:layout]), &block)
-            else
-              view_renderer.render(self, options, &block)
+          if options.key?(:renderable)
+            Template::Renderable.new(options[:renderable], &block).render(self, options[:locals] || {})
+          else
+            in_rendering_context(options) do |renderer|
+              if block_given?
+                view_renderer.render_partial(self, options.merge(partial: options[:layout]), &block)
+              else
+                view_renderer.render(self, options)
+              end
             end
           end
         else
           if options.respond_to?(:render_in)
-            view_renderer.render(self, renderable: options, locals: locals, &block)
+            Template::Renderable.new(options, &block).render(self, locals)
           else
             view_renderer.render_partial(self, partial: options, locals: locals, &block)
           end

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -2,6 +2,7 @@
 
 require "rails"
 require "action_view"
+require "action_view/structured_event_subscriber"
 
 module ActionView
   # = Action View Railtie
@@ -89,6 +90,12 @@ module ActionView
           next if k == :render_tracker
           send "#{k}=", v
         end
+      end
+    end
+
+    config.after_initialize do
+      if Rails.event.debug_mode?
+        ActionView::StructuredEventSubscriber.attach_to :action_view
       end
     end
 

--- a/actionview/lib/action_view/renderer/renderer.rb
+++ b/actionview/lib/action_view/renderer/renderer.rb
@@ -20,8 +20,8 @@ module ActionView
     end
 
     # Main render entry point shared by Action View and Action Controller.
-    def render(context, options, &block)
-      render_to_object(context, options, &block).body
+    def render(context, options)
+      render_to_object(context, options).body
     end
 
     def render_to_object(context, options, &block) # :nodoc:

--- a/actionview/lib/action_view/structured_event_subscriber.rb
+++ b/actionview/lib/action_view/structured_event_subscriber.rb
@@ -105,5 +105,3 @@ module ActionView
     end
   end
 end
-
-ActionView::StructuredEventSubscriber.attach_to :action_view

--- a/actionview/lib/action_view/template/renderable.rb
+++ b/actionview/lib/action_view/template/renderable.rb
@@ -14,19 +14,12 @@ module ActionView
       end
 
       def render(context, locals)
-        render_in_method = Kernel.instance_method(:method).bind_call(@renderable, :render_in)
+        @renderable.render_in(context, locals: locals, &@block)
+      rescue ArgumentError => error
+        render_in = Kernel.instance_method(:method).bind_call(@renderable, :render_in)
+        raise unless render_in.arity == 1
 
-        if render_in_method.arity == 1
-          ActionView.deprecator.warn <<~WARN
-            Action View support for #render_in without options is deprecated.
-
-            Change #render_in to accept keyword arguments.
-          WARN
-
-          @renderable.render_in(context, &@block)
-        else
-          @renderable.render_in(context, locals: locals, &@block)
-        end
+        raise ArgumentError, "#{identifier}#render_in must accept keyword arguments", error.backtrace
       rescue NameError
         if !@renderable.respond_to?(:render_in)
           raise ArgumentError, "'#{@renderable.inspect}' is not a renderable object. It must implement #render_in."

--- a/actionview/test/abstract_unit.rb
+++ b/actionview/test/abstract_unit.rb
@@ -19,6 +19,8 @@ require "active_support/testing/autorun"
 require "active_support/testing/method_call_assertions"
 require "action_controller"
 require "action_view"
+require "action_view/structured_event_subscriber"
+ActionView::StructuredEventSubscriber.attach_to :action_view
 require "action_view/testing/resolvers"
 require "active_support/dependencies"
 require "active_model"

--- a/actionview/test/lib/test_renderable.rb
+++ b/actionview/test/lib/test_renderable.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
 class TestRenderable
-  def render_in(view_context, **)
+  def render_in(view_context, locals: {}, **)
     if block_given?
       view_context.render(html: yield)
     else
-      view_context.render(inline: <<~ERB.strip, **)
-        Hello, <%= local_assigns[:name] || "World" %>!
-      ERB
+      "Hello, #{locals[:name] || "World"}!"
     end
   end
 end

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -410,24 +410,32 @@ module RenderTestCases
     assert_equal "NilClass", @view.render(partial: "test/klass", object: nil)
   end
 
-  def test_render_renderable_object_without_block_without_options_deprecated
+  def test_render_renderable_object_without_block_requires_options
     renderable = Object.new
     def renderable.render_in(view_context)
     end
 
-    assert_deprecated "without options", ActionView.deprecator do
-      @view.render renderable
-    end
+    error = assert_raises(ArgumentError) { @view.render renderable }
+    assert_equal "Object#render_in must accept keyword arguments", error.message
   end
 
-  def test_render_renderable_object_with_block_without_options_deprecated
+  def test_render_renderable_object_with_block_requires_options
     renderable = Object.new
     def renderable.render_in(view_context, &block)
     end
 
-    assert_deprecated "without options", ActionView.deprecator do
-      @view.render renderable
+    error = assert_raises(ArgumentError) { @view.render(renderable) {} }
+    assert_equal "Object#render_in must accept keyword arguments", error.message
+  end
+
+  def test_render_renderable_object_preserves_argument_error_from_render_in
+    renderable = Object.new
+    def renderable.render_in(view_context, **options)
+      raise ArgumentError, "from render_in"
     end
+
+    error = assert_raises(ArgumentError) { @view.render renderable }
+    assert_equal "from render_in", error.message
   end
 
   def test_render_renderable_object_with_method_reader
@@ -455,6 +463,16 @@ module RenderTestCases
 
     assert_equal "<h1>Goodbye, Block!</h1>", @view.render(TestRenderable.new) { @view.tag.h1 "Goodbye, Block!" }
     assert_equal "<h1>Goodbye, Block!</h1>", @view.render(renderable: TestRenderable.new) { @view.tag.h1 "Goodbye, Block!" }
+  end
+
+  def test_render_renderable_render_in_does_not_emit_active_support_notifications
+    assert_no_notifications "render_template.action_view" do
+      assert_equal "Hello, World!", @view.render(TestRenderable.new)
+    end
+
+    assert_no_notifications "render_template.action_view" do
+      assert_equal "Hello, World!", @view.render(renderable: TestRenderable.new)
+    end
   end
 
   def test_render_renderable_render_in_excludes_renderable_key


### PR DESCRIPTION
## Problem

In https://github.com/rails/rails/pull/50623, the pipeline for renderables was changed to align more closely with the code path for non-renderables. In a [GitHub.com](http://github.com/) request rendering 10,000 ViewComponents, allocations [doubled](https://github.com/rails/rails/issues/57781) to 1.2M. Garbage collections also doubled.

Specifically, RenderingHelper went from calling `render_in` on renderables to passing them to `view_renderer.render`: 

<img width="774" height="42" alt="Image" src="https://github.com/user-attachments/assets/601aed49-4a92-458f-aec5-cd0191482e43" />

I spent a [decent amount of time](https://github.com/rails/rails/pull/58621) trying to reduce the allocations made by the change, including [finding a bug](https://github.com/rails/rails/pull/58649) in the structured event logger (which we should fix too). I also looked for ways to reduce allocations in ViewComponent itself to compensate for the increase, but we’re fairly well optimized already and I could [only find 2-3](https://github.com/ViewComponent/view_component/pull/2710) to reduce on the hot render path. 

## Proposed solution

This PR builds on the [original proposed solution](https://github.com/rails/rails/compare/seanpdoyle:issue-57781) by @seanpdoyle. Instead of routing renderables through the instrumented template pipeline, it constructs `Template::Renderable` directly and invokes `#render`, preserving locals and blocks.

It also incorporates [#58649](https://github.com/rails/rails/pull/58649) by attaching `ActionView::StructuredEventSubscriber` only when `Rails.event.debug_mode?` is true. All of its handlers are debug-only, so attaching it in non-debug applications allocates and dispatches notifications that will be discarded.

`render_in` must now accept a `locals:` keyword argument. The normal path does not inspect method arity; positional-only implementations pay for the arity check only on the exceptional path and receive a clear error.

The changelog documents both changes.

## Benchmark

```ruby
# frozen_string_literal: true
# actionview/benchmark/render_in_allocations.rb

require "bundler/setup"
require "action_view"

class BenchmarkComponent
  def render_in(_view_context, **)
    "Hello, world!"
  end
end

iterations = Integer(ENV.fetch("ITERATIONS", 10_000))
view_context = ActionView::Base.empty
component = BenchmarkComponent.new

100.times { view_context.render(component) }
GC.start

allocated_before = GC.stat(:total_allocated_objects)
iterations.times { view_context.render(component) }
allocated_objects = GC.stat(:total_allocated_objects) - allocated_before

puts "Ruby: #{RUBY_DESCRIPTION}"
puts "Action View: #{ActionView.version}"
puts "Iterations: #{iterations}"
puts "Allocated objects: #{allocated_objects}"
puts "Allocated objects per render: #{allocated_objects.fdiv(iterations)}"
```

Results on Ruby 3.4.10 for 10,000 renders after 100 warmup renders. Each result was identical across three runs:

| Revision | Allocated objects | Allocations per render |
| --- | ---: | ---: |
| Before #50623 (`343fe92bd2`) | 10,001 | 1.0001 |
| #50623 merged (`f26f56ed4e`) | 580,001 | 58.0001 |
| Current `main`, before this PR (`71191796c0`) | 570,001 | 57.0001 |
| #58649 only, applied to current `main` | 160,001 | 16.0001 |
| This PR (`5cf9e2b78a`) | 30,001 | 3.0001 |

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.


Closes https://github.com/rails/rails/issues/57781