### PR TITLE
Remove the dead encryption performance reject clause from the Active Record Rakefile

### DIFF
--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -76,9 +76,8 @@ adapters.each do |adapter|
     Rake::TestTask.new(adapter => "#{adapter}:env") do |t|
       adapter_short = adapter[/^[a-z0-9]+/]
       t.libs << "test"
-      files = (FileList["test/cases/**/*_test.rb"].reject {
-        |x| x.include?("/adapters/") || x.include?("/encryption/performance")
-      } + FileList["test/cases/adapters/#{adapter_short}/**/*_test.rb"])
+      files = (FileList["test/cases/**/*_test.rb"].reject { |x| x.include?("/adapters/") } +
+        FileList["test/cases/adapters/#{adapter_short}/**/*_test.rb"])
       files = files + FileList["test/cases/adapters/abstract_mysql_adapter/**/*_test.rb"] if ["mysql2", "trilogy"].include?(adapter)
 
       t.test_files = files


### PR DESCRIPTION
The per-adapter test task filters a path that no test file has had since February 2024.

See https://github.com/rails/rails/pull/58697 for additional context, this cleans up one more location.