### PR TITLE
Action Cable fastlane broadcasts

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Add `config.action_cable.fastlane_broadcasts_enabled` to encode broadcasted
+    messages once per channel identifier instead of once per subscriber.
+
+    When enabled, messages sent via `ActionCable.server.broadcast` are only decoded-encoded from/to JSON once per channel identifier and not for every connected client. This significantly reduces the broadcasting latency.
+
+    The option is enabled by default for applications with `config.load_defaults 8.2`.
+
+    *Vladimir Dementyev*
+
 *   Move `ActionCable::Server::Configuration` to `ActionCable::Configuration`.
 
     The old constant remains available as an alias.

--- a/actioncable/lib/action_cable/channel/streams.rb
+++ b/actioncable/lib/action_cable/channel/streams.rb
@@ -97,7 +97,7 @@ module ActionCable
 
         # Build a stream handler by wrapping the user-provided callback with a decoder
         # or defaulting to a JSON-decoding retransmitter.
-        handler = worker_pool_stream_handler(broadcasting, callback || block, coder: coder)
+        handler = build_stream_handler(broadcasting, callback || block, coder: coder)
         streams[broadcasting] = handler
 
         pubsub.subscribe(broadcasting, handler, lambda do
@@ -160,12 +160,12 @@ module ActionCable
 
         # Always wrap the outermost handler to invoke the user handler on the worker
         # pool rather than blocking the event loop.
-        def worker_pool_stream_handler(broadcasting, user_handler, coder: nil)
+        def build_stream_handler(broadcasting, user_handler, coder: nil)
           handler = stream_handler(broadcasting, user_handler, coder: coder)
 
           if user_handler
             -> message do
-              connection.perform_work handler, :call, message
+              connection.perform_work handler, :call, message.data
             end
           else
             handler
@@ -185,19 +185,29 @@ module ActionCable
 
         # May be overridden to change the default stream handling behavior which decodes
         # JSON and transmits to the client.
-        #
-        # TODO: Room for optimization. Update transmit API to be coder-aware so we can
-        # no-op when pubsub and connection are both JSON-encoded. Then we can skip
-        # decode+encode if we're just proxying messages.
         def default_stream_handler(broadcasting, coder:)
+          if connection.config.fastlane_broadcasts_enabled && !coder
+            return opt_stream_handler(broadcasting)
+          end
+
           coder ||= ActiveSupport::JSON
           stream_transmitter stream_decoder(coder: coder), broadcasting: broadcasting
+        end
+
+        # Optimized stream handler that simply retransmits the message without
+        # encoding/decoding or instrumenting.
+        #
+        # May be overridden to add instrumentation, logging, etc.
+        def opt_stream_handler(_broadcasting)
+          -> message do
+            connection.raw_transmit message.encoded_for(@identifier)
+          end
         end
 
         def stream_decoder(handler = nil, coder:)
           if coder
             -> message do
-              message = coder.decode(message)
+              message = coder.decode(String(message))
 
               if handler
                 handler.(message)

--- a/actioncable/lib/action_cable/channel/streams.rb
+++ b/actioncable/lib/action_cable/channel/streams.rb
@@ -175,7 +175,6 @@ module ActionCable
         # May be overridden to add instrumentation, logging, specialized error handling,
         # or other forms of handler decoration.
         #
-        # TODO: Tests demonstrating this.
         def stream_handler(broadcasting, user_handler, coder: nil)
           if user_handler
             stream_decoder user_handler, coder: coder
@@ -186,8 +185,6 @@ module ActionCable
 
         # May be overridden to change the default stream handling behavior which decodes
         # JSON and transmits to the client.
-        #
-        # TODO: Tests demonstrating this.
         #
         # TODO: Room for optimization. Update transmit API to be coder-aware so we can
         # no-op when pubsub and connection are both JSON-encoded. Then we can skip

--- a/actioncable/lib/action_cable/configuration.rb
+++ b/actioncable/lib/action_cable/configuration.rb
@@ -19,6 +19,7 @@ module ActionCable
     attr_accessor :precompile_assets
     attr_accessor :health_check_path, :health_check_application
     attr_writer :pubsub_adapter
+    attr_accessor :fastlane_broadcasts_enabled
 
     def initialize
       @log_tags = []
@@ -30,6 +31,8 @@ module ActionCable
       @disable_request_forgery_protection = false
       @allow_same_origin_as_host = true
       @filter_parameters = []
+
+      @fastlane_broadcasts_enabled = false
 
       @health_check_application = ->(env) {
         [200, { Rack::CONTENT_TYPE => "text/html", "date" => Time.now.httpdate }, []]

--- a/actioncable/lib/action_cable/connection/base.rb
+++ b/actioncable/lib/action_cable/connection/base.rb
@@ -117,6 +117,10 @@ module ActionCable
         socket.transmit(data)
       end
 
+      def raw_transmit(data) # :nodoc:
+        socket.raw_transmit(data)
+      end
+
       # Close the connection.
       def close(reason: nil, reconnect: true)
         transmit(

--- a/actioncable/lib/action_cable/server/socket.rb
+++ b/actioncable/lib/action_cable/server/socket.rb
@@ -48,6 +48,13 @@ module ActionCable
         websocket.transmit encode(cable_message)
       end
 
+      # Send an already serialized message over the WebSocket connection.
+      def raw_transmit(message)
+        return unless websocket.alive?
+
+        websocket.transmit message
+      end
+
       # Close the WebSocket connection.
       def close(...)
         websocket.close(...) if websocket.alive?

--- a/actioncable/lib/action_cable/subscription_adapter/subscriber_map.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/subscriber_map.rb
@@ -2,9 +2,35 @@
 
 # :markup: markdown
 
+require "concurrent/map"
+
 module ActionCable
   module SubscriptionAdapter
     class SubscriberMap
+      # A broadcast payload shared by all subscribers of a channel. It caches the
+      # encoded cable message per channel identifier, so the payload is decoded and
+      # re-encoded once per identifier rather than once per subscriber.
+      #
+      class Message < Struct.new(:data) # :nodoc:
+        def initialize(...)
+          super
+          @cache = Concurrent::Map.new
+        end
+
+        def encoded_for(identifier)
+          @cache.compute_if_absent(identifier) do
+            ActiveSupport::JSON.encode({ identifier: identifier, message: ActiveSupport::JSON.decode(data) })
+          end
+        end
+
+        # Behave like the underlying payload string for subscribers that expect one.
+        def to_s = data
+        alias_method :to_str, :to_s
+
+        def ==(other) = data == other
+        def <=>(other) = data <=> other
+      end
+
       def initialize
         @subscribers = Hash.new { |h, k| h[k] = [] }
         @sync = Mutex.new
@@ -41,6 +67,8 @@ module ActionCable
           return if !@subscribers.key?(channel)
           @subscribers[channel].dup
         end
+
+        message = Message.new(message)
 
         list.each do |subscriber|
           invoke_callback(subscriber, message)

--- a/actioncable/test/channel/stream_test.rb
+++ b/actioncable/test/channel/stream_test.rb
@@ -494,6 +494,26 @@ module ActionCable::StreamTests
       end
     end
 
+    test "fastlane broadcasts deliver the pre-encoded message without going through transmit" do
+      server.config.fastlane_broadcasts_enabled = true
+
+      run_in_eventmachine do
+        open_connection
+        receive(command: "subscribe", channel: MultiChatChannel.name, identifiers: {})
+        wait_for_async
+
+        assert_not_called socket, :transmit do
+          server.broadcast "main_room", { foo: "bar" }
+          wait_for_async
+        end
+
+        assert_equal(
+          { "identifier" => { channel: MultiChatChannel.name }.to_json, "message" => { "foo" => "bar" } },
+          socket.last_transmission
+        )
+      end
+    end
+
     test "subscription confirmation should only be sent out once with multiple stream_from" do
       run_in_eventmachine do
         open_connection

--- a/actioncable/test/channel/stream_test.rb
+++ b/actioncable/test/channel/stream_test.rb
@@ -344,16 +344,61 @@ module ActionCable::StreamTests
     end
   end
 
+  class OverridenStreamHandlersChannel < ActionCable::Channel::Base
+    class << self
+      def handler_calls = @@handler_calls ||= []
+    end
+
+    private
+      def stream_handler(broadcasting, user_handler, coder: nil)
+        self.class.handler_calls << [:stream_handler, broadcasting, user_handler.present?, coder]
+        super
+      end
+
+      def default_stream_handler(broadcasting, coder: nil)
+        self.class.handler_calls << [:default_stream_handler, broadcasting, nil, coder]
+        super
+      end
+  end
+
+  class UserHandlerChannel < OverridenStreamHandlersChannel
+    def subscribed
+      stream_from "test_handler" do |message|
+        transmit({ "msg" => message })
+      end
+    end
+  end
+
+  class TestCoder
+    def self.encode(val) = ActiveSupport::JSON.encode(val)
+    def self.decode(val) = ActiveSupport::JSON.decode(val).merge("test" => true)
+  end
+
+  class CoderChannel < OverridenStreamHandlersChannel
+    def subscribed
+      stream_from "test_coder", coder: TestCoder
+    end
+  end
+
+  class UserHandlerWithCoderChannel < OverridenStreamHandlersChannel
+    def subscribed
+      stream_from "test_handler_with_coder", coder: TestCoder do |message|
+        transmit(message.invert)
+      end
+    end
+  end
+
   class StreamFromTest < ActionCable::TestCase
     setup do
       @server = TestServer.new(subscription_adapter: ActionCable::SubscriptionAdapter::Async)
       @server.config.allowed_request_origins = %w( http://rubyonrails.com )
       @server.config.connection_class = -> { Connection }
+      OverridenStreamHandlersChannel.handler_calls.clear
     end
 
     attr_reader :socket, :server, :connection
 
-    test "custom encoder" do
+    test "custom encoder broadcasts" do
       run_in_eventmachine do
         open_connection
         subscribe_to identifiers: { id: 1 }
@@ -391,6 +436,64 @@ module ActionCable::StreamTests
       end
     end
 
+    test "user handler without a coder receives the raw broadcast payload" do
+      run_in_eventmachine do
+        open_connection
+        receive(command: "subscribe", channel: UserHandlerChannel.name, identifiers: {})
+        wait_for_async
+
+        server.broadcast "test_handler", { foo: "bar" }
+        wait_for_async
+
+        assert_equal(
+          { "msg" => %({"foo":"bar"}) },
+          socket.last_transmission.fetch("message")
+        )
+
+        assert_equal 1, UserHandlerChannel.handler_calls.size
+        assert_equal [:stream_handler, "test_handler", true, nil], UserHandlerChannel.handler_calls.last
+      end
+    end
+
+    test "handler with a coder transmits the decoded payload" do
+      run_in_eventmachine do
+        open_connection
+        receive(command: "subscribe", channel: CoderChannel.name, identifiers: {})
+        wait_for_async
+
+        server.broadcast "test_coder", { foo: "bar" }
+        wait_for_async
+
+        assert_equal(
+          { "foo" => "bar", "test" => true },
+          socket.last_transmission.fetch("message")
+        )
+
+        assert_equal 2, CoderChannel.handler_calls.size
+        assert_equal [:stream_handler, "test_coder", false, TestCoder], CoderChannel.handler_calls.first
+        assert_equal [:default_stream_handler, "test_coder", nil, TestCoder], CoderChannel.handler_calls.last
+      end
+    end
+
+    test "user handler with a coder receives the decoded payload" do
+      run_in_eventmachine do
+        open_connection
+        receive(command: "subscribe", channel: UserHandlerWithCoderChannel.name, identifiers: {})
+        wait_for_async
+
+        server.broadcast "test_handler_with_coder", { foo: "bar" }
+        wait_for_async
+
+        assert_equal(
+          { "bar" => "foo", "true" => "test" },
+          socket.last_transmission.fetch("message")
+        )
+
+        assert_equal 1, UserHandlerWithCoderChannel.handler_calls.size
+        assert_equal [:stream_handler, "test_handler_with_coder", true, TestCoder], UserHandlerWithCoderChannel.handler_calls.last
+      end
+    end
+
     test "subscription confirmation should only be sent out once with multiple stream_from" do
       run_in_eventmachine do
         open_connection
@@ -414,7 +517,7 @@ module ActionCable::StreamTests
         @connection = Connection.new(@server, @socket)
       end
 
-      def receive(command:, identifiers:, channel: "ActionCable::StreamTests::ChatChannel")
+      def receive(command:, identifiers:, channel: "ActionCable::StreamTests::ChatChannel", connection: @connection)
         identifier = JSON.generate(identifiers.merge(channel: channel))
         connection.handle_incoming({ "command" => command, "identifier" => identifier })
       end

--- a/actioncable/test/client_test.rb
+++ b/actioncable/test/client_test.rb
@@ -73,6 +73,7 @@ class ClientTest < ActionCable::TestCase
 
     # and now the "real" setup for our test:
     server.config.disable_request_forgery_protection = true
+    server.config.fastlane_broadcasts_enabled = true
   end
 
   def with_puma_server(rack_app = ActionCable.server, port = 3099)

--- a/actioncable/test/stubs/test_socket.rb
+++ b/actioncable/test/stubs/test_socket.rb
@@ -26,6 +26,10 @@ class TestSocket
     @transmissions << encode(cable_message)
   end
 
+  def raw_transmit(message)
+    @transmissions << message
+  end
+
   def last_transmission
     decode @transmissions.last if @transmissions.any?
   end

--- a/actioncable/test/subscription_adapter/subscriber_map_test.rb
+++ b/actioncable/test/subscription_adapter/subscriber_map_test.rb
@@ -35,6 +35,24 @@ class SubscriberMapTest < ActionCable::TestCase
     assert_equal origin, @subscription_map.instance_variable_get(:@subscribers)
   end
 
+  test "broadcast encodes a message once per identifier" do
+    setup_subscription_map
+    received = []
+    received2 = []
+    @subscription_map.add_subscriber("channel", ->(message) { received << message.encoded_for("id-1") }, nil)
+    @subscription_map.add_subscriber("channel", ->(message) { received << message.encoded_for("id-1") }, nil)
+    @subscription_map.add_subscriber("channel", ->(message) { received2 << message.encoded_for("id-2") }, nil)
+
+    @subscription_map.broadcast("channel", %({"foo":"bar"}))
+
+    assert_equal 2, received.size
+    assert_same received[0], received[1]
+    assert_equal 1, received2.size
+
+    assert_equal({ "identifier" => "id-1", "message" => { "foo" => "bar" } }, ActiveSupport::JSON.decode(received[0]))
+    assert_equal({ "identifier" => "id-2", "message" => { "foo" => "bar" } }, ActiveSupport::JSON.decode(received2[0]))
+  end
+
   private
     def setup_subscription_map
       @subscription_map = ActionCable::SubscriptionAdapter::SubscriberMap.new

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -61,6 +61,7 @@ Below are the default values associated with each target version. In cases of co
 #### Default Values for Target Version 8.2
 
 - [`ActiveSupport.raise_on_invalid_time_zone_parse`](#activesupport-raise-on-invalid-time-zone-parse): `true`
+- [`config.action_cable.fastlane_broadcasts_enabled`](#config-action-cable-fastlane-broadcasts-enabled): `true`
 - [`config.action_controller.default_protect_from_forgery_with`](#config-action-controller-default-protect-from-forgery-with): `:exception`
 - [`config.action_controller.forgery_protection_verification_strategy`](#config-action-controller-forgery-protection-verification-strategy): `:header_only`
 - [`config.action_controller.rescue_from_event_backtrace`](#config-action-controller-rescue-from-event-backtrace): `:array`
@@ -3562,6 +3563,20 @@ only the configured origins.
 
 Determines the request origins which will be accepted by the cable server.
 The default value is `/https?:\/\/localhost:\d+/` in the `development` environment.
+
+#### `config.action_cable.fastlane_broadcasts_enabled`
+
+Determines whether broadcasted messages are encoded once per channel identifier
+instead of once per subscriber. When enabled, messages streamed to clients
+without a custom callback or coder skip the per-subscriber JSON decode and
+re-encode. Such messages do not emit the `transmit.action_cable` notification.
+
+The default value depends on the `config.load_defaults` target version:
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `false`              |
+| 8.2                   | `true`               |
 
 ### Configuring Active Storage
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -398,6 +398,10 @@ module Rails
             active_job.enqueue_after_transaction_commit = true
           end
 
+          if respond_to?(:action_cable)
+            action_cable.fastlane_broadcasts_enabled = true
+          end
+
           ActiveSupport.raise_on_invalid_time_zone_parse = true
         else
           raise "Unknown version #{target_version.to_s.inspect}"

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
@@ -109,6 +109,15 @@
 #++
 # Rails.application.config.action_dispatch.strict_accept_header = true
 
+###
+# Encode broadcasted messages once per channel identifier instead of once per subscriber.
+#
+# When enabled, messages sent via `ActionCable.server.broadcast` are only decoded-encoded from/to JSON once
+# per channel identifier and not for every connected client thus reducing the broadcasting latency.
+# NOTE: Such messages do not emit the `transmit.action_cable` notification.
+#
+# Rails.application.config.action_cable.fastlane_broadcasts_enabled = true
+
 # Raise `ArgumentError` on `ActiveSupport::TimeZone#parse` for any invalid
 # string.
 #

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -4071,6 +4071,29 @@ module ApplicationTests
       assert_kind_of ActiveSupport::HashWithIndifferentAccess, ActionCable.server.config.cable
     end
 
+    test "config.action_cable.fastlane_broadcasts_enabled defaults to true for new apps" do
+      app "development"
+
+      assert_equal true, ActionCable.server.config.fastlane_broadcasts_enabled
+    end
+
+    test "config.action_cable.fastlane_broadcasts_enabled can be set to false for new apps" do
+      add_to_config "config.action_cable.fastlane_broadcasts_enabled = false"
+
+      app "development"
+
+      assert_equal false, ActionCable.server.config.fastlane_broadcasts_enabled
+    end
+
+    test "config.action_cable.fastlane_broadcasts_enabled defaults to false for upgraded apps" do
+      remove_from_config '.*config\.load_defaults.*\n'
+      add_to_config 'config.load_defaults "8.1"'
+
+      app "development"
+
+      assert_equal false, ActionCable.server.config.fastlane_broadcasts_enabled
+    end
+
     test "action_text.config.attachment_tag_name is 'action-text-attachment' with Rails 6 defaults" do
       add_to_config 'config.load_defaults "6.1"'
 


### PR DESCRIPTION
### Motivation / Background

This PR introduces an optimization that significantly reduces Action Cable broadcasting latency by avoiding decoding-encoding every message for each client. The fastlane mode decodes/encodes once per identifier instead.

In addition to broadcasting latency improvement (which becomes impactful only at certain scale), this optimization reduces CPU usage and as a side effect reduce the number of out-of-order deliveries (though, can't eliminate them completely).

This optimization has been used in production for a while via [actioncable-next](https://github.com/anycable/actioncable-next) gem.

### Detail

A new Action Cable configuration parameter added, `config.action_cable.fastlane_broadcasts_enabled`. Defaults to  false but is set to true via `load_defaults 8.2`.

When enabled, it changes the way stream handler callbacks are generated: in case no user callback neither an explicit coder is provided, we use the most straightforward callback possible: just send the raw broadcast payload without decoding/encoding it. Almost: we still need to attach an identifier (for client-side routing) but that can be done once per identifier, not per client.

The once-per-identifier decoding is achieved by wrapping the broadcast payload into an _envelope struct_, Message. It quacks like a String (via `#to_str`, etc.), so the previous contract is satisfied (and we don't need to refactor, say, subscription adapters, built-in or third-party). It comes with the `#encoded_for(identifier)` method that caches a resulting identifier-specific payload during the first call (via Concurrent::Map).

#### Benchmarks

Using [action-cable-next-playground](https://github.com/anycable/action-cable-next-playground) setup (used for the original refactoring).

With fastlane mode on, **latency decreases by 1.5-2x** Here are example `websocket-bench` runs:

```
# fastlane=false
[2026-09-08T23:44:12+03:00] clients:   600    95per-rtt:  94ms    min-rtt:   1ms    median-rtt:  34ms    max-rtt: 127ms
[2026-09-08T23:44:15+03:00] clients:  1400    95per-rtt: 189ms    min-rtt:   1ms    median-rtt:  79ms    max-rtt: 253ms
[2026-09-08T23:44:23+03:00] clients:  2000    95per-rtt: 372ms    min-rtt:   1ms    median-rtt: 121ms    max-rtt: 472ms

# fastlane=true
[2026-09-08T23:45:08+03:00] clients:   600    95per-rtt:  77ms    min-rtt:   1ms    median-rtt:  23ms    max-rtt:  97ms
[2026-09-08T23:46:29+03:00] clients:  1400    95per-rtt: 157ms    min-rtt:   1ms    median-rtt:  52ms    max-rtt: 392ms
[2026-09-08T23:45:16+03:00] clients:  2000    95per-rtt: 219ms    min-rtt:   1ms    median-rtt:  79ms    max-rtt: 308ms
```

More benchmarks below: https://github.com/rails/rails/pull/58703#issuecomment-5597764373

#### JSON-only (which is fine)

The optimization only works for JSON payloads and is only activated if the `#stream_from` call has no user callback neither coder provided. This matches the current behaviour: even though we can specify a custom coder at broadacst time, the default stream handler always tries to parse the payload as JSON. Hence, custom-encoded broadcasts can only target stream handler with custom coders today; otherwise, JSON is implied.

### Additional information

This PR also increase `#stream_from` test coverage as well as adds missing (but years ago proposed) testing for `#stream_handler` and `#default_stream_handler` overrides (Closes https://github.com/rails/rails/pull/56505). The tests were added to ensure the optimization doesn't break the current behaviour.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
