### PR TITLE
Honor config.active_storage.streaming_max_ranges

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Honor `config.active_storage.streaming_max_ranges`.
+
+    The setting was documented but never read, so the number of ranges a byte
+    range request may contain stayed at 1. Applications that raised the limit
+    by assigning `ActiveStorage.streaming_max_ranges` directly should move the
+    value to `config.active_storage.streaming_max_ranges`, which now takes
+    precedence.
+
+    *Carlos Daniel Pohlod*
+
 *   Marcel 2 for content type detection
 
     Broader and more precise MIME type detection, security hardening, and uses canonical types

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -180,6 +180,7 @@ module ActiveStorage
         ActiveStorage.track_variants = app.config.active_storage.track_variants || false
         ActiveStorage.analyze = app.config.active_storage.analyze || :later
         ActiveStorage.streaming_chunk_max_size = app.config.active_storage.streaming_chunk_max_size || 100.megabytes
+        ActiveStorage.streaming_max_ranges = app.config.active_storage.streaming_max_ranges || 1
       end
     end
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -4469,6 +4469,20 @@ module ApplicationTests
       assert_equal "-codec_whitelist h264", ActiveStorage.ffprobe_arguments
     end
 
+    test "ActiveStorage.streaming_max_ranges is 1 by default" do
+      app "development"
+
+      assert_equal 1, ActiveStorage.streaming_max_ranges
+    end
+
+    test "ActiveStorage.streaming_max_ranges can be configured" do
+      add_to_config "config.active_storage.streaming_max_ranges = 5"
+
+      app "development"
+
+      assert_equal 5, ActiveStorage.streaming_max_ranges
+    end
+
     test "ActiveStorage.variant_processor uses mini_magick without Rails 7 defaults" do
       remove_from_config '.*config\.load_defaults.*\n'
 


### PR DESCRIPTION
### Motivation / Background

`config.active_storage.streaming_max_ranges` is documented in the configuring guide, but setting it does nothing:

```ruby
config.active_storage.streaming_max_ranges = 5
ActiveStorage.streaming_max_ranges # => 1
```

The setting was added with the multi-range limit in bb78f8cd63, along with the guide entry, but the `active_storage.configs` initializer never copied it into `ActiveStorage.streaming_max_ranges`. The guide says "If you need multiple byte range support, you can increase that setting", which is not possible today.

### Detail

Copies the value in the initializer, next to the fifteen settings already handled there.

Since the config was inert, an application that needed a higher limit had to assign `ActiveStorage.streaming_max_ranges` in an initializer. That assignment is now overwritten on boot, so the CHANGELOG entry points those applications at the config option.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
