### PR TITLE
Fix public file Cache-Control for non-digested assets

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/static.rb
+++ b/actionpack/lib/action_dispatch/middleware/static.rb
@@ -55,15 +55,26 @@ module ActionDispatch
     def initialize(root, index: "index", headers: {}, precompressed: %i[ br gzip ], compressible_content_types: /\A(?:text\/|application\/javascript|image\/svg\+xml)/)
       @root = root.chomp("/").b
       @index = index
+      @headers = headers
 
       @precompressed = Array(precompressed).map(&:to_s) | %w[ identity ]
       @compressible_content_types = compressible_content_types
 
-      @file_server = ::Rack::Files.new(@root, headers)
+      # Pass only non-callable headers to Rack::Files. Callables are resolved
+      # per-request in #serve so they are not stringified as #<Proc:...>.
+      static_headers = headers.reject { |_, value| value.respond_to?(:call) }
+      @file_server = ::Rack::Files.new(@root, static_headers)
     end
 
     def call(env)
-      attempt(env) || @file_server.call(env)
+      attempt(env) || begin
+        status, headers, body = @file_server.call(env)
+        if status != 304
+          request = Rack::Request.new(env)
+          headers = headers.merge(resolved_headers(request.path_info, env))
+        end
+        [status, headers, body]
+      end
     end
 
     def attempt(env)
@@ -78,17 +89,25 @@ module ActionDispatch
 
     private
       def serve(request, filepath, content_headers)
+        path_info = request.path_info
         original, request.path_info =
           request.path_info, ::Rack::Utils.escape_path(filepath).b
 
         @file_server.call(request.env).tap do |status, headers, body|
           # Omit content-encoding/type/etc headers for 304 Not Modified
           if status != 304
+            headers.update(resolved_headers(path_info, request.env))
             headers.update(content_headers)
           end
         end
       ensure
         request.path_info = original
+      end
+
+      def resolved_headers(path, env)
+        @headers.transform_values do |value|
+          value.respond_to?(:call) ? value.call(path, env) : value
+        end
       end
 
       # Match a URI path to a static file to be served.

--- a/actionpack/test/dispatch/static_test.rb
+++ b/actionpack/test/dispatch/static_test.rb
@@ -2,6 +2,7 @@
 
 require "abstract_unit"
 require "zlib"
+require "fileutils"
 
 class StaticTest < ActiveSupport::TestCase
   DummyApp = lambda { |env|
@@ -266,6 +267,28 @@ class StaticTest < ActiveSupport::TestCase
     assert_equal "http://rubyonrails.org", response.headers["access-control-allow-origin"]
     assert_equal "public, max-age=60",     response.headers["cache-control"]
     assert_equal "I'm a teapot",           response.headers["x-custom-header"]
+  end
+
+  def test_serves_files_with_callable_headers
+    headers = {
+      "cache-control" => ->(path, _) {
+        path.start_with?("/assets/") ? "public, max-age=31536000" : "public, max-age=86400"
+      }
+    }
+
+    @app = build_app(DummyApp, @root, headers: headers)
+
+    assets_dir = File.join(@root, "assets")
+    FileUtils.mkdir_p(assets_dir)
+    with_static_file "/assets/app.js" do
+      response = get("/assets/app.js")
+      assert_equal "public, max-age=31536000", response.headers["cache-control"]
+      assert_not_includes response.headers["cache-control"].to_s, "Proc"
+    end
+
+    response = get("/foo/bar.html")
+    assert_equal "public, max-age=86400", response.headers["cache-control"]
+    assert_not_includes response.headers["cache-control"].to_s, "Proc"
   end
 
   def test_ignores_unknown_http_methods

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -21,8 +21,17 @@ Rails.application.configure do
   config.action_controller.perform_caching = true
   <%- end -%>
 
-  # Cache assets for far-future expiry since they are all digest stamped.
-  config.public_file_server.headers = { "cache-control" => "public, max-age=#{1.year.to_i}" }
+  # Cache digest-stamped assets for far-future expiry; keep a short cache for
+  # other public files (robots.txt, favicons, 404.html, etc.).
+  config.public_file_server.headers = {
+    "cache-control" => lambda { |path, _|
+      if path.start_with?("/assets/")
+        "public, immutable, max-age=#{1.year.to_i}"
+      else
+        "public, max-age=#{1.day.to_i}"
+      end
+    }
+  }
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   config.asset_host = ENV["CDN_HOST"]

--- a/railties/test/application/middleware/static_test.rb
+++ b/railties/test/application/middleware/static_test.rb
@@ -46,6 +46,28 @@ module ApplicationTests
       assert_equal "public, max-age=60",     last_response.headers["Cache-Control"]
     end
 
+    test "callable headers resolve per path and are not stringified" do
+      app_file "public/robots.txt", "User-agent: *\nDisallow:"
+      app_file "public/assets/app.js", "console.log(1)"
+      add_to_config <<-CONFIG
+        config.public_file_server.headers = {
+          "Cache-Control" => ->(path, _) {
+            path.start_with?("/assets/") ? "public, max-age=31536000" : "public, max-age=86400"
+          }
+        }
+      CONFIG
+
+      require "#{app_path}/config/environment"
+
+      get "/robots.txt"
+      assert_equal "public, max-age=86400", last_response.headers["Cache-Control"]
+      assert_not_includes last_response.headers["Cache-Control"].to_s, "Proc"
+
+      get "/assets/app.js"
+      assert_equal "public, max-age=31536000", last_response.headers["Cache-Control"]
+      assert_not_includes last_response.headers["Cache-Control"].to_s, "Proc"
+    end
+
     test "public_file_server.index_name defaults to 'index'" do
       app_file "public/index.html", "/index.html"
 


### PR DESCRIPTION
### Motivation / Background

Fixes #53683.

Non-digested public files (`robots.txt`, favicons, `404.html`, etc.) currently get the same far-future `Cache-Control` as digest-stamped assets because the production generator sets a single 1-year header for everything.

A previous attempt (#55249) put a path-based lambda in `public_file_server.headers`, but `Rack::Files` stringifies Proc values, producing `Cache-Control: #<Proc:…>` (#55617). That change was reverted in #55633.

### Detail

1. **`ActionDispatch::FileHandler`** resolves header values that `respond_to?(:call)` per request `(path, env)` and merges them onto the response. Only non-callable headers are passed into `Rack::Files`, so callables are never stringified.
2. **Production generator template** restores path-based caching:
   - `/assets/*` → `public, immutable, max-age=1.year`
   - everything else → `public, max-age=1.day`

### Additional information

- Tests cover callable headers in `actionpack/test/dispatch/static_test.rb` and `railties/test/application/middleware/static_test.rb`.
- Existing string-header configuration is unchanged.