### PR TITLE
SQLite table reconstruction cascade-deletes child rows inside transac…

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Preserve rows referenced by cascading foreign keys when SQLite rebuilds a
+    table inside a transactional migration.
+
+    *Nicolas Vandenbogaerde*
+
 *   Re-enable PostgreSQL triggers when the block given to `disable_referential_integrity` raises.
 
     On PostgreSQL versions without `NOT ENFORCED` constraints (before 18.4), the

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -527,6 +527,10 @@ module ActiveRecord
         current_transaction.isolation = old_isolation if isolation_override
       end
 
+      def transaction_for_migration(&block) # :nodoc:
+        transaction(&block)
+      end
+
       attr_reader :transaction_manager # :nodoc:
 
       delegate :within_new_transaction, :open_transactions, :current_transaction, :begin_transaction,

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -198,6 +198,12 @@ module ActiveRecord
         true
       end
 
+      def transaction_for_migration(&block) # :nodoc:
+        disable_referential_integrity do
+          transaction(&block)
+        end
+      end
+
       def supports_savepoints?
         true
       end

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1604,7 +1604,7 @@ module ActiveRecord
       # Wrap the migration in a transaction only if supported by the adapter.
       def ddl_transaction(migration, &block)
         if use_transaction?(migration)
-          connection.transaction(&block)
+          connection.transaction_for_migration(&block)
         else
           yield
         end

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -5,6 +5,7 @@ require "cases/migration/helper"
 require "bigdecimal/util"
 require "concurrent/atomic/count_down_latch"
 require "active_support/core_ext/object/with"
+require "tmpdir"
 
 require "models/person"
 require "models/topic"
@@ -639,6 +640,51 @@ class MigrationTest < ActiveRecord::TestCase
 
       assert_no_column Person, :last_name,
         "On error, the Migrator should revert schema changes but it did not."
+    end
+
+    if current_adapter?(:SQLite3Adapter)
+      def test_table_rebuild_inside_migration_transaction_preserves_cascade_children
+        connection = ActiveRecord::Base.lease_connection
+        connection.create_table(:migration_authors) { |table| table.string :name, null: false }
+        connection.add_check_constraint(
+          :migration_authors,
+          "length(name) > 0",
+          name: "migration_authors_name_present"
+        )
+        connection.create_table(:migration_books) do |table|
+          table.references :migration_author,
+            null: false,
+            foreign_key: { to_table: :migration_authors, on_delete: :cascade }
+        end
+        connection.execute("INSERT INTO migration_authors (id, name) VALUES (1, 'Douglas Adams')")
+        connection.execute("INSERT INTO migration_books (id, migration_author_id) VALUES (1, 1)")
+
+        Dir.mktmpdir do |directory|
+          File.write(
+            File.join(directory, "20260909000000_remove_migration_author_name_check.rb"),
+            <<~RUBY
+              class RemoveMigrationAuthorNameCheck < ActiveRecord::Migration[8.1]
+                def change
+                  remove_check_constraint :migration_authors, name: "migration_authors_name_present"
+                end
+              end
+            RUBY
+          )
+
+          migration_context = ActiveRecord::MigrationContext.new(directory, @schema_migration, @internal_metadata)
+          migration_context.migrate
+        end
+
+        assert_equal 1, connection.select_value("SELECT COUNT(*) FROM migration_authors")
+        assert_equal 1, connection.select_value("SELECT COUNT(*) FROM migration_books")
+        assert_equal 1, connection.select_value("PRAGMA foreign_keys")
+
+        connection.execute("DELETE FROM migration_authors WHERE id = 1")
+        assert_equal 0, connection.select_value("SELECT COUNT(*) FROM migration_books")
+      ensure
+        connection&.drop_table(:migration_books, if_exists: true)
+        connection&.drop_table(:migration_authors, if_exists: true)
+      end
     end
 
     def test_migration_without_transaction


### PR DESCRIPTION
### Motivation / Background

SQLite does not allow `PRAGMA foreign_keys` to be changed while a transaction is active.
Although the SQLite adapter disables referential integrity before rebuilding a table,
`ActiveRecord::Migrator` has already opened an outer DDL transaction by that point.
Consequently, disabling foreign keys is a no-op and dropping the original table during
reconstruction can trigger `ON DELETE CASCADE`, silently deleting rows from referencing
tables.

Fixes #58705.

### Detail

This pull request introduces an adapter hook for migration transactions. The default
implementation preserves the existing transaction behavior, while SQLite overrides the
hook to disable referential integrity before opening the migration transaction and restore
it afterward.

The regression test runs the schema change through `MigrationContext`, verifies that
referencing rows survive the table reconstruction, and confirms that foreign key
enforcement and cascading deletes still work after the migration completes.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate pull requests.
* [x] Commit message has a detailed description of what changed and why. If this pull request fixes a related issue, include it in the commit message.
* [x] Tests are added or updated for the bug fix.
* [x] The Active Record changelog is updated.
