### PR TITLE
Share the time zone caches with Ractor workers

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -279,6 +279,16 @@ module ActiveSupport
         @zones_map = nil
       end
 
+      def make_shareable! # :nodoc:
+        all
+        TZInfo::Timezone.all_identifiers.each { |identifier| self[identifier] }
+        TZInfo::Country.all_codes.each { |code| country_zones(code) }
+
+        @lazy_zones_map = ActiveSupport::Ractors.make_shareable(@lazy_zones_map.each_pair.to_h)
+        @country_zones  = ActiveSupport::Ractors.make_shareable(@country_zones.each_pair.to_h)
+        ActiveSupport::Ractors.make_shareable(MAPPING)
+      end
+
       private
         def load_country_zones(code)
           country = TZInfo::Country.get(code)

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -1004,3 +1004,19 @@ class TimeZoneTest < ActiveSupport::TestCase
     assert_not_includes ca_zones.map(&:name), "America/Edmonton"
   end
 end
+
+class TimeZoneRactorTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::Isolation
+  include ActiveSupport::Testing::RactorsAssertions
+
+  def test_zones_are_usable_from_a_non_main_ractor_once_shared
+    ActiveSupport::TimeZone.make_shareable!
+
+    assert_equal "Europe/Paris", on_ractor { ActiveSupport::TimeZone["Paris"].tzinfo.name }
+    assert_equal "Europe/Paris", on_ractor { ActiveSupport::TimeZone["Europe/Paris"].tzinfo.name }
+    assert_equal 3600, on_ractor { ActiveSupport::TimeZone["Paris"].utc_offset }
+    assert_equal "2026-07-01 14:00:00 +0200", on_ractor { Time.utc(2026, 7, 1, 12).in_time_zone("Paris").to_s }
+    assert_equal "Asia/Tokyo", on_ractor { Time.use_zone("Tokyo") { Time.zone.tzinfo.name } }
+    assert_includes on_ractor { ActiveSupport::TimeZone.country_zones(:fr).map(&:name) }, "Paris"
+  end
+end

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -674,6 +674,7 @@ module Rails
       @autoloaders, @reloaders, @routes_reloader = nil, nil, nil
 
       ActionView::PathRegistry.make_shareable! if defined?(ActionView::PathRegistry)
+      ActiveSupport::TimeZone.make_shareable!
 
       if defined?(AbstractController::Base)
         [AbstractController::Base, *AbstractController::Base.descendants].each do |controller|


### PR DESCRIPTION
Eager-load and make ActiveSupport::TimeZone objects shareable.

Follow-up to https://github.com/rails/rails/pull/58067 which makes the objects shareable themselves, but still doesn't allow to access them from Ractors since the registry is a `Concurrent::Map` (not shareable).

This eager-loads all the timezones from TZInfo, and caches their identifier in the lazy zones map (same with countries), that way we can turn the `Concurrent::Map` into a simple frozen hash and make it readable from other Ractors during `Rails::Application#ractorize!`.

This adds maybe 200ms to boot time but it only applies to ractorized applications.