### PR TITLE
Don't write to the reloader class when there is nothing to reload

### DIFF
--- a/activesupport/lib/active_support/execution_wrapper.rb
+++ b/activesupport/lib/active_support/execution_wrapper.rb
@@ -11,6 +11,7 @@ module ActiveSupport
     Null = Object.new # :nodoc:
     def Null.complete! # :nodoc:
     end
+    Null.freeze
 
     define_callbacks :run
     define_callbacks :complete

--- a/activesupport/lib/active_support/reloader.rb
+++ b/activesupport/lib/active_support/reloader.rb
@@ -2,6 +2,7 @@
 
 require "active_support/execution_wrapper"
 require "active_support/executor"
+require "active_support/ractors"
 
 module ActiveSupport
   # = Active Support \Reloader
@@ -82,10 +83,13 @@ module ActiveSupport
     end
 
     class_attribute :executor, default: Executor
-    class_attribute :check, default: lambda { false }
+    class_attribute :check, default: Ractors.shareable_proc { false }
 
     def self.check! # :nodoc:
-      @should_reload ||= check.call
+      return @should_reload if @should_reload
+
+      should_reload = check.call
+      @should_reload = should_reload if should_reload
     end
 
     def self.reloaded! # :nodoc:

--- a/activesupport/test/reloader_test.rb
+++ b/activesupport/test/reloader_test.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require_relative "abstract_unit"
+require "active_support/testing/ractors_assertions"
 
 class ReloaderTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::RactorsAssertions
+
   def test_prepare_callback
     prepared = completed = false
     reloader.to_prepare { prepared = true }
@@ -94,6 +97,24 @@ class ReloaderTest < ActiveSupport::TestCase
       end
     end
     assert_equal 1, reports.size
+  end
+
+  def test_check_does_not_write_to_the_class_when_there_is_nothing_to_reload
+    reloader = new_reloader { false }
+
+    assert_not reloader.check!
+    assert_not reloader.instance_variable_defined?(:@should_reload)
+
+    reloader.check = lambda { true }
+
+    assert reloader.check!
+    assert reloader.instance_variable_get(:@should_reload)
+  end
+
+  def test_run_on_a_non_main_ractor_with_the_default_check
+    reloader = Class.new(ActiveSupport::Reloader)
+
+    assert on_ractor(reloader) { |r| r.run!.equal?(ActiveSupport::ExecutionWrapper::Null) }
   end
 
   private

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -199,8 +199,6 @@ module Rails
           else
             app.reloader.check = lambda { true }
           end
-        else
-          app.reloader.check = lambda { false }
         end
 
         if config.reloading_enabled?


### PR DESCRIPTION
This makes it more friendly to Ractor workers which, provided they never need a reload, won't have to write to the Reloader module instance variable.

I found this while making Active Job ractor-safe. Since the `active_job.set_reloader_hook` initializer calls `wrap` on the reloader, and the reloader's `run!` method is overridden to call `check!`, `check!` can't write if it's called from a Ractor (I don't have a ractor job adapter, but I was testing with the inline adapter from a request).

Even if the check says to never reload (Edit: ~in `ractorize!`~ the default), we always wrote to the instance variable because of the `||=`.