### PR TITLE
Remove the deprecated guides:generate:kindle task

### DIFF
--- a/guides/Rakefile
+++ b/guides/Rakefile
@@ -22,12 +22,6 @@ namespace :guides do
       generate_guides
     end
 
-    desc "Generate .mobi file"
-    task :kindle do
-      warn("DEPRECATION WARNING: The guides:generate:kindle rake task is deprecated and will be removed in 7.2. Run rake guides:generate:epub instead.")
-      Rake::Task["guides:generate:epub"].invoke
-    end
-
     desc "Generate .epub file"
     task :epub do
       ENV["EPUB"] = "1"
@@ -82,7 +76,7 @@ Guides are taken from the source directory, and the result goes into the
 output directory. Assets are stored under files, and copied to output/files as
 part of the generation process.
 
-You can generate HTML, Kindle or both formats using the `guides:generate` task.
+You can generate the HTML or the EPUB guides using the `guides:generate` task.
 
 All of these processes are handled via rake tasks, here's a full list of them:
 

--- a/guides/source/ruby_on_rails_guides_guidelines.md
+++ b/guides/source/ruby_on_rails_guides_guidelines.md
@@ -359,13 +359,14 @@ $ bundle exec rake guides:validate
 
 Particularly, titles get an ID generated from their content and this often leads to duplicates.
 
-Kindle Guides
--------------
+EPUB Guides
+-----------
 
 ### Generation
 
-To generate guides for the Kindle, use the following rake task:
+To generate the guides as an EPUB, readable on a Kindle and other e-readers,
+use the following rake task:
 
 ```bash
-$ bundle exec rake guides:generate:kindle
+$ bundle exec rake guides:generate:epub
 ```


### PR DESCRIPTION
This change removes the deprecated `guides:generate:kindle` rake task from `guides/Rakefile`. The task was due for removal in Rails 7.2, and with `RAILS_VERSION` now at 8.2.0.alpha, it is safe to drop it.

The `guides:generate:epub` task remains the supported way to generate e-reader formats.