### PR TITLE
[ci skip] Use supported positional enum form in Calculations guide example

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -3355,7 +3355,7 @@ SELECT COUNT(DISTINCT customers.id) FROM customers
   WHERE (customers.first_name = "Ryan" AND orders.status = 0)
 ```
 
-assuming that Order has `enum status: [ :shipped, :being_packed, :cancelled ]`.
+assuming that Order has `enum :status, [ :shipped, :being_packed, :cancelled ]`.
 
 ### `count`
 


### PR DESCRIPTION
The Calculations section of the Active Record Querying guide was using an `enum` declaration that doesn't work anymore. 

The example currently shows `enum status: [...]`, which is not compatible with the required positional enum form.