### PR TITLE
Remove the dead racc compile task from Action Pack

### DIFF
--- a/actionpack/Rakefile
+++ b/actionpack/Rakefile
@@ -35,9 +35,3 @@ task :lines do
   files = FileList["lib/**/*.rb"]
   CodeTools::LineStatistics.new(files).print_loc
 end
-
-rule ".rb" => ".y" do |t|
-  sh "racc -l -o #{t.name} #{t.source}"
-end
-
-task compile: "lib/action_dispatch/journey/parser.rb"


### PR DESCRIPTION
Remove the racc compile rule and associated `compile` task from `actionpack/Rakefile`. 

[The `.y` grammar it targeted was removed in August 2024](https://github.com/rails/rails/pull/52610).

Because `lib/action_dispatch/journey/parser.rb` exists on disk and has no rule source, Rake resolves the prerequisite as already satisfied, so the task reports success without doing anything:
```
    $ bundle exec rake compile --trace
    ** Invoke compile (first_time)
    ** Invoke lib/action_dispatch/journey/parser.rb (first_time, not_needed)
    ** Execute compile
```