### PR TITLE
Preserve read_multi key order when local cache is active

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Preserve the requested key order in `ActiveSupport::Cache::Store#read_multi`
+    when a local cache is active.
+
+    `fetch_multi` was fixed for this, but `read_multi` still returned the local
+    cache hits first instead of following the order of the requested keys.
+
+    *Carlos Daniel Pohlod*
+
 *   Preserve the requested key order in `ActiveSupport::Cache::Store#fetch_multi`
     when a local cache is active.
 

--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -199,7 +199,7 @@ module ActiveSupport
               results.merge!(super(names - results.keys, **options))
             end
 
-            results
+            results.slice(*names)
           end
 
           def write_serialized_entry(key, payload, **)

--- a/activesupport/test/cache/behaviors/local_cache_behavior.rb
+++ b/activesupport/test/cache/behaviors/local_cache_behavior.rb
@@ -293,6 +293,25 @@ module LocalCacheBehavior
     end
   end
 
+  def test_local_cache_of_read_multi_preserves_order
+    first_key = SecureRandom.uuid
+    cached_key = SecureRandom.uuid
+    last_key = SecureRandom.uuid
+
+    @peek.write(first_key, "1", raw: true)
+    @peek.write(last_key, "3", raw: true)
+
+    @cache.with_local_cache do
+      # Seed the local cache so that only the middle key is a local hit.
+      @cache.write(cached_key, "2", raw: true)
+
+      results = @cache.read_multi(first_key, cached_key, last_key, raw: true)
+
+      assert_equal [first_key, cached_key, last_key], results.keys
+      assert_equal ["1", "2", "3"], results.values
+    end
+  end
+
   def test_local_cache_of_read_multi
     key = SecureRandom.uuid
     value = SecureRandom.alphanumeric


### PR DESCRIPTION
### Motivation / Background

Inside `with_local_cache`, `read_multi` returns the local cache hits first rather than following the requested order:

```ruby
cache.read_multi("a", "b", "c").keys   # => ["b", "a", "c"], when only "b" was a local hit
```

0f231b0f6e fixed exactly this for `fetch_multi`. `read_multi_entries` sits two methods below, builds its result the same way (local hits, then `merge!` of whatever the store returns) and was left behind.

### Detail

Slices the result by the requested names, as `fetch_multi` does.

Keys that were not found stay absent rather than being filled in with `nil`, since `slice` only keeps keys the hash already has. That matters here because `read_multi` may legitimately return fewer keys than requested.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
