### PR TITLE
[ci-skip][doc] Fix Action Cable guide for connection callbacks

### DIFF
--- a/actioncable/lib/action_cable/connection/callbacks.rb
+++ b/actioncable/lib/action_cable/connection/callbacks.rb
@@ -11,8 +11,8 @@ module ActionCable
     # The [before_command](rdoc-ref:ClassMethods#before_command),
     # [after_command](rdoc-ref:ClassMethods#after_command), and
     # [around_command](rdoc-ref:ClassMethods#around_command) callbacks are invoked
-    # when sending commands to the client, such as when subscribing, unsubscribing,
-    # or performing an action.
+    # when receiving commands from the client, such as when subscribing,
+    # unsubscribing, or performing an action.
     #
     # #### Example
     #

--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -167,7 +167,7 @@ end
 #### Connection Callbacks
 
 [`ActionCable::Connection::Callbacks`][] provides callback hooks that are
-invoked when sending commands to the client, such as when subscribing,
+invoked when receiving commands from the client, such as when subscribing,
 unsubscribing, or performing an action:
 
 * [`before_command`][]


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because we received an issue https://github.com/yasslab/railsguides.jp/issues/1972 that the following "when sending commands to the client" in [Action Cable guide](https://guides.rubyonrails.org/v8.0/action_cable_overview.html#connection-callbacks) is inaccurate and should be "when receiving commands from the client" instead:

<img width="639" height="251" alt="image" src="https://github.com/user-attachments/assets/ff6840ca-3a06-4ef5-a797-1cf36d21620f" />

### Detail

This Pull Request changes the guide as:

```diff
[`ActionCable::Connection::Callbacks`][] provides callback hooks that are
-invoked when sending commands to the client, such as when subscribing,
+invoked when receiving commands from the client, such as when subscribing,
unsubscribing, or performing an action:
```

FYI: Here is [the code that calls `run_callbacks`](https://github.com/rails/rails/blob/52fa23ce8e1d39ff281bf300867e9ba7c7d66111/actioncable/lib/action_cable/connection/base.rb#L106):

```rb
def handle_channel_command(payload)
  run_callbacks :command do
    subscriptions.execute_command payload
  end
end
```

### Additional information

This also affects the following branches and should be backported to them:

- [8-1-stable](https://github.com/rails/rails/blob/8-1-stable/guides/source/action_cable_overview.md?plain=1#L170)
- [8-0-stable](https://github.com/rails/rails/blob/8-0-stable/guides/source/action_cable_overview.md?plain=1#L170)
- [7-2-stable](https://github.com/rails/rails/blob/7-2-stable/guides/source/action_cable_overview.md?plain=1#L170)
- [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/guides/source/action_cable_overview.md?plain=1#L170)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
