### PR TITLE
Generate the `has_rich_text` methods in a module so they can be overridden with `super`

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   Generate the `has_rich_text` methods in a module so they can be overridden with `super`.
+
+    `has_rich_text :content` defined `content`, `content=` and `content?` directly on the
+    model, so overriding one of them in the same class replaced the generated implementation
+    with no way to call back into it.
+
+    They are now defined in the model's `GeneratedAssociationMethods` module, matching
+    `has_one_attached` and `has_many_attached`:
+
+        class Message < ApplicationRecord
+          has_rich_text :content
+
+          def content=(body)
+            super(body&.strip)
+          end
+        end
+
+    *Felipe Felix*
+
 *   Add alternative text to Action Text attachments.
 
     Attachments could only be described by their caption, which is always shown

--- a/actiontext/lib/action_text/attribute.rb
+++ b/actiontext/lib/action_text/attribute.rb
@@ -51,7 +51,7 @@ module ActionText
       # `action_text_rich_texts.record_type` polymorphic type column of the
       # corresponding rows.
       def has_rich_text(name, encrypted: false, strict_loading: strict_loading_by_default, store_if_blank: true)
-        class_eval <<-CODE, __FILE__, __LINE__ + 1
+        generated_association_methods.class_eval <<-CODE, __FILE__, __LINE__ + 1
           def #{name}
             rich_text_#{name} || build_rich_text_#{name}
           end
@@ -62,13 +62,13 @@ module ActionText
         CODE
 
         if store_if_blank
-          class_eval <<-CODE, __FILE__, __LINE__ + 1
+          generated_association_methods.class_eval <<-CODE, __FILE__, __LINE__ + 1
             def #{name}=(body)
               self.#{name}.body = body
             end
           CODE
         else
-          class_eval <<-CODE, __FILE__, __LINE__ + 1
+          generated_association_methods.class_eval <<-CODE, __FILE__, __LINE__ + 1
             def #{name}=(body)
               if body.present?
                 self.#{name}.body = body

--- a/actiontext/test/unit/model_test.rb
+++ b/actiontext/test/unit/model_test.rb
@@ -179,4 +179,72 @@ class ActionText::ModelTest < ActiveSupport::TestCase
     message2.content = ""
     assert_not_predicate message2, :valid?
   end
+
+  test "overriding has_rich_text getter works" do
+    message = Message.create!(subject: "Greetings", content: "<h1>Hello world</h1>")
+
+    assert_equal "Hello world", message.content.to_plain_text
+
+    begin
+      Message.class_eval do
+        def content
+          super.to_plain_text.upcase
+        end
+      end
+
+      assert_equal "HELLO WORLD", message.content
+    ensure
+      Message.remove_method :content
+    end
+  end
+
+  test "overriding has_rich_text setter works" do
+    Message.class_eval do
+      def content=(body)
+        super("<h1>#{body}</h1>")
+      end
+    end
+
+    message = Message.create!(subject: "Greetings", content: "Hello world")
+    assert_equal "<h1>Hello world</h1>", message.content.body.to_html
+  ensure
+    Message.remove_method :content=
+  end
+
+  test "overriding has_rich_text setter works with store_if_blank: false" do
+    MessageWithoutBlanks.class_eval do
+      def content=(body)
+        super(body.presence && "<h1>#{body}</h1>")
+      end
+    end
+
+    assert_difference("ActionText::RichText.count" => 1) do
+      message = MessageWithoutBlanks.create!(subject: "Greetings", content: "Hello world")
+      assert_equal "<h1>Hello world</h1>", message.content.body.to_html
+    end
+
+    assert_difference("ActionText::RichText.count" => 0) do
+      assert_not_predicate MessageWithoutBlanks.create!(subject: "Greetings", content: ""), :content?
+    end
+  ensure
+    MessageWithoutBlanks.remove_method :content=
+  end
+
+  test "overriding has_rich_text predicate works" do
+    message = Message.create!(subject: "Greetings", content: "Hello world")
+
+    assert_predicate message, :content?
+
+    begin
+      Message.class_eval do
+        def content?
+          !super
+        end
+      end
+
+      assert_not_predicate message, :content?
+    ensure
+      Message.remove_method :content?
+    end
+  end
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the methods generated by `has_rich_text` could not be overridden and composed with `super`. `has_rich_text :content` defines `content`, `content=` and `content?` with `class_eval` directly on the model, so an override in the  same class replaces the generated implementation and there is no way to call back into it:

```ruby
class Message < ApplicationRecord
  has_rich_text :content

  def content=(body)
    super(body&.strip) # NoMethodError: super: no superclass method 'content='
  end
end
```

### Detail

This Pull Request changes the three `class_eval` calls in `ActionText::Attribute#has_rich_text` to `generated_association_methods.class_eval`, so the reader, the writer and the predicate are defined in a module included in the model instead of on the model itself. Overriding any of them in the class body and calling super now works, matching has_one_attached.

Both writer variants are covered, so the change applies with `store_if_blank: true` and `store_if_blank: false`.

Tests were added to `actiontext/test/unit/model_test.rb`, following the style of the Active Storage tests in `activestorage/test/models/attached/one_test.rb`.

### Additional information

Active Storage had the same problem and fixed it in https://github.com/rails/rails/pull/32921 by generating `has_one_attached` and `has_many_attached` methods in the model's `GeneratedAssociationMethods` module. This applies the same fix to Action Text.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
