### PR TITLE
Route `/.well-known/change-password` to the password reset page

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Route `/.well-known/change-password` to the password reset page.
+
+    Browsers and password managers use this well-known URL to send people
+    straight to a site's change password page, typically after warning them that
+    a saved password appeared in a breach. The route is a temporary redirect, as
+    the specification requires the well-known URL not host the page itself.
+
+        get "/.well-known/change-password", to: redirect("/passwords/new", status: 302)
+
+    API-only applications skip the route, since they generate no pages to
+    redirect to.
+
+    *Matheus Richard*
+
 *   Mark the generated `public/*.html` error pages as `linguist-generated` in
     the default `.gitattributes`.
 

--- a/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
+++ b/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
@@ -40,6 +40,10 @@ module Rails
       end
 
       def configure_authentication_routes
+        unless options.api?
+          route %(get "/.well-known/change-password", to: redirect("/passwords/new", status: 302))
+        end
+
         route "resources :passwords, param: :token, only: [ :new, :create, :edit, :update ]"
         route "resource :session, only: [ :new, :create, :destroy ]"
       end

--- a/railties/test/generators/authentication_generator_test.rb
+++ b/railties/test/generators/authentication_generator_test.rb
@@ -71,6 +71,16 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_authentication_generator_adds_change_password_well_known_route
+    generator([destination_root])
+
+    run_generator_instance
+
+    assert_file "config/routes.rb" do |content|
+      assert_match(%r{get "/\.well-known/change-password", to: redirect\("/passwords/new", status: 302\)}, content)
+    end
+  end
+
   def test_authentication_generator_without_bcrypt_in_gemfile
     File.write("#{destination_root}/Gemfile", File.read("#{destination_root}/Gemfile").sub(/# gem "bcrypt".*\n/, ""))
 
@@ -107,6 +117,7 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
     assert_file "config/routes.rb" do |content|
       assert_match(/resource :session, only: \[ :new, :create, :destroy \]/, content)
       assert_match(/resources :passwords, param: :token, only: \[ :new, :create, :edit, :update \]/, content)
+      assert_no_match(%r{/\.well-known/change-password}, content)
     end
 
     assert_includes @rails_commands, "generate migration CreateUsers email_address:string!:uniq password_digest:string! --force"


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

Browsers and password managers use this well-known URL to send people straight to a site's change password page, typically after warning them that a saved password appeared in a breach.

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->


### Detail

This Pull Request a new route on the authentication generator for a well-known URL. The route is a temporary redirect, as the specification requires the well-known URL not host the page itself.

    get "/.well-known/change-password", to: redirect("/passwords/new", status: 302)

API-only applications skip the route, since they generate no pages to redirect to.

### Additional information

[A Well-Known URL for Changing Passwords - W3C](https://www.w3.org/TR/change-password-url/)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
