### PR TITLE
Add ActiveRecord.with_async_query_execution_limit

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Add `ActiveRecord.with_async_query_execution_limit` to limit concurrent
+    queries started by `load_async` and `async_*` methods within a block.
+
+    The limit is shared across all connection pools in the current execution
+    context. Once the limit is reached, further calls wait for an earlier query
+    to complete before checking out a connection. Calls made while the caller
+    already holds a connection from the target pool are not limited.
+
+    The limit must be a positive integer. Nested calls raise `ArgumentError`.
+
+    *Yuhi Sato*
+
 *   Re-enable PostgreSQL triggers when the block given to `disable_referential_integrity` raises.
 
     On PostgreSQL versions without `NOT ENFORCED` constraints (before 18.4), the

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -97,6 +97,7 @@ module ActiveRecord
     autoload :Aggregations
     autoload :AssociationRelation
     autoload :Associations
+    autoload :AsyncQueryExecutionSemaphore
     autoload :AsynchronousQueriesTracker
     autoload :AttributeAssignment
     autoload :AttributeMethods
@@ -347,6 +348,21 @@ module ActiveRecord
 
   def self.global_executor_concurrency # :nodoc:
     @global_executor_concurrency ||= nil
+  end
+
+  # Limits concurrent queries started by +load_async+ and +async_*+ methods within
+  # the block. Additional calls wait until a previous query completes.
+  #
+  #   ActiveRecord.with_async_query_execution_limit(2) do
+  #     posts = Post.where(published: true).load_async
+  #     count = Comment.async_count
+  #   end
+  #
+  # The limit is shared by all connection pools in the current execution context.
+  # The limit must be a positive integer. Nested calls raise ArgumentError.
+  # Calls made while the caller holds a connection are not limited.
+  def self.with_async_query_execution_limit(limit, &block)
+    AsyncQueryExecutionSemaphore.with(limit, &block)
   end
 
   @permanent_connection_checkout = true

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -277,7 +277,7 @@ module ActiveRecord
           end
 
           binds = AssociationScope.get_bind_values(owner, reflection.chain)
-          klass.with_connection do |c|
+          klass.with_query_connection(async: async) do |c|
             sc.execute(binds, c, async: async) do |record|
               set_inverse_instance(record)
               set_strict_loading(record)

--- a/activerecord/lib/active_record/async_query_execution_semaphore.rb
+++ b/activerecord/lib/active_record/async_query_execution_semaphore.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+# :markup: markdown
+
+require "active_support/isolated_execution_state"
+require "concurrent/atomic/semaphore"
+
+module ActiveRecord
+  class AsyncQueryExecutionSemaphore # :nodoc:
+    STATE_KEY = :active_record_async_query_execution_semaphore
+    RESERVED_PERMIT_KEY = :active_record_async_query_execution_semaphore_permit
+    private_constant :STATE_KEY, :RESERVED_PERMIT_KEY
+
+    class Permit # :nodoc:
+      def initialize(semaphore)
+        @semaphore = semaphore
+        @mutex = Mutex.new
+        @claimed = false
+        @released = false
+      end
+
+      def claim
+        @mutex.synchronize do
+          return if @released
+
+          @claimed = true
+          self
+        end
+      end
+
+      def claimed?
+        @mutex.synchronize { @claimed }
+      end
+
+      def release
+        semaphore = @mutex.synchronize do
+          return if @released
+
+          @released = true
+          @semaphore
+        end
+        semaphore.release
+      end
+    end
+    private_constant :Permit
+
+    class << self
+      def with(limit, &block)
+        if current
+          raise ArgumentError, "nested async query execution limits are not supported"
+        end
+
+        with_state(STATE_KEY, new(limit), &block)
+      end
+
+      def reserve(pool, &block)
+        semaphore = current
+        return block.call unless semaphore && pool.async_executor
+        return block.call if pool.active_connection || reserved_permit?
+
+        permit = semaphore.acquire
+        with_state(RESERVED_PERMIT_KEY, permit, &block)
+      ensure
+        permit.release if permit && !permit.claimed?
+      end
+
+      def claim_reserved_permit
+        ActiveSupport::IsolatedExecutionState[RESERVED_PERMIT_KEY]&.claim
+      end
+
+      private
+        def current
+          ActiveSupport::IsolatedExecutionState[STATE_KEY]
+        end
+
+        def reserved_permit?
+          ActiveSupport::IsolatedExecutionState.key?(RESERVED_PERMIT_KEY)
+        end
+
+        def with_state(key, value)
+          state = ActiveSupport::IsolatedExecutionState
+          state[key] = value
+          yield
+        ensure
+          state.delete(key)
+        end
+    end
+
+    def initialize(limit)
+      unless limit.is_a?(Integer) && limit.positive?
+        raise ArgumentError, "limit must be a positive integer"
+      end
+
+      @semaphore = Concurrent::Semaphore.new(limit)
+    end
+
+    def acquire
+      @semaphore.acquire
+      Permit.new(@semaphore)
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -886,8 +886,9 @@ module ActiveRecord
       end
 
       def schedule_query(future_result) # :nodoc:
-        @async_executor.post { future_result.execute_or_skip }
+        accepted = @async_executor.post { future_result.execute_or_skip }
         Thread.pass
+        accepted
       end
 
       def new_connection # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/query_intent.rb
+++ b/activerecord/lib/active_record/connection_adapters/query_intent.rb
@@ -106,6 +106,7 @@ module ActiveRecord
         @event_buffer = nil
         @log_handle = nil
         @finalized = false
+        @async_query_execution_permit = nil
 
         @retry_budget = nil
       end
@@ -173,6 +174,8 @@ module ActiveRecord
             end
           end
         end
+      ensure
+        release_async_query_execution_permit
       end
 
       # Is this intent still pending (result not yet available)?
@@ -399,11 +402,15 @@ module ActiveRecord
           # Force preprocessing on original thread before queuing
           processed_sql
 
+          @async_query_execution_permit = ActiveRecord::AsyncQueryExecutionSemaphore.claim_reserved_permit
+
           # Detach from original adapter while in queue
           @adapter = nil
 
           # Schedule on the pool's async queue
-          @pool.schedule_query(self)
+          accepted = @pool.schedule_query(self)
+        ensure
+          release_async_query_execution_permit unless accepted
         end
 
         # Heuristically guesses whether this is a write query by examining the outermost
@@ -465,10 +472,16 @@ module ActiveRecord
           rescue => error
             @error = error
           end
+        ensure
+          release_async_query_execution_permit
         end
 
         def can_run_async?
           @allow_async && adapter.async_enabled?
+        end
+
+        def release_async_query_execution_permit
+          @async_query_execution_permit&.release
         end
 
         def run_query!

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -336,6 +336,17 @@ module ActiveRecord
       connection_pool.with_connection(prevent_permanent_checkout: prevent_permanent_checkout, &block)
     end
 
+    def with_query_connection(async:, &block) # :nodoc:
+      if async
+        pool = connection_pool
+        ActiveRecord::AsyncQueryExecutionSemaphore.reserve(pool) do
+          pool.with_connection(&block)
+        end
+      else
+        with_connection(&block)
+      end
+    end
+
     attr_writer :connection_specification_name
 
     # Returns the connection specification name from the current class or its parent.

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -69,7 +69,7 @@ module ActiveRecord
 
     # Same as #find_by_sql but perform the query asynchronously and returns an ActiveRecord::Promise.
     def async_find_by_sql(sql, binds = [], preparable: nil, allow_retry: false, &block)
-      with_connection do |c|
+      with_query_connection(async: true) do |c|
         _query_by_sql(c, sql, binds, preparable: preparable, allow_retry: allow_retry, async: true)
       end.then do |result|
         _load_from_sql(result, &block)
@@ -126,7 +126,7 @@ module ActiveRecord
 
     # Same as #count_by_sql but perform the query asynchronously and returns an ActiveRecord::Promise.
     def async_count_by_sql(sql)
-      with_connection do |c|
+      with_query_connection(async: true) do |c|
         c.select_value(_sql_for_find(sql), "#{name} Count", async: true).then(&:to_i)
       end
     end

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -1194,7 +1194,7 @@ module ActiveRecord
     #
     #   ASYNC Post Load (0.0ms) (db time 2ms)  SELECT "posts".* FROM "posts" LIMIT 100
     def load_async
-      with_connection do |c|
+      model.with_query_connection(async: true) do |c|
         return load if !c.async_enabled?
 
         unless loaded?
@@ -1506,7 +1506,7 @@ module ActiveRecord
           if where_clause.contradiction?
             [].freeze
           elsif eager_loading?
-            model.with_connection do |c|
+            model.with_query_connection(async: async) do |c|
               apply_join_dependency do |relation, join_dependency|
                 if relation.null_relation?
                   [].freeze
@@ -1518,7 +1518,7 @@ module ActiveRecord
               end
             end
           else
-            model.with_connection do |c|
+            model.with_query_connection(async: async) do |c|
               model._query_by_sql(c, arel, async: async)
             end
           end

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -323,7 +323,7 @@ module ActiveRecord
           if where_clause.contradiction? && !possible_aggregation?(column_names)
             ActiveRecord::Result.empty(async: @async)
           else
-            model.with_connection do |c|
+            model.with_query_connection(async: @async) do |c|
               c.select_all(relation.arel, "#{model.name} Pluck", async: @async)
             end
           end
@@ -481,7 +481,7 @@ module ActiveRecord
           end
         else
           skip_query_cache_if_necessary do
-            model.with_connection do |c|
+            model.with_query_connection(async: @async) do |c|
               c.select_all(query_builder, "#{model.name} #{operation.capitalize}", async: @async)
             end
           end
@@ -514,7 +514,7 @@ module ActiveRecord
         relation = except(:group).distinct!(false)
         group_fields = relation.arel_columns(group_fields)
 
-        model.with_connection do |connection|
+        model.with_query_connection(async: @async) do |connection|
           column_alias_tracker = ColumnAliasTracker.new(connection)
 
           group_aliases = group_fields.map { |field|

--- a/activerecord/test/cases/async_query_execution_semaphore_test.rb
+++ b/activerecord/test/cases/async_query_execution_semaphore_test.rb
@@ -1,0 +1,414 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/arunit2_model"
+require "models/other_dog"
+require "models/post"
+
+module AsyncQueryExecutionSemaphoreHelpers
+  private
+    def with_semaphore(semaphore, &block)
+      ActiveRecord::AsyncQueryExecutionSemaphore.send(:with_state, :active_record_async_query_execution_semaphore, semaphore, &block)
+    end
+end
+
+class AsyncQueryExecutionSemaphoreTest < ActiveRecord::TestCase
+  include AsyncQueryExecutionSemaphoreHelpers
+
+  FakePool = Struct.new(:async_executor, :active_connection)
+
+  def test_requires_a_positive_integer
+    assert_raises(ArgumentError) { ActiveRecord.with_async_query_execution_limit(0) { } }
+    assert_raises(ArgumentError) { ActiveRecord.with_async_query_execution_limit(-1) { } }
+    assert_raises(ArgumentError) { ActiveRecord.with_async_query_execution_limit("2") { } }
+    assert_raises(ArgumentError) { ActiveRecord.with_async_query_execution_limit(nil) { } }
+  end
+
+  def test_returns_the_block_value
+    result = ActiveRecord.with_async_query_execution_limit(2) { :result }
+
+    assert_equal :result, result
+  end
+
+  def test_nested_scopes_raise_without_changing_the_outer_semaphore
+    ActiveRecord.with_async_query_execution_limit(2) do
+      outer_semaphore = current_semaphore
+
+      error = assert_raises(ArgumentError) do
+        ActiveRecord.with_async_query_execution_limit(1) { flunk "block must not run" }
+      end
+
+      assert_equal "nested async query execution limits are not supported", error.message
+      assert_same outer_semaphore, current_semaphore
+    end
+
+    assert_nil current_semaphore
+  end
+
+  def test_nil_raises_without_changing_an_enclosing_limit
+    ActiveRecord.with_async_query_execution_limit(2) do
+      outer_semaphore = current_semaphore
+
+      assert_raises(ArgumentError) do
+        ActiveRecord.with_async_query_execution_limit(nil) { flunk "block must not run" }
+      end
+
+      assert_same outer_semaphore, current_semaphore
+    end
+  end
+
+  def test_restores_the_scope_when_the_block_raises
+    assert_raises(RuntimeError) do
+      ActiveRecord.with_async_query_execution_limit(1) { raise "boom" }
+    end
+
+    assert_nil current_semaphore
+  end
+
+  def test_the_scope_is_isolated_from_other_threads
+    ActiveRecord.with_async_query_execution_limit(1) do
+      semaphore_in_other_thread = Thread.new { current_semaphore }.value
+
+      assert_nil semaphore_in_other_thread
+      assert_not_nil current_semaphore
+    end
+  end
+
+  def test_the_scope_is_isolated_from_other_fibers_when_fiber_isolation_is_enabled
+    previous_isolation_level = ActiveSupport::IsolatedExecutionState.isolation_level
+    ActiveSupport::IsolatedExecutionState.isolation_level = :fiber
+
+    ActiveRecord.with_async_query_execution_limit(1) do
+      semaphore_in_other_fiber = Fiber.new { current_semaphore }.resume
+
+      assert_nil semaphore_in_other_fiber
+      assert_not_nil current_semaphore
+    end
+  ensure
+    ActiveSupport::IsolatedExecutionState.isolation_level = previous_isolation_level
+  end
+
+  def test_acquire_blocks_until_a_permit_is_released
+    semaphore = ActiveRecord::AsyncQueryExecutionSemaphore.new(1)
+    first_permit = semaphore.acquire
+    started = Queue.new
+    acquired = Queue.new
+
+    thread = Thread.new do
+      started << true
+      permit = semaphore.acquire
+      acquired << true
+      permit.release
+    end
+
+    started.pop
+    assert_raises(ThreadError) { acquired.pop(true) }
+
+    first_permit.release
+    assert acquired.pop
+    thread.join
+  end
+
+  def test_permit_can_only_be_released_once
+    semaphore = ActiveRecord::AsyncQueryExecutionSemaphore.new(1)
+    permit = semaphore.acquire
+
+    permit.release
+    permit.release
+
+    assert_equal 1, concurrent_semaphore(semaphore).available_permits
+  end
+
+  def test_reserve_releases_an_unclaimed_permit
+    semaphore = ActiveRecord::AsyncQueryExecutionSemaphore.new(1)
+    pool = FakePool.new(Object.new, nil)
+
+    with_semaphore(semaphore) { ActiveRecord::AsyncQueryExecutionSemaphore.reserve(pool) { } }
+
+    assert_equal 1, concurrent_semaphore(semaphore).available_permits
+  end
+
+  def test_reserve_blocks_before_yielding
+    semaphore = ActiveRecord::AsyncQueryExecutionSemaphore.new(1)
+    pool = FakePool.new(Object.new, nil)
+    first_permit = semaphore.acquire
+    started = Queue.new
+    reserved = Queue.new
+
+    thread = Thread.new do
+      with_semaphore(semaphore) do
+        started << true
+        ActiveRecord::AsyncQueryExecutionSemaphore.reserve(pool) { reserved << true }
+      end
+    end
+
+    started.pop
+    assert_raises(ThreadError) { reserved.pop(true) }
+
+    first_permit.release
+    assert reserved.pop
+    thread.join
+  end
+
+  def test_reserve_does_not_limit_calls_with_an_active_connection
+    semaphore = ActiveRecord::AsyncQueryExecutionSemaphore.new(1)
+    pool = FakePool.new(Object.new, Object.new)
+    permit = semaphore.acquire
+
+    with_semaphore(semaphore) do
+      result = ActiveRecord::AsyncQueryExecutionSemaphore.reserve(pool) { :result }
+      assert_equal :result, result
+    end
+  ensure
+    permit&.release
+  end
+
+  private
+    def concurrent_semaphore(semaphore)
+      semaphore.instance_variable_get(:@semaphore)
+    end
+
+    def current_semaphore
+      ActiveRecord::AsyncQueryExecutionSemaphore.send(:current)
+    end
+end
+
+class AsyncQueryExecutionLimitTest < ActiveRecord::TestCase
+  include AsyncQueryExecutionSemaphoreHelpers
+
+  self.use_transactional_tests = false
+
+  class QueueingExecutor
+    def initialize
+      @jobs = Queue.new
+    end
+
+    def post(&job)
+      @jobs << job
+      true
+    end
+
+    def size
+      @jobs.size
+    end
+
+    def run_next
+      @jobs.pop.call
+    end
+
+    def run_all
+      run_next until @jobs.empty?
+    end
+  end
+
+  class NotifyingSemaphore < ActiveRecord::AsyncQueryExecutionSemaphore
+    def initialize(limit)
+      super
+      @limit = limit
+      @acquisitions = 0
+      @mutex = Mutex.new
+      @waiting = Queue.new
+    end
+
+    def acquire
+      acquisition = @mutex.synchronize { @acquisitions += 1 }
+      @waiting << true if acquisition > @limit
+      super
+    end
+
+    def wait_until_blocked
+      @waiting.pop
+    end
+  end
+
+  class DiscardingExecutor
+    def post
+      false
+    end
+  end
+
+  class QueueThenCallerRunsExecutor
+    attr_reader :post_threads
+
+    def initialize
+      @jobs = Queue.new
+      @post_threads = []
+      @mutex = Mutex.new
+      @posts = 0
+    end
+
+    def post(&job)
+      post = @mutex.synchronize do
+        @post_threads << Thread.current
+        @posts += 1
+      end
+
+      if post == 1
+        @jobs << job
+      else
+        job.call
+      end
+      true
+    end
+
+    def run_next
+      @jobs.pop.call
+    end
+  end
+
+  class RejectingExecutor
+    def post
+      raise Concurrent::RejectedExecutionError
+    end
+  end
+
+  def test_async_query_calls_block_before_posting_past_the_limit
+    skip if in_memory_db?
+
+    with_async_executor(QueueingExecutor.new) do |executor|
+      semaphore = NotifyingSemaphore.new(2)
+      posted_before_release = Queue.new
+
+      with_semaphore(semaphore) do
+        count = Post.async_count
+        ids = Post.limit(2).async_pluck(:id)
+        runner = Thread.new do
+          semaphore.wait_until_blocked
+          posted_before_release << executor.size
+          executor.run_next
+        end
+
+        posts = Post.limit(2).load_async
+        runner.join
+
+        assert_equal 2, posted_before_release.pop
+        assert_equal 2, executor.size
+
+        executor.run_all
+
+        assert_equal Post.count, count.value
+        assert_equal Post.limit(2).pluck(:id), ids.value
+        assert_equal Post.limit(2).to_a, posts.to_a
+      end
+    end
+  end
+
+  def test_discarded_submission_releases_the_permit
+    skip if in_memory_db?
+
+    with_async_executor(DiscardingExecutor.new) do
+      ActiveRecord.with_async_query_execution_limit(1) do
+        first = Post.async_count
+        second = Post.async_count
+
+        assert_equal Post.count, first.value
+        assert_equal Post.count, second.value
+      end
+    end
+  end
+
+  def test_caller_runs_executes_on_the_waiting_caller
+    skip if in_memory_db?
+
+    executor = QueueThenCallerRunsExecutor.new
+    with_async_executor(executor) do
+      semaphore = NotifyingSemaphore.new(1)
+      caller = Thread.current
+
+      with_semaphore(semaphore) do
+        first = Post.async_count
+        runner = Thread.new do
+          semaphore.wait_until_blocked
+          executor.run_next
+        end
+
+        second = Post.limit(2).async_pluck(:id)
+        runner.join
+
+        assert_same caller, executor.post_threads.second
+        assert_equal Post.count, first.value
+        assert_equal Post.limit(2).pluck(:id), second.value
+      end
+    end
+  end
+
+  def test_limit_is_shared_across_connection_pools
+    skip if in_memory_db?
+
+    primary_executor = QueueingExecutor.new
+    secondary_executor = QueueingExecutor.new
+
+    with_async_executors(
+      ActiveRecord::Base.connection_pool => primary_executor,
+      ARUnit2Model.connection_pool => secondary_executor,
+    ) do
+      semaphore = NotifyingSemaphore.new(1)
+      posted_before_release = Queue.new
+
+      with_semaphore(semaphore) do
+        post_count = Post.async_count
+        runner = Thread.new do
+          semaphore.wait_until_blocked
+          posted_before_release << [primary_executor.size, secondary_executor.size]
+          primary_executor.run_next
+        end
+
+        dog_count = OtherDog.async_count
+        runner.join
+
+        assert_equal [1, 0], posted_before_release.pop
+        assert_equal 1, secondary_executor.size
+
+        secondary_executor.run_next
+
+        assert_equal Post.count, post_count.value
+        assert_equal OtherDog.count, dog_count.value
+      end
+    end
+  end
+
+  def test_rejected_submission_releases_the_permit
+    skip if in_memory_db?
+
+    with_async_executor(RejectingExecutor.new) do
+      ActiveRecord.with_async_query_execution_limit(1) do
+        assert_raises(Concurrent::RejectedExecutionError) { Post.async_count }
+        assert_raises(Concurrent::RejectedExecutionError) { Post.async_count }
+      end
+    end
+  end
+
+  def test_disabled_executor_executes_without_waiting_for_a_permit
+    semaphore = ActiveRecord::AsyncQueryExecutionSemaphore.new(1)
+    permit = semaphore.acquire
+
+    with_async_executor(nil) do
+      with_semaphore(semaphore) do
+        assert_equal Post.count, Post.async_count.value
+      end
+    end
+  ensure
+    permit&.release
+  end
+
+  private
+    def with_async_executor(executor)
+      pool = ActiveRecord::Base.connection_pool
+      with_async_executors(pool => executor) { yield executor }
+    end
+
+    def with_async_executors(executors)
+      original_executors = executors.to_h do |pool, executor|
+        pool.release_connection
+        original_executor = pool.async_executor
+        pool.instance_variable_set(:@async_executor, executor)
+        [pool, original_executor]
+      end
+
+      yield
+    ensure
+      original_executors&.each do |pool, executor|
+        pool.instance_variable_set(:@async_executor, executor)
+      end
+    end
+end

--- a/activerecord/test/cases/asynchronous_queries_test.rb
+++ b/activerecord/test/cases/asynchronous_queries_test.rb
@@ -187,6 +187,25 @@ class AsynchronousQueriesTest < ActiveRecord::TestCase
     end
   end
 
+  def test_async_query_execution_limit_keeps_failures_with_their_query
+    skip unless @connection.async_enabled?
+
+    failure = ActiveRecord::StatementInvalid.new("count failed")
+    matching = ->(intent) { intent.name == "Post Count" }
+    @connection.pool.release_connection
+
+    with_async_query_failures([failure], matching: matching) do
+      ActiveRecord.with_async_query_execution_limit(1) do
+        count = Post.async_count
+        titles = Post.limit(2).async_pluck(:title)
+
+        error = assert_raises(ActiveRecord::StatementInvalid) { count.value }
+        assert_equal "count failed", error.message
+        assert_equal Post.limit(2).pluck(:title), titles.value
+      end
+    end
+  end
+
   private
     def with_async_query_failures(failures, matching:, repeat_last: false)
       adapter_class = @connection.class


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Allow callers to limit concurrency for specific async query workloads without changing executor configuration, as discussed in [this proposal](https://discuss.rubyonrails.org/t/proposal-limit-concurrency-for-specific-async-query-workloads/91576).

### Detail

Add `ActiveRecord.with_async_query_execution_limit(limit)` for `load_async` and `async_*` methods. The limit is shared across connection pools in the current execution context.

Unlike the original proposal’s non-blocking scheduling, calls wait for capacity before checking out a connection.

The limit must be a positive integer, and limit blocks cannot be nested.

Queries made inside `with_connection` using the same connection pool are not limited. For example, `Post.async_count` inside `Post.with_connection` bypasses the limit to avoid waiting while holding a database connection.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
