### PR TITLE
Boot with an unsecurable libvips unless the processor uses it

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Boot with an unsupported libvips or ruby-vips unless the variant processor uses it.
+
+    An installed libvips or ruby-vips too old to block the unfuzzed loaders raised during application
+    boot for every variant processor. Active Storage now raises only when the `:vips` processor loads
+    or the Vips analyzer reads an image, so `:mini_magick` applications boot again.
+
+    Fixes #58394.
+
+    *Mike Dalessio*
+
 *   Marcel 2 for content type detection
 
     Broader and more precise MIME type detection, security hardening, and uses canonical types

--- a/activestorage/lib/active_storage/analyzer/image_analyzer/vips.rb
+++ b/activestorage/lib/active_storage/analyzer/image_analyzer/vips.rb
@@ -17,6 +17,8 @@ module ActiveStorage
           return {}
         end
 
+        ActiveStorage.require_securable_vips!
+
         download_blob_to_tempfile do |file|
           image = instrument("vips") do
             # ruby-vips will raise Vips::Error if it can't find an appropriate loader for the file

--- a/activestorage/lib/active_storage/transformers/vips.rb
+++ b/activestorage/lib/active_storage/transformers/vips.rb
@@ -7,6 +7,7 @@
 # active_storage/vips has already loaded image_processing/vips, but requiring it here is what
 # raises LoadError when the gem is missing, which the engine reports as an actionable warning.
 require "active_storage/vips"
+ActiveStorage.require_securable_vips!
 require "image_processing/vips"
 
 module ActiveStorage

--- a/activestorage/lib/active_storage/vips.rb
+++ b/activestorage/lib/active_storage/vips.rb
@@ -32,13 +32,22 @@ if ActiveStorage::VIPS_AVAILABLE
     # image_processing is only needed to generate variants, not to analyze blobs.
   end
 
-  unless Vips.respond_to?(:block_untrusted)
-    raise <<~ERROR.squish
-      libvips's unfuzzed operations are not safe to use with untrusted content, and Active Storage
-      cannot disable them. Disabling them requires libvips 8.13 or later and ruby-vips 2.2.1 or
-      later. Please upgrade libvips and ruby-vips, or remove the ruby-vips gem from your Gemfile.
-    ERROR
-  end
+  ActiveStorage::VIPS_UNSECURABLE = !Vips.respond_to?(:block_untrusted) # :nodoc:
+  Vips.block_untrusted(true) unless ActiveStorage::VIPS_UNSECURABLE
+else
+  ActiveStorage::VIPS_UNSECURABLE = false # :nodoc:
+end
 
-  Vips.block_untrusted(true)
+module ActiveStorage
+  # Raises when the installed libvips and ruby-vips cannot disable the unfuzzed loaders and savers.
+  # Called before Active Storage hands untrusted content to libvips.
+  def self.require_securable_vips! # :nodoc:
+    if VIPS_UNSECURABLE
+      raise <<~ERROR.squish
+        libvips's unfuzzed operations are not safe to use with untrusted content, and Active Storage
+        cannot disable them. Disabling them requires libvips 8.13 or later and ruby-vips 2.2.1 or
+        later. Please upgrade libvips and ruby-vips, or remove the ruby-vips gem from your Gemfile.
+      ERROR
+    end
+  end
 end

--- a/activestorage/test/analyzer/image_analyzer/vips_test.rb
+++ b/activestorage/test/analyzer/image_analyzer/vips_test.rb
@@ -6,6 +6,16 @@ require "database/setup"
 require "active_storage/analyzer/image_analyzer"
 
 class ActiveStorage::Analyzer::ImageAnalyzer::VipsTest < ActiveSupport::TestCase
+  test "analyzing raises when libvips cannot block its unfuzzed loaders" do
+    analyze_with_vips do
+      blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+
+      stub_const(ActiveStorage, :VIPS_UNSECURABLE, true) do
+        assert_raises(RuntimeError, match: /Active Storage cannot disable them/) { extract_metadata_from(blob) }
+      end
+    end
+  end
+
   test "analyzing a JPEG image" do
     analyze_with_vips do
       blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")

--- a/railties/test/application/active_storage/engine_integration_test.rb
+++ b/railties/test/application/active_storage/engine_integration_test.rb
@@ -87,7 +87,60 @@ module ApplicationTests
       assert_includes(output, "Unknown variant processor :nope")
     end
 
+    def test_mini_magick_transformer_boots_with_unsecurable_vips
+      add_to_config "config.active_storage.variant_processor = :mini_magick"
+      add_ruby_vips_stub "module Vips; end"
+
+      output = run_command("puts :booted")
+
+      assert_includes(output, "booted")
+    end
+
+    def test_vips_transformer_raises_at_boot_with_unsecurable_vips
+      add_to_config "config.active_storage.variant_processor = :vips"
+      add_ruby_vips_stub "module Vips; end"
+
+      output = run_command("puts :booted")
+
+      assert_not_includes(output, "booted")
+      assert_includes(output, "remove the ruby-vips gem from your Gemfile. (RuntimeError)")
+    end
+
+    def test_block_untrusted_runs_before_initializers_without_vips_transformer
+      add_to_config "config.active_storage.variant_processor = :mini_magick"
+      add_ruby_vips_stub <<~'RUBY'
+        module Vips
+          def self.block_untrusted(state) = puts("block_untrusted(#{state})")
+        end
+      RUBY
+      app_file "config/initializers/probe.rb", 'puts "initializer"'
+
+      output = run_command("puts :booted")
+
+      assert_equal %w[block_untrusted(true) initializer booted], output.lines.map(&:chomp).grep(/^(block_untrusted|initializer|booted)/)
+    end
+
     private
+      def add_ruby_vips_stub(source)
+        FileUtils.mkdir_p app_path("ruby-vips", "lib")
+
+        File.write app_path("ruby-vips", "ruby-vips.gemspec"), <<~RUBY
+          Gem::Specification.new do |spec|
+            spec.name = "ruby-vips"
+            spec.version = "2.3.0"
+            spec.summary = "ruby-vips stub"
+            spec.authors = [ "Rails test" ]
+            spec.files = [ "lib/ruby-vips.rb" ]
+          end
+        RUBY
+
+        File.write app_path("ruby-vips", "lib", "ruby-vips.rb"), source
+
+        File.open app_path("Gemfile"), "a" do |f|
+          f.puts %(gem "ruby-vips", path: "#{app_path("ruby-vips")}")
+        end
+      end
+
       def run_command(cmd)
         Dir.chdir(app_path) do
           Bundler.with_original_env do


### PR DESCRIPTION
### Motivation / Background

Since cd0a2588 (released in 8.1.3.1), loading `active_storage/vips` at boot raised whenever ruby-vips was installed but libvips or ruby-vips was too old to block the unfuzzed loaders. That stopped `:mini_magick` applications from booting even though Active Storage never hands them content through libvips.

Fixes #58394.

### Detail

Keep loading ruby-vips and calling `Vips.block_untrusted(true)` at boot for every processor, and raise only where libvips is used: when the Vips transformer loads, and when the Vips analyzer reads an image. For `:vips` applications the error still fires during boot, now from `after_initialize` rather than engine load.

### Additional information

This is an alternative to #58406, which moves the require out of boot and so drops the boot-time block for every processor other than `:vips`. A CHANGELOG entry is included. Reproduced with a demo app pinning ruby-vips 2.1.4 and `variant_processor = :mini_magick`: 8.1.3.1 and main fail to boot, this branch boots.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
