### PR TITLE
Move timestamp_attributes_for into SchemaContext

### DIFF
--- a/activerecord/lib/active_record/model_schema/schema_context.rb
+++ b/activerecord/lib/active_record/model_schema/schema_context.rb
@@ -39,6 +39,10 @@ module ActiveRecord
       attr_reader :model_class, :columns_hash, :columns, :column_names,
                   :content_columns
 
+      attr_reader :timestamp_attributes_for_create_in_model,
+        :timestamp_attributes_for_update_in_model,
+        :all_timestamp_attributes_in_model
+
       def initialize(model_class)
         @model_class = model_class
         @schema_loaded = false
@@ -123,6 +127,10 @@ module ActiveRecord
           c.name == model_class.inheritance_column ||
           c.name.end_with?("_id", "_count")
         end.freeze
+
+        @timestamp_attributes_for_create_in_model = (model_class.timestamp_attributes_for_create & @column_names).freeze
+        @timestamp_attributes_for_update_in_model = (model_class.timestamp_attributes_for_update & @column_names).freeze
+        @all_timestamp_attributes_in_model = (@timestamp_attributes_for_create_in_model + @timestamp_attributes_for_update_in_model).freeze
 
         model_class.make_pending_attribute_modifications_shareable
         attributes

--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -62,40 +62,28 @@ module ActiveRecord
       end
 
       def timestamp_attributes_for_create_in_model
-        @timestamp_attributes_for_create_in_model ||=
-          (timestamp_attributes_for_create & column_names).freeze
+        schema_context.timestamp_attributes_for_create_in_model
       end
 
       def timestamp_attributes_for_update_in_model
-        @timestamp_attributes_for_update_in_model ||=
-          (timestamp_attributes_for_update & column_names).freeze
+        schema_context.timestamp_attributes_for_update_in_model
       end
 
       def all_timestamp_attributes_in_model
-        @all_timestamp_attributes_in_model ||=
-          (timestamp_attributes_for_create_in_model + timestamp_attributes_for_update_in_model).freeze
+        schema_context.all_timestamp_attributes_in_model
       end
 
       def current_time_from_proper_timezone
         with_connection { |c| c.default_timezone == :utc ? Time.now.utc : Time.now }
       end
 
-      protected
-        def reload_schema_from_cache(recursive = true)
-          @timestamp_attributes_for_create_in_model = nil
-          @timestamp_attributes_for_update_in_model = nil
-          @all_timestamp_attributes_in_model = nil
-          super
-        end
+      def timestamp_attributes_for_create
+        ["created_at", "created_on"].map! { |name| attribute_aliases[name] || name }
+      end
 
-      private
-        def timestamp_attributes_for_create
-          ["created_at", "created_on"].map! { |name| attribute_aliases[name] || name }
-        end
-
-        def timestamp_attributes_for_update
-          ["updated_at", "updated_on"].map! { |name| attribute_aliases[name] || name }
-        end
+      def timestamp_attributes_for_update
+        ["updated_at", "updated_on"].map! { |name| attribute_aliases[name] || name }
+      end
     end
 
   private


### PR DESCRIPTION
Instead of computing the values lazily (which doesn't play well with Ractors), this now computes the values when the schema is loaded. Now, as long as the schema is loaded on the main Ractor, these values can be used on non-main Ractors.

For some code specific "why":
- Hooking reload_from_schema_cache is no longer needed because when the
  schema reloads, the SchemaContext object is thrown away (so there's
  nothing to manually reset)
- timestamp_attribute_for_{create,update} were made public because we
  have to call them inside the SchemaContext now