### PR TITLE
Fix FileSystemResolver Ractor test on Ruby master

### DIFF
--- a/actionview/test/template/file_system_resolver_test.rb
+++ b/actionview/test/template/file_system_resolver_test.rb
@@ -134,22 +134,6 @@ class FileSystemResolverRactorTest < ActiveSupport::TestCase
   include ActiveSupport::Testing::Isolation
   include ActiveSupport::Testing::RactorsAssertions
 
-  # Compiling methods into FakeView from another Ractor is how frozen non-strict templates
-  # are compiled in a ractorized application, with the view class container built in the
-  # main Ractor and other Ractors compiling methods into it. This might stop working with
-  # https://bugs.ruby-lang.org/issues/22226, which would require compiling into a
-  # Ractor-local container instead.
-  class FakeView
-    def compiled_method_container
-      self.class
-    end
-
-    def _run(method, template, locals, buffer, add_to_stack:, has_strict_locals:, &block)
-      @output_buffer = buffer
-      public_send(method, locals, buffer, &block)
-    end
-  end
-
   test "non-strict templates compile inside a non-main Ractor" do
     Dir.mktmpdir do |dir|
       Dir.mkdir(File.join(dir, "test"))
@@ -170,7 +154,19 @@ class FileSystemResolverRactorTest < ActiveSupport::TestCase
       rendered = on_ractor(resolver) do |resolver|
         details = { locale: [:en].freeze, formats: [:html].freeze, variants: [].freeze, handlers: [:erb].freeze }.freeze
         template = resolver.find_all("card", "test", true, details, nil, [:post])[0]
-        template.render(FakeView.new, { post: "hello" })
+        # Keep the compiled method container local to the Ractor that compiles the template.
+        view = Class.new do
+          def compiled_method_container
+            self.class
+          end
+
+          def _run(method, template, locals, buffer, add_to_stack:, has_strict_locals:, &block)
+            @output_buffer = buffer
+            public_send(method, locals, buffer, &block)
+          end
+        end.new
+
+        template.render(view, { post: "hello" })
       end
 
       assert_equal "hello", rendered


### PR DESCRIPTION
### Motivation / Background

Fixes #58736. Ruby master now prevents a worker Ractor from defining compiled template methods on a class that the main Ractor created. The test fixture's `FakeView` class was created in the main Ractor and therefore caused `Ractor::IsolationError` during the non-main-Ractor render.

### Detail

Build the minimal view fixture inside the `on_ractor` block. Its compiled method container is therefore owned by the Ractor compiling the non-strict template, while the test continues to render through a frozen `FileSystemResolver`.

### Additional information

Manual validation on Ruby master:

- Reproduced the reported `Ractor::IsolationError` before the change.
- Ran a standalone Action View render using a frozen `FileSystemResolver` in a non-main Ractor; it rendered `"hello"` after the change.
- Ran `cd actionview && bundle exec bin/test test/template/file_system_resolver_test.rb` successfully.
- Ran `bundle exec rubocop actionview/test/template/file_system_resolver_test.rb` successfully.

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why, including the related issue.
* [x] Tests are updated for the Ruby master regression.
* [x] CHANGELOG files are not needed because this is a test-only change with no behavior change.
