### PR TITLE
Fix docker-entrypoint to detect bin/rails server behind Thruster too

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/docker-entrypoint.tt
+++ b/railties/lib/rails/generators/rails/app/templates/docker-entrypoint.tt
@@ -1,8 +1,20 @@
 #!/bin/bash -e
 
 <% unless skip_active_record? -%>
-# If running the rails server then create or migrate existing database
-if [ "${1}" == "./bin/rails" ] && [ "${2}" == "server" ]; then
+# If running the rails server (optionally via Thruster, and with any extra
+# flags such as -b) then create or migrate existing database
+rails_server_command() {
+  local prev=""
+  for arg in "$@"; do
+    if [ "$prev" == "./bin/rails" ] && [ "$arg" == "server" ]; then
+      return 0
+    fi
+    prev="$arg"
+  done
+  return 1
+}
+
+if rails_server_command "$@"; then
   ./bin/rails db:prepare
 fi
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1477,13 +1477,31 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_file "bin/docker-entrypoint"
   end
 
-  def test_docker_entrypoint_checks_first_two_arguments_so_extra_server_flags_still_trigger_db_prepare
+  def test_docker_entrypoint_prepares_database_for_rails_server_with_thruster_prefix_or_extra_flags
     run_generator
 
-    assert_file "bin/docker-entrypoint" do |content|
-      assert_match(/if \[ "\$\{1\}" == "\.\/bin\/rails" \] && \[ "\$\{2\}" == "server" \]; then/, content)
-      assert_no_match(/\$\{@: -2:1\}|\$\{@: -1:1\}/, content)
+    entrypoint = File.expand_path("bin/docker-entrypoint", destination_root)
+    fake_rails = File.expand_path("bin/rails", destination_root)
+    File.write(fake_rails, "#!/bin/bash\necho \"CALLED: ./bin/rails $@\"\n")
+    FileUtils.chmod("+x", fake_rails)
+
+    # bin/rails server can be invoked directly, prefixed by Thruster
+    # (the default in generated Dockerfiles), and/or with extra flags
+    # like -b for network binding. db:prepare must run in every case.
+    matching_commands = [
+      %w(./bin/rails server),
+      %w(./bin/rails server -b 0.0.0.0),
+      %w(./bin/thrust ./bin/rails server),
+      %w(./bin/thrust ./bin/rails server -b 0.0.0.0),
+    ]
+
+    matching_commands.each do |command|
+      output = IO.popen([entrypoint, *command], chdir: destination_root, err: [:child, :out], &:read)
+      assert_match(/CALLED: \.\/bin\/rails db:prepare/, output, "expected db:prepare to run for: #{command.join(" ")}")
     end
+
+    output = IO.popen([entrypoint, "bash", "-c", "echo hi"], chdir: destination_root, err: [:child, :out], &:read)
+    assert_no_match(/db:prepare/, output)
   end
 
   def test_docker_entrypoint_omits_db_prepare_check_when_skipping_active_record


### PR DESCRIPTION
### Follow-up to #58675

#58675 fixed `db:prepare` being silently skipped when extra flags (e.g.
`-b 0.0.0.0`, needed for Docker/Podman network binding) were passed to
`bin/rails server`, by checking the first two arguments instead of the
last two.

As @maxime-carbonneau pointed out on that PR, this broke the default
case: Rails 8+ apps include Thruster by default, and the generated
Dockerfile's CMD is `["./bin/thrust", "./bin/rails", "server"]`, not
`["./bin/rails", "server"]`. Checking the first two arguments assumes
`./bin/rails` is always first, which isn't true with Thruster in front
of it.

This check has actually flipped between first-two-args and
last-two-args once before in this file's history (7aaea30dd5 →
11a93a05a7), each time trading one bug for the other. This PR replaces
the fixed-position check with one that scans the full argument list
for `./bin/rails` immediately followed by `server`, wherever it
appears — correct regardless of a Thruster prefix, trailing flags,
both, or neither.

### Tests

Replaced the previous test (which only pattern-matched the script's
source text) with one that actually executes the generated
`bin/docker-entrypoint` against real invocation shapes — plain, with
flags, behind Thruster, behind Thruster with flags — plus a negative
case confirming unrelated commands don't trigger `db:prepare`.