### PR TITLE
Fix #58736: make Action View template compilation Ractor-local

### DIFF
--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -98,14 +98,23 @@ module ActionView
     end
 
     def self.reset_view_context_class
-      @view_context_mutex.synchronize { @view_context_class = nil }
+      if ActiveSupport::Ractors.main?
+        @view_context_mutex.synchronize { @view_context_class = nil }
+      else
+        ActiveSupport::Ractors[:action_view_context_class]&.clear
+      end
     end
 
     def self.view_context_class
-      return @view_context_class if @view_context_class
       base = ActionView::Base # prevent recursive locking
-      @view_context_mutex.synchronize do
-        @view_context_class = base.with_empty_template_cache
+      if ActiveSupport::Ractors.main?
+        return @view_context_class if @view_context_class
+        @view_context_mutex.synchronize do
+          @view_context_class = base.with_empty_template_cache
+        end
+      else
+        cache = ActiveSupport::Ractors.store_if_absent(:action_view_context_class) { Concurrent::Map.new }
+        cache.compute_if_absent(:class) { base.with_empty_template_cache }
       end
     end
     @view_context_mutex = Mutex.new

--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "concurrent/map"
 require "action_view/view_paths"
 require "active_support/core_ext/module/attr_internal"
 
@@ -83,13 +84,25 @@ module ActionView
       def view_context_class
         klass = ActionView::LookupContext.view_context_class
 
-        @view_context_class ||= build_view_context_class(klass, supports_path?, _routes, _helpers)
+        if ActiveSupport::Ractors.main?
+          @view_context_class ||= build_view_context_class(klass, supports_path?, _routes, _helpers)
 
-        if klass.changed?(@view_context_class)
-          @view_context_class = build_view_context_class(klass, supports_path?, _routes, _helpers)
+          if klass.changed?(@view_context_class)
+            @view_context_class = build_view_context_class(klass, supports_path?, _routes, _helpers)
+          end
+
+          @view_context_class
+        else
+          view_context_classes = ActiveSupport::Ractors.store_if_absent(:action_view_context_classes) { Concurrent::Map.new }
+          view_context_class = view_context_classes[self]
+
+          if !view_context_class || klass.changed?(view_context_class)
+            view_context_class = build_view_context_class(klass, supports_path?, _routes, _helpers)
+            view_context_classes[self] = view_context_class
+          end
+
+          view_context_class
         end
-
-        @view_context_class
       end
     end
 

--- a/actionview/test/template/file_system_resolver_test.rb
+++ b/actionview/test/template/file_system_resolver_test.rb
@@ -134,22 +134,6 @@ class FileSystemResolverRactorTest < ActiveSupport::TestCase
   include ActiveSupport::Testing::Isolation
   include ActiveSupport::Testing::RactorsAssertions
 
-  # Compiling methods into FakeView from another Ractor is how frozen non-strict templates
-  # are compiled in a ractorized application, with the view class container built in the
-  # main Ractor and other Ractors compiling methods into it. This might stop working with
-  # https://bugs.ruby-lang.org/issues/22226, which would require compiling into a
-  # Ractor-local container instead.
-  class FakeView
-    def compiled_method_container
-      self.class
-    end
-
-    def _run(method, template, locals, buffer, add_to_stack:, has_strict_locals:, &block)
-      @output_buffer = buffer
-      public_send(method, locals, buffer, &block)
-    end
-  end
-
   test "non-strict templates compile inside a non-main Ractor" do
     Dir.mktmpdir do |dir|
       Dir.mkdir(File.join(dir, "test"))
@@ -170,7 +154,19 @@ class FileSystemResolverRactorTest < ActiveSupport::TestCase
       rendered = on_ractor(resolver) do |resolver|
         details = { locale: [:en].freeze, formats: [:html].freeze, variants: [].freeze, handlers: [:erb].freeze }.freeze
         template = resolver.find_all("card", "test", true, details, nil, [:post])[0]
-        template.render(FakeView.new, { post: "hello" })
+        # Keep the compiled method container local to the Ractor that compiles the template.
+        view = Class.new do
+          def compiled_method_container
+            self.class
+          end
+
+          def _run(method, template, locals, buffer, add_to_stack:, has_strict_locals:, &block)
+            @output_buffer = buffer
+            public_send(method, locals, buffer, &block)
+          end
+        end.new
+
+        template.render(view, { post: "hello" })
       end
 
       assert_equal "hello", rendered

--- a/actionview/test/template/file_system_resolver_test.rb
+++ b/actionview/test/template/file_system_resolver_test.rb
@@ -151,25 +151,18 @@ class FileSystemResolverRactorTest < ActiveSupport::TestCase
       resolver.eager_load_templates
       resolver.freeze
 
-      rendered = on_ractor(resolver) do |resolver|
+      main_view_class = ActionView::LookupContext.view_context_class
+      rendered, worker_view_class = on_ractor(resolver) do |resolver|
         details = { locale: [:en].freeze, formats: [:html].freeze, variants: [].freeze, handlers: [:erb].freeze }.freeze
         template = resolver.find_all("card", "test", true, details, nil, [:post])[0]
-        # Keep the compiled method container local to the Ractor that compiles the template.
-        view = Class.new do
-          def compiled_method_container
-            self.class
-          end
+        view_class = ActionView::LookupContext.view_context_class
+        view = view_class.new(ActionView::LookupContext.new([], details), {}, nil)
 
-          def _run(method, template, locals, buffer, add_to_stack:, has_strict_locals:, &block)
-            @output_buffer = buffer
-            public_send(method, locals, buffer, &block)
-          end
-        end.new
-
-        template.render(view, { post: "hello" })
+        [template.render(view, { post: "hello" }), view_class]
       end
 
       assert_equal "hello", rendered
+      assert_not_same main_view_class, worker_view_class if RUBY_VERSION >= "4.0"
     end
   end
 end

--- a/actionview/test/template/lookup_context_test.rb
+++ b/actionview/test/template/lookup_context_test.rb
@@ -205,21 +205,38 @@ if RUBY_VERSION >= "4.0"
     include ActiveSupport::Testing::Isolation
     include ActiveSupport::Testing::RactorsAssertions
 
-    test "view_context_class's compiled method container is readable from a non-main Ractor" do
-      klass = ActionView::LookupContext.view_context_class
+    test "view_context_class has a Ractor-local compiled method container" do
+      main_class = ActionView::LookupContext.view_context_class
 
-      singleton_container, instance_container = on_ractor(klass) do |k|
-        [k.compiled_method_container, k.allocate.compiled_method_container]
+      worker_class, singleton_container, instance_container, reset_class = on_ractor do
+        klass = ActionView::LookupContext.view_context_class
+        ActionView::LookupContext.reset_view_context_class
+        [klass, klass.compiled_method_container, klass.allocate.compiled_method_container,
+          ActionView::LookupContext.view_context_class]
       end
 
-      assert_same klass, singleton_container
-      assert_same klass, instance_container
+      assert_not_same main_class, worker_class
+      assert_same worker_class, singleton_container
+      assert_same worker_class, instance_container
+      assert_not_same worker_class, reset_class
     end
 
-    test "view_context_class is Ractor-shareable" do
-      ActionView::LookupContext.view_context_class # needs to be eager-loaded to be ractor-shareable
-      assert_same ActionView::LookupContext.view_context_class,
-        on_ractor { ActionView::LookupContext.view_context_class }
+    test "controller view_context_class is Ractor-local" do
+      controller = Class.new(AbstractController::Base) do
+        include AbstractController::Rendering
+        include ActionView::Rendering
+      end
+      main_class = controller.view_context_class
+
+      worker_base_class, worker_class, compiled_method_container = on_ractor(controller) do |klass|
+        base_class = ActionView::LookupContext.view_context_class
+        view_class = klass.view_context_class
+        [base_class, view_class, view_class.compiled_method_container]
+      end
+
+      assert_not_same main_class, worker_class
+      assert_same worker_base_class, worker_class.superclass
+      assert_same worker_base_class, compiled_method_container
     end
 
     if RUBY_VERSION >= "4.0"


### PR DESCRIPTION
### Motivation / Background

Fixes #58736. Ruby master ([Feature #22226](https://bugs.ruby-lang.org/issues/22226)) prevents a worker Ractor from compiling a previously unseen non-strict template into a view context class that the main Ractor owns. That raises `Ractor::IsolationError` in the actual Action View rendering path, not only in the test.

### Detail

Each worker Ractor gets its own view context class, built with `ActionView::Base.with_empty_template_cache` on top of the main Ractor's class:

* Templates precompiled at boot from the main Ractor (strict-locals templates) stay callable in workers through inheritance, so the precompilation step keeps working. `Template#compile!` now checks that the rendering view's compiled method container inherits from the one the template was compiled with, instead of requiring the same class.
* Templates first compiled inside a worker (non-strict templates with new locals) are compiled into the worker-owned subclass, so the worker never modifies a main-Ractor-owned class.
* Both the instance and singleton `compiled_method_container` of the worker class return that subclass, matching the main Ractor's behavior: controller-specific view classes built in the worker share one container, and `changed?` detects a worker-side `reset_view_context_class`.
* `ActionView::Rendering#view_context_class` caches controller-specific view classes per Ractor. The main Ractor keeps using the existing instance-variable cache.

The resolver regression test renders through a real Action View class from a main-Ractor-owned frozen `FileSystemResolver`, and a new test checks that a strict-locals template precompiled in the main Ractor renders inside a non-main Ractor.

The design follows @etiennebarrie's suggestion and the implementation is @nicolasva's commit, cherry-picked with authorship preserved, plus a follow-up commit for the container definition.

### Additional information

Verified on Ruby 3.3.12 (where `on_ractor` runs in the main Ractor, so the `RUBY_VERSION >= "4.0"` assertions do not run): `bin/test test/template/file_system_resolver_test.rb test/template/lookup_context_test.rb test/template/render_test.rb test/template/template_test.rb` (667 runs, 0 failures), the full Action View suite (3282 runs, 0 failures), and RuboCop on the changed files with no offenses. The real Ractor assertions rely on the Ruby master CI jobs.

### Checklist

* [x] This Pull Request is related to one change.
* [x] Commit message has a detailed description of what changed and why, including the related issue.
* [x] Tests are updated for the Ruby master regression.
* [x] CHANGELOG files are not needed for this bug fix to main-only Ractor support.
