### PR TITLE
Boot when ruby-vips cannot load its libraries

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Boot when libvips is missing.
+
+    An application with the ruby-vips gem installed but no libvips could not start. Active Storage
+    now treats any `LoadError` from requiring ruby-vips as ruby-vips being unavailable, and stops
+    loading `image_processing/vips` once it is. The application boots and logs a warning that
+    generating variants needs libvips.
+
+    Fixes #58723.
+
+    *Mike Dalessio*, *Vandenbogaerde Nicolas*
+
 *   Boot with an unsupported libvips or ruby-vips unless the variant processor uses it.
 
     An installed libvips or ruby-vips too old to block the unfuzzed loaders raised during application

--- a/activestorage/lib/active_storage/transformers/vips.rb
+++ b/activestorage/lib/active_storage/transformers/vips.rb
@@ -1,13 +1,19 @@
 # frozen_string_literal: true
 
-# Do not remove either of these requires.
+# Do not remove or reorder these setup steps.
 #
-# active_storage/vips disables libvips's unfuzzed loaders and savers.
+# active_storage/vips disables libvips's unfuzzed loaders and savers. Requiring image_processing
+# on its own is what raises the LoadError the engine reports when that gem is missing.
 #
-# active_storage/vips has already loaded image_processing/vips, but requiring it here is what
-# raises LoadError when the gem is missing, which the engine reports as an actionable warning.
+# Do not require image_processing/vips when ruby-vips is unavailable: it requires ruby-vips a
+# second time, and image_processing before 2.0.2 raises ImageProcessing::Error instead of
+# LoadError, which aborts boot.
 require "active_storage/vips"
 ActiveStorage.require_securable_vips!
+require "image_processing"
+
+raise LoadError, "libvips or the ruby-vips gem is not available" unless ActiveStorage::VIPS_AVAILABLE
+
 require "image_processing/vips"
 
 module ActiveStorage

--- a/activestorage/lib/active_storage/vips.rb
+++ b/activestorage/lib/active_storage/vips.rb
@@ -17,9 +17,8 @@ begin
   gem "ruby-vips"
   require "ruby-vips"
   ActiveStorage::VIPS_AVAILABLE = true # :nodoc:
-rescue LoadError => error
+rescue LoadError
   ActiveStorage::VIPS_AVAILABLE = false # :nodoc:
-  raise error unless error.message.match?(/libvips|ruby-vips/)
 end
 
 if ActiveStorage::VIPS_AVAILABLE

--- a/railties/test/application/active_storage/engine_integration_test.rb
+++ b/railties/test/application/active_storage/engine_integration_test.rb
@@ -120,6 +120,33 @@ module ApplicationTests
       assert_equal %w[block_untrusted(true) initializer booted], output.lines.map(&:chomp).grep(/^(block_untrusted|initializer|booted)/)
     end
 
+    def test_boots_when_ruby_vips_cannot_load_its_libraries
+      File.open("#{app_path}/Gemfile", "a") { |f| f.puts 'gem "image_processing", "~> 2.0"' }
+      add_ruby_vips_stub 'require "vips"'
+      File.write app_path("ruby-vips", "lib", "vips.rb"), <<~'RUBY'
+        raise LoadError, "Could not open library 'glib-2.0.0': dlopen(glib-2.0.0, 0x0005): tried: 'glib-2.0.0' (no such file)."
+      RUBY
+
+      output = run_command("puts :booted")
+
+      assert_includes(output, "booted")
+    end
+
+    def test_does_not_require_ruby_vips_again_after_it_fails_to_load
+      File.open("#{app_path}/Gemfile", "a") { |f| f.puts 'gem "image_processing", "~> 2.0"' }
+      add_ruby_vips_stub 'require "vips"'
+      File.write app_path("ruby-vips", "lib", "vips.rb"), <<~'RUBY'
+        raise "ruby-vips was required again after it failed to load" if $vips_required
+        $vips_required = true
+        raise LoadError, "Could not open library 'glib-2.0.0': dlopen(glib-2.0.0, 0x0005): tried: 'glib-2.0.0' (no such file)."
+      RUBY
+
+      output = run_command("puts :booted")
+
+      assert_includes(output, "Using vips to process variants requires the libvips library")
+      assert_includes(output, "booted")
+    end
+
     private
       def add_ruby_vips_stub(source)
         FileUtils.mkdir_p app_path("ruby-vips", "lib")


### PR DESCRIPTION
### Motivation / Background

An application with the `ruby-vips` gem installed but no libvips could not start.

ruby-vips loads glib before libvips, so the `LoadError` names glib-2.0 rather than either name `active_storage/vips` looked for:

    rescue LoadError => error
      ActiveStorage::VIPS_AVAILABLE = false # :nodoc:
      raise error unless error.message.match?(/libvips|ruby-vips/)

The re-raised error aborts boot, for every variant processor.

Dropping that message check is not enough on its own. `ActiveStorage::Transformers::Vips` requires `image_processing/vips` unconditionally, which requires ruby-vips a second time. image_processing 2.0.0 and 2.0.1 translate that `LoadError` into an `ImageProcessing::Error`, which `ActiveStorage::Engine`'s `rescue LoadError` does not catch, so boot still fails for anyone whose lockfile predates image_processing 2.0.2 — including this repository's own.

Fixes #58723

### Detail

Treat every `LoadError` from requiring ruby-vips as ruby-vips being unavailable, and stop requiring `image_processing/vips` once it is.

`Transformers::Vips` now requires `image_processing` on its own, which is what still raises the `LoadError` the engine reports when only that gem is missing, and then raises a `LoadError` itself when vips is unavailable.

An application with ruby-vips but no libvips previously aborted during initialization. Now it boots and logs:

    Using vips to process variants requires the libvips library. Please install libvips using the instructions on the libvips website.

### Additional information

Rebased onto #58734 (fcca87cf), which moved the unsecurable-vips check into `ActiveStorage.require_securable_vips!`. That call keeps its position ahead of the new availability check, so an unsecurable ruby-vips still raises for the `:vips` processor whether or not image_processing is installed.

`test_does_not_require_ruby_vips_again_after_it_fails_to_load` asserts that the second require does not happen rather than pinning an image_processing version: its ruby-vips stub raises a plain `RuntimeError` if it is loaded twice.

Thanks to @nicolasva for spotting the second load, credited as co-author on the commit.

### Checklist

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Additional lines should be added or removed as appropriate.
