### PR TITLE
Clarify  has_one  replacement behavior when building an association #58732

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -620,6 +620,12 @@ object, use the `build_association` method. This method creates a new, unsaved
 instance of the associated object, allowing you to work with it before deciding
 to save it.
 
+WARNING: Although the object returned by `build_association` is not saved,
+building it replaces the current target of the association. If the existing
+target is persisted, Rails immediately removes it according to the association's
+`:dependent` option. For example, with `dependent: :destroy`, the existing
+target is destroyed before the newly built object is saved.
+
 Use `autosave: false` when you want to control the saving behavior of the
 associated objects for the model. This setting prevents the associated object
 from being saved automatically when the parent object is saved. In contrast, use


### PR DESCRIPTION
### Motivation / Background

The Associations Guide explains that `build_association` returns a new, unsaved object for a `has_one` association. However, it does not make clear that building this object replaces the association's current target and may immediately modify or destroy the existing persisted record.

This behavior is particularly surprising with `dependent: :destroy`, where calling `build_association` destroys the existing target before the newly built object is saved.

Related to #58732.

### Detail

This Pull Request adds a warning to the `has_one` saving behavior documentation clarifying that:

* the object returned by `build_association` remains unsaved;
* building it replaces the current association target; and
* Rails immediately removes a persisted target according to the association's `:dependent` option, including destroying it when `dependent: :destroy` is configured.

This is a documentation-only change and does not alter the existing Active Record behavior.

### Additional information

No tests or CHANGELOG entry are needed because this change only clarifies existing documented behavior.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
