### PR TITLE
Escape JSON with String#tr! 

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Speed up JSON escaping with `String#tr!` on Ruby 4.1+.
+
+    `ActiveSupport::JSON.encode` escaped `<`, `>`, `&`, U+2028 and U+2029 by
+    forcing the generated JSON to BINARY and running `gsub!` over it. Ruby 4.1
+    accepts a Hash of pairs in `String#tr!`, which does the same substitution in
+    a single pass, with no Regexp and no encoding round-trip.
+
+    Escaping is 2x to 10x faster on documents that are large or contain many
+    escapable characters, and allocates fewer intermediate strings. Documents
+    smaller than roughly 128 bytes with nothing to escape are marginally
+    slower, since `tr!` builds a translation table where a pre-compiled Regexp
+    just fails to match. Strings that aren't valid UTF-8 keep taking the
+    `gsub!` path.
+
+    *Jean Boussier*, *Federico Carrocera*
+
 *   Preserve the requested key order in `ActiveSupport::Cache::Store#fetch_multi`
     when a local cache is active.
 

--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -83,6 +83,18 @@ module ActiveSupport
       FULL_ESCAPE_REGEX = Regexp.union(*ESCAPED_CHARS.keys).freeze
       JS_SEPARATORS_REGEX = Regexp.union(U2028, U2029).freeze
 
+      UTF8_ESCAPED_CHARS = {
+        "\u2028" => -'\u2028',
+        "\u2029" => -'\u2029',
+        ">" => -'\u003e',
+        "<" => -'\u003c',
+        "&" => -'\u0026',
+      }.freeze
+      UTF8_HTML_ENTITIES = UTF8_ESCAPED_CHARS.except("\u2028", "\u2029").freeze
+      UTF8_JS_SEPARATORS = UTF8_ESCAPED_CHARS.slice("\u2028", "\u2029").freeze
+
+      TR_ESCAPE_SUPPORTED = Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("4.1.0")
+
       class JSONGemEncoder # :nodoc:
         attr_reader :options
 
@@ -99,17 +111,30 @@ module ActiveSupport
 
           return json unless @options.fetch(:escape, true)
 
-          json.force_encoding(::Encoding::BINARY)
-          if @options.fetch(:escape_html_entities, Encoding.escape_html_entities_in_json)
-            if Encoding.escape_js_separators_in_json
-              json.gsub!(FULL_ESCAPE_REGEX, ESCAPED_CHARS)
-            else
-              json.gsub!(HTML_ENTITIES_REGEX, ESCAPED_CHARS)
+          if TR_ESCAPE_SUPPORTED && json.encoding == ::Encoding::UTF_8 && json.valid_encoding?
+            if @options.fetch(:escape_html_entities, Encoding.escape_html_entities_in_json)
+              if Encoding.escape_js_separators_in_json
+                json.tr!(UTF8_ESCAPED_CHARS)
+              else
+                json.tr!(UTF8_HTML_ENTITIES)
+              end
+            elsif Encoding.escape_js_separators_in_json
+              json.tr!(UTF8_JS_SEPARATORS)
             end
-          elsif Encoding.escape_js_separators_in_json
-            json.gsub!(JS_SEPARATORS_REGEX, ESCAPED_CHARS)
+            json
+          else
+            json.force_encoding(::Encoding::BINARY)
+            if @options.fetch(:escape_html_entities, Encoding.escape_html_entities_in_json)
+              if Encoding.escape_js_separators_in_json
+                json.gsub!(FULL_ESCAPE_REGEX, ESCAPED_CHARS)
+              else
+                json.gsub!(HTML_ENTITIES_REGEX, ESCAPED_CHARS)
+              end
+            elsif Encoding.escape_js_separators_in_json
+              json.gsub!(JS_SEPARATORS_REGEX, ESCAPED_CHARS)
+            end
+            json.force_encoding(::Encoding::UTF_8)
           end
-          json.force_encoding(::Encoding::UTF_8)
         end
 
         private
@@ -209,17 +234,30 @@ module ActiveSupport
 
             return json unless @escape
 
-            json.force_encoding(::Encoding::BINARY)
-            if @options.fetch(:escape_html_entities, Encoding.escape_html_entities_in_json)
-              if Encoding.escape_js_separators_in_json
-                json.gsub!(FULL_ESCAPE_REGEX, ESCAPED_CHARS)
-              else
-                json.gsub!(HTML_ENTITIES_REGEX, ESCAPED_CHARS)
+            if TR_ESCAPE_SUPPORTED && json.encoding == ::Encoding::UTF_8 && json.valid_encoding?
+              if @options.fetch(:escape_html_entities, Encoding.escape_html_entities_in_json)
+                if Encoding.escape_js_separators_in_json
+                  json.tr!(UTF8_ESCAPED_CHARS)
+                else
+                  json.tr!(UTF8_HTML_ENTITIES)
+                end
+              elsif Encoding.escape_js_separators_in_json
+                json.tr!(UTF8_JS_SEPARATORS)
               end
-            elsif Encoding.escape_js_separators_in_json
-              json.gsub!(JS_SEPARATORS_REGEX, ESCAPED_CHARS)
+              json
+            else
+              json.force_encoding(::Encoding::BINARY)
+              if @options.fetch(:escape_html_entities, Encoding.escape_html_entities_in_json)
+                if Encoding.escape_js_separators_in_json
+                  json.gsub!(FULL_ESCAPE_REGEX, ESCAPED_CHARS)
+                else
+                  json.gsub!(HTML_ENTITIES_REGEX, ESCAPED_CHARS)
+                end
+              elsif Encoding.escape_js_separators_in_json
+                json.gsub!(JS_SEPARATORS_REGEX, ESCAPED_CHARS)
+              end
+              json.force_encoding(::Encoding::UTF_8)
             end
-            json.force_encoding(::Encoding::UTF_8)
           end
         end
       end

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -61,6 +61,19 @@ class TestJSONEncoding < ActiveSupport::TestCase
     end
   end
 
+  def test_fragment_with_invalid_encoding_still_escapes
+    ActiveSupport.escape_html_entities_in_json = true
+    fragment = JSON::Fragment.new(%{"<&} + 255.chr + %{"})
+    result = ActiveSupport::JSON.encode("a" => fragment)
+
+    assert_not_predicate result, :valid_encoding?
+    assert_equal Encoding::UTF_8, result.encoding
+    assert_includes result.b, '\u003c'
+    assert_includes result.b, '\u0026'
+  ensure
+    ActiveSupport.escape_html_entities_in_json = false
+  end
+
   def test_hash_keys_encoding
     ActiveSupport.escape_html_entities_in_json = true
     assert_equal "{\"\\u003c\\u003e\":\"\\u003c\\u003e\"}", ActiveSupport::JSON.encode("<>" => "<>")


### PR DESCRIPTION
Following on from https://github.com/ruby/ruby/pull/18647

`String#tr!`now accepts a Hash, which substitutes in one pass over the UTF-8 string with no Regexp and no round-trip.

`tr!` raises on invalid encodings, so the fast path is guarded on `valid_encoding?` and falls back to `gsub!`.

Both encoders are updated, though `JSONGemCoderEncoder` is the one installed by default whenever `JSON::Coder` is available.

The escape step in isolation. `tr!` builds a translation table per call, so its slower on pre-compiled Regexp for documents under 128 bytes with nothing to escape and is faster  everywhere else:
```
small: 48 bytes
ruby 4.1.0dev (2026-09-11T11:29:25Z master d6b4cbbbb1) +PRISM [arm64-darwin25]
Warming up --------------------------------------
               gsub!   619.603k i/100ms
                 tr!   459.017k i/100ms
Calculating -------------------------------------
               gsub!      6.181M (± 2.7%) i/s  (161.79 ns/i) -     30.980M in   5.012225s
                 tr!      4.512M (± 1.7%) i/s  (221.63 ns/i) -     22.951M in   5.086542s

Comparison:
gsub!:  6180917.7 i/s
  tr!:  4512073.2 i/s - 1.37x  slower

large html: 51300 bytes
ruby 4.1.0dev (2026-09-11T11:29:25Z master d6b4cbbbb1) +PRISM [arm64-darwin25]
Warming up --------------------------------------
               gsub!   191.000 i/100ms
                 tr!     2.010k i/100ms
Calculating -------------------------------------
               gsub!      1.954k (± 1.3%) i/s  (511.68 μs/i) -      9.932k in   5.082055s
                 tr!     20.452k (± 1.0%) i/s   (48.89 μs/i) -    102.510k in   5.012214s

Comparison:
gsub!:     1954.3 i/s
  tr!:    20452.0 i/s - 10.47x  faster
```

```ruby
require "benchmark/ips"

UTF8 = Encoding.find("UTF-8")
BINARY = Encoding.find("ASCII-8BIT")

ESCAPES = {
  "\u2028" => '\u2028', "\u2029" => '\u2029',
  ">" => '\u003e', "<" => '\u003c', "&" => '\u0026',
}
BYTES = ESCAPES.to_h { |k, v| [k.b, v.b] }
REGEX = Regexp.union(*BYTES.keys)

def escape_gsub(json)
  json.force_encoding(BINARY)
  json.gsub!(REGEX, BYTES)
  json.force_encoding(UTF8)
end

def escape_tr(json)
  return escape_gsub(json) unless json.valid_encoding?
  json.tr!(ESCAPES)
  json
end

CLEAN = %({"id":1,"title":"a perfectly ordinary document"})
HTML = %({"id":1,"title":"a <b>perfectly</b> ordinary & document"})

{ "small" => CLEAN, "large html" => HTML * 900 }.each do |name, src|
  raise "paths disagree" unless escape_gsub(src.dup).b == escape_tr(src.dup).b
  puts "#{name}: #{src.bytesize} bytes"

  Benchmark.ips do |x|
    x.report("gsub!") { escape_gsub(src.dup) }
    x.report("tr!") { escape_tr(src.dup) }
    x.compare!(order: :baseline)
  end
end
```