### PR TITLE
Make finder_needs_type_condition? ractor safe

### DIFF
--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -92,7 +92,9 @@ module ActiveRecord
 
       def finder_needs_type_condition? # :nodoc:
         # This is like this because benchmarking justifies the strange :false stuff
-        :true == (@finder_needs_type_condition ||= descends_from_active_record? ? :false : :true)
+        :true == (@finder_needs_type_condition || ActiveSupport::Ractors.on_main(self) do
+          @finder_needs_type_condition ||= descends_from_active_record? ? :false : :true
+        end)
       end
 
       # Returns the first class in the inheritance hierarchy that descends from either an

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -3,6 +3,7 @@
 require "active_support/inflector"
 require "zeitwerk"
 require "cases/helper"
+require "active_support/testing/ractors_assertions"
 require "models/author"
 require "models/company"
 require "models/membership"
@@ -499,6 +500,34 @@ class InheritanceTest < ActiveRecord::TestCase
 
   def test_inheritance_with_default_scope
     assert_equal 1, SelectedMembership.count(:all)
+  end
+
+  if RUBY_VERSION >= "4.0" && !in_memory_db?
+    class InheritanceRactorTest < ActiveRecord::TestCase
+      include ActiveSupport::Testing::Isolation
+      include ActiveSupport::Testing::RactorsAssertions
+
+      def test_finder_needs_type_condition_can_be_computed_from_a_ractor_for_an_sti_subclass
+        model, sti_model = ractor_sti_models
+
+        assert_equal true, on_ractor { sti_model.finder_needs_type_condition? }
+        assert_equal false, on_ractor { model.finder_needs_type_condition? }
+      end
+
+      private
+        def ractor_sti_models
+          model = Class.new(ActiveRecord::Base) do
+            def self.name = "RactorCompany"
+            self.table_name = "companies"
+          end
+          sti_model = Class.new(model) do
+            def self.name = "RactorFirm"
+          end
+          model.load_schema
+
+          [model, sti_model]
+        end
+    end
   end
 end
 


### PR DESCRIPTION
### Motivation / Background

Similar to https://github.com/rails/rails/pull/58399

This Pull Request has been created because calculating `ActiveRecord::Base.finder_needs_type_condition?` on a non main ractor doesn't work.

### Detail

This Pull Request changes the implementation of the method to proxy to main in order to calculate the memoized value.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
