### PR TITLE
Fix custom Active Job serializers ignored when Arguments loads early

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Fix custom serializers being ignored when `ActiveJob::Arguments` is loaded before initializers.
+
+    If a gem required `active_job/arguments` during boot, the `:active_job_arguments`
+    load hook ran before `config/initializers` populated `config.active_job.custom_serializers`.
+    Serializers registered the documented way were then never added, and `perform_later`
+    raised `ActiveJob::SerializationError` for those types.
+
+    The load hook is now registered after config initializers so an already-loaded
+    `Arguments` module still sees the complete list, while registration remains
+    deferred until first use when `Arguments` has not been loaded yet.
+
+    *leslieJt*
+
 *   Fix continuation step cursors losing their type when a job is interrupted
     and resumed.
 

--- a/activejob/lib/active_job/railtie.rb
+++ b/activejob/lib/active_job/railtie.rb
@@ -21,7 +21,7 @@ module ActiveJob
       ActiveSupport.on_load(:active_job) { self.logger = ::Rails.logger }
     end
 
-    initializer "active_job.custom_serializers" do |app|
+    initializer "active_job.custom_serializers", after: :load_config_initializers do |app|
       ActiveSupport.on_load(:active_job_arguments) do
         custom_serializers = app.config.active_job.custom_serializers
         ActiveJob::Serializers.add_serializers custom_serializers

--- a/railties/test/application/active_job_railtie_test.rb
+++ b/railties/test/application/active_job_railtie_test.rb
@@ -22,21 +22,39 @@ module ApplicationTests
     end
 
     test "custom serializers are loaded for Arguments#serialize" do
-      app_file "config/initializers/custom_serializers.rb", <<~RUBY
-        class Money; end
-
-        class MoneySerializer < ActiveJob::Serializers::ObjectSerializer
-          def klass = Money
-          def serialize(money) = {}
-          def deserialize(hash) = Money.new
-        end
-
-        Rails.configuration.active_job.custom_serializers << MoneySerializer
-      RUBY
+      add_custom_serializer_initializer
 
       app "development"
 
       assert_equal([{}], ActiveJob::Arguments.serialize([Money.new]))
     end
+
+    test "custom serializers are loaded when Arguments was required before initializers" do
+      application_path = "#{app_path}/config/application.rb"
+      contents = File.read(application_path)
+      contents.sub!(/Bundler\.require\(\*Rails\.groups\)/, "\\0\nrequire \"active_job/arguments\"")
+      File.write(application_path, contents)
+
+      add_custom_serializer_initializer
+
+      app "development"
+
+      assert_equal([{}], ActiveJob::Arguments.serialize([Money.new]))
+    end
+
+    private
+      def add_custom_serializer_initializer
+        app_file "config/initializers/custom_serializers.rb", <<~RUBY
+          class Money; end
+
+          class MoneySerializer < ActiveJob::Serializers::ObjectSerializer
+            def klass = Money
+            def serialize(money) = {}
+            def deserialize(hash) = Money.new
+          end
+
+          Rails.configuration.active_job.custom_serializers << MoneySerializer
+        RUBY
+      end
   end
 end


### PR DESCRIPTION
### Motivation / Background

Fixes #58737

If a gem requires `ActiveJob::Arguments` before application initializers run (for example `noticed` does this during `Bundler.require`), the `:active_job_arguments` load hook fires while `config.active_job.custom_serializers` is still empty. Serializers registered the way the [guide](https://guides.rubyonrails.org/active_job_basics.html#serializers) prescribes are then never added. `config.active_job.custom_serializers` looks correct after boot, but `perform_later` raises `ActiveJob::SerializationError`.

This is the remaining case after #56093, which fixed the hook never firing when `Arguments` had not been loaded yet.

### Detail

Register the `active_job.custom_serializers` initializer `after: :load_config_initializers`. The load hook still defers registration until first use when `Arguments` has not been loaded (so boot does not pull in application serializer classes). When `Arguments` is already loaded, `on_load` runs immediately and now sees the complete serializer list.

### Additional information

`railties/test/application/active_job_railtie_test.rb`:

```
3 runs, 3 assertions, 0 failures, 0 errors, 0 skips
```

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
