### PR TITLE
Add `innermost` and `outermost` callback options

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,42 @@
+*   Add `innermost_before_action`, `innermost_around_action`,
+    `innermost_after_action`, and their `outermost_*` counterparts.
+
+    They are shorthands for the `:innermost` and `:outermost` options added to
+    `ActiveSupport::Callbacks`, which controller callbacks accept like any other
+    option.
+
+    A callback registered with `innermost: true` is kept closest to the action,
+    so every regular `before_action`, including the ones registered later on by
+    subclasses, runs before it. This makes it possible for a base controller to
+    register a callback that depends on the state its subclasses set up.
+
+    ```ruby
+    class ApplicationController < ActionController::Base
+      before_action :authorize_record, innermost: true, only: %i[ show edit ]
+      # or: innermost_before_action :authorize_record, only: %i[ show edit ]
+    end
+
+    class ArticlesController < ApplicationController
+      before_action :set_record # runs before :authorize_record
+    end
+    ```
+
+    `outermost: true` is the counterpart: the callback is kept furthest from the
+    action, so every regular `before_action`, including the ones prepended later
+    on by a concern included later, runs after it.
+
+    ```ruby
+    class ApplicationController < ActionController::Base
+      before_action :set_current_tenant, outermost: true
+    end
+
+    class ArticlesController < ApplicationController
+      prepend_before_action :authenticate # runs after :set_current_tenant
+    end
+    ```
+
+    *Roman Sklenar*
+
 *   Include default headers in `ActionController::Live` responses.
 
     Previously, responses from `ActionController::Live` controllers, including

--- a/actionpack/lib/abstract_controller/callbacks.rb
+++ b/actionpack/lib/abstract_controller/callbacks.rb
@@ -15,12 +15,40 @@ module AbstractController
   # *   `append_before_action`
   # *   `around_action`
   # *   `before_action`
+  # *   `innermost_after_action`
+  # *   `innermost_around_action`
+  # *   `innermost_before_action`
+  # *   `outermost_after_action`
+  # *   `outermost_around_action`
+  # *   `outermost_before_action`
   # *   `prepend_after_action`
   # *   `prepend_around_action`
   # *   `prepend_before_action`
   # *   `skip_after_action`
   # *   `skip_around_action`
   # *   `skip_before_action`
+  #
+  # Callbacks run in the order they are registered, and the ones inherited from a
+  # parent controller come first. Think of the chain as a set of layers wrapped
+  # around the action: the callbacks registered first are the outermost ones, the
+  # ones registered last are the closest to the action.
+  #
+  # `prepend_before_action` and its siblings move a callback to the front of the
+  # chain, and the `:innermost` and `:outermost` options pin it to one end of it,
+  # where no regular callback registered later on, by a subclass or otherwise,
+  # can displace it:
+  #
+  #     class ApplicationController < ActionController::Base
+  #       before_action :set_current_tenant, outermost: true
+  #       before_action :authorize_record, innermost: true, only: %i[ show edit ]
+  #     end
+  #
+  #     class ArticlesController < ApplicationController
+  #       before_action :set_article # runs after :set_current_tenant, before :authorize_record
+  #     end
+  #
+  # The `innermost_*_action` and `outermost_*_action` callbacks are shorthands for
+  # the same options.
   module Callbacks
     extend ActiveSupport::Concern
 
@@ -154,6 +182,50 @@ module AbstractController
       # cancelled.
 
       ##
+      # :method: outermost_before_action
+      #
+      # :call-seq: outermost_before_action(names, block)
+      #
+      # Append a callback that is kept furthest from the action: every regular
+      # `before_action`, including the ones prepended later on by subclasses, runs
+      # after it. See _insert_callbacks for parameter details.
+      #
+      # `prepend_before_action` puts a callback in front of the callbacks registered
+      # so far, but it cannot stay there, since the next `prepend_before_action`
+      # wins. Use this for the callback that establishes the context every other
+      # callback relies on, such as the tenant a request belongs to. It does not
+      # have to be the only one: several of them keep the order they were
+      # registered in, and a subclass registering its own lands after it, so this
+      # one stays the first to run.
+      #
+      #     class ApplicationController < ActionController::Base
+      #       outermost_before_action :set_current_tenant
+      #
+      #       private
+      #         def set_current_tenant
+      #           Current.tenant = Tenant.find_by!(host: request.host)
+      #         end
+      #     end
+      #
+      #     module Authentication
+      #       extend ActiveSupport::Concern
+      #
+      #       included do
+      #         # Needs Current.tenant, and has to run before everything else.
+      #         prepend_before_action :authenticate
+      #       end
+      #     end
+      #
+      # The concern keeps working the way it was written, no matter which
+      # controller includes it or in which order.
+      #
+      # If the callback renders or redirects, the action will not run. If there are
+      # additional callbacks scheduled to run after that callback, they are also
+      # cancelled.
+      #
+      # Shorthand for `before_action names, outermost: true`.
+
+      ##
       # :method: skip_before_action
       #
       # :call-seq: skip_before_action(names)
@@ -172,6 +244,48 @@ module AbstractController
       # cancelled.
 
       ##
+      # :method: innermost_before_action
+      #
+      # :call-seq: innermost_before_action(names, block)
+      #
+      # Append a callback that is kept closest to the action: every regular
+      # `before_action`, including the ones registered later on by subclasses,
+      # runs before it. See _insert_callbacks for parameter details.
+      #
+      # Callbacks otherwise run from the base controller down, which makes it
+      # impossible for a base controller to act on a record its subclasses load.
+      # This is what authorization, canonical redirects, breadcrumbs, or conditional
+      # GET support in a base controller usually need:
+      #
+      #     class ApplicationController < ActionController::Base
+      #       innermost_before_action :authorize_record, only: %i[ show edit update destroy ]
+      #       innermost_before_action :set_cache_headers, only: :show
+      #
+      #       private
+      #         def authorize_record
+      #           head :forbidden unless Current.user.can?(action_name, @record)
+      #         end
+      #
+      #         def set_cache_headers
+      #           fresh_when(@record)
+      #         end
+      #     end
+      #
+      #     class ArticlesController < ApplicationController
+      #       before_action :set_record # runs before :authorize_record
+      #     end
+      #
+      # Without it, every subclass has to remember to re-register the inherited
+      # callback after its own, which is easy to get wrong and impossible to
+      # enforce.
+      #
+      # If the callback renders or redirects, the action will not run. If there are
+      # additional callbacks scheduled to run after that callback, they are also
+      # cancelled.
+      #
+      # Shorthand for `before_action names, innermost: true`.
+
+      ##
       # :method: after_action
       #
       # :call-seq: after_action(names, block)
@@ -186,6 +300,26 @@ module AbstractController
       # Prepend a callback after actions. See _insert_callbacks for parameter details.
 
       ##
+      # :method: outermost_after_action
+      #
+      # :call-seq: outermost_after_action(names, block)
+      #
+      # Append a callback that is kept furthest from the action: every regular
+      # `after_action`, including the ones prepended later on by subclasses, runs
+      # before it, since `after_action` callbacks run in reverse order. See
+      # _insert_callbacks for parameter details.
+      #
+      # Useful to tear down what an `outermost_before_action` set up, once every
+      # other callback is done with it.
+      #
+      #     class ApplicationController < ActionController::Base
+      #       outermost_before_action :set_current_tenant
+      #       outermost_after_action :reset_current_tenant
+      #     end
+      #
+      # Shorthand for `after_action names, outermost: true`.
+
+      ##
       # :method: skip_after_action
       #
       # :call-seq: skip_after_action(names)
@@ -198,6 +332,25 @@ module AbstractController
       # :call-seq: append_after_action(names, block)
       #
       # Append a callback after actions. See _insert_callbacks for parameter details.
+
+      ##
+      # :method: innermost_after_action
+      #
+      # :call-seq: innermost_after_action(names, block)
+      #
+      # Append a callback that is kept closest to the action: every regular
+      # `after_action`, including the ones registered later on by subclasses, runs
+      # after it, since `after_action` callbacks run in reverse order. See
+      # _insert_callbacks for parameter details.
+      #
+      # Useful to capture what the action did before any subclass gets a chance to
+      # alter it.
+      #
+      #     class ApplicationController < ActionController::Base
+      #       innermost_after_action :record_audit_entry, only: %i[ create update destroy ]
+      #     end
+      #
+      # Shorthand for `after_action names, innermost: true`.
 
       ##
       # :method: around_action
@@ -215,6 +368,33 @@ module AbstractController
       # details.
 
       ##
+      # :method: outermost_around_action
+      #
+      # :call-seq: outermost_around_action(names, block)
+      #
+      # Append a callback that is kept furthest from the action: every regular
+      # `around_action`, including the ones prepended later on by subclasses, is
+      # wrapped by it. See _insert_callbacks for parameter details.
+      #
+      # It observes everything that the callbacks registered after it do,
+      # including what they raise, render, or redirect, which is what request-wide
+      # instrumentation and error reporting need:
+      #
+      #     class ApplicationController < ActionController::Base
+      #       outermost_around_action :report_errors
+      #
+      #       private
+      #         def report_errors
+      #           yield
+      #         rescue => error
+      #           ErrorReporter.report(error, context: { action: action_name })
+      #           raise
+      #         end
+      #     end
+      #
+      # Shorthand for `around_action names, outermost: true`.
+
+      ##
       # :method: skip_around_action
       #
       # :call-seq: skip_around_action(names)
@@ -227,6 +407,32 @@ module AbstractController
       # :call-seq: append_around_action(names, block)
       #
       # Append a callback around actions. See _insert_callbacks for parameter details.
+
+      ##
+      # :method: innermost_around_action
+      #
+      # :call-seq: innermost_around_action(names, block)
+      #
+      # Append a callback that is kept closest to the action: every regular
+      # `around_action`, including the ones registered later on by subclasses,
+      # wraps it. See _insert_callbacks for parameter details.
+      #
+      # Useful when the callback has to wrap the action alone, with no other
+      # callback inside it: measuring how long the action itself takes, or opening
+      # a transaction only once the records the action needs are loaded and
+      # authorized.
+      #
+      #     class ApplicationController < ActionController::Base
+      #       innermost_around_action :wrap_in_transaction, only: %i[ create update destroy ]
+      #
+      #       private
+      #         def wrap_in_transaction(&block)
+      #           ApplicationRecord.transaction(&block)
+      #         end
+      #     end
+      #
+      # Shorthand for `around_action names, innermost: true`.
+
       # set up before_action, prepend_before_action, skip_before_action, etc. for each
       # of before, after, and around.
       [:before, :after, :around].each do |callback|
@@ -239,6 +445,18 @@ module AbstractController
         define_method "prepend_#{callback}_action" do |*names, &blk|
           _insert_callbacks(names, blk) do |name, options|
             set_callback(:process_action, callback, name, options.merge(prepend: true))
+          end
+        end
+
+        define_method "outermost_#{callback}_action" do |*names, &blk|
+          _insert_callbacks(names, blk) do |name, options|
+            set_callback(:process_action, callback, name, options.merge(outermost: true))
+          end
+        end
+
+        define_method "innermost_#{callback}_action" do |*names, &blk|
+          _insert_callbacks(names, blk) do |name, options|
+            set_callback(:process_action, callback, name, options.merge(innermost: true))
           end
         end
 

--- a/actionpack/test/controller/filters_test.rb
+++ b/actionpack/test/controller/filters_test.rb
@@ -255,6 +255,96 @@ class FilterTest < ActionController::TestCase
       end
   end
 
+  class InnermostFilterController < TestController
+    innermost_before_action :wonderful_life
+    innermost_around_action :its_a_wrap
+    innermost_after_action :the_end
+
+    private
+      def wonderful_life
+        @ran_filter ||= []
+        @ran_filter << "wonderful_life"
+      end
+
+      def its_a_wrap
+        @ran_filter ||= []
+        @ran_filter << "its_a_wrap_before"
+        yield
+        @ran_filter << "its_a_wrap_after"
+      end
+
+      def the_end
+        @ran_filter ||= []
+        @ran_filter << "the_end"
+      end
+  end
+
+  class OutermostFilterController < TestController
+    outermost_before_action :once_upon_a_time
+
+    private
+      def once_upon_a_time
+        @ran_filter ||= []
+        @ran_filter << "once_upon_a_time"
+      end
+  end
+
+  class OutermostFilterInheritedController < OutermostFilterController
+    prepend_before_action :wonderful_life
+
+    private
+      def wonderful_life
+        @ran_filter ||= []
+        @ran_filter << "wonderful_life"
+      end
+  end
+
+  class InnermostFilterInheritedController < InnermostFilterController
+    before_action :beautiful_day
+    around_action :another_day
+    after_action :good_night
+
+    private
+      def beautiful_day
+        @ran_filter ||= []
+        @ran_filter << "beautiful_day"
+      end
+
+      def another_day
+        @ran_filter ||= []
+        @ran_filter << "another_day_before"
+        yield
+        @ran_filter << "another_day_after"
+      end
+
+      def good_night
+        @ran_filter ||= []
+        @ran_filter << "good_night"
+      end
+  end
+
+  class NestedOptionFilterController < TestController
+    before_action :wonderful_life, innermost: true
+    before_action :once_upon_a_time, outermost: true
+    before_action :beautiful_day, innermost: false
+
+    private
+      def wonderful_life
+        @ran_filter ||= []
+        @ran_filter << "wonderful_life"
+      end
+
+      def once_upon_a_time
+        @ran_filter ||= []
+        @ran_filter << "once_upon_a_time"
+      end
+
+      def beautiful_day
+        @ran_filter ||= []
+        @ran_filter << "beautiful_day"
+      end
+  end
+
   class SkippingAndLimitedController < TestController
     skip_before_action :ensure_login
     before_action :ensure_login, only: :index
@@ -591,6 +681,60 @@ class FilterTest < ActionController::TestCase
     test_process(PrependingController)
     assert_equal %w( wonderful_life ensure_login ),
       @controller.instance_variable_get(:@ran_filter)
+  end
+
+  def test_innermost_action
+    assert_equal [ :ensure_login, :wonderful_life ], InnermostFilterController.before_actions
+  end
+
+  def test_innermost_action_is_kept_innermost_when_a_subclass_appends_its_own_actions
+    assert_equal [ :ensure_login, :beautiful_day, :wonderful_life ], InnermostFilterInheritedController.before_actions
+  end
+
+  def test_running_innermost_actions
+    test_process(InnermostFilterInheritedController)
+    assert_equal %w( ensure_login beautiful_day another_day_before wonderful_life its_a_wrap_before
+                     the_end its_a_wrap_after good_night another_day_after ),
+      @controller.instance_variable_get(:@ran_filter)
+  end
+
+  def test_outermost_action
+    assert_equal [ :once_upon_a_time, :ensure_login ], OutermostFilterController.before_actions
+  end
+
+  def test_outermost_action_is_kept_outermost_when_a_subclass_prepends_its_own_actions
+    assert_equal [ :once_upon_a_time, :wonderful_life, :ensure_login ],
+      OutermostFilterInheritedController.before_actions
+  end
+
+  def test_outermost_actions_keep_the_order_they_were_registered_in
+    controller = Class.new(OutermostFilterController) do
+      outermost_before_action :in_a_land_far_far_away
+      def self.name; "AnotherOutermostFilterController"; end
+    end
+
+    assert_equal [ :once_upon_a_time, :in_a_land_far_far_away, :ensure_login ], controller.before_actions
+  end
+
+  def test_running_outermost_actions
+    test_process(OutermostFilterInheritedController)
+    assert_equal %w( once_upon_a_time wonderful_life ensure_login ),
+      @controller.instance_variable_get(:@ran_filter)
+  end
+
+  def test_the_nesting_options_are_accepted_by_the_regular_action_callbacks
+    assert_equal [ :once_upon_a_time, :ensure_login, :beautiful_day, :wonderful_life ],
+      NestedOptionFilterController.before_actions
+  end
+
+  def test_the_nesting_options_and_their_callbacks_are_interchangeable
+    controller = Class.new(TestController) do
+      outermost_before_action :once_upon_a_time
+      innermost_before_action :wonderful_life
+      def self.name; "EquivalentFilterController"; end
+    end
+
+    assert_equal [ :once_upon_a_time, :ensure_login, :wonderful_life ], controller.before_actions
   end
 
   def test_running_actions_with_proc

--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,25 @@
+*   Accept the `:innermost` and `:outermost` callback options in the callbacks
+    defined by `define_model_callbacks`.
+
+    A callback registered with `innermost: true` is kept closest to the event, so
+    every callback that is not itself `:innermost`, including the ones registered
+    later on by subclasses, runs before it. `outermost: true` does the opposite.
+
+    ```ruby
+    class ApplicationRecord < ActiveRecord::Base
+      self.abstract_class = true
+      before_save :recompute_search_index, innermost: true
+    end
+
+    class Article < ApplicationRecord
+      before_save :render_body_html
+    end
+
+    # Article runs :render_body_html, then :recompute_search_index.
+    ```
+
+    *Roman Sklenar*
+
 *   Implement `ActiveModel::Type::Binary::Data#as_json`
 
     Delegates JSON conversion to the underlying binary data value (instead of

--- a/activemodel/lib/active_model/callbacks.rb
+++ b/activemodel/lib/active_model/callbacks.rb
@@ -128,21 +128,21 @@ module ActiveModel
     private
       def _define_before_model_callback(klass, callback)
         klass.define_singleton_method("before_#{callback}") do |*args, **options, &block|
-          options.assert_valid_keys(:if, :unless, :prepend)
+          options.assert_valid_keys(:if, :unless, :prepend, :innermost, :outermost)
           set_callback(:"#{callback}", :before, *args, options, &block)
         end
       end
 
       def _define_around_model_callback(klass, callback)
         klass.define_singleton_method("around_#{callback}") do |*args, **options, &block|
-          options.assert_valid_keys(:if, :unless, :prepend)
+          options.assert_valid_keys(:if, :unless, :prepend, :innermost, :outermost)
           set_callback(:"#{callback}", :around, *args, options, &block)
         end
       end
 
       def _define_after_model_callback(klass, callback)
         klass.define_singleton_method("after_#{callback}") do |*args, **options, &block|
-          options.assert_valid_keys(:if, :unless, :prepend)
+          options.assert_valid_keys(:if, :unless, :prepend, :innermost, :outermost)
           options[:prepend] = true
           conditional = ActiveSupport::Callbacks::Conditionals::Value.new { |v|
             v != false

--- a/activemodel/test/cases/callbacks_test.rb
+++ b/activemodel/test/cases/callbacks_test.rb
@@ -143,4 +143,76 @@ class CallbacksTest < ActiveModel::TestCase
   test "after_create callbacks with both callbacks declared in different lines" do
     assert_equal ["callback1", "callback2"], Violin2.new.create.history
   end
+
+  class Cello
+    attr_reader :history
+    def initialize
+      @history = []
+    end
+    extend ActiveModel::Callbacks
+    define_model_callbacks :create
+    before_create :tune, innermost: true
+    before_create :rosin_the_bow, outermost: true
+    def tune; history << "tune"; end
+    def rosin_the_bow; history << "rosin_the_bow"; end
+    def unpack; history << "unpack"; end
+    def plug_in; history << "plug_in"; end
+    def create
+      run_callbacks(:create) { }
+      self
+    end
+  end
+
+  class ElectricCello < Cello
+    before_create :unpack
+    before_create :plug_in, prepend: true
+  end
+
+  test "model callbacks accept the :innermost and :outermost options" do
+    assert_equal ["rosin_the_bow", "tune"], Cello.new.create.history
+  end
+
+  test "innermost and outermost model callbacks stay in place in subclasses" do
+    assert_equal ["rosin_the_bow", "plug_in", "unpack", "tune"], ElectricCello.new.create.history
+  end
+
+  class Bassoon
+    attr_reader :history
+    def initialize
+      @history = []
+    end
+    extend ActiveModel::Callbacks
+    define_model_callbacks :create
+    after_create :swab, innermost: true
+    after_create :pack_up, innermost: true
+    after_create :log, outermost: true
+    def swab; history << "swab"; end
+    def pack_up; history << "pack_up"; end
+    def log; history << "log"; end
+    def create
+      run_callbacks(:create) { }
+      self
+    end
+  end
+
+  class Clarinet < Cello
+    before_create :unpack, innermost: false
+  end
+
+  test "the :innermost and :outermost options are ignored when false" do
+    assert_equal ["rosin_the_bow", "unpack", "tune"], Clarinet.new.create.history
+  end
+
+  test "innermost and outermost after callbacks run in the order they were declared" do
+    assert_equal ["swab", "pack_up", "log"], Bassoon.new.create.history
+  end
+
+  class ContraBassoon < Bassoon
+    after_create :polish, innermost: true, prepend: true
+    def polish; history << "polish"; end
+  end
+
+  test "after callbacks are always prepended, so :prepend has no effect on them" do
+    assert_equal ["swab", "pack_up", "polish", "log"], ContraBassoon.new.create.history
+  end
 end

--- a/activerecord/test/cases/callbacks_test.rb
+++ b/activerecord/test/cases/callbacks_test.rb
@@ -479,7 +479,7 @@ class CallbacksTest < ActiveRecord::TestCase
         before_save(on: :create) { }
       end
     end
-    assert_equal "Unknown key: :on. Valid keys are: :if, :unless, :prepend", exception.message
+    assert_equal "Unknown key: :on. Valid keys are: :if, :unless, :prepend, :innermost, :outermost", exception.message
   end
 
   def test_around_save_doesnt_allow_on_option
@@ -488,7 +488,7 @@ class CallbacksTest < ActiveRecord::TestCase
         around_save(on: :create) { }
       end
     end
-    assert_equal "Unknown key: :on. Valid keys are: :if, :unless, :prepend", exception.message
+    assert_equal "Unknown key: :on. Valid keys are: :if, :unless, :prepend, :innermost, :outermost", exception.message
   end
 
   def test_after_save_doesnt_allow_on_option
@@ -497,6 +497,6 @@ class CallbacksTest < ActiveRecord::TestCase
         after_save(on: :create) { }
       end
     end
-    assert_equal "Unknown key: :on. Valid keys are: :if, :unless, :prepend", exception.message
+    assert_equal "Unknown key: :on. Valid keys are: :if, :unless, :prepend, :innermost, :outermost", exception.message
   end
 end

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,55 @@
+*   Add `:innermost` and `:outermost` options to
+    `ActiveSupport::Callbacks::ClassMethods#set_callback`.
+
+    A callback registered with `innermost: true` is kept closest to the event, so
+    every callback that is not itself `:innermost`, including the ones registered
+    later on by subclasses, runs before it. This makes it possible for a base
+    class to register a callback that depends on the state its subclasses set up.
+
+    ```ruby
+    class Base
+      include ActiveSupport::Callbacks
+      define_callbacks :save
+      set_callback :save, :before, :check_invariants, innermost: true
+    end
+
+    class Post < Base
+      set_callback :save, :before, :assign_defaults
+    end
+
+    # Post runs :assign_defaults, then :check_invariants.
+    ```
+
+    `outermost: true` is the counterpart: the callback is kept furthest from the
+    event, so every callback that is not itself `:outermost`, including the ones
+    prepended later on by subclasses, runs after it.
+
+    ```ruby
+    class Base
+      include ActiveSupport::Callbacks
+      define_callbacks :save
+      set_callback :save, :before, :set_current_tenant, outermost: true
+    end
+
+    class Post < Base
+      set_callback :save, :before, :authorize, prepend: true
+    end
+
+    # Post runs :set_current_tenant, then :authorize.
+    ```
+
+    Both options only say which end of the chain the callback belongs to, they do
+    not make it unique. Several callbacks can share an end, where they keep the
+    order they were registered in, and `prepend: true` still moves a callback in
+    front of the ones it shares that end with. Setting both options on the same
+    callback raises an `ArgumentError`.
+
+    The options are available wherever Active Support callbacks are, including
+    Active Record models, Action Controller controllers, Action Mailer mailers,
+    and Active Job jobs.
+
+    *Roman Sklenar*
+
 *   Preserve the requested key order in `ActiveSupport::Cache::Store#fetch_multi`
     when a local cache is active.
 

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -252,14 +252,30 @@ module ActiveSupport
           @filter          = try_shareable_proc(filter)
           @if              = check_conditionals(options[:if])
           @unless          = check_conditionals(options[:unless])
+          @outermost       = !!options[:outermost]
+          @innermost       = !!options[:innermost]
+
+          if @outermost && @innermost
+            raise ArgumentError, "Cannot set a callback as both :outermost and :innermost"
+          end
 
           compiled
+        end
+
+        def outermost?
+          @outermost
+        end
+
+        def innermost?
+          @innermost
         end
 
         def merge_conditional_options(chain, if_option:, unless_option:)
           options = {
             if: @if.dup,
-            unless: @unless.dup
+            unless: @unless.dup,
+            outermost: @outermost,
+            innermost: @innermost
           }
 
           options[:if].concat     Array(unless_option)
@@ -662,11 +678,11 @@ module ActiveSupport
         end
 
         def append(*callbacks)
-          callbacks.each { |c| append_one(c) }
+          callbacks.each { |c| insert_one(c, prepend: false) }
         end
 
         def prepend(*callbacks)
-          callbacks.each { |c| prepend_one(c) }
+          callbacks.each { |c| insert_one(c, prepend: true) }
         end
 
         def freeze
@@ -693,18 +709,29 @@ module ActiveSupport
             end
           end
 
-          def append_one(callback)
+          def insert_one(callback, prepend:)
             @all_callbacks = nil
             @single_callbacks.clear
             remove_duplicates(callback)
-            @chain.push(callback)
+            @chain.insert(insertion_index(callback, prepend), callback)
           end
 
-          def prepend_one(callback)
-            @all_callbacks = nil
-            @single_callbacks.clear
-            remove_duplicates(callback)
-            @chain.unshift(callback)
+          # The chain is ordered from the outermost callback to the innermost
+          # one, and is partitioned into the outermost, the regular, and the
+          # innermost callbacks. A callback is inserted at the inside end of its
+          # own partition, or at the outside end of it when prepended.
+          def insertion_index(callback, prepend)
+            if callback.outermost?
+              prepend ? 0 : @chain.count(&:outermost?)
+            elsif callback.innermost?
+              prepend ? first_innermost_index : @chain.length
+            else
+              prepend ? @chain.count(&:outermost?) : first_innermost_index
+            end
+          end
+
+          def first_innermost_index
+            @chain.index(&:innermost?) || @chain.length
           end
 
           def remove_duplicates(callback)
@@ -787,6 +814,67 @@ module ActiveSupport
         #   an argument.
         # * <tt>:prepend</tt> - If +true+, the callback will be prepended to the
         #   existing chain rather than appended.
+        # * <tt>:innermost</tt> - If +true+, the callback is kept closest to the
+        #   event, after every callback that is not itself <tt>:innermost</tt>,
+        #   including the ones registered later on by subclasses. A +before+
+        #   callback registered this way runs after all of them, an +around+
+        #   callback is wrapped by all of them, and an +after+ callback runs
+        #   before all of them, since +after+ callbacks run in reverse order.
+        #
+        #   Callbacks are otherwise run from the base class down, which makes it
+        #   impossible for a base class to act on the state its subclasses set
+        #   up. This option lifts that restriction:
+        #
+        #     class ApplicationRecord < ActiveRecord::Base
+        #       self.abstract_class = true
+        #
+        #       # Runs once every subclass has filled in its own attributes.
+        #       before_save :recompute_search_index, innermost: true
+        #     end
+        #
+        #     class Article < ApplicationRecord
+        #       before_save :render_body_html
+        #       before_save :extract_mentions
+        #     end
+        #
+        #     # Article runs :render_body_html, :extract_mentions, and only then
+        #     # :recompute_search_index.
+        #
+        # * <tt>:outermost</tt> - The counterpart of <tt>:innermost</tt>. If
+        #   +true+, the callback is kept furthest from the event, before every
+        #   callback that is not itself <tt>:outermost</tt>, including the ones
+        #   prepended later on by subclasses.
+        #
+        #   <tt>:prepend</tt> puts a callback in front of the callbacks
+        #   registered so far, but it cannot keep it there, since the next
+        #   <tt>:prepend</tt> wins. Use this option for the callback that
+        #   establishes the context every other callback relies on:
+        #
+        #     class ApplicationRecord < ActiveRecord::Base
+        #       self.abstract_class = true
+        #
+        #       # Every other callback, prepended or not, sees the audit context.
+        #       around_save :with_audit_context, outermost: true
+        #     end
+        #
+        #   Both options only say which end of the chain the callback belongs to,
+        #   they do not make it unique. Several callbacks can share an end, where
+        #   they keep the order they were registered in, and <tt>:prepend</tt>
+        #   still moves a callback in front of the ones it shares that end with:
+        #
+        #     set_callback :save, :before, :check_invariants, innermost: true
+        #     set_callback :save, :before, :notify, innermost: true
+        #     set_callback :save, :before, :reload, innermost: true, prepend: true
+        #
+        #     # Runs :reload, :check_invariants, and then :notify, after every
+        #     # before callback that is not innermost.
+        #
+        #   A subclass that registers its own pinned callback lands after the one
+        #   of its parent, just like any callback registered later: at the
+        #   outermost end the parent's callback stays the first to run, and at
+        #   the innermost end the subclass's becomes the last to run. Setting
+        #   both options on the same callback raises an +ArgumentError+.
+        #
         def set_callback(name, *filter_list, &block)
           type, filters, options = normalize_callback_params(filter_list, block)
 

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -843,7 +843,10 @@ module ActiveSupport
         # * <tt>:outermost</tt> - The counterpart of <tt>:innermost</tt>. If
         #   +true+, the callback is kept furthest from the event, before every
         #   callback that is not itself <tt>:outermost</tt>, including the ones
-        #   prepended later on by subclasses.
+        #   prepended later on by subclasses. A +before+ callback registered this
+        #   way runs before all of them, an +around+ callback wraps all of them,
+        #   and an +after+ callback runs after all of them, since +after+
+        #   callbacks run in reverse order.
         #
         #   <tt>:prepend</tt> puts a callback in front of the callbacks
         #   registered so far, but it cannot keep it there, since the next
@@ -853,7 +856,7 @@ module ActiveSupport
         #     class ApplicationRecord < ActiveRecord::Base
         #       self.abstract_class = true
         #
-        #       # Every other callback, prepended or not, sees the audit context.
+        #       # Every regular callback, prepended or not, sees the audit context.
         #       around_save :with_audit_context, outermost: true
         #     end
         #
@@ -870,10 +873,10 @@ module ActiveSupport
         #     # before callback that is not innermost.
         #
         #   A subclass that registers its own pinned callback lands after the one
-        #   of its parent, just like any callback registered later: at the
-        #   outermost end the parent's callback stays the first to run, and at
-        #   the innermost end the subclass's becomes the last to run. Setting
-        #   both options on the same callback raises an +ArgumentError+.
+        #   of its parent, just like any callback registered later, so at the
+        #   outermost end the parent's callback stays the outer one, and at the
+        #   innermost end the subclass's becomes the inner one. Setting both
+        #   options on the same callback raises an +ArgumentError+.
         #
         def set_callback(name, *filter_list, &block)
           type, filters, options = normalize_callback_params(filter_list, block)

--- a/activesupport/test/callbacks_test.rb
+++ b/activesupport/test/callbacks_test.rb
@@ -1392,4 +1392,241 @@ module CallbacksTest
       assert_equal ["after_save_2", "after_save_1"], klass.history
     end
   end
+
+  class NestedCallbacksRecord
+    include ActiveSupport::Callbacks
+
+    define_callbacks :save
+
+    attr_reader :history
+
+    def initialize
+      @history = []
+    end
+
+    def save
+      run_callbacks(:save) { @history << "save" }
+    end
+
+    %w( parent parent_outermost parent_innermost child grandchild_outermost grandchild_innermost ).each do |name|
+      define_method("before_#{name}") { @history << "before_#{name}" }
+      define_method("after_#{name}") { @history << "after_#{name}" }
+      define_method("around_#{name}") do |&block|
+        @history << "around_#{name}_before"
+        block.call
+        @history << "around_#{name}_after"
+      end
+    end
+  end
+
+  class ParentWithNestedCallbacks < NestedCallbacksRecord
+    set_callback :save, :before, :before_parent_outermost, outermost: true
+    set_callback :save, :around, :around_parent_outermost, outermost: true
+    set_callback :save, :after, :after_parent_outermost, outermost: true
+
+    set_callback :save, :before, :before_parent_innermost, innermost: true
+    set_callback :save, :around, :around_parent_innermost, innermost: true
+    set_callback :save, :after, :after_parent_innermost, innermost: true
+
+    set_callback :save, :before, :before_parent
+    set_callback :save, :around, :around_parent
+    set_callback :save, :after, :after_parent
+  end
+
+  class ChildWithNestedCallbacks < ParentWithNestedCallbacks
+    set_callback :save, :before, :before_child
+    set_callback :save, :around, :around_child
+    set_callback :save, :after, :after_child
+  end
+
+  class GrandChildWithNestedCallbacks < ChildWithNestedCallbacks
+    set_callback :save, :before, :before_grandchild_innermost, innermost: true
+  end
+
+  module PrependingCallbackConcern
+    extend ActiveSupport::Concern
+
+    included do
+      set_callback :save, :before, :before_child, prepend: true
+    end
+  end
+
+  class NestedCallbacksTest < ActiveSupport::TestCase
+    def test_innermost_callbacks_run_after_the_appended_ones
+      assert_equal [
+        "before_parent_outermost",
+        "around_parent_outermost_before",
+        "before_parent",
+        "around_parent_before",
+        "before_parent_innermost",
+        "around_parent_innermost_before",
+        "save",
+        "after_parent_innermost",
+        "around_parent_innermost_after",
+        "after_parent",
+        "around_parent_after",
+        "after_parent_outermost",
+        "around_parent_outermost_after",
+      ], ParentWithNestedCallbacks.new.tap(&:save).history
+    end
+
+    def test_innermost_callbacks_run_after_the_ones_appended_by_subclasses
+      assert_equal [
+        "before_parent_outermost",
+        "around_parent_outermost_before",
+        "before_parent",
+        "around_parent_before",
+        "before_child",
+        "around_child_before",
+        "before_parent_innermost",
+        "around_parent_innermost_before",
+        "save",
+        "after_parent_innermost",
+        "around_parent_innermost_after",
+        "after_child",
+        "around_child_after",
+        "after_parent",
+        "around_parent_after",
+        "after_parent_outermost",
+        "around_parent_outermost_after",
+      ], ChildWithNestedCallbacks.new.tap(&:save).history
+    end
+
+    def test_innermost_callbacks_keep_the_order_they_were_set_in
+      history = GrandChildWithNestedCallbacks.new.tap(&:save).history
+
+      assert_equal ["before_parent_outermost", "before_parent", "before_child", "before_parent_innermost", "before_grandchild_innermost"],
+        history.grep(/\Abefore_/)
+    end
+
+    def test_innermost_callbacks_can_be_skipped
+      klass = Class.new(ParentWithNestedCallbacks) do
+        skip_callback :save, :before, :before_parent_innermost
+      end
+
+      assert_equal ["before_parent_outermost", "before_parent"], klass.new.tap(&:save).history.grep(/\Abefore_/)
+    end
+
+    def test_innermost_callbacks_can_be_conditionally_skipped
+      klass = Class.new(ParentWithNestedCallbacks) do
+        attr_accessor :skip_it
+        skip_callback :save, :before, :before_parent_innermost, if: :skip_it
+      end
+
+      record = klass.new
+      record.skip_it = true
+      assert_equal ["before_parent_outermost", "before_parent"], record.tap(&:save).history.grep(/\Abefore_/)
+
+      record = klass.new
+      record.skip_it = false
+      assert_equal ["before_parent_outermost", "before_parent", "before_parent_innermost"], record.tap(&:save).history.grep(/\Abefore_/)
+    end
+
+    def test_conditionally_skipping_an_innermost_callback_keeps_it_innermost
+      klass = Class.new(ParentWithNestedCallbacks) do
+        attr_accessor :skip_it
+        skip_callback :save, :before, :before_parent_innermost, if: :skip_it
+        set_callback :save, :before, :before_child
+      end
+
+      record = klass.new
+      record.skip_it = false
+      assert_equal ["before_parent_outermost", "before_parent", "before_child", "before_parent_innermost"],
+        record.tap(&:save).history.grep(/\Abefore_/)
+    end
+
+    def test_setting_an_innermost_callback_again_without_the_option_moves_it_back
+      klass = Class.new(ParentWithNestedCallbacks) do
+        set_callback :save, :before, :before_parent_innermost
+        set_callback :save, :before, :before_child
+      end
+
+      assert_equal ["before_parent_outermost", "before_parent", "before_parent_innermost", "before_child"],
+        klass.new.tap(&:save).history.grep(/\Abefore_/)
+    end
+
+    def test_setting_an_innermost_callback_twice_does_not_duplicate_it
+      klass = Class.new(ParentWithNestedCallbacks) do
+        set_callback :save, :before, :before_parent_innermost, innermost: true
+      end
+
+      assert_equal ["before_parent_outermost", "before_parent", "before_parent_innermost"],
+        klass.new.tap(&:save).history.grep(/\Abefore_/)
+    end
+
+    def test_outermost_callbacks_run_before_the_prepended_ones
+      klass = Class.new(ParentWithNestedCallbacks) do
+        set_callback :save, :before, :before_child, prepend: true
+      end
+
+      assert_equal ["before_parent_outermost", "before_child", "before_parent", "before_parent_innermost"],
+        klass.new.tap(&:save).history.grep(/\Abefore_/)
+    end
+
+    def test_outermost_callbacks_run_before_the_ones_prepended_by_a_concern_included_later
+      klass = Class.new(ParentWithNestedCallbacks) do
+        include PrependingCallbackConcern
+      end
+
+      assert_equal ["before_parent_outermost", "before_child", "before_parent", "before_parent_innermost"],
+        klass.new.tap(&:save).history.grep(/\Abefore_/)
+    end
+
+    def test_outermost_callbacks_keep_the_order_they_were_set_in
+      klass = Class.new(ParentWithNestedCallbacks) do
+        set_callback :save, :before, :before_grandchild_outermost, outermost: true
+      end
+
+      assert_equal ["before_parent_outermost", "before_grandchild_outermost", "before_parent", "before_parent_innermost"],
+        klass.new.tap(&:save).history.grep(/\Abefore_/)
+    end
+
+    def test_prepending_an_outermost_callback_puts_it_in_front_of_the_other_outermost_ones
+      klass = Class.new(ParentWithNestedCallbacks) do
+        set_callback :save, :before, :before_grandchild_outermost, outermost: true, prepend: true
+      end
+
+      assert_equal ["before_grandchild_outermost", "before_parent_outermost", "before_parent", "before_parent_innermost"],
+        klass.new.tap(&:save).history.grep(/\Abefore_/)
+    end
+
+    def test_prepending_an_innermost_callback_puts_it_in_front_of_the_other_innermost_ones
+      klass = Class.new(ParentWithNestedCallbacks) do
+        set_callback :save, :before, :before_grandchild_innermost, innermost: true, prepend: true
+      end
+
+      assert_equal ["before_parent_outermost", "before_parent", "before_grandchild_innermost", "before_parent_innermost"],
+        klass.new.tap(&:save).history.grep(/\Abefore_/)
+    end
+
+    def test_the_options_are_ignored_when_false
+      klass = Class.new(ParentWithNestedCallbacks) do
+        set_callback :save, :before, :before_child, innermost: false
+        set_callback :save, :before, :before_grandchild_outermost, outermost: false
+      end
+
+      assert_equal ["before_parent_outermost", "before_parent", "before_child",
+                    "before_grandchild_outermost", "before_parent_innermost"],
+        klass.new.tap(&:save).history.grep(/\Abefore_/)
+    end
+
+    def test_a_callback_cannot_be_both_outermost_and_innermost
+      error = assert_raises(ArgumentError) do
+        Class.new(ParentWithNestedCallbacks) do
+          set_callback :save, :before, :before_child, outermost: true, innermost: true
+        end
+      end
+
+      assert_equal "Cannot set a callback as both :outermost and :innermost", error.message
+    end
+
+    def test_reset_callbacks_also_resets_nested_callbacks
+      klass = Class.new(ParentWithNestedCallbacks) do
+        reset_callbacks :save
+      end
+
+      assert_predicate klass.send(:get_callbacks, :save), :empty?
+      assert_equal ["save"], klass.new.tap(&:save).history
+    end
+  end
 end

--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -570,8 +570,8 @@ end
 
 A subclass registering its own pinned callback lands after the one of its
 parent, just like any callback registered later. At the outermost end that means
-the parent's callback stays the first to run; at the innermost end it means the
-subclass's callback becomes the last to run.
+the parent's callback stays the outer one; at the innermost end it means the
+subclass's callback becomes the inner one.
 
 ```ruby
 class ArticlesController < ApplicationController

--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -460,6 +460,159 @@ cancels any `after_action` callbacks.
 [`around_action`]:
   https://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html#method-i-around_action
 
+### Callback Ordering
+
+Callbacks run in the order they are registered, and the ones inherited from a
+parent controller come first. `before_action` and `around_action` callbacks run
+from the first registered to the last, while `after_action` callbacks run in
+reverse order. Think of the chain as a set of layers wrapped around the action:
+the callbacks registered first are the outermost ones, and the ones registered
+last are the closest to the action.
+
+[`prepend_before_action`][] moves a callback to the front of the chain, so it
+runs before every other `before_action` registered so far, including the
+inherited ones. This is what a concern should use when its callback has to run
+before the ones of the controller including it.
+
+```ruby
+module Authentication
+  extend ActiveSupport::Concern
+
+  included do
+    prepend_before_action :authenticate # runs before the inherited callbacks
+  end
+end
+```
+
+[`prepend_before_action`]:
+  https://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html#method-i-prepend_before_action
+
+### `innermost` and `outermost` Callbacks
+
+`prepend_before_action` puts a callback in front of the callbacks registered so
+far, but it cannot keep it there: the next `prepend_before_action` wins. The
+same goes for the other end of the chain, where a plain `before_action` is
+always overtaken by the ones a subclass registers later.
+
+The `:innermost` and `:outermost` options pin a callback to one end of the
+chain, where nothing registered later on can displace it.
+
+#### `innermost: true`
+
+A callback registered with `innermost: true` is kept closest to the action, so
+every regular `before_action`, including the ones registered later on by
+subclasses, runs before it. That is what a base controller needs when its
+callback depends on a record its subclasses load:
+
+```ruby
+class ApplicationController < ActionController::Base
+  before_action :authorize_record, innermost: true, only: [:show, :edit]
+
+  private
+    def authorize_record
+      head :forbidden unless Current.user.can?(action_name, @record)
+    end
+end
+
+class ArticlesController < ApplicationController
+  before_action :set_record # runs before :authorize_record
+end
+```
+
+Without it, every subclass has to remember to re-register the inherited callback
+after its own, which is easy to get wrong and impossible to enforce.
+
+Being closest to the action means being wrapped by everything else, so an
+`around_action` registered this way is wrapped by every regular `around_action`,
+and an `after_action` registered this way runs before every regular
+`after_action`, since `after_action` callbacks run in reverse order.
+
+#### `outermost: true`
+
+`outermost: true` does the opposite: the callback is kept furthest from the
+action, so every regular `before_action`, including the ones prepended later on
+by subclasses or by a concern included later, runs after it. Use it for the
+callback that establishes the context every other callback relies on:
+
+```ruby
+class ApplicationController < ActionController::Base
+  before_action :set_current_tenant, outermost: true
+
+  private
+    def set_current_tenant
+      Current.tenant = Tenant.find_by!(host: request.host)
+    end
+end
+
+class ArticlesController < ApplicationController
+  # Its prepended :authenticate runs after :set_current_tenant.
+  include Authentication
+end
+```
+
+An `around_action` registered this way wraps every regular `around_action`,
+which makes it observe everything the callbacks registered after it do,
+including what they raise, render, or redirect.
+
+#### Ordering within Each End
+
+Both options only say which end of the chain a callback belongs to, they do not
+make it unique. Several callbacks can share an end, where they keep the order
+they were registered in, and `prepend: true` still moves a callback in front of
+the ones it shares that end with.
+
+```ruby
+class ApplicationController < ActionController::Base
+  before_action :set_current_tenant, outermost: true
+  before_action :set_locale, outermost: true # needs the tenant, runs second
+end
+```
+
+A subclass registering its own pinned callback lands after the one of its
+parent, just like any callback registered later. At the outermost end that means
+the parent's callback stays the first to run; at the innermost end it means the
+subclass's callback becomes the last to run.
+
+```ruby
+class ArticlesController < ApplicationController
+  before_action :set_current_account, outermost: true # after :set_locale
+  before_action :track_view, innermost: true          # after :authorize_record
+end
+```
+
+Setting both options on the same callback raises an `ArgumentError`.
+
+#### Shorthands
+
+Every combination has a matching callback, should you prefer it to the option:
+
+| Option | Shorthand |
+| --- | --- |
+| `before_action :foo, innermost: true` | [`innermost_before_action`][] `:foo` |
+| `around_action :foo, innermost: true` | [`innermost_around_action`][] `:foo` |
+| `after_action :foo, innermost: true` | [`innermost_after_action`][] `:foo` |
+| `before_action :foo, outermost: true` | [`outermost_before_action`][] `:foo` |
+| `around_action :foo, outermost: true` | [`outermost_around_action`][] `:foo` |
+| `after_action :foo, outermost: true` | [`outermost_after_action`][] `:foo` |
+
+The options work everywhere Active Support callbacks do, so Active Record
+models, mailers, and jobs take them too. See the [Active Record Callbacks
+guide](active_record_callbacks.html#callback-ordering-in-inheritance-hierarchies)
+for the model side.
+
+[`innermost_before_action`]:
+  https://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html#method-i-innermost_before_action
+[`innermost_after_action`]:
+  https://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html#method-i-innermost_after_action
+[`innermost_around_action`]:
+  https://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html#method-i-innermost_around_action
+[`outermost_before_action`]:
+  https://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html#method-i-outermost_before_action
+[`outermost_after_action`]:
+  https://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html#method-i-outermost_after_action
+[`outermost_around_action`]:
+  https://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html#method-i-outermost_around_action
+
 ### Advanced Techniques to Register Callbacks
 
 In addition to registering a method name using `before_action`, `after_action`,

--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -160,6 +160,61 @@ effects during commit. <br><br> Instead, you can assign values directly (e.g.,
 `self.attribute = "value"`) in `before_create`, `before_update`, or earlier
 callbacks for a safer approach.
 
+### Callback Ordering in Inheritance Hierarchies
+
+Callbacks run in the order they are registered, and the ones inherited from a
+parent class come first. That makes it impossible for a base class to register a
+callback that depends on the state its subclasses set up, because the base class
+body is evaluated first.
+
+The `:innermost` option lifts that restriction: the callback is kept closest to
+the event, so every callback that is not itself `:innermost`, including the ones
+registered later on by subclasses, runs before it.
+
+```ruby
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+
+  # Runs once every subclass has filled in its own attributes.
+  before_save :recompute_search_index, innermost: true
+end
+
+class Article < ApplicationRecord
+  before_save :render_body_html
+  before_save :extract_mentions
+end
+
+# Article runs :render_body_html, :extract_mentions, and only then
+# :recompute_search_index.
+```
+
+The `:outermost` option does the opposite: the callback is kept furthest from
+the event, so every callback that is not itself `:outermost`, including the ones
+prepended later on by subclasses, runs after it. Use it for the callback that
+establishes the context every other callback relies on.
+
+```ruby
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+
+  # Every other callback, prepended or not, sees the audit context.
+  around_save :with_audit_context, outermost: true
+end
+```
+
+Both options only say which end of the chain a callback belongs to, they do not
+make it unique. Several callbacks can share an end, where they keep the order
+they were registered in, and `prepend: true` still moves a callback in front of
+the ones it shares that end with. A subclass registering its own pinned callback
+lands after the one of its parent, so at the outermost end the parent's callback
+stays the first to run, and at the innermost end the subclass's becomes the last
+to run. Setting both options on the same callback raises an `ArgumentError`.
+
+NOTE: Since `after_*` callbacks run in reverse order, an `innermost` one runs
+before the regular ones and an `outermost` one after them. Active Record always
+registers them as `prepend` so that they run in declaration order, which is also
+why passing `prepend: true` to an `after_*` callback has no effect.
+
 Available Callbacks
 -------------------
 

--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -197,7 +197,7 @@ establishes the context every other callback relies on.
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
-  # Every other callback, prepended or not, sees the audit context.
+  # Every regular callback, prepended or not, sees the audit context.
   around_save :with_audit_context, outermost: true
 end
 ```
@@ -207,13 +207,17 @@ make it unique. Several callbacks can share an end, where they keep the order
 they were registered in, and `prepend: true` still moves a callback in front of
 the ones it shares that end with. A subclass registering its own pinned callback
 lands after the one of its parent, so at the outermost end the parent's callback
-stays the first to run, and at the innermost end the subclass's becomes the last
-to run. Setting both options on the same callback raises an `ArgumentError`.
+stays the outer one, and at the innermost end the subclass's becomes the inner
+one. Setting both options on the same callback raises an `ArgumentError`.
 
 NOTE: Since `after_*` callbacks run in reverse order, an `innermost` one runs
-before the regular ones and an `outermost` one after them. Active Record always
-registers them as `prepend` so that they run in declaration order, which is also
-why passing `prepend: true` to an `after_*` callback has no effect.
+before the regular ones and an `outermost` one after them. Active Record
+registers the model ones (`after_save`, `after_create`, and so on) as `prepend`
+so that they run in declaration order, which is also why passing `prepend: true`
+to them has no effect. The transactional ones (`after_commit` and
+`after_rollback`) are ordered by
+[`config.active_record.run_after_transaction_callbacks_in_order_defined`](configuring.html#config-active-record-run-after-transaction-callbacks-in-order-defined)
+instead, and `prepend: true` does change their order.
 
 Available Callbacks
 -------------------


### PR DESCRIPTION
### Motivation / Background

Callbacks run in the order they are registered, and the ones inherited from a parent class come first. Since the parent class body is evaluated before the subclass body, **a base class cannot register a callback that depends on the state its subclasses set up**. In a base controller this comes up constantly: authorization, canonical redirects, breadcrumbs, conditional GET support.

`prepend` has the mirror problem. It puts a callback in front of the callbacks registered so far, which is what a concern needs in order to run before the callbacks it inherits, but it cannot keep it there: the next `prepend` wins. So a base class cannot reliably register the callback that establishes the context — the current tenant, say — that every other callback, prepended or not, relies on.

Neither end of the chain can be claimed, and the ordering information is already in the chain, so this seems worth having in the framework.

#### Example 1: a base controller acting on a record its subclasses load

Today, since `set_callback` removes duplicates, a subclass can re-register the inherited callback to move it after its own. This is the workaround the [filter ordering write-up](https://reganchan.ca/blog/ordering-of-filters-in-rails-controllers/) documents, and it does work:

```ruby
# Today
class ApplicationController < ActionController::Base
  before_action :authorize_record, only: %i[ show edit ]

  private
    def authorize_record
      head :forbidden unless Current.user.can?(action_name, @record)
    end
end

class ArticlesController < ApplicationController
  before_action :set_record
  # Required, or :authorize_record runs first and @record is nil.
  append_before_action :authorize_record, only: %i[ show edit ]
end

class CommentsController < ApplicationController
  before_action :set_record
  append_before_action :authorize_record, only: %i[ show edit ] # ... and again
end
```

The line — conditions included — has to be repeated in every subclass, it silently stops authorizing the moment one of them forgets it, and the base class has no way to enforce it. In the application this patch grew out of, that was 17 of 21 subclasses of one base controller repeating the same callback with the same `:if` condition. The other approach people reach for is deferring the registration with `TracePoint` until the subclass body has been evaluated, which is not thread-safe and breaks on anonymous and reopened classes.

```ruby
# This Pull Request
class ApplicationController < ActionController::Base
  before_action :authorize_record, innermost: true, only: %i[ show edit ]
end

class ArticlesController < ApplicationController
  before_action :set_record # runs before :authorize_record
end
```

#### Example 2: a base controller establishing the context everything else needs

```ruby
# Today
class ApplicationController < ActionController::Base
  prepend_before_action :set_current_tenant
end

module Authentication
  extend ActiveSupport::Concern

  included do
    # Needs Current.tenant. Prepending puts it in front of :set_current_tenant,
    # so the tenant is nil. Appending puts it behind callbacks that must not run
    # before authentication. There is no correct place for it.
    prepend_before_action :authenticate
  end
end
```

Unlike the first example, this one has no workaround at all: whichever callback prepends last wins, so the base controller can only hope that nothing prepends after it.

```ruby
# This Pull Request
class ApplicationController < ActionController::Base
  before_action :set_current_tenant, outermost: true
end

# The concern keeps working the way it was written, no matter which controller
# includes it or in which order: :authenticate is prepended in front of every
# regular callback, and still runs after :set_current_tenant.
```

### Detail

`ActiveSupport::Callbacks::ClassMethods#set_callback` accepts two new options. Think of the chain as a set of layers wrapped around the event: `innermost: true` keeps the callback closest to it, so every callback that is not itself `innermost` — including the ones registered later on by subclasses — wraps it. `outermost: true` keeps it furthest from it, so every callback that is not itself `outermost` is wrapped by it.

They are named after the nesting rather than after the position in the chain, which keeps them accurate for every kind of callback: an `innermost` `before` callback runs after the regular ones, an `innermost` `around` callback is wrapped by them, and, since `after` callbacks run in reverse order, an `innermost` `after` callback runs before them. `first`/`last` would have been shorter and closer to `prepend`/`append`, but would have read backwards for `after`.

The options only say which end of the chain a callback belongs to, they do not make it unique, and they compose with `prepend` rather than override it: within its end, a callback is appended, or prepended when `prepend: true` is given. This is what the `after_*` callbacks defined by `define_model_callbacks` rely on to run in declaration order. A subclass registering its own pinned callback lands after the one of its parent, just like any callback registered later, so at the outermost end the parent's stays the first to run and at the innermost end the subclass's becomes the last to run. Asking for both ends at once raises an `ArgumentError`.

The options work wherever Active Support callbacks do. `ActiveModel::Callbacks` had to be taught to accept them, since `define_model_callbacks` validates its option keys; Active Job and Action Mailer pass them through already.

#### Implementation

The chain is ordered from the outermost callback to the innermost one, and is now read as three partitions: the outermost callbacks, the regular ones, and the innermost ones. A callback is inserted at the inside end of its own partition, or at the outside end of it when prepended, which is the whole of it:

```ruby
def insertion_index(callback, prepend)
  if callback.outermost?
    prepend ? 0 : @chain.count(&:outermost?)
  elsif callback.innermost?
    prepend ? first_innermost_index : @chain.length
  else
    prepend ? @chain.count(&:outermost?) : first_innermost_index
  end
end
```

The partition a callback belongs to is recorded on the `Callback` itself, so the chain stays a single list and `skip_callback`, `reset_callbacks`, and the duplicate removal performed by `set_callback` keep working on it unchanged. `merge_conditional_options` carries the flags over, so a conditionally skipped callback keeps its place. With no pinned callback in a chain, both branches reduce to the previous `push` and `unshift`, so existing chains are unaffected.

#### The `innermost_*_action` and `outermost_*_action` callbacks are optional

`AbstractController::Callbacks` additionally defines `innermost_before_action`, `innermost_around_action`, `innermost_after_action`, and their `outermost_*` counterparts. They are only shorthands for the options, added for symmetry with `prepend_before_action`; the options are the API, and are what the guides lead with.

If growing the public surface of `AbstractController::Callbacks` by six methods is not wanted, **they can be dropped from this Pull Request without touching anything else** — the feature is fully usable through the options, and the tests cover both forms and assert that they produce identical chains.

### Additional information

Beyond the tests in the diff, the following was verified while writing this and is not part of the commit:

- **Randomized differential test against the previous behavior.** 200 iterations of random `set_callback` calls with and without `:prepend`, interleaved with `skip_callback`, compared against a reference model implementing the old `push`/`unshift`/`delete` semantics. Zero divergence for chains that use neither option, which is the backward-compatibility claim.
- **Randomized check of the partition invariant.** `insertion_index` assumes the chain is always `[outermost*, regular*, innermost*]`. 300 runs over a three-level inheritance hierarchy with mixed `:before`/`:after`/`:around`, random pin flags, random `:prepend` and interleaved `skip_callback` never broke it.
- **Every behavioral claim in the documentation was executed.** A script asserts the twelve statements made in the RDoc, the guides, and the CHANGELOGs against real callback chains, including the ones about `after` callbacks running in reverse order and about where a subclass's pinned callback lands. Two claims were wrong when first written and were corrected this way.
- **Mutation test on `merge_conditional_options`.** Removing the propagation of the flags there makes `test_conditionally_skipping_an_innermost_callback_keeps_it_innermost` fail, which confirms that test actually covers the path.
- A local run of GitHub Copilot's reviewer and a security review found, respectively, three documentation defects (since fixed) and no security findings; notably, no callback registered by the framework itself uses either option, so no existing chain changes.

The test suites were run on Ruby 3.4.1 and 4.0.5, including the Ractor tests that only run on 4.0: `activesupport/test/callbacks_test.rb`, `actionpack/test/controller/filters_test.rb`, `actionpack/test/abstract/callbacks_test.rb`, `activemodel/test/cases/callbacks_test.rb`, `activemodel/test/cases/validations/callbacks_test.rb` and `actionmailer/test/callbacks_test.rb`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
