### PR TITLE
Action View test stubs Rails.root and breaks main

### DIFF
--- a/actionview/test/template/structured_event_subscriber_test.rb
+++ b/actionview/test/template/structured_event_subscriber_test.rb
@@ -34,20 +34,18 @@ module ActionView
       original = ActiveSupport.event_reporter.debug_mode?
       ActiveSupport.event_reporter.debug_mode = false
 
-      Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
-        assert_not ActiveSupport::Notifications.notifier.listening?("render_template.action_view")
-        assert_not ActiveSupport::Notifications.notifier.listening?("render_layout.action_view")
+      assert_not ActiveSupport::Notifications.notifier.listening?("render_template.action_view")
+      assert_not ActiveSupport::Notifications.notifier.listening?("render_layout.action_view")
 
-        assert_no_event_reported("action_view.render_start") do
-          assert_equal "Hello world!", @view.render(template: "test/hello_world")
-        end
+      assert_no_event_reported("action_view.render_start") do
+        assert_equal "Hello world!", @view.render(template: "test/hello_world")
+      end
 
-        with_debug_event_reporting do
-          assert ActiveSupport::Notifications.notifier.listening?("render_template.action_view")
+      with_debug_event_reporting do
+        assert ActiveSupport::Notifications.notifier.listening?("render_template.action_view")
 
-          assert_event_reported("action_view.render_start", payload: { identifier: "test/hello_world.erb" }) do
-            @view.render(template: "test/hello_world")
-          end
+        assert_event_reported("action_view.render_start", payload: { identifier: "test/hello_world.erb" }) do
+          @view.render(template: "test/hello_world")
         end
       end
     ensure


### PR DESCRIPTION
### Motivation / Background

main has been red since 16ad4bb6, the merge of #58261. `actionview/test/template/structured_event_subscriber_test.rb:37` errors:

    NameError: undefined method 'root' for class 'Rails'

That branch predates 85127cd9, which replaced this file's `Rails.root` stubbing with `StructuredEventSubscriber.rails_root` and dropped the `Rails.stub(:root, ...)` wrapper from every test. Merging it restored the file's only remaining wrapper. `Minitest::Mock#stub` refuses to stub a method the receiver does not respond to, and Action View's test environment defines no `Rails.root`.

### Detail

Drop the wrapper from `test_render_notifications_are_silenced_outside_debug_mode`. `setup` already points `rails_root` at the fixture path.

### Additional information

Deleting `silenced?` from `ActionView::StructuredEventSubscriber::Start` still fails the test, so it continues to guard what #58261 restored.

### Checklist

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
