### PR TITLE
to_markdown code/pre content escapes its delimiter (stored XSS)

### DIFF
--- a/actiontext/lib/action_text/markdown_conversion.rb
+++ b/actiontext/lib/action_text/markdown_conversion.rb
@@ -112,10 +112,11 @@ module ActionText
         a abbr b bdi bdo cite code data del dfn em i kbd mark q
         rp rt ruby s samp small span strong sub sup time u var
       ] ].freeze
+      SINGLE_LINE_ANCESTORS = [ *INLINE_ELEMENTS, *%w[h1 h2 h3 h4 h5 h6 summary td th] ].freeze
       LEADING_PRETTY_PRINT_WHITESPACE = /\A\s*\n\s*/
       TRAILING_PRETTY_PRINT_WHITESPACE = /\s*\n\s*\z/
       private_constant :BOLD_TAGS, :ITALIC_TAGS, :LIST_BULLET, :LIST_INDENT, :ENCODE_HREF_CHARS,
-        :MARKDOWN_METACHARACTERS, :SKIP_ESCAPING_PARENTS, :INLINE_ELEMENTS,
+        :MARKDOWN_METACHARACTERS, :SKIP_ESCAPING_PARENTS, :INLINE_ELEMENTS, :SINGLE_LINE_ANCESTORS,
         :LEADING_PRETTY_PRINT_WHITESPACE, :TRAILING_PRETTY_PRINT_WHITESPACE
 
       def markdown_for_node(node, child_values)
@@ -177,10 +178,15 @@ module ActionText
         end
       end
 
-      def visit_pre(_node, child_values)
+      def visit_pre(node, child_values)
         inner = join_children(child_values).delete_prefix("\n").delete_suffix("\n")
-        fence = code_fence(inner)
-        "#{fence}\n#{inner}\n#{fence}\n\n"
+
+        if single_line_context?(node)
+          inline_code(inner)
+        else
+          fence = code_fence(inner)
+          "#{fence}\n#{inner}\n#{fence}\n\n"
+        end
       end
 
       def visit_p(_node, child_values)
@@ -365,7 +371,12 @@ module ActionText
         "`" * [3, max_run + 1].max
       end
 
+      # A code span cannot hold a blank line: the blank line closes the paragraph before the
+      # closing backtick string arrives, and the content is released as Markdown source.
+      # Markdown turns the line endings inside a code span into spaces anyway, so collapse
+      # them here and the delimiter always holds.
       def inline_code(content)
+        content = flatten_to_inline(content)
         max_run = content.scan(/`+/).map(&:length).max || 0
         fence = "`" * [1, max_run + 1].max
         if content.start_with?("`") || content.end_with?("`")
@@ -405,6 +416,14 @@ module ActionText
 
       def encode_href(href)
         URI::RFC2396_PARSER.escape(href, ENCODE_HREF_CHARS)
+      end
+
+      # A fenced code block opens only at the start of a line. Inside a link, a heading, a
+      # table cell or an inline element, the parent visitor lays its children out on one
+      # line, so the fence would land mid-line and never open, releasing the `pre` content
+      # that #markdown_for_node emits unescaped. See SKIP_ESCAPING_PARENTS.
+      def single_line_context?(node)
+        node.ancestors.any? { |ancestor| ancestor.element? && ancestor.name.in?(SINGLE_LINE_ANCESTORS) }
       end
 
       def skip_markdown_escaping?(node)

--- a/actiontext/lib/action_text/markdown_conversion.rb
+++ b/actiontext/lib/action_text/markdown_conversion.rb
@@ -112,7 +112,7 @@ module ActionText
         a abbr b bdi bdo cite code data del dfn em i kbd mark q
         rp rt ruby s samp small span strong sub sup time u var
       ] ].freeze
-      SINGLE_LINE_ANCESTORS = [ *INLINE_ELEMENTS, *%w[h1 h2 h3 h4 h5 h6 summary td th] ].freeze
+      SINGLE_LINE_ANCESTORS = [ *INLINE_ELEMENTS, *%w[h1 h2 h3 h4 h5 h6 summary tr td th] ].freeze
       LEADING_PRETTY_PRINT_WHITESPACE = /\A\s*\n\s*/
       TRAILING_PRETTY_PRINT_WHITESPACE = /\s*\n\s*\z/
       private_constant :BOLD_TAGS, :ITALIC_TAGS, :LIST_BULLET, :LIST_INDENT, :ENCODE_HREF_CHARS,
@@ -133,7 +133,7 @@ module ActionText
           if respond_to?(method_name, true)
             send(method_name, node, child_values)
           else
-            join_children(child_values).strip
+            visit__container(node, child_values)
           end
         else
           join_children(child_values)
@@ -179,7 +179,7 @@ module ActionText
       end
 
       def visit_pre(node, child_values)
-        inner = join_children(child_values).delete_prefix("\n").delete_suffix("\n")
+        inner = normalize_line_endings(join_children(child_values)).delete_prefix("\n").delete_suffix("\n")
 
         if single_line_context?(node)
           inline_code(inner)
@@ -191,13 +191,6 @@ module ActionText
 
       def visit_p(_node, child_values)
         "#{join_children(child_values)}\n\n"
-      end
-
-      # Trix uses <div> as its default block element and represents newlines as <br> tags
-      # (see piece_view.js and block_view.js in the Trix source). Unlike <p>, we don't append
-      # paragraph-separating newlines here because the <br> children already provide spacing.
-      def visit_div(_node, child_values)
-        join_children(child_values)
       end
 
       def visit__heading(_node, child_values, level)
@@ -240,6 +233,13 @@ module ActionText
         text.gsub(/[\r\n]+/, " ")
       end
 
+      # Markdown ends a line at a bare CR, but String#lines and String#split("\n") do not, so a
+      # CR inside a fence would slip past the indentation #format_list_item and #visit_blockquote
+      # add to each line and land outside the block.
+      def normalize_line_endings(text)
+        text.gsub(/\r\n?/, "\n")
+      end
+
       def visit_tr(node, child_values)
         # lexxy does not emit `thead`, so we need to infer header rows from `tr` contents
         if node.element_children.all? { |cell| cell.name == "th" }
@@ -268,22 +268,40 @@ module ActionText
         join_children(child_values)
       end
 
+      # A container contributes no Markdown of its own, and neither does an element with no
+      # visitor at all. #join_children reads a trailing blank line as "this value is a block"
+      # and uses it to keep the next value off the same line, so a container holding a block
+      # has to report one too. Flatten that away and a fence inside the container lands
+      # mid-line, releasing the `pre` content #markdown_for_node emits unescaped.
+      def visit__container(_node, child_values)
+        inner = join_children(child_values)
+
+        if child_values.any? { |value| block_value?(value) }
+          "#{inner.rstrip}\n\n"
+        else
+          inner
+        end
+      end
+      # Trix uses <div> as its default block element and represents newlines as <br> tags (see
+      # piece_view.js and block_view.js in the Trix source). Unlike <p>, a div of inline content
+      # adds no paragraph-separating newlines: its <br> children already provide the spacing.
+      alias_method :visit_div, :visit__container
+      alias_method :visit_li, :visit__container
+      alias_method :visit_td, :visit__container
+      alias_method :visit_th, :visit__container
+      alias_method :visit_thead, :visit__container
+      alias_method :visit_tbody, :visit__container
+
+      def block_value?(value)
+        stringify(value).end_with?("\n\n")
+      end
+
       # Avoid including content from elements that aren't meaningful for markdown output
       def visit__unsupported(_node, _child_values)
         ""
       end
       alias_method :visit_script, :visit__unsupported
       alias_method :visit_style, :visit__unsupported
-
-      # These elements pass through their content (parent handlers use child_values directly)
-      def visit__passthrough(_node, child_values)
-        join_children(child_values)
-      end
-      alias_method :visit_li, :visit__passthrough
-      alias_method :visit_td, :visit__passthrough
-      alias_method :visit_th, :visit__passthrough
-      alias_method :visit_thead, :visit__passthrough
-      alias_method :visit_tbody, :visit__passthrough
 
       def visit__table_header_row(node, child_values)
         cells = child_values_for_elements(node, child_values).map { |v| stringify(v).strip }
@@ -304,10 +322,15 @@ module ActionText
         end.join("\n")
       end
 
+      # A list item's later lines have to be indented to the width of its marker. Indent them
+      # less and the item ends there, which for a fenced code block means the fence closes
+      # early and the rest of the `pre` content #markdown_for_node emits unescaped is released
+      # as Markdown source. `- ` happens to be as wide as LIST_INDENT; `1. ` is not.
       def format_list_item(lines, bullet)
         first, *rest = lines
         leader = first.match?(LIST_BULLET) ? LIST_INDENT : bullet
-        ([ leader + first ] + rest.map { |line| LIST_INDENT + line }).join("\n")
+        indent = " " * leader.length
+        ([ leader + first ] + rest.map { |line| indent + line }).join("\n")
       end
 
       def join_children(child_values)
@@ -329,9 +352,11 @@ module ActionText
         parts = merged.map { |v| stringify(v) }
         result = +""
         parts.each do |part|
-          # Nested block elements (e.g., lists and blockquotes) need an initial newline injected
-          if !result.empty? && !result.end_with?("\n") && part.end_with?("\n\n")
-            result << "\n"
+          # A block child has to begin its own block. Renderers disagree about whether a fence or
+          # a list may interrupt a paragraph, and one that says no releases the content the fence
+          # was holding, so separate with a blank line rather than a single newline.
+          if !result.empty? && part.end_with?("\n\n")
+            result << "\n" until result.end_with?("\n\n")
           end
           result << part
         end
@@ -371,14 +396,15 @@ module ActionText
         "`" * [3, max_run + 1].max
       end
 
-      # A code span cannot hold a blank line: the blank line closes the paragraph before the
-      # closing backtick string arrives, and the content is released as Markdown source.
-      # Markdown turns the line endings inside a code span into spaces anyway, so collapse
-      # them here and the delimiter always holds.
+      # Two things break a code span's delimiter. A blank line closes the paragraph before the
+      # closing backtick string arrives -- Markdown turns the line endings inside a code span
+      # into spaces anyway, so collapse them and the span always closes. And a lone backtick
+      # followed by whitespace does not open a span in every renderer (kramdown refuses it), so
+      # widen the delimiter when the content leads with whitespace.
       def inline_code(content)
         content = flatten_to_inline(content)
         max_run = content.scan(/`+/).map(&:length).max || 0
-        fence = "`" * [1, max_run + 1].max
+        fence = "`" * [content.match?(/\A\s/) ? 2 : 1, max_run + 1].max
         if content.start_with?("`") || content.end_with?("`")
           "#{fence} #{content} #{fence}"
         else
@@ -418,10 +444,11 @@ module ActionText
         URI::RFC2396_PARSER.escape(href, ENCODE_HREF_CHARS)
       end
 
-      # A fenced code block opens only at the start of a line. Inside a link, a heading, a
-      # table cell or an inline element, the parent visitor lays its children out on one
-      # line, so the fence would land mid-line and never open, releasing the `pre` content
-      # that #markdown_for_node emits unescaped. See SKIP_ESCAPING_PARENTS.
+      # A fenced code block opens only at the start of a line. A link, a heading, a summary
+      # and a table row or cell each splice their descendants into a line they have already
+      # begun, and Markdown cannot hold a block inside an inline element at all, so under
+      # any of them the fence never opens and the `pre` content #markdown_for_node emits
+      # unescaped is released as Markdown source. See SKIP_ESCAPING_PARENTS.
       def single_line_context?(node)
         node.ancestors.any? { |ancestor| ancestor.element? && ancestor.name.in?(SINGLE_LINE_ANCESTORS) }
       end

--- a/actiontext/test/integration/markdown_sanitization_test.rb
+++ b/actiontext/test/integration/markdown_sanitization_test.rb
@@ -37,6 +37,22 @@ class ActionText::MarkdownSanitizationTest < ActionDispatch::IntegrationTest
     assert_equal "| `#{PAYLOAD}` |", markdown_for("<table><tr><td><pre>#{PAYLOAD}</pre></td></tr></table>")
   end
 
+  test "a table row cannot break the payload out of a code block" do
+    assert_equal "| `#{PAYLOAD}` |", markdown_for("<table><tr><template><pre>#{PAYLOAD}</pre></template></tr></table>")
+  end
+
+  test "an ordered list marker cannot break the payload out of a code block" do
+    assert_equal "1. ```\n   #{PAYLOAD}\n   ```", markdown_for("<ol><li><pre>#{PAYLOAD}</pre></li></ol>")
+  end
+
+  test "leading whitespace cannot break the payload out of a code span" do
+    assert_equal "`` #{PAYLOAD}``", markdown_for("<code> #{PAYLOAD}</code>")
+  end
+
+  test "a preceding sibling cannot break the payload out of a code block" do
+    assert_equal "before\n\n```\n#{PAYLOAD}\n```", markdown_for("<div>before</div><figure><pre>#{PAYLOAD}</pre></figure>")
+  end
+
   private
     def markdown_for(content)
       post messages_path, params: { message: { subject: "x", content: content } }

--- a/actiontext/test/integration/markdown_sanitization_test.rb
+++ b/actiontext/test/integration/markdown_sanitization_test.rb
@@ -25,6 +25,18 @@ class ActionText::MarkdownSanitizationTest < ActionDispatch::IntegrationTest
     assert_equal ESCAPED, rich_text.reload.body.to_markdown
   end
 
+  test "a blank line cannot break the payload out of a code span" do
+    assert_equal "`a #{PAYLOAD}`", markdown_for("<code>a<br><br>#{PAYLOAD}</code>")
+  end
+
+  test "a heading cannot break the payload out of a code block" do
+    assert_equal "# `#{PAYLOAD}`", markdown_for("<h1><pre>#{PAYLOAD}</pre></h1>")
+  end
+
+  test "a table cell cannot break the payload out of a code block" do
+    assert_equal "| `#{PAYLOAD}` |", markdown_for("<table><tr><td><pre>#{PAYLOAD}</pre></td></tr></table>")
+  end
+
   private
     def markdown_for(content)
       post messages_path, params: { message: { subject: "x", content: content } }

--- a/actiontext/test/unit/markdown_conversion_test.rb
+++ b/actiontext/test/unit/markdown_conversion_test.rb
@@ -348,7 +348,7 @@ class ActionText::MarkdownConversionTest < ActiveSupport::TestCase
 
   test "nested <blockquote> tags produce nested quotes" do
     assert_converted_to(
-      "> this is a quote\n> > of a quote",
+      "> this is a quote\n> \n> > of a quote",
       "<blockquote>this is a quote<blockquote>of a quote</blockquote></blockquote>"
     )
   end
@@ -439,6 +439,83 @@ class ActionText::MarkdownConversionTest < ActiveSupport::TestCase
     )
   end
 
+  test "<pre> inside a <template> in a table row is flattened into an inline code span" do
+    assert_converted_to(
+      "| `[click](javascript:alert(1))` |",
+      "<table><tr><template><pre>[click](javascript:alert(1))</pre></template></tr></table>"
+    )
+  end
+
+  test "<pre> in a table row from an HTML4-parsed fragment is flattened into an inline code span" do
+    fragment = Nokogiri::HTML4.fragment("<table><tr><div><pre>[click](javascript:alert(1))</pre></div></tr></table>")
+    assert_equal "| `[click](javascript:alert(1))` |", ActionText::MarkdownConversion.node_to_markdown(fragment)
+  end
+
+  test "<pre> in an <ol> item is indented to the width of the marker so the fence holds" do
+    assert_converted_to(
+      "1. ```\n   [click](javascript:alert(1))\n   ```",
+      "<ol><li><pre>[click](javascript:alert(1))</pre></li></ol>"
+    )
+  end
+
+  test "<pre> in the tenth <ol> item is indented to the width of the wider marker" do
+    assert_converted_to(
+      "#{(1..9).map { |i| "#{i}. x" }.join("\n")}\n10. ```\n    [click](javascript:alert(1))\n    ```",
+      "<ol>#{"<li>x</li>" * 9}<li><pre>[click](javascript:alert(1))</pre></li></ol>"
+    )
+  end
+
+  test "a nested <ol> is indented to the width of the marker it sits under" do
+    assert_converted_to(
+      "1. one\n   1. nested",
+      "<ol><li>one<ol><li>nested</li></ol></li></ol>"
+    )
+  end
+
+  test "<code> content starting with whitespace gets a wider code span delimiter" do
+    assert_converted_to(
+      "`` [click](javascript:alert(1))``",
+      "<code> [click](javascript:alert(1))</code>"
+    )
+    assert_converted_to(
+      "``\t[click](javascript:alert(1))``",
+      "<code>\t[click](javascript:alert(1))</code>"
+    )
+  end
+
+  test "<pre> that follows a sibling starts its own block" do
+    assert_converted_to(
+      "before\n\n```\n[click](javascript:alert(1))\n```",
+      "<div>before</div><figure><pre>[click](javascript:alert(1))</pre></figure>"
+    )
+    assert_converted_to(
+      "lead\n\n```\n[click](javascript:alert(1))\n```",
+      "<div>lead<pre>[click](javascript:alert(1))</pre></div>"
+    )
+  end
+
+  test "<pre> in a container that has more content after it still starts its own block" do
+    assert_converted_to(
+      "before\n\n```\n[click](javascript:alert(1))\n```\n\nafter",
+      "<div>before</div><figure><pre>[click](javascript:alert(1))</pre>after</figure>"
+    )
+  end
+
+  test "<div> holding a <pre> reports itself as a block" do
+    assert_converted_to(
+      "before\n\n```\n[click](javascript:alert(1))\n```\n\nafter",
+      "<div>before</div><div><pre>[click](javascript:alert(1))</pre>after</div>"
+    )
+  end
+
+  test "<pre> with CR line endings from an HTML4-parsed fragment keeps every line in the fence" do
+    fragment = Nokogiri::HTML4.fragment("<ol><li><pre>one\rtwo</pre></li></ol>")
+    assert_equal "1. ```\n   one\n   two\n   ```", ActionText::MarkdownConversion.node_to_markdown(fragment)
+
+    fragment = Nokogiri::HTML4.fragment("<blockquote><pre>one\r\ntwo</pre></blockquote>")
+    assert_equal "> ```\n> one\n> two\n> ```", ActionText::MarkdownConversion.node_to_markdown(fragment)
+  end
+
   test "<pre> inside <strong> is flattened into an inline code span" do
     assert_converted_to(
       "**`[click](javascript:alert(1))`**",
@@ -485,6 +562,13 @@ class ActionText::MarkdownConversionTest < ActiveSupport::TestCase
     assert_converted_to(
       "- one\n  - nested\n- two",
       "<ul><li>one<ul><li>nested</li></ul></li><li>two</li></ul>"
+    )
+  end
+
+  test "an <ol> item holding only a nested <ol> keeps its marker" do
+    assert_converted_to(
+      "1.   1. c",
+      "<ol><li><ol><li><ol><li>c</li></ol></li></ol></li></ol>"
     )
   end
 

--- a/actiontext/test/unit/markdown_conversion_test.rb
+++ b/actiontext/test/unit/markdown_conversion_test.rb
@@ -397,6 +397,69 @@ class ActionText::MarkdownConversionTest < ActiveSupport::TestCase
     )
   end
 
+  test "<code> containing a blank line keeps its content in one code span" do
+    assert_converted_to(
+      "`a [click](javascript:alert(1))`",
+      "<code>a<br><br>[click](javascript:alert(1))</code>"
+    )
+  end
+
+  test "<code> containing a line break keeps its content in one code span" do
+    assert_converted_to(
+      "`a [click](javascript:alert(1))`",
+      "<code>a<br>[click](javascript:alert(1))</code>"
+    )
+  end
+
+  test "<pre> inside a heading is flattened into an inline code span" do
+    assert_converted_to(
+      "# `[click](javascript:alert(1))`",
+      "<h1><pre>[click](javascript:alert(1))</pre></h1>"
+    )
+  end
+
+  test "<pre> inside <summary> is flattened into an inline code span" do
+    assert_converted_to(
+      "**`[click](javascript:alert(1))`**",
+      "<details><summary><pre>[click](javascript:alert(1))</pre></summary></details>"
+    )
+  end
+
+  test "<pre> inside a table cell is flattened into an inline code span" do
+    assert_converted_to(
+      "| `[click](javascript:alert(1))` | x |",
+      "<table><tr><td><pre>[click](javascript:alert(1))</pre></td><td>x</td></tr></table>"
+    )
+  end
+
+  test "<pre> inside a table header cell is flattened into an inline code span" do
+    assert_converted_to(
+      "| `[click](javascript:alert(1))` |\n| --- |",
+      "<table><tr><th><pre>[click](javascript:alert(1))</pre></th></tr></table>"
+    )
+  end
+
+  test "<pre> inside <strong> is flattened into an inline code span" do
+    assert_converted_to(
+      "**`[click](javascript:alert(1))`**",
+      "<strong><pre>[click](javascript:alert(1))</pre></strong>"
+    )
+  end
+
+  test "<pre> inside <em> is flattened into an inline code span" do
+    assert_converted_to(
+      "*`[click](javascript:alert(1))`*",
+      "<em><pre>[click](javascript:alert(1))</pre></em>"
+    )
+  end
+
+  test "<pre> inside <del> is flattened into an inline code span" do
+    assert_converted_to(
+      "~~`[click](javascript:alert(1))`~~",
+      "<del><pre>[click](javascript:alert(1))</pre></del>"
+    )
+  end
+
   test "<ul> tags are converted to unordered lists" do
     assert_converted_to(
       "before\n\n- one\n- two\n- three\n\nafter",
@@ -603,21 +666,21 @@ class ActionText::MarkdownConversionTest < ActiveSupport::TestCase
 
   test "<a> tags containing <pre> are flattened into an inline code span" do
     assert_converted_to(
-      "[``` puts 1 ``` ](https://example.com)",
+      "[`puts 1`](https://example.com)",
       '<a href="https://example.com"><pre>puts 1</pre></a>'
     )
   end
 
   test "<a> tags containing multiline <pre> are flattened into an inline code span" do
     assert_converted_to(
-      "[``` line one line two ``` ](https://example.com)",
+      "[`line one line two`](https://example.com)",
       "<a href=\"https://example.com\"><pre>line one\nline two</pre></a>"
     )
   end
 
   test "<a> tags containing <pre> with backticks are flattened into an inline code span" do
     assert_converted_to(
-      "[```` a ``` b ```` ](https://example.com)",
+      "[````a ``` b````](https://example.com)",
       '<a href="https://example.com"><pre>a ``` b</pre></a>'
     )
   end
@@ -673,26 +736,26 @@ class ActionText::MarkdownConversionTest < ActiveSupport::TestCase
 
   test "<a> tags containing <pre> with CRLF line endings are flattened into an inline code span" do
     assert_converted_to(
-      "[``` line one line two ``` ](https://example.com)",
+      "[`line one line two`](https://example.com)",
       "<a href=\"https://example.com\"><pre>line one\r\nline two</pre></a>"
     )
   end
 
   test "<a> tags containing <pre> with CR line endings are flattened into an inline code span" do
     assert_converted_to(
-      "[``` line one line two ``` ](https://example.com)",
+      "[`line one line two`](https://example.com)",
       "<a href=\"https://example.com\"><pre>line one\rline two</pre></a>"
     )
   end
 
   test "<a> tags containing <pre> with CR line endings from an HTML4-parsed fragment are flattened" do
     fragment = Nokogiri::HTML4.fragment("<a href=\"https://example.com\"><pre>line one\rline two</pre></a>")
-    assert_equal "[``` line one line two ``` ](https://example.com)", ActionText::MarkdownConversion.node_to_markdown(fragment)
+    assert_equal "[`line one line two`](https://example.com)", ActionText::MarkdownConversion.node_to_markdown(fragment)
   end
 
   test "<a> tags containing <pre> with CRLF line endings from an HTML4-parsed fragment are flattened" do
     fragment = Nokogiri::HTML4.fragment("<a href=\"https://example.com\"><pre>line one\r\nline two</pre></a>")
-    assert_equal "[``` line one line two ``` ](https://example.com)", ActionText::MarkdownConversion.node_to_markdown(fragment)
+    assert_equal "[`line one line two`](https://example.com)", ActionText::MarkdownConversion.node_to_markdown(fragment)
   end
 
   test "<a> tags containing <br> are flattened into link text" do


### PR DESCRIPTION
### Motivation / Background

`ActionText::MarkdownConversion` lists `code` and `pre` in `SKIP_ESCAPING_PARENTS`, so their text is emitted without Markdown escaping. Safety rests on the delimiter `#visit_code` or `#visit_pre` wraps around the content, and nothing checks that it holds. Seven positions break it.

A code span cannot cross a blank line. Trix encodes a blank line as `<br><br>`, so an author only has to press return twice:

    <code>a<br><br>[click](javascript:alert(1))</code>

    `a
    [click](javascript:alert(1))`

A fenced code block opens only at the start of a line. `#visit__heading`, `#visit_summary`, `#visit_tr`, `#visit__table_header_row` and the emphasis visitors lay their children out on one line, so the fence lands mid-line and never opens:

    <h1><pre>[click](javascript:alert(1))</pre></h1>

    # ```
    [click](javascript:alert(1))
    ```

Five more positions break a delimiter the same way:

- A `pre` in a container with content after it. `#visit_div` dropped the trailing blank line `#join_children` reads as "this value is a block", so the fence was spliced onto the preceding text. `<div>before</div><div><pre>…</pre>after</div>` is ordinary Trix output.
- A `pre` under a `tr` rather than a `td`, which `<template>` and the HTML4 parser both allow.
- A `pre` in an `ol` item. Continuation lines were indented two spaces under the three-column `1. ` marker, so the item ended before the closing fence.
- Code content starting with whitespace, which kramdown will not open a one-backtick span for.
- A bare CR, which Markdown ends a line at and `String#lines` does not, so the indentation `#format_list_item` and `#visit_blockquote` add to each line stopped at the CR.

In each case the payload reaches the Markdown renderer as source. `#visit_a` rejects a `javascript:` href for a real `<a href>`, so this hands a rich text author a link they cannot otherwise write. In an application that stores rich text and renders `#to_markdown` output, that is stored XSS.

### Detail

Two commits: the first closes the two reported positions, the second the five found in review.

`#inline_code` collapses line endings before wrapping. Markdown turns line endings inside a code span into spaces anyway, so the rendered content is unchanged and no blank line survives to end the paragraph. It also widens the delimiter to two backticks when the content leads with whitespace.

`#visit_pre` emits an inline code span rather than a fence when an ancestor in `SINGLE_LINE_ANCESTORS` — an inline element, a heading, `summary`, `tr`, `td` or `th` — lays its children out on one line. It also normalizes CR line endings to LF.

    <h1><pre>[click](javascript:alert(1))</pre></h1>

previously produced

    # ```
    [click](javascript:alert(1))
    ```

and now produces

    # `[click](javascript:alert(1))`

The transparent visitors (`div`, `li`, `td`, `th`, `thead`, `tbody`, and any element without a visitor) share one `#visit__container`, which reports itself as a block when any of its children is a block. `#join_children` separates a block child from what precedes it with a blank line rather than a single newline, because redcarpet does not let a fence interrupt a paragraph.

    <div>before</div><div><pre>[click](javascript:alert(1))</pre>after</div>

previously produced

    before```
    [click](javascript:alert(1))
    ```

    after

and now produces

    before

    ```
    [click](javascript:alert(1))
    ```

    after

`#format_list_item` indents continuation lines to the width of the marker: three spaces under `1. `, two under `- `.

Six existing expectations for `<a>` wrapping `<pre>` changed. `#visit_a` already flattened the fence into the link text; the link text now carries a code span instead. `<a href="https://example.com"><pre>puts 1</pre></a>` produced ``[``` puts 1 ``` ](https://example.com)`` and now produces ``[`puts 1`](https://example.com)``.

### Additional information

ref: https://hackerone.com/reports/3994016, reported by [seoafoz](https://hackerone.com/seoafoz).

This is the second report against the `SKIP_ESCAPING_PARENTS` assumption, after the `<action-text-markdown>` marker tag (2191ca0d), so the fix states an invariant on the delimiter rather than guarding the reported paths, and the tests cover every container that lays a `pre` out on one line.

`#to_markdown` is absent from the `v8.1.0` tag, so there is nothing to backport and no release to coordinate.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
