### PR TITLE
Render Action Text content attachments by partial path

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Render content attachments by partial path.
+
+    `ActionText::Attachables::ContentAttachment#to_html` handed the
+    `ActionText::Content` object to the renderer, which resolved it as an object
+    partial: prefixed with the rendering controller's namespace (a missing
+    `admin/action_text/contents/_content` from `Admin::MessagesController`),
+    restricted to the request's formats (missing from a JSON request), and
+    raising `NoMethodError` on the nil prefix of the fallback renderer when
+    rendering outside a request, such as from a job.
+
+    *Jeremy Daer*
+
 *   Add alternative text to Action Text attachments.
 
     Attachments could only be described by their caption, which is always shown

--- a/actiontext/lib/action_text/attachables/content_attachment.rb
+++ b/actiontext/lib/action_text/attachables/content_attachment.rb
@@ -26,7 +26,7 @@ module ActionText
       end
 
       def to_html
-        @to_html ||= content_instance.render(content_instance)
+        @to_html ||= content_instance.render(partial: content_instance.to_partial_path, formats: :html, locals: { content: content_instance })
       end
 
       def to_s

--- a/actiontext/test/integration/controller_render_test.rb
+++ b/actiontext/test/integration/controller_render_test.rb
@@ -61,6 +61,21 @@ class ActionText::ControllerRenderTest < ActionDispatch::IntegrationTest
     assert_select "#content-html .trix-content .attachment--jpg"
   end
 
+  test "renders content attachments when controller is namespaced" do
+    message = Message.create!(content: content_attachment_html)
+
+    get admin_message_path(message)
+    assert_select "#content-html .attachment--content strong", text: "Hello"
+  end
+
+  test "renders content attachments as HTML when the request format is not HTML" do
+    message = Message.create!(content: content_attachment_html)
+
+    get message_path(message, format: :json)
+    content = ActionText.html_document_fragment_class.parse(response.parsed_body["content"])
+    assert_select content, ".attachment--content strong", text: "Hello"
+  end
+
   test "resolves ActionText::Attachable based on their to_attachable_partial_path" do
     alice = people(:alice)
 
@@ -77,4 +92,9 @@ class ActionText::ControllerRenderTest < ActionDispatch::IntegrationTest
 
     assert_select ".missing-attachable", text: "Missing person"
   end
+
+  private
+    def content_attachment_html
+      '<action-text-attachment content-type="text/html" content="&lt;strong&gt;Hello&lt;/strong&gt;"></action-text-attachment>'
+    end
 end

--- a/actiontext/test/integration/job_render_test.rb
+++ b/actiontext/test/integration/job_render_test.rb
@@ -23,6 +23,20 @@ class ActionText::JobRenderTest < ActiveJob::TestCase
     end
   end
 
+  test "renders content attachments" do
+    message = Message.create!(content: '<action-text-attachment content-type="text/html" content="&lt;strong&gt;Hello&lt;/strong&gt;"></action-text-attachment>')
+
+    Dir.mktmpdir do |dir|
+      file = File.join(dir, "broadcast.html")
+
+      BroadcastJob.perform_later(file, message)
+      perform_enqueued_jobs
+
+      rendered = ActionText.html_document_fragment_class.parse(File.read(file))
+      assert_select rendered, ".attachment--content strong", text: "Hello"
+    end
+  end
+
   private
     def with_default_url_options(default_url_options)
       original_default_url_options = Dummy::Application.default_url_options


### PR DESCRIPTION
### Motivation / Background

Rich text holding a content attachment (`<action-text-attachment content-type="text/html" content="…">`) can't be rendered from a namespaced controller, from a non-HTML request, or outside a request. `ActionText::Attachables::ContentAttachment#to_html` hands the `ActionText::Content` object to the renderer, so Action View resolves it as an *object* partial:

- From `Admin::MessagesController`, `prefix_partial_path_with_controller_namespace` turns `action_text/contents/content` into `admin/action_text/contents/_content`, which doesn't exist: `ActionView::MissingTemplate`.
- From a JSON request, the lookup is restricted to `formats: [:json]`, so the HTML partial isn't found either. (Top-level content passes `formats: :html` explicitly; the nested render doesn't.)
- From a job, there's no controller renderer, so Action Text falls back to `Class.new(ActionController::Base).renderer`, whose prefix is `nil`, and `merge_prefix_into_object_path` raises `undefined method 'include?' for nil`.

We hit all three in production this evening: a comment with a content attachment 500'd the create request from a namespaced comments controller and then failed every webhook delivery job for that event.

### Detail

Render the content partial by path with `formats: :html`, the same way `ActionText::Content#to_rendered_html_with_layout` renders top-level content. Adds tests for the namespaced controller, the JSON request, and the job, each of which raises without the change.

### Checklist

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries.
