### PR TITLE
`render_in`: Skip emission of `render_template.action_view`

### DIFF
--- a/actionview/lib/action_view/helpers/rendering_helper.rb
+++ b/actionview/lib/action_view/helpers/rendering_helper.rb
@@ -142,16 +142,20 @@ module ActionView
       def render(options = {}, locals = {}, &block)
         case options
         when Hash
-          in_rendering_context(options) do |renderer|
-            if block_given? && !options.key?(:renderable)
-              view_renderer.render_partial(self, options.merge(partial: options[:layout]), &block)
-            else
-              view_renderer.render(self, options, &block)
+          if options.key?(:renderable)
+            Template::Renderable.new(options[:renderable], &block).render(self, options[:locals] || {})
+          else
+            in_rendering_context(options) do |renderer|
+              if block_given?
+                view_renderer.render_partial(self, options.merge(partial: options[:layout]), &block)
+              else
+                view_renderer.render(self, options, &block)
+              end
             end
           end
         else
           if options.respond_to?(:render_in)
-            view_renderer.render(self, renderable: options, locals: locals, &block)
+            Template::Renderable.new(options, &block).render(self, locals)
           else
             view_renderer.render_partial(self, partial: options, locals: locals, &block)
           end

--- a/actionview/test/lib/test_renderable.rb
+++ b/actionview/test/lib/test_renderable.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
 class TestRenderable
-  def render_in(view_context, **)
+  def render_in(view_context, locals: {}, **)
     if block_given?
-      view_context.render(html: yield)
+      yield.to_s
     else
-      view_context.render(inline: <<~ERB.strip, **)
-        Hello, <%= local_assigns[:name] || "World" %>!
-      ERB
+      "Hello, #{locals[:name] || "World"}!"
     end
   end
 end

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -456,6 +456,15 @@ module RenderTestCases
     assert_equal "<h1>Goodbye, Block!</h1>", @view.render(renderable: TestRenderable.new) { @view.tag.h1 "Goodbye, Block!" }
   end
 
+  def test_render_renderable_render_in_does_not_emit_active_support_notifications
+    assert_no_notifications "render_template.action_view" do
+      assert_equal "Hello, World!", @view.render(TestRenderable.new)
+    end
+    assert_no_notifications "render_template.action_view" do
+      assert_equal "Hello, World!", @view.render(renderable: TestRenderable.new)
+    end
+  end
+
   def test_render_renderable_render_in_excludes_renderable_key
     renderable = Object.new
     def renderable.render_in(view_context, **options)


### PR DESCRIPTION
Related to https://github.com/rails/rails/issues/57781

As reported in #57781, new calls to `#render_in` emit `render_template.action_view` Active Support notifications, which themselves cause a spike in object allocations.

This commit explores an alternative that preserves the behavior introduced in [#50623][] (support for passing `:locals` at the `#render_in` call-site) without also emitting `render_template.action_view` notifications.

Rather than rely on the `ActionView::Renderer` instance returned by the `ActionView::Helpers::RenderingHelper#view_renderer` invocation, construct an instance of `Template::Renderable` and invoke `#render` on it directly.

[#50623]: https://github.com/rails/rails/pull/50623

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
